### PR TITLE
fix: hide Windows runtime console windows

### DIFF
--- a/homerail_cli/src/commands/doctor.ts
+++ b/homerail_cli/src/commands/doctor.ts
@@ -135,7 +135,10 @@ function modelRuntimeBaseUrl(setting: LlmSettingSummary): string {
   return stringValue(setting.base_url ?? setting.baseUrl);
 }
 
-const defaultCommandRunner: CommandRunner = (file, args, options) => spawnSync(file, args, options);
+const defaultCommandRunner: CommandRunner = (file, args, options) => spawnSync(file, args, {
+  ...options,
+  windowsHide: true,
+});
 
 function outputText(value: string | Buffer | null | undefined): string {
   if (typeof value === "string") return value;

--- a/homerail_cli/src/commands/runtime.ts
+++ b/homerail_cli/src/commands/runtime.ts
@@ -6,7 +6,7 @@ import * as net from "node:net";
 import * as path from "node:path";
 import { createHash } from "node:crypto";
 import { fileURLToPath } from "node:url";
-import { spawn, spawnSync } from "node:child_process";
+import { spawn, spawnSync, type SpawnSyncOptionsWithStringEncoding } from "node:child_process";
 import { HomeRailClient } from "../client.js";
 import type { BaseResponse } from "../client.js";
 import {
@@ -1243,6 +1243,17 @@ export function workerImageBuildReason(
   return null;
 }
 
+export function workerImageDockerBuildSpawnOptions(): SpawnSyncOptionsWithStringEncoding {
+  return {
+    cwd: resolveRepoRoot(),
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+    env: { ...process.env, ...loadLocalSecrets(), HOMERAIL_HOME: getHomerailHome() },
+    maxBuffer: 20 * 1024 * 1024,
+    windowsHide: true,
+  };
+}
+
 function ensureWorkerImage(forceRebuild = false): void {
   const dockerBin = resolveDockerBinary();
   writeWorkerImageRuntimeStatus("checking", {
@@ -1293,12 +1304,12 @@ function ensureWorkerImage(forceRebuild = false): void {
     "-t",
     WORKER_IMAGE_TAG,
     ".",
-  ], {
-    cwd: resolveRepoRoot(),
-    stdio: "inherit",
-    env: { ...process.env, ...loadLocalSecrets(), HOMERAIL_HOME: getHomerailHome() },
-    windowsHide: true,
-  });
+  ], workerImageDockerBuildSpawnOptions());
+  if (build.stdout) process.stdout.write(build.stdout);
+  if (build.stderr) process.stderr.write(build.stderr);
+  if (build.error) {
+    throw build.error;
+  }
   if (build.status !== 0) {
     throw new Error(`failed to build ${WORKER_IMAGE_TAG}`);
   }

--- a/homerail_cli/src/commands/runtime.ts
+++ b/homerail_cli/src/commands/runtime.ts
@@ -620,6 +620,7 @@ function startService(name: RuntimeServiceName, relativeScript: string, env: Rec
     },
     detached: true,
     stdio: ["ignore", out, err],
+    windowsHide: true,
   });
   child.unref();
   if (!child.pid) throw new Error(`failed to start ${name}`);
@@ -762,6 +763,7 @@ function startUiProcess(opts: StartUiProcessOpts): number {
       },
       detached: true,
       stdio: ["ignore", out, err],
+      windowsHide: true,
     });
   } else {
     child = spawn(npmExecutable(), [
@@ -794,6 +796,7 @@ function startUiProcess(opts: StartUiProcessOpts): number {
       },
       detached: true,
       stdio: ["ignore", out, err],
+      windowsHide: true,
     });
   }
   child.unref();
