### PR TITLE
feat: surface desktop update prompt

### DIFF
--- a/agent-ui/src/components/agent/AgentModeTopBar.vue
+++ b/agent-ui/src/components/agent/AgentModeTopBar.vue
@@ -88,19 +88,23 @@ function startDesktopUpdateWatcher(): void {
   const bridge = desktopBridge()
   if (!bridge?.updateStatus) return
 
-  void bridge.updateStatus()
-    .then((status) => {
-      desktopUpdateStatus.value = status
-    })
-    .catch(() => {
-      desktopUpdateStatus.value = null
-    })
-
   removeUpdateListener = bridge.onUpdateStatus?.((status) => {
     desktopUpdateStatus.value = status
   }) ?? null
 
-  void bridge.checkForUpdates?.().catch(() => undefined)
+  void bridge.updateStatus()
+    .then((status) => {
+      desktopUpdateStatus.value = status
+      if (status.state === 'downloaded' || !bridge.checkForUpdates) return
+      void bridge.checkForUpdates()
+        .then((nextStatus) => {
+          desktopUpdateStatus.value = nextStatus
+        })
+        .catch(() => undefined)
+    })
+    .catch(() => {
+      desktopUpdateStatus.value = null
+    })
 }
 
 function stopDesktopUpdateWatcher(): void {

--- a/agent-ui/src/components/agent/AgentModeTopBar.vue
+++ b/agent-ui/src/components/agent/AgentModeTopBar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
-import { Eye, EyeOff, Loader2, Network, Settings } from 'lucide-vue-next'
+import { Eye, EyeOff, Loader2, Network, RotateCcw, Settings } from 'lucide-vue-next'
 import { http } from '@/api/clients/http-client'
 
 const props = defineProps<{
@@ -35,11 +35,22 @@ const activeRunCount = ref(0)
 let activeRunTimer: ReturnType<typeof setInterval> | null = null
 
 const hasActiveRuns = computed(() => activeRunCount.value > 0)
+const desktopUpdateStatus = ref<DesktopUpdateStatus | null>(null)
+const updateInstalling = ref(false)
+let removeUpdateListener: (() => void) | null = null
+
 const runtimeTitle = computed(() =>
   hasActiveRuns.value
     ? `DAG dashboard: ${activeRunCount.value} run${activeRunCount.value === 1 ? '' : 's'} running`
     : 'DAG dashboard',
 )
+const downloadedUpdate = computed(() =>
+  Boolean(desktopUpdateStatus.value?.supported && desktopUpdateStatus.value.state === 'downloaded'),
+)
+const updateButtonTitle = computed(() => {
+  const version = desktopUpdateStatus.value?.update?.version
+  return version ? `HomeRail ${version} 已下载，重启后安装` : '新版本已下载，重启后安装'
+})
 
 async function refreshActiveRuns(): Promise<void> {
   if (!props.showRuntime) {
@@ -69,8 +80,51 @@ function stopActiveRunPolling(): void {
   activeRunTimer = null
 }
 
+function desktopBridge(): HomeRailDesktopBridge | null {
+  return typeof window === 'undefined' ? null : window.homerailDesktop ?? null
+}
+
+function startDesktopUpdateWatcher(): void {
+  const bridge = desktopBridge()
+  if (!bridge?.updateStatus) return
+
+  void bridge.updateStatus()
+    .then((status) => {
+      desktopUpdateStatus.value = status
+    })
+    .catch(() => {
+      desktopUpdateStatus.value = null
+    })
+
+  removeUpdateListener = bridge.onUpdateStatus?.((status) => {
+    desktopUpdateStatus.value = status
+  }) ?? null
+
+  void bridge.checkForUpdates?.().catch(() => undefined)
+}
+
+function stopDesktopUpdateWatcher(): void {
+  removeUpdateListener?.()
+  removeUpdateListener = null
+}
+
+async function installDesktopUpdate(): Promise<void> {
+  const bridge = desktopBridge()
+  if (!bridge?.installUpdate || updateInstalling.value) return
+  updateInstalling.value = true
+  try {
+    const status = await bridge.installUpdate()
+    if (status.state !== 'downloaded') {
+      updateInstalling.value = false
+    }
+  } catch {
+    updateInstalling.value = false
+  }
+}
+
 onMounted(() => {
   if (props.showRuntime) startActiveRunPolling()
+  startDesktopUpdateWatcher()
 })
 
 watch(() => props.showRuntime, (showRuntime) => {
@@ -82,7 +136,10 @@ watch(() => props.showRuntime, (showRuntime) => {
   }
 })
 
-onBeforeUnmount(stopActiveRunPolling)
+onBeforeUnmount(() => {
+  stopActiveRunPolling()
+  stopDesktopUpdateWatcher()
+})
 </script>
 
 <template>
@@ -114,6 +171,16 @@ onBeforeUnmount(stopActiveRunPolling)
 
     <div class="agent-mode-topbar__right flex flex-shrink-0 items-center gap-2">
       <slot name="right" />
+      <button
+        v-if="downloadedUpdate"
+        class="flex h-9 items-center gap-2 rounded-full border border-cyan-200/35 bg-cyan-300/14 px-3 text-sm font-medium text-cyan-50 shadow-[0_0_18px_rgba(103,232,249,0.18)] transition-colors hover:bg-cyan-300/20"
+        :title="updateButtonTitle"
+        type="button"
+        @click="installDesktopUpdate"
+      >
+        <RotateCcw class="h-4 w-4" :class="updateInstalling ? 'animate-spin' : ''" />
+        重启更新
+      </button>
       <button
         v-if="showRuntime"
         class="flex h-9 items-center gap-2 rounded-full border px-3 text-sm transition-colors hover:bg-cyan-200/10 hover:text-white"

--- a/agent-ui/src/types/homerail-desktop.d.ts
+++ b/agent-ui/src/types/homerail-desktop.d.ts
@@ -1,0 +1,44 @@
+export {}
+
+declare global {
+  type DesktopUpdateState =
+    | 'idle'
+    | 'checking'
+    | 'available'
+    | 'downloading'
+    | 'downloaded'
+    | 'not-available'
+    | 'error'
+
+  interface DesktopUpdateStatus {
+    supported: boolean
+    state: DesktopUpdateState
+    currentVersion: string
+    update?: {
+      version?: string
+      releaseName?: string | null
+      releaseDate?: string
+    }
+    error?: string
+    checkedAt?: number
+    downloadedAt?: number
+  }
+
+  interface HomeRailDesktopBridge {
+    getStatus?: () => Promise<unknown>
+    start?: () => Promise<unknown>
+    stop?: () => Promise<unknown>
+    restart?: () => Promise<unknown>
+    doctor?: () => Promise<unknown>
+    openLogs?: () => Promise<unknown>
+    version?: () => Promise<unknown>
+    updateStatus?: () => Promise<DesktopUpdateStatus>
+    checkForUpdates?: () => Promise<DesktopUpdateStatus>
+    installUpdate?: () => Promise<DesktopUpdateStatus>
+    onUpdateStatus?: (handler: (status: DesktopUpdateStatus) => void) => () => void
+  }
+
+  interface Window {
+    homerailDesktop?: HomeRailDesktopBridge
+  }
+}


### PR DESCRIPTION
## Context

HomeRail can run as a normal web app, but the desktop shell needs a small bridge for release updates. Without a UI surface for downloaded updates, the app can download a desktop update without giving the user a clear restart/install action.

This PR adds the public web-side pieces only. The Electron implementation lives in the private desktop repository.

## Changes

- Add an Electron-only update prompt in the HomeRail top bar when a desktop update has been downloaded.
- Add TypeScript declarations for the desktop preload update bridge.
- Keep the web app behavior unchanged when it is not running inside Electron.
- Preserve update status returned by `checkForUpdates()` so the prompt can appear even when the desktop bridge does not emit a separate status event.

## Validation

- npm --prefix agent-ui run typecheck
- npm --prefix agent-ui run build

## Risk

Low for the browser build because the update UI is gated on the desktop preload bridge. The main risk is integration drift with the private desktop shell, which is covered by the paired desktop PR and Windows/macOS release testing.