### PR TITLE
fix: remove default manager agent turn timeout

### DIFF
--- a/homerail_manager/src/server/host-codex-manager-agent.ts
+++ b/homerail_manager/src/server/host-codex-manager-agent.ts
@@ -148,7 +148,11 @@ const CLIENT_NAME = "homerail_host_codex_manager_agent";
 const CLIENT_TITLE = "HomeRail Host Codex Manager Agent";
 const DEFAULT_CODEX_BIN = "codex";
 const RESPONSE_TIMEOUT_MS = 60_000;
-const TURN_TIMEOUT_MS = 240_000;
+
+function managerAgentTurnTimeoutMs(): number {
+  const raw = Number(process.env.MANAGER_AGENT_TURN_TIMEOUT_MS ?? "0");
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : 0;
+}
 
 const SECRET_KEYS = [
   "apiKey",
@@ -1094,8 +1098,9 @@ async function* runHostCodexManagerAgentTurnEvents(
   const toolCommentaryTexts: string[] = [];
   let emittedVoiceSurfaceCommentaryCount = 0;
   const abortController = new AbortController();
-  const timeout = setTimeout(() => abortController.abort(), TURN_TIMEOUT_MS);
-  timeout.unref?.();
+  const turnTimeoutMs = managerAgentTurnTimeoutMs();
+  const timeout = turnTimeoutMs > 0 ? setTimeout(() => abortController.abort(), turnTimeoutMs) : undefined;
+  timeout?.unref?.();
   const adapter = new HostCodexAppServerAdapter();
   try {
     for await (const event of adapter.run(
@@ -1135,7 +1140,7 @@ async function* runHostCodexManagerAgentTurnEvents(
       }
     }
   } finally {
-    clearTimeout(timeout);
+    if (timeout) clearTimeout(timeout);
   }
   const remainingSurfaceCommentary = state.voiceSurface.commentaryTexts.slice(emittedVoiceSurfaceCommentaryCount);
   for (const text of remainingSurfaceCommentary) {

--- a/homerail_worker/src/__tests__/manager-agent-server.test.ts
+++ b/homerail_worker/src/__tests__/manager-agent-server.test.ts
@@ -163,6 +163,21 @@ class AbortAwareHangingAgent implements AgentClient {
   }
 }
 
+class SlowCompletingAgent implements AgentClient {
+  observedAbort = false;
+
+  async *run(
+    _prompt: string,
+    _tools: DagToolDefinition[],
+    context: AgentRunContext,
+  ): AsyncIterable<AgentEvent> {
+    await new Promise((resolve) => setTimeout(resolve, 35));
+    this.observedAbort = context.abortSignal?.aborted === true;
+    yield { type: "text", text: "slow turn completed" };
+    yield { type: "done" };
+  }
+}
+
 describe("manager-agent server", () => {
   const tmpDirs: string[] = [];
 
@@ -553,6 +568,42 @@ describe("manager-agent server", () => {
       expect(body.error).toContain("timed out");
       expect(body.data?.objective_tool_calls).toEqual([]);
       expect(agent.observedAbort).toBe(true);
+    } finally {
+      await close(server);
+      await close(managerApi);
+    }
+  });
+
+  it("does not apply an absolute Manager Agent turn timeout by default", async () => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-manager-agent-workspace-"));
+    tmpDirs.push(workspace);
+    const agent = new SlowCompletingAgent();
+    registerAgentBackend("manager-agent-slow-completing-test", () => agent);
+    vi.stubEnv("PROJECT_WORKSPACE", workspace);
+
+    const managerApi = makeManagerApiServer();
+    const managerPort = await listen(managerApi);
+    vi.stubEnv("MANAGER_REST_URL", `http://127.0.0.1:${managerPort}/api`);
+
+    const server = startManagerAgentServer(0);
+    await new Promise<void>((resolve) => server.once("listening", () => resolve()));
+    const addr = server.address();
+    const port = typeof addr === "object" && addr ? addr.port : 0;
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/chat`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          message: "慢一点完成",
+          agent_config: { agent_type: "manager-agent-slow-completing-test", model: "test-model" },
+        }),
+      });
+      const body = await response.json() as { text?: string; error?: string };
+      expect(response.status).toBe(200);
+      expect(body.error).toBeUndefined();
+      expect(body.text).toBe("slow turn completed");
+      expect(agent.observedAbort).toBe(false);
     } finally {
       await close(server);
       await close(managerApi);

--- a/homerail_worker/src/manager-agent/server.ts
+++ b/homerail_worker/src/manager-agent/server.ts
@@ -135,7 +135,7 @@ function managerRestUrl(): string {
 }
 
 function managerAgentTurnTimeoutMs(): number {
-  const raw = Number(process.env.MANAGER_AGENT_TURN_TIMEOUT_MS ?? "240000");
+  const raw = Number(process.env.MANAGER_AGENT_TURN_TIMEOUT_MS ?? "0");
   return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : 0;
 }
 


### PR DESCRIPTION
## Context

Manager Agent turns can be long-running agent workflows. Treating them like ordinary short HTTP calls caused active turns to be aborted after the default 240 seconds, which surfaced as `Manager Agent HTTP 504` even when the runtime, model, and tools were still working.

That behavior is wrong for HomeRail: a Manager Agent turn should only be interrupted by explicit cancellation, process shutdown, or an explicitly configured operational timeout.

## Changes

- Disable the default absolute Manager Agent turn timeout for container Manager Agent runtime.
- Apply the same default no-timeout behavior to the host Codex Manager Agent runtime.
- Keep `MANAGER_AGENT_TURN_TIMEOUT_MS` as an explicit opt-in override for operators who want a hard cap.
- Add a regression test proving that Manager Agent turns are not aborted by default.

## Validation

- `npm --prefix homerail_worker test -- manager-agent-server`
- `npm --prefix homerail_worker run typecheck`
- `npm --prefix homerail_manager run typecheck`

## Risk

Medium-low. Long-running turns can now continue indefinitely by default, which matches the product model but means cancellation and runtime supervision matter more. Existing per-tool timeouts remain in place, and operators can still set `MANAGER_AGENT_TURN_TIMEOUT_MS` when they explicitly need a hard cap.