@@ -961,6 +964,7 @@ function killProcessTree(pid: number, signal: NodeJS.Signals): boolean {
   if (process.platform === "win32") {
     const result = spawnSync("taskkill", ["/PID", String(pid), "/T", "/F"], {
       stdio: "ignore",
+      windowsHide: true,
     });
     return result.status === 0;
   }
@@ -1012,6 +1016,7 @@ function ensureUiCertificate(host: string): UiCertificate {
   ], {
     encoding: "utf-8",
     stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
   });
   if (result.error && (result.error as NodeJS.ErrnoException).code === "ENOENT") {
     throw new Error("openssl is required to generate the local Agent UI HTTPS certificate");
@@ -1245,6 +1250,7 @@ function ensureWorkerImage(forceRebuild = false): void {
   });
   const dockerVersion = spawnSync(dockerBin, ["--version"], {
     encoding: "utf-8",
+    windowsHide: true,
   });
   if (dockerVersion.error && (dockerVersion.error as NodeJS.ErrnoException).code === "ENOENT") {
     throw new Error(dockerMissingMessage(dockerBin));
@@ -1263,6 +1269,7 @@ function ensureWorkerImage(forceRebuild = false): void {
     WORKER_IMAGE_TAG,
   ], {
     encoding: "utf-8",
+    windowsHide: true,
   });
   const reason = workerImageBuildReason(inspect.status === 0, inspect.stdout, sourceFingerprint, forceRebuild);
   if (!reason) {
@@ -1290,6 +1297,7 @@ function ensureWorkerImage(forceRebuild = false): void {
     cwd: resolveRepoRoot(),
     stdio: "inherit",
     env: { ...process.env, ...loadLocalSecrets(), HOMERAIL_HOME: getHomerailHome() },
+    windowsHide: true,
   });
   if (build.status !== 0) {
     throw new Error(`failed to build ${WORKER_IMAGE_TAG}`);

--- a/homerail_cli/src/commands/runtime.ts
+++ b/homerail_cli/src/commands/runtime.ts
@@ -6,7 +6,7 @@ import * as net from "node:net";
 import * as path from "node:path";
 import { createHash } from "node:crypto";
 import { fileURLToPath } from "node:url";
-import { spawn, spawnSync, type SpawnSyncOptionsWithStringEncoding } from "node:child_process";
+import { spawn, spawnSync, type SpawnOptions } from "node:child_process";
 import { HomeRailClient } from "../client.js";
 import type { BaseResponse } from "../client.js";
 import {
@@ -475,7 +475,7 @@ async function startRuntime(globalOpts: GlobalOpts, opts: StartOpts): Promise<nu
   const shouldBuildImage = opts.buildWorkerImage === false ? false : cfg.runtime?.buildWorkerImage !== false;
   if (shouldBuildImage) {
     try {
-      ensureWorkerImage(Boolean(opts.rebuildWorkerImage));
+      await ensureWorkerImage(Boolean(opts.rebuildWorkerImage));
     } catch (err) {
       writeWorkerImageRuntimeStatus("error", {
         error: err instanceof Error ? err.message : String(err),
@@ -619,6 +619,7 @@ function startService(name: RuntimeServiceName, relativeScript: string, env: Rec
       ...env,
     },
     detached: true,
+    shell: false,
     stdio: ["ignore", out, err],
     windowsHide: true,
   });
@@ -725,6 +726,13 @@ interface UiCertificate {
   certPath: string;
 }
 
+export function agentUiDevServerCommand(agentUiDir: string): { command: string; args: string[] } {
+  return {
+    command: process.execPath,
+    args: [path.join(agentUiDir, "node_modules", "vite", "bin", "vite.js")],
+  };
+}
+
 function startUiProcess(opts: StartUiProcessOpts): number {
   const agentUiDir = path.join(resolveRepoRoot(), "agent-ui");
   const out = fs.openSync(logPath(opts.name), "a");
@@ -733,8 +741,7 @@ function startUiProcess(opts: StartUiProcessOpts): number {
   // Production / packaged mode: serve the prebuilt agent-ui/dist with a tiny
   // zero-dependency static server (see static-ui-server.ts), avoiding the need
   // to ship agent-ui's full node_modules (vite toolchain). On Windows this is
-  // also the most reliable source-deploy path when dist exists, because
-  // detached npm.cmd spawning can fail before Vite starts.
+  // also the most reliable source-deploy path when dist exists.
   const serveStatic = shouldServeStaticAgentUi(agentUiDir);
 
   let child: import("child_process").ChildProcess;
@@ -762,14 +769,14 @@ function startUiProcess(opts: StartUiProcessOpts): number {
           : {}),
       },
       detached: true,
+      shell: false,
       stdio: ["ignore", out, err],
       windowsHide: true,
     });
   } else {
-    child = spawn(npmExecutable(), [
-      "run",
-      "dev",
-      "--",
+    const devServer = agentUiDevServerCommand(agentUiDir);
+    child = spawn(devServer.command, [
+      ...devServer.args,
       "--host",
       opts.host,
       "--port",
@@ -795,6 +802,7 @@ function startUiProcess(opts: StartUiProcessOpts): number {
           : {}),
       },
       detached: true,
+      shell: false,
       stdio: ["ignore", out, err],
       windowsHide: true,
     });
@@ -926,10 +934,6 @@ export function shouldServeStaticAgentUi(
   if (mode === "0") return false;
   if (platform === "win32" && hasDist) return true;
   return hasDist && !fs.existsSync(path.join(agentUiDir, "node_modules"));
-}
-
-function npmExecutable(): string {
-  return process.platform === "win32" ? "npm.cmd" : "npm";
 }
 
 function stopService(name: RuntimeServiceName): boolean {
@@ -1243,18 +1247,56 @@ export function workerImageBuildReason(
   return null;
 }
 
-export function workerImageDockerBuildSpawnOptions(): SpawnSyncOptionsWithStringEncoding {
+export function workerImageDockerBuildSpawnOptions(): SpawnOptions {
   return {
     cwd: resolveRepoRoot(),
-    encoding: "utf-8",
     stdio: ["ignore", "pipe", "pipe"],
     env: { ...process.env, ...loadLocalSecrets(), HOMERAIL_HOME: getHomerailHome() },
-    maxBuffer: 20 * 1024 * 1024,
+    shell: false,
     windowsHide: true,
   };
 }
 
-function ensureWorkerImage(forceRebuild = false): void {
+export function runWorkerImageDockerBuild(
+  dockerBin: string,
+  args: string[],
+  spawnImpl: typeof spawn = spawn,
+  writeStdout: (chunk: Buffer | string) => void = (chunk) => { process.stdout.write(chunk); },
+  writeStderr: (chunk: Buffer | string) => void = (chunk) => { process.stderr.write(chunk); },
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawnImpl(dockerBin, args, workerImageDockerBuildSpawnOptions());
+    } catch (error) {
+      reject(error);
+      return;
+    }
+
+    let settled = false;
+    const finish = (error?: Error): void => {
+      if (settled) return;
+      settled = true;
+      if (error) reject(error);
+      else resolve();
+    };
+    child.stdout?.on("data", writeStdout);
+    child.stderr?.on("data", writeStderr);
+    child.once("error", (error) => finish(error));
+    child.once("close", (code, signal) => {
+      if (code === 0) {
+        finish();
+        return;
+      }
+      const detail = code === null
+        ? signal ? `signal ${signal}` : "unknown exit status"
+        : `exit code ${code}`;
+      finish(new Error(`failed to build ${WORKER_IMAGE_TAG} (${detail})`));
+    });
+  });
+}
+
+async function ensureWorkerImage(forceRebuild = false): Promise<void> {
   const dockerBin = resolveDockerBinary();
   writeWorkerImageRuntimeStatus("checking", {
     message: "Checking DAG worker image before DAG runs are enabled.",
@@ -1295,7 +1337,7 @@ function ensureWorkerImage(forceRebuild = false): void {
     reason,
     message: `${label} DAG worker image. DAG runs are temporarily unavailable until this finishes.`,
   });
-  const build = spawnSync(dockerBin, [
+  await runWorkerImageDockerBuild(dockerBin, [
     "build",
     "-f",
     "homerail_worker/Dockerfile",
@@ -1304,15 +1346,7 @@ function ensureWorkerImage(forceRebuild = false): void {
     "-t",
     WORKER_IMAGE_TAG,
     ".",
-  ], workerImageDockerBuildSpawnOptions());
-  if (build.stdout) process.stdout.write(build.stdout);
-  if (build.stderr) process.stderr.write(build.stderr);
-  if (build.error) {
-    throw build.error;
-  }
-  if (build.status !== 0) {
-    throw new Error(`failed to build ${WORKER_IMAGE_TAG}`);
-  }
+  ]);
   writeWorkerImageRuntimeStatus("ready", {
     reason,
     message: `${WORKER_IMAGE_TAG} is ready for DAG runs.`,

--- a/homerail_cli/tests/commands.test.ts
+++ b/homerail_cli/tests/commands.test.ts
@@ -11,6 +11,7 @@ import {
   shouldAbortStartForModelConfig,
   shouldServeStaticAgentUi,
   workerImageBuildReason,
+  workerImageDockerBuildSpawnOptions,
   workerImageSourceFingerprint,
 } from "../src/commands/runtime.js";
 import { createLaunchAgentPlist, installRuntimeService, uninstallRuntimeService } from "../src/local-service-lifecycle.js";
@@ -1907,6 +1908,15 @@ describe("runtime command", () => {
     expect(dockerMissingMessage("docker")).toContain("Docker CLI was not found");
     expect(dockerMissingMessage("docker")).toContain("HOMERAIL_DOCKER_BIN");
     expect(dockerMissingMessage()).toContain("hr start --no-build-worker-image");
+  });
+
+  it("builds the worker image without inheriting a Windows console", () => {
+    const options = workerImageDockerBuildSpawnOptions();
+    expect(options.stdio).toEqual(["ignore", "pipe", "pipe"]);
+    expect(options.windowsHide).toBe(true);
+    expect(options.encoding).toBe("utf-8");
+    expect(options.maxBuffer).toBeGreaterThanOrEqual(20 * 1024 * 1024);
+    expect(options.env?.HOMERAIL_HOME).toBe(tempHome);
   });
 
   it("serves prebuilt Agent UI statically on Windows when dist exists", () => {

--- a/homerail_cli/tests/commands.test.ts
+++ b/homerail_cli/tests/commands.test.ts
@@ -1,15 +1,19 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { EventEmitter } from "node:events";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Readable } from "node:stream";
+import { PassThrough, Readable } from "node:stream";
+import type { ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createProgram } from "../src/index.js";
 import { readLineFromStdin, redactSecret } from "../src/commands/llm-settings.js";
 import {
+  agentUiDevServerCommand,
   dockerMissingMessage,
   isMissingModelCredential,
   shouldAbortStartForModelConfig,
   shouldServeStaticAgentUi,
+  runWorkerImageDockerBuild,
   workerImageBuildReason,
   workerImageDockerBuildSpawnOptions,
   workerImageSourceFingerprint,
@@ -1913,10 +1917,68 @@ describe("runtime command", () => {
   it("builds the worker image without inheriting a Windows console", () => {
     const options = workerImageDockerBuildSpawnOptions();
     expect(options.stdio).toEqual(["ignore", "pipe", "pipe"]);
+    expect(options.shell).toBe(false);
     expect(options.windowsHide).toBe(true);
-    expect(options.encoding).toBe("utf-8");
-    expect(options.maxBuffer).toBeGreaterThanOrEqual(20 * 1024 * 1024);
+    expect(options).not.toHaveProperty("maxBuffer");
     expect(options.env?.HOMERAIL_HOME).toBe(tempHome);
+  });
+
+  it("streams worker image build output without buffering it", async () => {
+    class FakeChildProcess extends EventEmitter {
+      stdin = new PassThrough();
+      stdout = new PassThrough();
+      stderr = new PassThrough();
+    }
+    const child = new FakeChildProcess();
+    let stdout = "";
+    let stderr = "";
+    const build = runWorkerImageDockerBuild(
+      "docker",
+      ["build", "."],
+      (() => child as unknown as ChildProcessWithoutNullStreams) as typeof spawn,
+      (chunk) => { stdout += chunk.toString(); },
+      (chunk) => { stderr += chunk.toString(); },
+    );
+
+    child.stdout.write("build output\n");
+    child.stderr.write("build warning\n");
+    child.emit("close", 0, null);
+
+    await build;
+    expect(stdout).toBe("build output\n");
+    expect(stderr).toBe("build warning\n");
+  });
+
+  it("reports worker image build exit failures after streaming output", async () => {
+    class FakeChildProcess extends EventEmitter {
+      stdin = new PassThrough();
+      stdout = new PassThrough();
+      stderr = new PassThrough();
+    }
+    const child = new FakeChildProcess();
+    let stderr = "";
+    const build = runWorkerImageDockerBuild(
+      "docker",
+      ["build", "."],
+      (() => child as unknown as ChildProcessWithoutNullStreams) as typeof spawn,
+      () => {},
+      (chunk) => { stderr += chunk.toString(); },
+    );
+
+    child.stderr.write("docker failed\n");
+    child.emit("close", 17, null);
+
+    await expect(build).rejects.toThrow("failed to build homerail-worker:latest (exit code 17)");
+    expect(stderr).toBe("docker failed\n");
+  });
+
+  it("launches the Agent UI dev server directly through Node", () => {
+    const uiDir = join(tempHome, "agent-ui");
+    const command = agentUiDevServerCommand(uiDir);
+
+    expect(command.command).toBe(process.execPath);
+    expect(command.args).toEqual([join(uiDir, "node_modules", "vite", "bin", "vite.js")]);
+    expect(command.command.toLowerCase()).not.toMatch(/\.(cmd|bat)$/);
   });
 
   it("serves prebuilt Agent UI statically on Windows when dist exists", () => {

--- a/homerail_manager/src/node/worker-provisioner.ts
+++ b/homerail_manager/src/node/worker-provisioner.ts
@@ -212,7 +212,7 @@ export async function deprovisionWorkerContainer(
       const { spawnSync } = await import("node:child_process");
       const result = spawnSync("docker", [
         "ps", "-a", "--filter", `label=${options.labelKey}=${options.labelValue}`, "-q",
-      ], { encoding: "utf-8", timeout: 10_000 });
+      ], { encoding: "utf-8", timeout: 10_000, windowsHide: true });
       dockerCleanupVerified = (result.stdout ?? "").trim() === "";
     } catch {
       dockerCleanupVerified = false;

--- a/homerail_manager/src/server/host-shell-manager-agent.ts
+++ b/homerail_manager/src/server/host-shell-manager-agent.ts
@@ -271,6 +271,7 @@ export async function ensureHostShellManagerAgent(
   const child = spawn(process.execPath, [diagnostics.worker_entry], {
     cwd: processCwd,
     detached: true,
+    shell: false,
     stdio: ["ignore", out, err],
     env: {
       ...process.env,

--- a/homerail_manager/src/server/manager-agent-container.ts
+++ b/homerail_manager/src/server/manager-agent-container.ts
@@ -174,6 +174,7 @@ async function ensureLocalDockerNode(options: ManagerAgentContainerOptions, proj
     const child = spawn(process.execPath, [cliPath], {
       cwd: runtimeRoot(),
       detached: true,
+      shell: false,
       stdio: ["ignore", out, err],
       windowsHide: true,
       env: {

--- a/homerail_manager/src/server/manager-agent-container.ts
+++ b/homerail_manager/src/server/manager-agent-container.ts
@@ -175,6 +175,7 @@ async function ensureLocalDockerNode(options: ManagerAgentContainerOptions, proj
       cwd: runtimeRoot(),
       detached: true,
       stdio: ["ignore", out, err],
+      windowsHide: true,
       env: {
         ...process.env,
         HOMERAIL_HOME: getHomerailHome(),

--- a/homerail_node/src/storage/workspace-prepare.ts
+++ b/homerail_node/src/storage/workspace-prepare.ts
@@ -75,6 +75,7 @@ async function defaultRunCommand(
     cwd: options.cwd,
     timeout: 120_000,
     maxBuffer: 1024 * 1024,
+    windowsHide: true,
   });
 }
 


### PR DESCRIPTION
## Context

On Windows, HomeRail desktop was repeatedly flashing command prompt windows while preparing DAG resources. The visible symptom happened during normal UI use, but the root cause was lower level: several background runtime commands were launched from a GUI process without `windowsHide: true`.

The most visible path is DAG resource preparation, which can run service startup and Docker image checks/builds. Those commands should remain logged and observable through HomeRail, but they should not open foreground terminals.

## Changes

- Hide Windows console windows for runtime service startup and UI startup helpers.
- Hide console windows for Docker worker image checks and builds.
- Hide console windows for Manager Agent readiness and cleanup helper commands.
- Preserve existing stdout/stderr handling, exit codes, and log files.

## Validation

- `npm --prefix homerail_manager run typecheck`
- `npm --prefix homerail_cli run typecheck`
- `npm --prefix homerail_node run typecheck`

## Risk

Low. This only changes child-process window visibility on Windows. It does not change command arguments, process lifecycle, logging, or failure handling. Real Windows visual validation is being run from the integrated release-candidate branch.