### PR TITLE
fix: detect Codex CLI on Windows

### DIFF
--- a/homerail_manager/src/server/codex-binary.ts
+++ b/homerail_manager/src/server/codex-binary.ts
@@ -1,0 +1,114 @@
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const DEFAULT_CODEX_BIN = "codex";
+
+export interface CodexBinaryResolution {
+  command: string;
+  requested: string;
+  needsShell: boolean;
+}
+
+function isWindows(): boolean {
+  return process.platform === "win32";
+}
+
+function isPathLike(command: string): boolean {
+  return path.isAbsolute(command) || command.includes("/") || command.includes("\\");
+}
+
+function windowsCommandNeedsShell(command: string): boolean {
+  return isWindows() && /\.(cmd|bat)$/i.test(command);
+}
+
+function windowsExecutableNames(command: string): string[] {
+  if (!isWindows()) return [command];
+  if (/\.(exe|cmd|bat)$/i.test(command)) return [command];
+  return [`${command}.exe`, `${command}.cmd`, `${command}.bat`, command];
+}
+
+function pathCandidates(command: string): string[] {
+  if (!isWindows()) return [command];
+  const parsed = path.parse(command);
+  if (/\.(exe|cmd|bat)$/i.test(parsed.base)) return [command];
+  return windowsExecutableNames(parsed.base).map((name) => path.join(parsed.dir, name));
+}
+
+function existingFile(filePath: string): string | null {
+  try {
+    return fs.existsSync(filePath) && fs.statSync(filePath).isFile() ? filePath : null;
+  } catch {
+    return null;
+  }
+}
+
+function findExecutableOnPath(command: string): string | null {
+  const pathEnv = process.env.PATH ?? "";
+  const names = windowsExecutableNames(command);
+  for (const dir of pathEnv.split(path.delimiter)) {
+    if (!dir) continue;
+    for (const name of names) {
+      const candidate = path.join(dir, name);
+      const found = existingFile(candidate);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+function commonCodexCandidates(): string[] {
+  const home = os.homedir();
+  const candidates = [
+    path.join(home, ".codex", "bin", "codex"),
+    "/opt/homebrew/bin/codex",
+    "/usr/local/bin/codex",
+    "/usr/bin/codex",
+  ];
+
+  if (isWindows()) {
+    const appData = process.env.APPDATA;
+    const localAppData = process.env.LOCALAPPDATA;
+    candidates.push(...pathCandidates(path.join(home, ".codex", "bin", "codex")));
+    if (appData) candidates.push(...pathCandidates(path.join(appData, "npm", "codex")));
+    if (localAppData) {
+      candidates.push(...pathCandidates(path.join(localAppData, "Programs", "OpenAI", "Codex", "bin", "codex")));
+      candidates.push(...pathCandidates(path.join(localAppData, "Microsoft", "WindowsApps", "codex")));
+      candidates.push(...pathCandidates(path.join(localAppData, "pnpm", "codex")));
+      candidates.push(...pathCandidates(path.join(localAppData, "Volta", "bin", "codex")));
+    }
+  }
+
+  return Array.from(new Set(candidates));
+}
+
+export function resolveCodexBinary(requested = process.env.HOMERAIL_CODEX_BIN ?? process.env.CODEX_BIN_PATH ?? DEFAULT_CODEX_BIN): CodexBinaryResolution | null {
+  const trimmed = requested.trim() || DEFAULT_CODEX_BIN;
+
+  if (isPathLike(trimmed)) {
+    for (const candidate of pathCandidates(trimmed)) {
+      const found = existingFile(candidate);
+      if (found) return { command: found, requested: trimmed, needsShell: windowsCommandNeedsShell(found) };
+    }
+    return null;
+  }
+
+  for (const candidate of commonCodexCandidates()) {
+    const found = existingFile(candidate);
+    if (found) return { command: found, requested: trimmed, needsShell: windowsCommandNeedsShell(found) };
+  }
+
+  const fromPath = findExecutableOnPath(trimmed);
+  if (fromPath) return { command: fromPath, requested: trimmed, needsShell: windowsCommandNeedsShell(fromPath) };
+  return null;
+}
+
+export function runCodexCommandSync(command: string, args: string[], timeoutMs = 5_000): SpawnSyncReturns<string> {
+  return spawnSync(command, args, {
+    timeout: timeoutMs,
+    encoding: "utf-8",
+    env: process.env,
+    shell: windowsCommandNeedsShell(command),
+  });
+}

--- a/homerail_manager/src/server/codex-binary.ts
+++ b/homerail_manager/src/server/codex-binary.ts
@@ -133,6 +133,12 @@ export function resolveCodexBinary(
     return null;
   }
 
+  if (trimmed !== DEFAULT_CODEX_BIN) {
+    const fromPath = findExecutableOnPath(trimmed, options);
+    if (fromPath) return { command: fromPath, requested: trimmed, needsShell: windowsCommandNeedsShell(fromPath, options.platform) };
+    return null;
+  }
+
   for (const candidate of commonCodexCandidates(options)) {
     const found = existingFile(candidate, options.fileExists);
     if (found) return { command: found, requested: trimmed, needsShell: windowsCommandNeedsShell(found, options.platform) };
@@ -183,6 +189,7 @@ export function runCodexCommandSync(
       encoding: "utf-8",
       env: options.env ?? process.env,
       shell: windowsCommandNeedsShell(command, options.platform ?? process.platform),
+      windowsHide: true,
     });
   } catch (error) {
     return failedSpawnResult(error);

--- a/homerail_manager/src/server/codex-binary.ts
+++ b/homerail_manager/src/server/codex-binary.ts
@@ -11,96 +11,128 @@ export interface CodexBinaryResolution {
   needsShell: boolean;
 }
 
-function isWindows(): boolean {
-  return process.platform === "win32";
+export interface CodexBinaryResolveOptions {
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  homeDir?: string;
+  fileExists?: (filePath: string) => boolean;
 }
 
-function isPathLike(command: string): boolean {
-  return path.isAbsolute(command) || command.includes("/") || command.includes("\\");
+function isWindows(platform: NodeJS.Platform): boolean {
+  return platform === "win32";
 }
 
-function windowsCommandNeedsShell(command: string): boolean {
-  return isWindows() && /\.(cmd|bat)$/i.test(command);
+function pathApi(platform: NodeJS.Platform): typeof path.win32 | typeof path.posix {
+  return isWindows(platform) ? path.win32 : path.posix;
 }
 
-function windowsExecutableNames(command: string): string[] {
-  if (!isWindows()) return [command];
+function isPathLike(command: string, platform: NodeJS.Platform): boolean {
+  return pathApi(platform).isAbsolute(command) || command.includes("/") || command.includes("\\");
+}
+
+function windowsCommandNeedsShell(command: string, platform = process.platform): boolean {
+  return isWindows(platform) && /\.(cmd|bat)$/i.test(command);
+}
+
+function windowsExecutableNames(command: string, platform: NodeJS.Platform): string[] {
+  if (!isWindows(platform)) return [command];
   if (/\.(exe|cmd|bat)$/i.test(command)) return [command];
   return [`${command}.exe`, `${command}.cmd`, `${command}.bat`, command];
 }
 
-function pathCandidates(command: string): string[] {
-  if (!isWindows()) return [command];
-  const parsed = path.parse(command);
+function pathCandidates(command: string, platform: NodeJS.Platform): string[] {
+  if (!isWindows(platform)) return [command];
+  const paths = pathApi(platform);
+  const parsed = paths.parse(command);
   if (/\.(exe|cmd|bat)$/i.test(parsed.base)) return [command];
-  return windowsExecutableNames(parsed.base).map((name) => path.join(parsed.dir, name));
+  return windowsExecutableNames(parsed.base, platform).map((name) => paths.join(parsed.dir, name));
 }
 
-function existingFile(filePath: string): string | null {
+function existingFile(filePath: string, fileExists: (filePath: string) => boolean): string | null {
   try {
-    return fs.existsSync(filePath) && fs.statSync(filePath).isFile() ? filePath : null;
+    return fileExists(filePath) ? filePath : null;
   } catch {
     return null;
   }
 }
 
-function findExecutableOnPath(command: string): string | null {
-  const pathEnv = process.env.PATH ?? "";
-  const names = windowsExecutableNames(command);
-  for (const dir of pathEnv.split(path.delimiter)) {
+function defaultFileExists(filePath: string): boolean {
+  return fs.existsSync(filePath) && fs.statSync(filePath).isFile();
+}
+
+function findExecutableOnPath(command: string, options: Required<CodexBinaryResolveOptions>): string | null {
+  const pathEnv = options.env.PATH ?? "";
+  const paths = pathApi(options.platform);
+  const names = windowsExecutableNames(command, options.platform);
+  for (const dir of pathEnv.split(paths.delimiter)) {
     if (!dir) continue;
     for (const name of names) {
-      const candidate = path.join(dir, name);
-      const found = existingFile(candidate);
+      const candidate = paths.join(dir, name);
+      const found = existingFile(candidate, options.fileExists);
       if (found) return found;
     }
   }
   return null;
 }
 
-function commonCodexCandidates(): string[] {
-  const home = os.homedir();
+function commonCodexCandidates(options: Required<CodexBinaryResolveOptions>): string[] {
+  const paths = pathApi(options.platform);
+  const home = options.homeDir;
   const candidates = [
-    path.join(home, ".codex", "bin", "codex"),
+    paths.join(home, ".codex", "bin", "codex"),
     "/opt/homebrew/bin/codex",
     "/usr/local/bin/codex",
     "/usr/bin/codex",
   ];
 
-  if (isWindows()) {
-    const appData = process.env.APPDATA;
-    const localAppData = process.env.LOCALAPPDATA;
-    candidates.push(...pathCandidates(path.join(home, ".codex", "bin", "codex")));
-    if (appData) candidates.push(...pathCandidates(path.join(appData, "npm", "codex")));
+  if (isWindows(options.platform)) {
+    const appData = options.env.APPDATA;
+    const localAppData = options.env.LOCALAPPDATA;
+    candidates.push(...pathCandidates(paths.join(home, ".codex", "bin", "codex"), options.platform));
+    if (appData) candidates.push(...pathCandidates(paths.join(appData, "npm", "codex"), options.platform));
     if (localAppData) {
-      candidates.push(...pathCandidates(path.join(localAppData, "Programs", "OpenAI", "Codex", "bin", "codex")));
-      candidates.push(...pathCandidates(path.join(localAppData, "Microsoft", "WindowsApps", "codex")));
-      candidates.push(...pathCandidates(path.join(localAppData, "pnpm", "codex")));
-      candidates.push(...pathCandidates(path.join(localAppData, "Volta", "bin", "codex")));
+      candidates.push(...pathCandidates(paths.join(localAppData, "Programs", "OpenAI", "Codex", "bin", "codex"), options.platform));
+      candidates.push(...pathCandidates(paths.join(localAppData, "Microsoft", "WindowsApps", "codex"), options.platform));
+      candidates.push(...pathCandidates(paths.join(localAppData, "pnpm", "codex"), options.platform));
+      candidates.push(...pathCandidates(paths.join(localAppData, "Volta", "bin", "codex"), options.platform));
     }
   }
 
   return Array.from(new Set(candidates));
 }
 
-export function resolveCodexBinary(requested = process.env.HOMERAIL_CODEX_BIN ?? process.env.CODEX_BIN_PATH ?? DEFAULT_CODEX_BIN): CodexBinaryResolution | null {
-  const trimmed = requested.trim() || DEFAULT_CODEX_BIN;
+function resolveOptions(options: CodexBinaryResolveOptions): Required<CodexBinaryResolveOptions> {
+  return {
+    platform: options.platform ?? process.platform,
+    env: options.env ?? process.env,
+    homeDir: options.homeDir ?? os.homedir(),
+    fileExists: options.fileExists ?? defaultFileExists,
+  };
+}
 
-  if (isPathLike(trimmed)) {
-    for (const candidate of pathCandidates(trimmed)) {
-      const found = existingFile(candidate);
-      if (found) return { command: found, requested: trimmed, needsShell: windowsCommandNeedsShell(found) };
+export function resolveCodexBinary(
+  requested?: string,
+  resolveOptionsInput: CodexBinaryResolveOptions = {},
+): CodexBinaryResolution | null {
+  const options = resolveOptions(resolveOptionsInput);
+  const effectiveRequested = requested ?? options.env.HOMERAIL_CODEX_BIN ?? options.env.CODEX_BIN_PATH ?? DEFAULT_CODEX_BIN;
+  const trimmed = effectiveRequested.trim() || DEFAULT_CODEX_BIN;
+
+  if (isPathLike(trimmed, options.platform)) {
+    for (const candidate of pathCandidates(trimmed, options.platform)) {
+      const found = existingFile(candidate, options.fileExists);
+      if (found) return { command: found, requested: trimmed, needsShell: windowsCommandNeedsShell(found, options.platform) };
     }
     return null;
   }
 
-  for (const candidate of commonCodexCandidates()) {
-    const found = existingFile(candidate);
-    if (found) return { command: found, requested: trimmed, needsShell: windowsCommandNeedsShell(found) };
+  for (const candidate of commonCodexCandidates(options)) {
+    const found = existingFile(candidate, options.fileExists);
+    if (found) return { command: found, requested: trimmed, needsShell: windowsCommandNeedsShell(found, options.platform) };
   }
 
-  const fromPath = findExecutableOnPath(trimmed);
-  if (fromPath) return { command: fromPath, requested: trimmed, needsShell: windowsCommandNeedsShell(fromPath) };
+  const fromPath = findExecutableOnPath(trimmed, options);
+  if (fromPath) return { command: fromPath, requested: trimmed, needsShell: windowsCommandNeedsShell(fromPath, options.platform) };
   return null;
 }
 

--- a/homerail_manager/src/server/codex-binary.ts
+++ b/homerail_manager/src/server/codex-binary.ts
@@ -18,6 +18,13 @@ export interface CodexBinaryResolveOptions {
   fileExists?: (filePath: string) => boolean;
 }
 
+export interface CodexCommandRunOptions {
+  timeoutMs?: number;
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  spawnSyncImpl?: typeof spawnSync;
+}
+
 function isWindows(platform: NodeJS.Platform): boolean {
   return platform === "win32";
 }
@@ -136,11 +143,48 @@ export function resolveCodexBinary(
   return null;
 }
 
-export function runCodexCommandSync(command: string, args: string[], timeoutMs = 5_000): SpawnSyncReturns<string> {
-  return spawnSync(command, args, {
-    timeout: timeoutMs,
-    encoding: "utf-8",
-    env: process.env,
-    shell: windowsCommandNeedsShell(command),
-  });
+export function codexBinaryNotFoundMessage(
+  requested?: string,
+  resolveOptionsInput: CodexBinaryResolveOptions = {},
+): string {
+  const options = resolveOptions(resolveOptionsInput);
+  const effectiveRequested = requested ?? options.env.HOMERAIL_CODEX_BIN ?? options.env.CODEX_BIN_PATH ?? DEFAULT_CODEX_BIN;
+  const trimmed = effectiveRequested.trim() || DEFAULT_CODEX_BIN;
+  if (isPathLike(trimmed, options.platform)) {
+    return `Codex binary not found at: ${trimmed}. Install codex or set HOMERAIL_CODEX_BIN.`;
+  }
+  return "Codex binary not found. Install codex or set HOMERAIL_CODEX_BIN.";
+}
+
+function failedSpawnResult(error: unknown): SpawnSyncReturns<string> {
+  const message = error instanceof Error ? error.message : String(error);
+  const result: SpawnSyncReturns<string> = {
+    pid: 0,
+    output: [null, "", message],
+    stdout: "",
+    stderr: message,
+    status: null,
+    signal: null,
+  };
+  if (error instanceof Error) result.error = error;
+  return result;
+}
+
+export function runCodexCommandSync(
+  command: string,
+  args: string[],
+  optionsOrTimeout: number | CodexCommandRunOptions = 5_000,
+): SpawnSyncReturns<string> {
+  const options: CodexCommandRunOptions =
+    typeof optionsOrTimeout === "number" ? { timeoutMs: optionsOrTimeout } : optionsOrTimeout;
+  try {
+    return (options.spawnSyncImpl ?? spawnSync)(command, args, {
+      timeout: options.timeoutMs ?? 5_000,
+      encoding: "utf-8",
+      env: options.env ?? process.env,
+      shell: windowsCommandNeedsShell(command, options.platform ?? process.platform),
+    });
+  } catch (error) {
+    return failedSpawnResult(error);
+  }
 }

--- a/homerail_manager/src/server/host-codex-manager-agent.ts
+++ b/homerail_manager/src/server/host-codex-manager-agent.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { createHash, randomUUID } from "node:crypto";
 import { createInterface, type Interface as ReadlineInterface } from "node:readline";
 import { ensureDefaultWorkspacePath, getHomerailHome } from "../config/env.js";
+import { resolveCodexBinary } from "./codex-binary.js";
 import {
   readWidgetFile,
   removeWidgetFile,
@@ -1197,6 +1198,7 @@ class HostCodexAppServerAdapter {
   private notifications: Array<Record<string, unknown>> = [];
   private notifyWaiters: Array<() => void> = [];
   private codexBin: string;
+  private codexNeedsShell = false;
 
   constructor(codexBin?: string) {
     this.codexBin = codexBin ?? process.env.HOMERAIL_CODEX_BIN ?? process.env.CODEX_BIN_PATH ?? DEFAULT_CODEX_BIN;
@@ -1223,6 +1225,7 @@ class HostCodexAppServerAdapter {
         stdio: ["pipe", "pipe", "pipe"],
         env: this.buildEnv(context),
         cwd: context.workspace ?? process.cwd(),
+        shell: this.codexNeedsShell,
         windowsHide: true,
       });
       this.setupReadline();
@@ -1599,25 +1602,10 @@ class HostCodexAppServerAdapter {
   }
 
   private async validateBinary(): Promise<void> {
-    if (this.codexBin !== DEFAULT_CODEX_BIN && this.codexBin.includes(path.sep)) {
-      if (!fs.existsSync(this.codexBin)) throw new Error(`Codex binary not found at: ${this.codexBin}`);
-      return;
-    }
-    const alternatives = [
-      "/opt/homebrew/bin/codex",
-      path.join(os.homedir(), ".codex", "bin", "codex"),
-      "/usr/local/bin/codex",
-      "/usr/bin/codex",
-    ];
-    for (const alt of alternatives) {
-      if (fs.existsSync(alt)) {
-        this.codexBin = alt;
-        return;
-      }
-    }
-    const fromPath = findExecutableOnPath(this.codexBin);
-    if (fromPath) {
-      this.codexBin = fromPath;
+    const resolved = resolveCodexBinary(this.codexBin);
+    if (resolved) {
+      this.codexBin = resolved.command;
+      this.codexNeedsShell = resolved.needsShell;
       return;
     }
     throw new Error("Codex binary not found. Install codex or set HOMERAIL_CODEX_BIN.");
@@ -1630,14 +1618,4 @@ class HostCodexAppServerAdapter {
       inputSchema: tool.input_schema,
     }));
   }
-}
-
-function findExecutableOnPath(command: string): string | null {
-  const pathEnv = process.env.PATH ?? "";
-  for (const dir of pathEnv.split(path.delimiter)) {
-    if (!dir) continue;
-    const candidate = path.join(dir, command);
-    if (fs.existsSync(candidate)) return candidate;
-  }
-  return null;
 }

--- a/homerail_manager/src/server/host-codex-manager-agent.ts
+++ b/homerail_manager/src/server/host-codex-manager-agent.ts
@@ -5,7 +5,7 @@ import * as path from "node:path";
 import { createHash, randomUUID } from "node:crypto";
 import { createInterface, type Interface as ReadlineInterface } from "node:readline";
 import { ensureDefaultWorkspacePath, getHomerailHome } from "../config/env.js";
-import { resolveCodexBinary } from "./codex-binary.js";
+import { codexBinaryNotFoundMessage, resolveCodexBinary } from "./codex-binary.js";
 import {
   readWidgetFile,
   removeWidgetFile,
@@ -1608,7 +1608,7 @@ class HostCodexAppServerAdapter {
       this.codexNeedsShell = resolved.needsShell;
       return;
     }
-    throw new Error("Codex binary not found. Install codex or set HOMERAIL_CODEX_BIN.");
+    throw new Error(codexBinaryNotFoundMessage(this.codexBin));
   }
 
   private buildDynamicToolSpecs(tools: ToolDefinition[]): Array<Record<string, unknown>> {

--- a/homerail_manager/src/server/manager-agent-readiness.ts
+++ b/homerail_manager/src/server/manager-agent-readiness.ts
@@ -2,7 +2,6 @@ import * as fs from "node:fs";
 import * as http from "node:http";
 import * as os from "node:os";
 import * as path from "node:path";
-import { spawnSync } from "node:child_process";
 import { getAllNodes, isDockerCapableNode } from "../node/registry.js";
 import { readManagerAgentConfig } from "../persistence/manager-agent-config.js";
 import { sendLifecycleRequest } from "../node/lifecycle-request.js";
@@ -13,6 +12,7 @@ import {
 } from "./manager-agent-container.js";
 import { hostShellDiagnostics } from "./host-shell-manager-agent.js";
 import { readDagResourceStatus, type DagResourceStatus } from "./dag-resource-status.js";
+import { resolveCodexBinary, runCodexCommandSync } from "./codex-binary.js";
 
 interface ReadinessBlocker {
   code: string;
@@ -73,21 +73,16 @@ function methodNotAllowed(res: http.ServerResponse): void {
 }
 
 function codexStatus(): CodexCheck {
-  const codexBin = process.env.HOMERAIL_CODEX_BIN || "codex";
+  const requested = process.env.HOMERAIL_CODEX_BIN || process.env.CODEX_BIN_PATH || "codex";
+  const resolved = resolveCodexBinary(requested);
   let available = false;
   let version: string | undefined;
-  try {
-    const result = spawnSync(codexBin, ["--version"], {
-      timeout: 5_000,
-      encoding: "utf-8",
-      env: process.env,
-    });
+  if (resolved) {
+    const result = runCodexCommandSync(resolved.command, ["--version"]);
     if (result.status === 0) {
       available = true;
       version = (result.stdout || "").trim().split("\n")[0] || undefined;
     }
-  } catch {
-    available = false;
   }
   let loggedIn = false;
   try {
@@ -99,7 +94,7 @@ function codexStatus(): CodexCheck {
   } catch {
     loggedIn = false;
   }
-  return { available, logged_in: loggedIn, version, binary: codexBin };
+  return { available, logged_in: loggedIn, version, binary: resolved?.command ?? requested };
 }
 
 function dockerCapableNodeIds(): string[] {

--- a/homerail_manager/src/server/voice-agent-bootstrap.ts
+++ b/homerail_manager/src/server/voice-agent-bootstrap.ts
@@ -3,7 +3,6 @@ import * as fs from "node:fs";
 import * as http from "node:http";
 import * as os from "node:os";
 import * as path from "node:path";
-import { spawnSync } from "node:child_process";
 import { getDataRoot } from "../config/env.js";
 import { encodeJson, getDb, parseJsonRow } from "../persistence/db.js";
 import { getProject } from "../persistence/projects-changes.js";
@@ -22,6 +21,7 @@ import {
   type RunManagerAgentTurnInput,
 } from "./manager-agent-runtime.js";
 import { validateConfigPatch } from "./manager-agent-config.js";
+import { resolveCodexBinary, runCodexCommandSync } from "./codex-binary.js";
 import { managerAgentRuntimePlacementForHarness, normalizeManagerAgentHarness } from "homerail-protocol";
 import {
   listWidgetFileTypes,
@@ -1228,21 +1228,16 @@ export function voiceAgentBootstrapHandler(
 
   // Codex 可用性检测：检查 CLI 是否安装 + 是否有登录态
   if (method === "GET" && pathname === "/api/voice-agent/codex-status") {
-    const codexBin = process.env.HOMERAIL_CODEX_BIN || "codex";
+    const requested = process.env.HOMERAIL_CODEX_BIN || process.env.CODEX_BIN_PATH || "codex";
+    const resolved = resolveCodexBinary(requested);
     let available = false;
     let version: string | undefined;
-    try {
-      const result = spawnSync(codexBin, ["--version"], {
-        timeout: 5_000,
-        encoding: "utf-8",
-        env: process.env,
-      });
+    if (resolved) {
+      const result = runCodexCommandSync(resolved.command, ["--version"]);
       if (result.status === 0) {
         available = true;
         version = (result.stdout || "").trim().split("\n")[0] || undefined;
       }
-    } catch {
-      available = false;
     }
     // 检查登录态：~/.codex/auth.json 存在且非空
     let loggedIn = false;
@@ -1255,7 +1250,7 @@ export function voiceAgentBootstrapHandler(
     } catch {
       loggedIn = false;
     }
-    ok(res, "Codex status checked", { available, logged_in: loggedIn, version });
+    ok(res, "Codex status checked", { available, logged_in: loggedIn, version, binary: resolved?.command ?? requested });
     return true;
   }
 

--- a/homerail_manager/tests/codex-binary.test.ts
+++ b/homerail_manager/tests/codex-binary.test.ts
@@ -65,6 +65,34 @@ describe("resolveCodexBinary", () => {
     });
   });
 
+  it("finds the Codex desktop app installation on Windows", () => {
+    const localAppData = "C:\\Users\\alice\\AppData\\Local";
+    const exe = path.win32.join(localAppData, "Programs", "OpenAI", "Codex", "bin", "codex.exe");
+
+    expect(resolveCodexBinary("codex", {
+      platform: "win32",
+      env: { LOCALAPPDATA: localAppData },
+      homeDir: "C:\\Users\\alice",
+      fileExists: fakeExistingFiles([exe]),
+    })).toEqual({
+      command: exe,
+      requested: "codex",
+      needsShell: false,
+    });
+  });
+
+  it("does not replace an explicit command name with a common Codex installation", () => {
+    const localAppData = "C:\\Users\\alice\\AppData\\Local";
+    const exe = path.win32.join(localAppData, "Programs", "OpenAI", "Codex", "bin", "codex.exe");
+
+    expect(resolveCodexBinary("custom-codex", {
+      platform: "win32",
+      env: { LOCALAPPDATA: localAppData },
+      homeDir: "C:\\Users\\alice",
+      fileExists: fakeExistingFiles([exe]),
+    })).toBeNull();
+  });
+
   it("includes explicit missing paths in not-found messages", () => {
     expect(codexBinaryNotFoundMessage("/wrong/path/codex", {
       platform: "linux",
@@ -75,10 +103,12 @@ describe("resolveCodexBinary", () => {
 
   it("returns a failed result instead of throwing when spawnSync throws", () => {
     const error = new Error("spawn exploded");
+    let spawnOptions: Record<string, unknown> | undefined;
     const result = runCodexCommandSync("C:\\Tools\\codex.cmd", ["--version"], {
       platform: "win32",
       env: {},
-      spawnSyncImpl: (() => {
+      spawnSyncImpl: ((_command, _args, options) => {
+        spawnOptions = options as Record<string, unknown>;
         throw error;
       }) as typeof import("node:child_process").spawnSync,
     });
@@ -87,5 +117,9 @@ describe("resolveCodexBinary", () => {
     expect(result.stdout).toBe("");
     expect(result.stderr).toBe("spawn exploded");
     expect(result.error).toBe(error);
+    expect(spawnOptions).toMatchObject({
+      shell: true,
+      windowsHide: true,
+    });
   });
 });

--- a/homerail_manager/tests/codex-binary.test.ts
+++ b/homerail_manager/tests/codex-binary.test.ts
@@ -1,7 +1,11 @@
 import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 
-import { resolveCodexBinary } from "../src/server/codex-binary.js";
+import {
+  codexBinaryNotFoundMessage,
+  resolveCodexBinary,
+  runCodexCommandSync,
+} from "../src/server/codex-binary.js";
 
 function fakeExistingFiles(files: string[]): (filePath: string) => boolean {
   const normalized = new Set(files.map((filePath) => path.win32.normalize(filePath)));
@@ -59,5 +63,29 @@ describe("resolveCodexBinary", () => {
       requested: "codex",
       needsShell: false,
     });
+  });
+
+  it("includes explicit missing paths in not-found messages", () => {
+    expect(codexBinaryNotFoundMessage("/wrong/path/codex", {
+      platform: "linux",
+      env: {},
+      homeDir: "/home/alice",
+    })).toBe("Codex binary not found at: /wrong/path/codex. Install codex or set HOMERAIL_CODEX_BIN.");
+  });
+
+  it("returns a failed result instead of throwing when spawnSync throws", () => {
+    const error = new Error("spawn exploded");
+    const result = runCodexCommandSync("C:\\Tools\\codex.cmd", ["--version"], {
+      platform: "win32",
+      env: {},
+      spawnSyncImpl: (() => {
+        throw error;
+      }) as typeof import("node:child_process").spawnSync,
+    });
+
+    expect(result.status).toBeNull();
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("spawn exploded");
+    expect(result.error).toBe(error);
   });
 });

--- a/homerail_manager/tests/codex-binary.test.ts
+++ b/homerail_manager/tests/codex-binary.test.ts
@@ -1,0 +1,63 @@
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { resolveCodexBinary } from "../src/server/codex-binary.js";
+
+function fakeExistingFiles(files: string[]): (filePath: string) => boolean {
+  const normalized = new Set(files.map((filePath) => path.win32.normalize(filePath)));
+  return (filePath: string) => normalized.has(path.win32.normalize(filePath));
+}
+
+describe("resolveCodexBinary", () => {
+  it("resolves Windows npm cmd shims from an explicit path and marks them shell-backed", () => {
+    const appData = "C:\\Users\\alice\\AppData\\Roaming";
+    const requested = path.win32.join(appData, "npm", "codex");
+    const shim = path.win32.join(appData, "npm", "codex.cmd");
+
+    expect(resolveCodexBinary(requested, {
+      platform: "win32",
+      env: {},
+      homeDir: "C:\\Users\\alice",
+      fileExists: fakeExistingFiles([shim]),
+    })).toEqual({
+      command: shim,
+      requested,
+      needsShell: true,
+    });
+  });
+
+  it("uses HOMERAIL_CODEX_BIN before CODEX_BIN_PATH", () => {
+    const preferred = "/custom/codex";
+    const fallback = "/fallback/codex";
+
+    expect(resolveCodexBinary(undefined, {
+      platform: "darwin",
+      env: {
+        HOMERAIL_CODEX_BIN: preferred,
+        CODEX_BIN_PATH: fallback,
+      },
+      homeDir: "/Users/alice",
+      fileExists: fakeExistingFiles([preferred, fallback]),
+    })).toEqual({
+      command: preferred,
+      requested: preferred,
+      needsShell: false,
+    });
+  });
+
+  it("finds Windows PATH executables with supported extensions", () => {
+    const binDir = "C:\\Tools\\Codex";
+    const exe = path.win32.join(binDir, "codex.exe");
+
+    expect(resolveCodexBinary("codex", {
+      platform: "win32",
+      env: { PATH: binDir },
+      homeDir: "C:\\Users\\alice",
+      fileExists: fakeExistingFiles([exe]),
+    })).toEqual({
+      command: exe,
+      requested: "codex",
+      needsShell: false,
+    });
+  });
+});


### PR DESCRIPTION
## Context

Windows npm installs often expose Codex through .cmd/.bat/.exe shims instead of a bare executable name. The Manager Agent readiness checks and host Codex app-server launch path need to resolve those shims consistently.

## Changes

- Add shared Codex binary resolution for host Manager Agent paths.
- Support explicit binary paths, PATH lookup, and common Windows install locations.
- Preserve shell execution for Windows .cmd/.bat shims.
- Add focused tests for Windows shim resolution, env precedence, and PATH lookup.

## Validation

- npm --prefix homerail_manager run typecheck
- npm --prefix homerail_manager exec vitest run tests/codex-binary.test.ts