### PR TITLE
fix: align Codex app-server reasoning protocol

### DIFF
--- a/agent-ui/src/api/agent/agent-voice-api.ts
+++ b/agent-ui/src/api/agent/agent-voice-api.ts
@@ -26,6 +26,7 @@ export type {
   ManagerAgentReadiness,
   CodexModel,
   CodexModelCatalog,
+  CodexReasoningEffortOption,
   CodexModelServiceTier,
   VoiceAgentConfig,
   UpdateVoiceAgentConfigRequest,

--- a/agent-ui/src/api/services/voice-agent-api.ts
+++ b/agent-ui/src/api/services/voice-agent-api.ts
@@ -133,6 +133,7 @@ export interface ManagerAgentConfig {
   provider_name?: string | null
   model_name?: string | null
   reasoning_effort?: ManagerAgentReasoningEffort
+  service_tier?: string | null
   system_prompt: string
   session_policy: Record<string, unknown>
 }
@@ -145,6 +146,7 @@ export interface UpdateManagerAgentConfigRequest {
   provider_name?: string | null
   model_name?: string | null
   reasoning_effort?: ManagerAgentReasoningEffort
+  service_tier?: string | null
   system_prompt?: string
   session_policy?: Record<string, unknown>
 }
@@ -251,6 +253,11 @@ export interface CodexModelServiceTier {
   description: string
 }
 
+export interface CodexReasoningEffortOption {
+  reasoning_effort: string
+  description: string
+}
+
 export interface CodexModel {
   id: string
   model: string
@@ -259,6 +266,7 @@ export interface CodexModel {
   is_default: boolean
   default_reasoning_effort: string
   supported_reasoning_efforts: string[]
+  reasoning_effort_options?: CodexReasoningEffortOption[]
   service_tiers: CodexModelServiceTier[]
 }
 

--- a/agent-ui/src/components/agent/AgentSettingsPage.test.ts
+++ b/agent-ui/src/components/agent/AgentSettingsPage.test.ts
@@ -40,6 +40,7 @@ vi.mock('@/api/agent', () => ({
   uploadSkill: vi.fn(() => Promise.resolve({ data: {} })),
   listVoiceModels: vi.fn(() => Promise.resolve({ data: { models: [] } })),
   testVoiceConnection: vi.fn(() => Promise.resolve({ data: { models: [] } })),
+  getCodexModels: vi.fn(() => Promise.resolve({ data: { binary: '', models: [] } })),
   getExperienceGraphSummary: vi.fn(() => Promise.resolve({ data: null })),
   getAssetDiagnostics: vi.fn(() => Promise.resolve({ data: null })),
   getOrchestrationTemplates: vi.fn(() => Promise.resolve({ data: { orchestrations: [] } })),

--- a/agent-ui/src/components/agent/AgentSettingsPage.vue
+++ b/agent-ui/src/components/agent/AgentSettingsPage.vue
@@ -46,8 +46,10 @@ import {
   getExperienceGraphSummary,
   getAssetDiagnostics,
   getOrchestrationTemplates,
+  getCodexModels,
   type VoiceSettings,
   type VoiceTtsOutputChannel,
+  type CodexModel,
   type ExperienceGraphSummary,
   type AssetDiagnostics,
   type OrchestrationTemplate,
@@ -152,6 +154,7 @@ const workspaceSettings = ref<AgentWorkspaceSettings | null>(null)
 const storageInfo = ref<AgentStorageRetentionInfo | null>(null)
 const voiceSettings = ref<VoiceSettings | null>(null)
 const voiceAgentConfig = ref<VoiceAgentConfig | null>(null)
+const codexModels = ref<CodexModel[]>([])
 const voiceForm = ref({
   recognition_mode: 'asr' as 'omni' | 'asr',
   omni_base_url: '',
@@ -759,6 +762,7 @@ async function refreshAll(): Promise<void> {
       experienceRes,
       voiceRes,
       voiceAgentRes,
+      codexModelRes,
       assetDiagRes,
       orchestrationTemplateRes,
       runtimeStatusRes,
@@ -777,6 +781,7 @@ async function refreshAll(): Promise<void> {
       hiddenSettingsTabs.has('memory') ? Promise.resolve(null) : loadExperienceGraph(12),
       agentSettingsApi.getVoiceSettings().catch(() => null),
       agentSettingsApi.getVoiceAgentConfig().catch(() => null),
+      getCodexModels().catch(() => null),
       hiddenSettingsTabs.has('memory') ? Promise.resolve(null) : loadAssetDiagnostics(),
       hiddenSettingsTabs.has('memory') ? Promise.resolve(null) : loadOrchestrationTemplates(),
       agentSettingsApi.getRuntimeStatus().catch(() => null),
@@ -797,6 +802,7 @@ async function refreshAll(): Promise<void> {
     assetDiagnostics.value = assetDiagRes ?? null
     orchestrationTemplates.value = orchestrationTemplateRes ?? []
     voiceAgentConfig.value = voiceAgentRes?.data ?? null
+    codexModels.value = codexModelRes?.data?.models ?? []
     runtimeStatus.value = runtimeStatusRes ?? null
     workspaceSettings.value = workspaceSettingsRes ?? null
     storageInfo.value = storageInfoRes ?? null
@@ -1683,6 +1689,8 @@ onUnmounted(() => {
           v-if="activeTab === 'providers'"
           :providers="providers"
           :llm-settings="llmSettings"
+          :manager-config="voiceAgentConfig"
+          :codex-models="codexModels"
           :loading="loading"
           @refresh="refreshAll"
           @set-notice="setNotice"

--- a/agent-ui/src/components/agent/AgentVoiceCockpit.vue
+++ b/agent-ui/src/components/agent/AgentVoiceCockpit.vue
@@ -32,7 +32,11 @@ import VoiceDynamicWidget from '@/components/agent/VoiceDynamicWidget.vue'
 import {
   isCodexModelUnavailable,
   resolveCodexModelOptions,
-  resolveSelectedCodexModel
+  resolveSelectedCodexModel,
+  resolveCodexReasoningEffortForModel,
+  resolveCodexReasoningEffortOptions,
+  resolveCodexServiceTierForModel,
+  resolveCodexServiceTierOptions
 } from '@/components/agent/codex-model-selection'
 import { voiceWs } from '@/api/clients/events-ws'
 import { useOnboardingStatus } from '@/composables/useOnboardingStatus'
@@ -375,17 +379,16 @@ const selectedManagerAgentModelId = computed(() => {
   return managerAgentModelOptions.value[0]?.id ?? ''
 })
 const codexReasoningEffort = computed(() => voiceAgentConfig.value?.reasoning_effort || 'low')
-const codexReasoningEffortOptions: Array<{
-  value: CodexReasoningEffort
-  label: string
-  description: string
-}> = [
-  { value: 'minimal', label: 'minimal', description: '最快，适合简单整理。' },
-  { value: 'low', label: 'low', description: '低推理，适合语音交互默认流程。' },
-  { value: 'medium', label: 'medium', description: '平衡速度和推理。' },
-  { value: 'high', label: 'high', description: '更强推理，响应更慢。' },
-  { value: 'xhigh', label: 'xhigh', description: '最高推理，通常不适合实时语音。' }
-]
+const codexReasoningEffortOptions = computed(() => resolveCodexReasoningEffortOptions(
+  codexModels.value,
+  selectedCodexModel.value,
+  codexReasoningEffort.value
+))
+const codexServiceTier = computed(() => voiceAgentConfig.value?.service_tier || '')
+const codexServiceTierOptions = computed(() => resolveCodexServiceTierOptions(
+  codexModels.value,
+  selectedCodexModel.value
+))
 const recognitionMode = computed<'omni' | 'asr'>(() =>
   voiceSettings.value?.recognition_mode === 'asr' ? 'asr' : 'omni'
 )
@@ -2397,8 +2400,20 @@ async function setVoiceAgentHarness(harness: VoiceAgentConfig['harness']): Promi
             null,
       reasoning_effort:
         harness === 'codex_appserver'
-          ? codexReasoningEffort.value
+          ? resolveCodexReasoningEffortForModel(
+              codexModels.value,
+              selectedCodexModel.value,
+              codexReasoningEffort.value
+            )
           : voiceAgentConfig.value?.reasoning_effort,
+      service_tier:
+        harness === 'codex_appserver'
+          ? resolveCodexServiceTierForModel(
+              codexModels.value,
+              selectedCodexModel.value,
+              codexServiceTier.value
+            )
+          : voiceAgentConfig.value?.service_tier,
       session_policy:
         harness === 'codex_appserver'
           ? {
@@ -2444,17 +2459,50 @@ function handleCodexReasoningEffortChange(event: Event): void {
   void setCodexReasoningEffort((event.target as HTMLSelectElement).value as CodexReasoningEffort)
 }
 
+async function setCodexServiceTier(serviceTier: string): Promise<void> {
+  if (!selectedCodexModel.value || configuredCodexModelUnavailable.value) return
+  voiceAgentSaving.value = true
+  voiceConfigError.value = ''
+  try {
+    const res = await updateVoiceAgentConfig({
+      harness: 'codex_appserver',
+      model_name: selectedCodexModel.value,
+      service_tier: serviceTier || null
+    })
+    voiceAgentConfig.value = res.data
+  } catch (err: any) {
+    voiceConfigError.value = err?.message || 'Codex speed save failed'
+  } finally {
+    voiceAgentSaving.value = false
+  }
+}
+
+function handleCodexServiceTierChange(event: Event): void {
+  void setCodexServiceTier((event.target as HTMLSelectElement).value)
+}
+
 async function setCodexModel(model: string): Promise<void> {
   if (!model || voiceAgentConfig.value?.model_name === model) return
   voiceAgentSaving.value = true
   voiceConfigError.value = ''
   try {
+    const reasoningEffort = resolveCodexReasoningEffortForModel(
+      codexModels.value,
+      model,
+      codexReasoningEffort.value
+    )
+    const serviceTier = resolveCodexServiceTierForModel(
+      codexModels.value,
+      model,
+      codexServiceTier.value
+    )
     const response = await updateVoiceAgentConfig({
       harness: 'codex_appserver',
       llm_setting_id: null,
       provider_name: null,
       model_name: model,
-      reasoning_effort: codexReasoningEffort.value
+      reasoning_effort: reasoningEffort,
+      service_tier: serviceTier
     })
     voiceAgentConfig.value = response.data
   } catch (err: any) {
@@ -4449,6 +4497,32 @@ function summarizeTask(value: string): string {
                 <option
                   v-for="option in codexReasoningEffortOptions"
                   :key="option.value"
+                  :value="option.value"
+                  class="bg-[#111315] text-white"
+                >
+                  {{ option.label }}
+                </option>
+              </select>
+            </label>
+
+            <label v-if="codexHarnessActive" class="voice-model-menu__row">
+              <span class="voice-model-menu__label">
+                <strong>Codex 速度</strong>
+                <em>{{
+                  codexServiceTierOptions.find(option => option.value === codexServiceTier)
+                    ?.description
+                }}</em>
+              </span>
+              <select
+                :value="codexServiceTier"
+                :disabled="voiceAgentSaving || !selectedCodexModel || configuredCodexModelUnavailable"
+                title="Codex speed"
+                data-testid="voice-model-agent-service-tier-select"
+                @change="handleCodexServiceTierChange"
+              >
+                <option
+                  v-for="option in codexServiceTierOptions"
+                  :key="option.value || 'standard'"
                   :value="option.value"
                   class="bg-[#111315] text-white"
                 >

--- a/agent-ui/src/components/agent/codex-model-selection.test.ts
+++ b/agent-ui/src/components/agent/codex-model-selection.test.ts
@@ -4,19 +4,35 @@ import type { CodexModel } from '@/api/agent'
 import {
   isCodexModelUnavailable,
   resolveCodexModelOptions,
-  resolveSelectedCodexModel
+  resolveSelectedCodexModel,
+  resolveCodexReasoningEffortForModel,
+  resolveCodexReasoningEffortOptions,
+  resolveCodexServiceTierForModel,
+  resolveCodexServiceTierOptions
 } from './codex-model-selection'
 
-function model(id: string, isDefault = false): CodexModel {
+function model(
+  id: string,
+  isDefault = false,
+  efforts = ['medium'],
+  defaultEffort = 'medium',
+  fast = false
+): CodexModel {
   return {
     id,
     model: id,
     display_name: id,
     description: '',
     is_default: isDefault,
-    default_reasoning_effort: 'medium',
-    supported_reasoning_efforts: ['medium'],
-    service_tiers: []
+    default_reasoning_effort: defaultEffort,
+    supported_reasoning_efforts: efforts,
+    reasoning_effort_options: efforts.map(effort => ({
+      reasoning_effort: effort,
+      description: `${effort} description`
+    })),
+    service_tiers: fast
+      ? [{ id: 'priority', name: 'Fast', description: '1.5x speed, increased usage' }]
+      : []
   }
 }
 
@@ -50,5 +66,41 @@ describe('Codex model selection', () => {
 
     expect(options).toEqual([])
     expect(resolveSelectedCodexModel(options, null)).toBe('')
+  })
+
+  it('uses all six Sol reasoning efforts and OpenAI descriptions', () => {
+    const sol = model(
+      'gpt-5.6-sol',
+      true,
+      ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
+      'low',
+      true
+    )
+    const options = resolveCodexReasoningEffortOptions([sol], sol.model, 'medium')
+
+    expect(options.map(option => option.value)).toEqual(['low', 'medium', 'high', 'xhigh', 'max', 'ultra'])
+    expect(options.find(option => option.value === 'ultra')).toEqual({
+      value: 'ultra',
+      label: 'Ultra',
+      description: 'ultra description'
+    })
+  })
+
+  it('falls back to the new model default when the current effort is unsupported', () => {
+    const luna = model('gpt-5.6-luna', false, ['low', 'medium', 'high', 'xhigh', 'max'], 'medium')
+
+    expect(resolveCodexReasoningEffortForModel([luna], luna.model, 'ultra')).toBe('medium')
+    expect(resolveCodexReasoningEffortForModel([luna], luna.model, 'max')).toBe('max')
+  })
+
+  it('uses OpenAI service tier labels and defaults to Standard', () => {
+    const sol = model('gpt-5.6-sol', true, ['low'], 'low', true)
+
+    expect(resolveCodexServiceTierOptions([sol], sol.model)).toEqual([
+      { value: '', label: 'Standard', description: 'Standard speed and usage' },
+      { value: 'priority', label: 'Fast', description: '1.5x speed, increased usage' }
+    ])
+    expect(resolveCodexServiceTierForModel([sol], sol.model, 'priority')).toBe('priority')
+    expect(resolveCodexServiceTierForModel([sol], sol.model, 'flex')).toBeNull()
   })
 })

--- a/agent-ui/src/components/agent/codex-model-selection.ts
+++ b/agent-ui/src/components/agent/codex-model-selection.ts
@@ -1,5 +1,35 @@
 import type { CodexModel } from '@/api/agent'
 
+export interface CodexOptionView {
+  value: string
+  label: string
+  description: string
+}
+
+const reasoningLabels: Record<string, string> = {
+  minimal: 'Minimal',
+  low: 'Low',
+  medium: 'Medium',
+  high: 'High',
+  xhigh: 'Extra high',
+  max: 'Max',
+  ultra: 'Ultra'
+}
+
+const reasoningDescriptions: Record<string, string> = {
+  minimal: 'Minimal reasoning for the fastest responses',
+  low: 'Fast responses with lighter reasoning',
+  medium: 'Balances speed and reasoning depth for everyday tasks',
+  high: 'Greater reasoning depth for complex problems',
+  xhigh: 'Extra high reasoning depth for complex problems',
+  max: 'Maximum reasoning depth for the hardest problems',
+  ultra: 'Maximum reasoning with automatic task delegation'
+}
+
+function findModel(models: CodexModel[], modelName: string | null | undefined): CodexModel | undefined {
+  return models.find(model => model.model === modelName || model.id === modelName)
+}
+
 function fallbackModel(model: string): CodexModel {
   return {
     id: model,
@@ -40,4 +70,67 @@ export function isCodexModelUnavailable(
     currentModel &&
     !models.some(model => model.model === currentModel)
   )
+}
+
+export function resolveCodexReasoningEffortOptions(
+  models: CodexModel[],
+  modelName: string | null | undefined,
+  currentEffort: string | null | undefined
+): CodexOptionView[] {
+  const model = findModel(models, modelName)
+  const efforts = model?.supported_reasoning_efforts?.length
+    ? model.supported_reasoning_efforts
+    : currentEffort
+      ? [currentEffort]
+      : ['low']
+  const advertisedDescriptions = new Map(
+    (model?.reasoning_effort_options ?? []).map(option => [option.reasoning_effort, option.description])
+  )
+  return efforts.map(effort => ({
+    value: effort,
+    label: reasoningLabels[effort] ?? effort,
+    description: advertisedDescriptions.get(effort) || reasoningDescriptions[effort] || ''
+  }))
+}
+
+export function resolveCodexReasoningEffortForModel(
+  models: CodexModel[],
+  modelName: string,
+  currentEffort: string | null | undefined
+): string {
+  const model = findModel(models, modelName)
+  const supported = model?.supported_reasoning_efforts ?? []
+  if (currentEffort && (!supported.length || supported.includes(currentEffort))) return currentEffort
+  if (model?.default_reasoning_effort && supported.includes(model.default_reasoning_effort)) {
+    return model.default_reasoning_effort
+  }
+  if (supported.includes('medium')) return 'medium'
+  return supported[0] || currentEffort || 'low'
+}
+
+export function resolveCodexServiceTierOptions(
+  models: CodexModel[],
+  modelName: string | null | undefined
+): CodexOptionView[] {
+  const model = findModel(models, modelName)
+  return [
+    { value: '', label: 'Standard', description: 'Standard speed and usage' },
+    ...(model?.service_tiers ?? []).map(tier => ({
+      value: tier.id,
+      label: tier.name,
+      description: tier.description
+    }))
+  ]
+}
+
+export function resolveCodexServiceTierForModel(
+  models: CodexModel[],
+  modelName: string,
+  currentServiceTier: string | null | undefined
+): string | null {
+  if (!currentServiceTier) return null
+  const model = findModel(models, modelName)
+  return model?.service_tiers.some(tier => tier.id === currentServiceTier)
+    ? currentServiceTier
+    : null
 }

--- a/agent-ui/src/components/agent/settings/ModelSettings.test.ts
+++ b/agent-ui/src/components/agent/settings/ModelSettings.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, type App } from 'vue'
+import ModelSettings from './ModelSettings.vue'
+
+const managerStore = {
+  managerProviderName: '',
+  managerModelName: '',
+  managerRuntimeLoading: false,
+  managerProviderOptions: [] as string[],
+  managerModelOptions: [] as string[],
+  managerProviderLabel: (provider: string) => provider,
+  managerModelLabel: (_provider: string, model: string) => model,
+  setManagerRuntime: vi.fn(),
+  loadManagerRuntimeOptions: vi.fn(() => Promise.resolve()),
+}
+
+vi.mock('@/stores/agent-store', () => ({
+  useAgentStore: () => managerStore,
+}))
+
+vi.mock('@/components/controls/useToast', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}))
+
+vi.mock('@/api/agent', () => ({
+  agentSettingsApi: {},
+}))
+
+function codexModel(model: string, displayName: string, isDefault = false) {
+  return {
+    id: model,
+    model,
+    display_name: displayName,
+    description: '',
+    is_default: isDefault,
+    default_reasoning_effort: 'medium',
+    supported_reasoning_efforts: ['low', 'medium', 'high', 'xhigh'],
+    service_tiers: [],
+  }
+}
+
+const codexModels = [
+  codexModel('gpt-5.5', 'GPT-5.5', true),
+  codexModel('gpt-5.4', 'GPT-5.4'),
+  codexModel('gpt-5.4-mini', 'GPT-5.4-Mini'),
+  codexModel('gpt-5.3-codex-spark', 'GPT-5.3-Codex-Spark'),
+]
+
+function managerConfig(harness: 'codex_appserver' | 'claude_agent_sdk') {
+  return {
+    agent_type: 'manager_agent' as const,
+    harness,
+    llm_setting_id: null,
+    provider_name: null,
+    model_name: harness === 'codex_appserver' ? 'gpt-5.5' : null,
+    reasoning_effort: 'xhigh' as const,
+    system_prompt: '',
+    session_policy: {},
+  }
+}
+
+let app: App<Element> | null = null
+
+async function mountSettings(harness: 'codex_appserver' | 'claude_agent_sdk') {
+  const root = document.createElement('div')
+  document.body.appendChild(root)
+  app = createApp(ModelSettings, {
+    providers: [],
+    llmSettings: [],
+    managerConfig: managerConfig(harness),
+    codexModels,
+    loading: false,
+  })
+  app.mount(root)
+  await nextTick()
+  return root
+}
+
+afterEach(() => {
+  app?.unmount()
+  app = null
+  document.body.innerHTML = ''
+})
+
+describe('ModelSettings detected Codex runtime', () => {
+  it('renders the active Codex runtime and full catalog as read-only', async () => {
+    const root = await mountSettings('codex_appserver')
+    const codexItem = root.querySelector<HTMLElement>('[data-testid="agent-settings-model-item-codex"]')
+
+    expect(root.querySelector('[data-testid="agent-settings-manager-runtime-provider-readonly"]')?.textContent).toContain('Codex')
+    expect(root.querySelector('[data-testid="agent-settings-manager-runtime-model-readonly"]')?.textContent).toContain('GPT-5.5')
+    expect(root.querySelector('[data-testid="agent-settings-manager-runtime-count"]')?.textContent).toContain('4 个可用模型')
+    expect(codexItem?.textContent).toContain('自动检测')
+    expect(codexItem?.textContent).toContain('只读')
+    expect(codexItem?.textContent).toContain('GPT-5.5, GPT-5.4, GPT-5.4-Mini, GPT-5.3-Codex-Spark')
+    expect(codexItem?.querySelectorAll('button')).toHaveLength(0)
+    expect(root.querySelectorAll('select')).toHaveLength(0)
+  })
+
+  it('keeps detected Codex visible when another Manager runtime is selected', async () => {
+    const root = await mountSettings('claude_agent_sdk')
+
+    expect(root.querySelector('[data-testid="agent-settings-model-item-codex"]')).not.toBeNull()
+    expect(root.querySelectorAll('select')).toHaveLength(2)
+  })
+})

--- a/agent-ui/src/components/agent/settings/ModelSettings.test.ts
+++ b/agent-ui/src/components/agent/settings/ModelSettings.test.ts
@@ -54,6 +54,7 @@ function managerConfig(harness: 'codex_appserver' | 'claude_agent_sdk') {
     provider_name: null,
     model_name: harness === 'codex_appserver' ? 'gpt-5.5' : null,
     reasoning_effort: 'xhigh' as const,
+    service_tier: null,
     system_prompt: '',
     session_policy: {},
   }
@@ -89,6 +90,7 @@ describe('ModelSettings detected Codex runtime', () => {
 
     expect(root.querySelector('[data-testid="agent-settings-manager-runtime-provider-readonly"]')?.textContent).toContain('Codex')
     expect(root.querySelector('[data-testid="agent-settings-manager-runtime-model-readonly"]')?.textContent).toContain('GPT-5.5')
+    expect(root.querySelector('[data-testid="agent-settings-manager-runtime-model-readonly"]')?.textContent).toContain('Standard')
     expect(root.querySelector('[data-testid="agent-settings-manager-runtime-count"]')?.textContent).toContain('4 个可用模型')
     expect(codexItem?.textContent).toContain('自动检测')
     expect(codexItem?.textContent).toContain('只读')

--- a/agent-ui/src/components/agent/settings/ModelSettings.vue
+++ b/agent-ui/src/components/agent/settings/ModelSettings.vue
@@ -2,11 +2,13 @@
 import { computed, ref } from 'vue'
 import {
   Loader2,
+  LockKeyhole,
   Pencil,
   Plus,
   Trash2,
 } from 'lucide-vue-next'
 import { agentSettingsApi } from '@/api/agent'
+import type { CodexModel, VoiceAgentConfig } from '@/api/agent'
 import { useAgentStore } from '@/stores/agent-store'
 import { planLabel } from '@/lib/protocol-labels'
 import { useToast } from '@/components/controls/useToast'
@@ -19,6 +21,8 @@ import type { ModelFormPayload } from './ModelForm.vue'
 const props = defineProps<{
   providers: Provider[]
   llmSettings: LLMSetting[]
+  managerConfig: VoiceAgentConfig | null
+  codexModels: CodexModel[]
   loading: boolean
 }>()
 
@@ -36,6 +40,32 @@ const savingId = ref<string | null>(null)
 
 const activeSettings = computed(() => props.llmSettings.filter(s => s.is_active))
 const inactiveSettings = computed(() => props.llmSettings.filter(s => !s.is_active))
+const currentManagerUsesCodex = computed(() => props.managerConfig?.harness === 'codex_appserver')
+const showCodexRuntime = computed(() => currentManagerUsesCodex.value || props.codexModels.length > 0)
+const activeManagerSettings = computed(() => activeSettings.value.filter(setting =>
+  setting.supports_llm && !setting.supports_asr && !setting.supports_tts
+))
+const availableManagerModelCount = computed(() => activeManagerSettings.value.length + props.codexModels.length)
+const configuredModelCount = computed(() => props.llmSettings.length + (showCodexRuntime.value ? 1 : 0))
+
+function codexModelLabel(modelName: string | null | undefined): string {
+  if (!modelName) return '-'
+  const model = props.codexModels.find(item => item.model === modelName || item.id === modelName)
+  return model?.display_name || modelName
+}
+
+const currentCodexModelName = computed(() => {
+  if (currentManagerUsesCodex.value && props.managerConfig?.model_name) {
+    return props.managerConfig.model_name
+  }
+  return props.codexModels.find(model => model.is_default)?.model
+    || props.codexModels[0]?.model
+    || null
+})
+const currentCodexModelLabel = computed(() => codexModelLabel(currentCodexModelName.value))
+const codexModelSummary = computed(() => props.codexModels
+  .map(model => model.display_name || model.model)
+  .join(', '))
 
 function handleManagerProviderChange(event: Event): void {
   store.setManagerRuntime((event.target as HTMLSelectElement).value)
@@ -240,9 +270,28 @@ function capabilityList(setting: LLMSetting): Array<{ key: 'llm' | 'asr' | 'tts'
           <h2 class="font-semibold">Manager Runtime</h2>
           <div class="mt-1 text-xs text-gray-500">当前会话使用的模型</div>
         </div>
-        <span class="rounded-full border border-white/10 px-3 py-1 text-xs text-gray-400">{{ activeSettings.length }} 个可用模型</span>
+        <span data-testid="agent-settings-manager-runtime-count" class="rounded-full border border-white/10 px-3 py-1 text-xs text-gray-400">{{ availableManagerModelCount }} 个可用模型</span>
       </div>
-      <div class="mt-4 grid gap-3 md:grid-cols-2">
+      <div v-if="currentManagerUsesCodex" class="mt-4 grid gap-3 md:grid-cols-2">
+        <div
+          data-testid="agent-settings-manager-runtime-provider-readonly"
+          class="flex h-10 items-center justify-between rounded-md border border-white/10 bg-[#343434] px-3 text-sm"
+        >
+          <span>Codex</span>
+          <span class="inline-flex items-center gap-1 text-xs text-cyan-200/70">
+            <LockKeyhole class="h-3.5 w-3.5" />
+            自动检测
+          </span>
+        </div>
+        <div
+          data-testid="agent-settings-manager-runtime-model-readonly"
+          class="flex h-10 items-center justify-between rounded-md border border-white/10 bg-[#343434] px-3 text-sm"
+        >
+          <span>{{ currentCodexModelLabel }}</span>
+          <span v-if="managerConfig?.reasoning_effort" class="text-xs text-gray-500">{{ managerConfig.reasoning_effort }}</span>
+        </div>
+      </div>
+      <div v-else class="mt-4 grid gap-3 md:grid-cols-2">
         <select
           :value="store.managerProviderName"
           class="h-10 rounded-md border border-white/10 bg-[#343434] px-3 text-sm outline-none"
@@ -264,7 +313,10 @@ function capabilityList(setting: LLMSetting): Array<{ key: 'llm' | 'asr' | 'tts'
           </option>
         </select>
       </div>
-      <div class="mt-3 text-xs leading-relaxed text-gray-500">
+      <div v-if="currentManagerUsesCodex" class="mt-3 text-xs leading-relaxed text-gray-500">
+        本机 Codex CLI · 当前配置由自动检测结果管理
+      </div>
+      <div v-else class="mt-3 text-xs leading-relaxed text-gray-500">
         切换 runtime 后，新 Manager 会话会使用所选模型。当前已进行中的会话不受影响。
       </div>
     </div>
@@ -273,7 +325,7 @@ function capabilityList(setting: LLMSetting): Array<{ key: 'llm' | 'asr' | 'tts'
       <div class="flex flex-wrap items-center justify-between gap-3 border-b border-white/10 px-4 py-3">
         <div>
           <h2 class="font-semibold">已配置模型</h2>
-          <div class="mt-1 text-xs text-gray-500">{{ providers.length }} 个供应商 · {{ llmSettings.length }} 个模型配置</div>
+          <div class="mt-1 text-xs text-gray-500">{{ providers.length }} 个供应商 · {{ configuredModelCount }} 个模型配置</div>
         </div>
         <button
           class="inline-flex items-center gap-2 rounded-md bg-blue-500 px-3 py-2 text-sm text-white hover:bg-blue-400 disabled:opacity-50"
@@ -285,16 +337,57 @@ function capabilityList(setting: LLMSetting): Array<{ key: 'llm' | 'asr' | 'tts'
         </button>
       </div>
 
-      <div v-if="loading && !llmSettings.length" class="px-4 py-8 text-center text-sm text-gray-500">
+      <div v-if="loading && !configuredModelCount" class="px-4 py-8 text-center text-sm text-gray-500">
         <Loader2 class="mx-auto h-5 w-5 animate-spin" />
         <div class="mt-2">加载中...</div>
       </div>
 
-      <div v-else-if="!llmSettings.length" class="px-4 py-8 text-center text-sm text-gray-500">
+      <div v-else-if="!configuredModelCount" class="px-4 py-8 text-center text-sm text-gray-500">
         暂无模型配置，点击右上角添加。
       </div>
 
       <template v-else>
+        <div
+          v-if="showCodexRuntime"
+          data-testid="agent-settings-model-item-codex"
+          class="border-b border-white/10 px-4 py-4"
+        >
+          <div class="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
+            <div class="min-w-0 flex-1">
+              <div class="flex flex-wrap items-center gap-2">
+                <span class="font-medium">Codex</span>
+                <span v-if="currentManagerUsesCodex" class="rounded-full bg-emerald-400/10 px-2 py-0.5 text-[10px] text-emerald-200">当前 Manager</span>
+                <span v-if="codexModels.length" class="rounded-full bg-cyan-400/10 px-2 py-0.5 text-[10px] text-cyan-200">自动检测</span>
+                <span class="rounded-full bg-white/5 px-2 py-0.5 text-[10px] text-gray-300">只读</span>
+              </div>
+              <div class="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500">
+                <span>OpenAI Codex</span>
+                <span>·</span>
+                <span>本机 CLI</span>
+                <template v-if="codexModels.length">
+                  <span>·</span>
+                  <span>{{ codexModels.length }} 个可用模型: {{ codexModelSummary }}</span>
+                </template>
+                <template v-else-if="currentCodexModelName">
+                  <span>·</span>
+                  <span>当前模型: {{ currentCodexModelLabel }}</span>
+                </template>
+              </div>
+              <div class="mt-2 flex flex-wrap items-center gap-2">
+                <CapabilityBadge capability="llm" :active="true" />
+                <span v-if="currentManagerUsesCodex" class="rounded-full bg-white/5 px-2 py-0.5 text-[10px] text-gray-300">
+                  {{ currentCodexModelLabel }}<template v-if="managerConfig?.reasoning_effort"> · {{ managerConfig.reasoning_effort }}</template>
+                </span>
+              </div>
+            </div>
+
+            <div class="inline-flex items-center gap-1.5 text-xs text-gray-500 xl:pt-1">
+              <LockKeyhole class="h-3.5 w-3.5" />
+              系统自动管理
+            </div>
+          </div>
+        </div>
+
         <div
           v-for="setting in activeSettings"
           :key="setting.id"

--- a/agent-ui/src/components/agent/settings/ModelSettings.vue
+++ b/agent-ui/src/components/agent/settings/ModelSettings.vue
@@ -63,6 +63,12 @@ const currentCodexModelName = computed(() => {
     || null
 })
 const currentCodexModelLabel = computed(() => codexModelLabel(currentCodexModelName.value))
+const currentCodexServiceTierLabel = computed(() => {
+  const serviceTier = props.managerConfig?.service_tier
+  if (!serviceTier) return 'Standard'
+  const model = props.codexModels.find(item => item.model === currentCodexModelName.value)
+  return model?.service_tiers.find(tier => tier.id === serviceTier)?.name || serviceTier
+})
 const codexModelSummary = computed(() => props.codexModels
   .map(model => model.display_name || model.model)
   .join(', '))
@@ -288,7 +294,9 @@ function capabilityList(setting: LLMSetting): Array<{ key: 'llm' | 'asr' | 'tts'
           class="flex h-10 items-center justify-between rounded-md border border-white/10 bg-[#343434] px-3 text-sm"
         >
           <span>{{ currentCodexModelLabel }}</span>
-          <span v-if="managerConfig?.reasoning_effort" class="text-xs text-gray-500">{{ managerConfig.reasoning_effort }}</span>
+          <span class="text-xs text-gray-500">
+            <template v-if="managerConfig?.reasoning_effort">{{ managerConfig.reasoning_effort }} · </template>{{ currentCodexServiceTierLabel }}
+          </span>
         </div>
       </div>
       <div v-else class="mt-4 grid gap-3 md:grid-cols-2">
@@ -376,7 +384,7 @@ function capabilityList(setting: LLMSetting): Array<{ key: 'llm' | 'asr' | 'tts'
               <div class="mt-2 flex flex-wrap items-center gap-2">
                 <CapabilityBadge capability="llm" :active="true" />
                 <span v-if="currentManagerUsesCodex" class="rounded-full bg-white/5 px-2 py-0.5 text-[10px] text-gray-300">
-                  {{ currentCodexModelLabel }}<template v-if="managerConfig?.reasoning_effort"> · {{ managerConfig.reasoning_effort }}</template>
+                  {{ currentCodexModelLabel }}<template v-if="managerConfig?.reasoning_effort"> · {{ managerConfig.reasoning_effort }}</template> · {{ currentCodexServiceTierLabel }}
                 </span>
               </div>
             </div>

--- a/homerail_manager/src/persistence/manager-agent-config.ts
+++ b/homerail_manager/src/persistence/manager-agent-config.ts
@@ -1,7 +1,12 @@
 import { encodeJson, getDb, parseJsonRow } from "./db.js";
 import { getSetting } from "./llm-settings.js";
 import { nowIso } from "./time.js";
-import { normalizeManagerAgentHarness, type ManagerAgentHarness } from "homerail-protocol";
+import {
+  normalizeManagerAgentHarness,
+  type ManagerAgentHarness,
+  type ManagerAgentReasoningEffort,
+  type ManagerAgentServiceTier,
+} from "homerail-protocol";
 
 export interface ManagerAgentConfig {
   agent_type: "manager_agent";
@@ -9,7 +14,8 @@ export interface ManagerAgentConfig {
   llm_setting_id: string | null;
   provider_name: string | null;
   model_name: string | null;
-  reasoning_effort: "minimal" | "low" | "medium" | "high" | "xhigh";
+  reasoning_effort: ManagerAgentReasoningEffort;
+  service_tier: ManagerAgentServiceTier;
   system_prompt: string;
   session_policy: Record<string, unknown>;
 }
@@ -21,6 +27,7 @@ export const DEFAULT_MANAGER_AGENT_CONFIG: ManagerAgentConfig = {
   provider_name: null,
   model_name: null,
   reasoning_effort: "low",
+  service_tier: null,
   system_prompt: "",
   session_policy: {
     persist_conversation: true,
@@ -36,9 +43,12 @@ function _string(value: unknown): string | null {
 }
 
 function _reasoningEffort(value: unknown): ManagerAgentConfig["reasoning_effort"] {
-  return value === "minimal" || value === "low" || value === "medium" || value === "high" || value === "xhigh"
-    ? value
-    : DEFAULT_MANAGER_AGENT_CONFIG.reasoning_effort;
+  return _string(value) ?? DEFAULT_MANAGER_AGENT_CONFIG.reasoning_effort;
+}
+
+function _serviceTier(value: unknown): ManagerAgentConfig["service_tier"] {
+  const tier = _string(value);
+  return tier === "fast" ? "priority" : tier;
 }
 
 function _harness(value: unknown): ManagerAgentHarness {
@@ -63,6 +73,7 @@ function _normalize(raw?: Record<string, unknown> | null): ManagerAgentConfig {
       provider_name: null,
       model_name: modelName,
       reasoning_effort: _reasoningEffort(base.reasoning_effort),
+      service_tier: _serviceTier(base.service_tier),
       system_prompt: typeof base.system_prompt === "string" ? base.system_prompt : "",
       session_policy: {
         ...DEFAULT_MANAGER_AGENT_CONFIG.session_policy,
@@ -77,6 +88,7 @@ function _normalize(raw?: Record<string, unknown> | null): ManagerAgentConfig {
     provider_name: _string(base.provider_name),
     model_name: _string(base.model_name),
     reasoning_effort: _reasoningEffort(base.reasoning_effort),
+    service_tier: _serviceTier(base.service_tier),
     system_prompt: typeof base.system_prompt === "string" ? base.system_prompt : "",
     session_policy: {
       ...DEFAULT_MANAGER_AGENT_CONFIG.session_policy,

--- a/homerail_manager/src/persistence/manager-agent-config.ts
+++ b/homerail_manager/src/persistence/manager-agent-config.ts
@@ -104,6 +104,12 @@ export function readManagerAgentConfig(): ManagerAgentConfig {
   return DEFAULT_MANAGER_AGENT_CONFIG;
 }
 
+export function hasManagerAgentConfig(): boolean {
+  return Boolean(getDb()
+    .prepare("SELECT 1 FROM manager_agent_config WHERE id = ?")
+    .get("default"));
+}
+
 export function saveManagerAgentConfig(patch: Record<string, unknown>): ManagerAgentConfig {
   const current = readManagerAgentConfig();
   const next = _normalize({

--- a/homerail_manager/src/server/codex-models.ts
+++ b/homerail_manager/src/server/codex-models.ts
@@ -19,6 +19,11 @@ export interface CodexModelServiceTier {
   description: string;
 }
 
+export interface CodexReasoningEffortOption {
+  reasoning_effort: string;
+  description: string;
+}
+
 export interface CodexModel {
   id: string;
   model: string;
@@ -27,6 +32,7 @@ export interface CodexModel {
   is_default: boolean;
   default_reasoning_effort: string;
   supported_reasoning_efforts: string[];
+  reasoning_effort_options?: CodexReasoningEffortOption[];
   service_tiers: CodexModelServiceTier[];
 }
 
@@ -53,11 +59,17 @@ function stringValue(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
 
-function normalizeReasoningEfforts(value: unknown): string[] {
+function normalizeReasoningEffortOptions(value: unknown): CodexReasoningEffortOption[] {
   if (!Array.isArray(value)) return [];
-  return value
-    .map((item) => stringValue(record(item)?.reasoningEffort ?? item))
-    .filter(Boolean);
+  return value.flatMap((item) => {
+    const raw = record(item);
+    const reasoningEffort = stringValue(raw?.reasoningEffort ?? item);
+    if (!reasoningEffort) return [];
+    return [{
+      reasoning_effort: reasoningEffort,
+      description: stringValue(raw?.description),
+    }];
+  });
 }
 
 function normalizeServiceTiers(value: unknown): CodexModelServiceTier[] {
@@ -81,6 +93,7 @@ function normalizeModel(value: unknown): CodexModel | null {
   const id = stringValue(raw.id) || stringValue(raw.model);
   if (!id) return null;
   const model = stringValue(raw.model) || id;
+  const reasoningEffortOptions = normalizeReasoningEffortOptions(raw.supportedReasoningEfforts);
   return {
     id,
     model,
@@ -88,7 +101,8 @@ function normalizeModel(value: unknown): CodexModel | null {
     description: stringValue(raw.description),
     is_default: raw.isDefault === true,
     default_reasoning_effort: stringValue(raw.defaultReasoningEffort),
-    supported_reasoning_efforts: normalizeReasoningEfforts(raw.supportedReasoningEfforts),
+    supported_reasoning_efforts: reasoningEffortOptions.map((option) => option.reasoning_effort),
+    reasoning_effort_options: reasoningEffortOptions,
     service_tiers: normalizeServiceTiers(raw.serviceTiers),
   };
 }

--- a/homerail_manager/src/server/host-codex-manager-agent.ts
+++ b/homerail_manager/src/server/host-codex-manager-agent.ts
@@ -109,6 +109,8 @@ interface PendingRequest {
   timer: ReturnType<typeof setTimeout>;
 }
 
+type CodexReasoningEffort = NonNullable<AgentRunContext["reasoning_effort"]>;
+
 export interface HostCodexManagerAgentInput {
   message: string;
   project_id?: string;
@@ -143,6 +145,47 @@ export function _setHostCodexManagerAgentRunnerForTest(runner?: HostCodexManager
 
 export function _setHostCodexManagerAgentStreamRunnerForTest(runner?: HostCodexManagerAgentStreamRunner): void {
   hostStreamRunnerOverride = runner;
+}
+
+export function _buildCodexThreadStartParamsForTest(input: {
+  systemPrompt?: string;
+  cwd: string;
+  model: string;
+  provider?: string;
+  serviceTier: string;
+  sandbox: string;
+  dynamicTools: Array<Record<string, unknown>>;
+  reasoningEffort?: CodexReasoningEffort;
+}): Record<string, unknown> {
+  return {
+    baseInstructions: input.systemPrompt ?? null,
+    developerInstructions: null,
+    cwd: input.cwd,
+    model: input.model,
+    modelProvider: input.provider || null,
+    serviceTier: input.serviceTier,
+    approvalPolicy: "never",
+    sandbox: input.sandbox,
+    ephemeral: true,
+    dynamicTools: input.dynamicTools,
+    ...(input.reasoningEffort ? { config: { model_reasoning_effort: input.reasoningEffort } } : {}),
+  };
+}
+
+export function _buildCodexTurnStartParamsForTest(input: {
+  threadId: string;
+  prompt?: string;
+  cwd: string;
+  model: string;
+  reasoningEffort?: CodexReasoningEffort;
+}): Record<string, unknown> {
+  return {
+    threadId: input.threadId,
+    input: input.prompt ? [{ type: "text", text: input.prompt, text_elements: [] }] : [],
+    cwd: input.cwd,
+    model: input.model,
+    ...(input.reasoningEffort ? { effort: input.reasoningEffort } : {}),
+  };
 }
 
 const CLIENT_NAME = "homerail_host_codex_manager_agent";
@@ -1272,20 +1315,17 @@ class HostCodexAppServerAdapter {
       });
       yield this.debugEvent("appserver_initialized", this.redactSecrets(initResult));
       const dynamicTools = this.buildDynamicToolSpecs(tools);
-      const threadResult = await this.sendRequest("thread/start", {
-        baseInstructions: context.systemPrompt ?? null,
-        developerInstructions: null,
-        cwd: context.workspace ?? process.cwd(),
+      const cwd = context.workspace ?? process.cwd();
+      const threadResult = await this.sendRequest("thread/start", _buildCodexThreadStartParamsForTest({
+        systemPrompt: context.systemPrompt,
+        cwd,
         model: context.model,
-        modelProvider: context.provider || null,
+        provider: context.provider,
         serviceTier: process.env.HOMERAIL_CODEX_SERVICE_TIER || "fast",
-        approvalPolicy: "never",
         sandbox: process.env.HOMERAIL_CODEX_MANAGER_SANDBOX || "workspace-write",
-        ephemeral: true,
         dynamicTools,
-        // 每轮实时生效的推理幅度（对齐 Python config={"model_reasoning_effort": ...}）
-        ...(context.reasoning_effort ? { modelReasoningEffort: context.reasoning_effort } : {}),
-      });
+        reasoningEffort: context.reasoning_effort,
+      }));
       const threadId =
         (threadResult.thread_id as string | undefined) ??
         ((threadResult.thread as Record<string, unknown> | undefined)?.id as string | undefined);
@@ -1296,14 +1336,13 @@ class HostCodexAppServerAdapter {
       let turnComplete = false;
       while (iteration < maxIterations && !turnComplete && !context.abortSignal?.aborted) {
         iteration++;
-        const turnResult = await this.sendRequest("turn/start", {
+        const turnResult = await this.sendRequest("turn/start", _buildCodexTurnStartParamsForTest({
           threadId,
-          input: iteration === 1 ? [{ type: "text", text: prompt, text_elements: [] }] : [],
-          cwd: context.workspace ?? process.cwd(),
+          prompt: iteration === 1 ? prompt : undefined,
+          cwd,
           model: context.model,
-          // 每轮显式传推理幅度，确保改配置即时生效（对齐 Python effort= 每轮取 config）
-          ...(context.reasoning_effort ? { modelReasoningEffort: context.reasoning_effort } : {}),
-        });
+          reasoningEffort: context.reasoning_effort,
+        }));
         const turnId =
           (turnResult.turn_id as string | undefined) ??
           ((turnResult.turn as Record<string, unknown> | undefined)?.id as string | undefined) ??

--- a/homerail_manager/src/server/host-codex-manager-agent.ts
+++ b/homerail_manager/src/server/host-codex-manager-agent.ts
@@ -23,6 +23,7 @@ import {
   type ManagerAgentWidgetFileToolAdapter,
   type ManagerAgentWidgetFileToolResult,
   type ManagerAgentToolName,
+  type ManagerAgentReasoningEffort,
 } from "homerail-protocol";
 
 type ToolHandlerResult = {
@@ -80,7 +81,8 @@ interface AgentRunContext {
   workspace?: string;
   maxIterations?: number;
   abortSignal?: AbortSignal;
-  reasoning_effort?: "minimal" | "low" | "medium" | "high" | "xhigh";
+  reasoning_effort?: ManagerAgentReasoningEffort;
+  service_tier?: string | null;
 }
 
 interface JsonRpcRequest {
@@ -147,12 +149,16 @@ export function _setHostCodexManagerAgentStreamRunnerForTest(runner?: HostCodexM
   hostStreamRunnerOverride = runner;
 }
 
+export function _buildCodexAppServerArgsForTest(): string[] {
+  return ["app-server"];
+}
+
 export function _buildCodexThreadStartParamsForTest(input: {
   systemPrompt?: string;
   cwd: string;
   model: string;
   provider?: string;
-  serviceTier: string;
+  serviceTier?: string | null;
   sandbox: string;
   dynamicTools: Array<Record<string, unknown>>;
   reasoningEffort?: CodexReasoningEffort;
@@ -163,7 +169,7 @@ export function _buildCodexThreadStartParamsForTest(input: {
     cwd: input.cwd,
     model: input.model,
     modelProvider: input.provider || null,
-    serviceTier: input.serviceTier,
+    serviceTier: input.serviceTier ?? null,
     approvalPolicy: "never",
     sandbox: input.sandbox,
     ephemeral: true,
@@ -178,6 +184,7 @@ export function _buildCodexTurnStartParamsForTest(input: {
   cwd: string;
   model: string;
   reasoningEffort?: CodexReasoningEffort;
+  serviceTier?: string | null;
 }): Record<string, unknown> {
   return {
     threadId: input.threadId,
@@ -185,6 +192,7 @@ export function _buildCodexTurnStartParamsForTest(input: {
     cwd: input.cwd,
     model: input.model,
     ...(input.reasoningEffort ? { effort: input.reasoningEffort } : {}),
+    serviceTier: input.serviceTier ?? null,
   };
 }
 
@@ -1099,6 +1107,7 @@ function buildHostCodexManagerAgentResult(
       provider: config.provider_name || null,
       model: config.model || null,
       reasoning_effort: config.reasoning_effort || null,
+      service_tier: config.service_tier,
       workspace: state.workspace,
       voice_system_source: voiceSystemContract?.source ?? null,
       voice_system_hash: voiceSystemContract ? createHash("sha256").update(voiceSystemContract.prompt).digest("hex").slice(0, 16) : null,
@@ -1159,6 +1168,7 @@ async function* runHostCodexManagerAgentTurnEvents(
         workspace,
         abortSignal: abortController.signal,
         reasoning_effort: config.reasoning_effort,
+        service_tier: config.service_tier,
       },
     )) {
       if (event.type === "text") {
@@ -1263,8 +1273,7 @@ class HostCodexAppServerAdapter {
       return;
     }
     try {
-      const serviceTier = process.env.HOMERAIL_CODEX_SERVICE_TIER || "fast";
-      this.process = spawn(this.codexBin, ["app-server", "-c", `service_tier="${serviceTier}"`], {
+      this.process = spawn(this.codexBin, _buildCodexAppServerArgsForTest(), {
         stdio: ["pipe", "pipe", "pipe"],
         env: this.buildEnv(context),
         cwd: context.workspace ?? process.cwd(),
@@ -1300,7 +1309,7 @@ class HostCodexAppServerAdapter {
         workspace: context.workspace ?? process.cwd(),
         tool_count: tools.length,
         home: os.homedir(),
-        service_tier: process.env.HOMERAIL_CODEX_SERVICE_TIER || "fast",
+        service_tier: context.service_tier ?? null,
       });
       const initResult = await this.sendRequest("initialize", {
         clientInfo: {
@@ -1321,7 +1330,7 @@ class HostCodexAppServerAdapter {
         cwd,
         model: context.model,
         provider: context.provider,
-        serviceTier: process.env.HOMERAIL_CODEX_SERVICE_TIER || "fast",
+        serviceTier: context.service_tier,
         sandbox: process.env.HOMERAIL_CODEX_MANAGER_SANDBOX || "workspace-write",
         dynamicTools,
         reasoningEffort: context.reasoning_effort,
@@ -1342,6 +1351,7 @@ class HostCodexAppServerAdapter {
           cwd,
           model: context.model,
           reasoningEffort: context.reasoning_effort,
+          serviceTier: context.service_tier,
         }));
         const turnId =
           (turnResult.turn_id as string | undefined) ??

--- a/homerail_manager/src/server/http.ts
+++ b/homerail_manager/src/server/http.ts
@@ -176,7 +176,7 @@ export function createServer(
       return;
     }
 
-    if (mutationRoutesHandler(req, res, changeOrchestrator, managerAgentContainerOptions)) {
+    if (mutationRoutesHandler(req, res, changeOrchestrator, managerAgentContainerOptions, managerAgentConfigOptions)) {
       return;
     }
 
@@ -224,7 +224,7 @@ export function createServer(
       return;
     }
 
-    if (managerAgentReadinessRoutesHandler(req, res, managerAgentContainerOptions)) {
+    if (managerAgentReadinessRoutesHandler(req, res, managerAgentContainerOptions, managerAgentConfigOptions)) {
       return;
     }
 

--- a/homerail_manager/src/server/http.ts
+++ b/homerail_manager/src/server/http.ts
@@ -17,7 +17,10 @@ import { dagWorkflowRoutesHandler } from "./dag-workflows.js";
 import { settingsBootstrapHandler } from "./settings-bootstrap.js";
 import { settingsStorageInfoHandler } from "./settings-storage-info.js";
 import { voiceAgentBootstrapHandler } from "./voice-agent-bootstrap.js";
-import { managerAgentConfigRoutesHandler } from "./manager-agent-config.js";
+import {
+  managerAgentConfigRoutesHandler,
+  type ManagerAgentConfigRoutesOptions,
+} from "./manager-agent-config.js";
 import { managerAgentReadinessRoutesHandler } from "./manager-agent-readiness.js";
 import { setupEventWebSocket } from "./events-websocket.js";
 import { ChangeOrchestrator } from "../orchestration/change-orchestrator.js";
@@ -114,6 +117,7 @@ export function createServer(
   wsOptions?: WorkerWebSocketOptions & NodeWebSocketOptions,
   dispatcher?: DAGDispatcher,
   provisionerOptions?: WsDispatchAdapterOptions | false,
+  managerAgentConfigOptions: ManagerAgentConfigRoutesOptions = {},
 ) {
   let server: http.Server;
   const workerImage = process.env.HOMERAIL_WORKER_IMAGE || "homerail-worker:latest";
@@ -216,7 +220,7 @@ export function createServer(
       return;
     }
 
-    if (managerAgentConfigRoutesHandler(req, res)) {
+    if (managerAgentConfigRoutesHandler(req, res, managerAgentConfigOptions)) {
       return;
     }
 
@@ -224,7 +228,7 @@ export function createServer(
       return;
     }
 
-    if (voiceAgentBootstrapHandler(req, res, managerAgentContainerOptions)) {
+    if (voiceAgentBootstrapHandler(req, res, managerAgentContainerOptions, managerAgentConfigOptions)) {
       return;
     }
 

--- a/homerail_manager/src/server/manager-agent-config.ts
+++ b/homerail_manager/src/server/manager-agent-config.ts
@@ -5,7 +5,8 @@ import {
 } from "../persistence/manager-agent-config.js";
 import { resolveManagerAgentConfig } from "./manager-agent-container.js";
 import { normalizeManagerAgentHarness } from "homerail-protocol";
-import { listCodexModels, type CodexModelCatalog } from "./codex-models.js";
+import { listCodexModels, type CodexModel, type CodexModelCatalog } from "./codex-models.js";
+import type { ManagerAgentConfig } from "../persistence/manager-agent-config.js";
 
 interface BaseResponse {
   success: boolean;
@@ -56,6 +57,10 @@ function _string(value: unknown): string | null | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
+function isReasoningEffort(value: string): value is ManagerAgentConfig["reasoning_effort"] {
+  return value === "minimal" || value === "low" || value === "medium" || value === "high" || value === "xhigh";
+}
+
 function validateManagerConfig(config: ReturnType<typeof readManagerAgentConfig>): void {
   if (!config.llm_setting_id && !config.provider_name && config.harness !== "kimi_code") return;
   resolveManagerAgentConfig(
@@ -68,19 +73,74 @@ function validateManagerConfig(config: ReturnType<typeof readManagerAgentConfig>
   );
 }
 
-export function validateConfigPatch(patch: Record<string, unknown>): void {
+function patchedConfig(patch: Record<string, unknown>): ManagerAgentConfig {
   const current = readManagerAgentConfig();
   const settingId = _string(patch.llm_setting_id);
   const providerName = _string(patch.provider_name);
   const modelName = _string(patch.model_name);
+  const reasoningEffort = _string(patch.reasoning_effort);
+  if (reasoningEffort !== undefined && reasoningEffort !== null && !isReasoningEffort(reasoningEffort)) {
+    throw new Error(`Unsupported Manager Agent reasoning effort '${reasoningEffort}'. Supported values: minimal, low, medium, high, xhigh.`);
+  }
   const harness = normalizeManagerAgentHarness(patch.harness) ?? current.harness;
-  validateManagerConfig({
+  const mergedSettingId = settingId === undefined ? current.llm_setting_id : settingId;
+  const mergedProviderName = providerName === undefined ? current.provider_name : providerName;
+  const mergedModelName = modelName === undefined ? current.model_name : modelName;
+  const mergedReasoningEffort = reasoningEffort && isReasoningEffort(reasoningEffort)
+    ? reasoningEffort
+    : current.reasoning_effort;
+  if (harness === "codex_appserver") {
+    return {
+      ...current,
+      harness,
+      llm_setting_id: null,
+      provider_name: null,
+      model_name: mergedSettingId || mergedProviderName ? "gpt-5.5" : mergedModelName ?? "gpt-5.5",
+      reasoning_effort: mergedReasoningEffort,
+    };
+  }
+  return {
     ...current,
     harness,
-    llm_setting_id: settingId === undefined ? current.llm_setting_id : settingId,
-    provider_name: providerName === undefined ? current.provider_name : providerName,
-    model_name: modelName === undefined ? current.model_name : modelName,
-  });
+    llm_setting_id: mergedSettingId,
+    provider_name: mergedProviderName,
+    model_name: mergedModelName,
+    reasoning_effort: mergedReasoningEffort,
+  };
+}
+
+export function validateConfigPatch(patch: Record<string, unknown>): void {
+  validateManagerConfig(patchedConfig(patch));
+}
+
+function codexModelMatches(model: CodexModel, modelName: string): boolean {
+  return model.model === modelName || model.id === modelName;
+}
+
+function validateCodexReasoningEffort(config: ManagerAgentConfig, catalog: CodexModelCatalog): void {
+  if (config.harness !== "codex_appserver") return;
+  const modelName = config.model_name || "gpt-5.5";
+  const model = catalog.models.find((item) => codexModelMatches(item, modelName));
+  if (!model) {
+    throw new Error(`Codex model '${modelName}' is not available for the current account.`);
+  }
+  const supported = model.supported_reasoning_efforts;
+  if (supported.length > 0 && !supported.includes(config.reasoning_effort)) {
+    throw new Error(
+      `Codex model '${modelName}' does not support reasoning effort '${config.reasoning_effort}'. Supported values: ${supported.join(", ")}.`,
+    );
+  }
+}
+
+async function validateConfigPatchWithCatalog(
+  patch: Record<string, unknown>,
+  loadCodexModels: () => Promise<CodexModelCatalog>,
+): Promise<void> {
+  const next = patchedConfig(patch);
+  validateManagerConfig(next);
+  if (next.harness !== "codex_appserver") return;
+  const catalog = await loadCodexModels();
+  validateCodexReasoningEffort(next, catalog);
 }
 
 export function managerAgentConfigRoutesHandler(
@@ -111,9 +171,9 @@ export function managerAgentConfigRoutesHandler(
 
   if (method === "PUT") {
     readJsonBody(req)
-      .then((body) => {
+      .then(async (body) => {
         try {
-          validateConfigPatch(body);
+          await validateConfigPatchWithCatalog(body, options.loadCodexModels ?? listCodexModels);
         } catch (err) {
           badRequest(res, err instanceof Error ? err.message : String(err));
           return;

--- a/homerail_manager/src/server/manager-agent-config.ts
+++ b/homerail_manager/src/server/manager-agent-config.ts
@@ -19,6 +19,16 @@ export interface ManagerAgentConfigRoutesOptions {
   loadCodexModels?: () => Promise<CodexModelCatalog>;
 }
 
+export class ManagerAgentConfigValidationError extends Error {
+  readonly cause: unknown;
+
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = "ManagerAgentConfigValidationError";
+    this.cause = cause;
+  }
+}
+
 function json(res: http.ServerResponse, status: number, body: BaseResponse): void {
   res.writeHead(status, { "Content-Type": "application/json" });
   res.end(JSON.stringify(body));
@@ -109,10 +119,6 @@ function patchedConfig(patch: Record<string, unknown>): ManagerAgentConfig {
   };
 }
 
-export function validateConfigPatch(patch: Record<string, unknown>): void {
-  validateManagerConfig(patchedConfig(patch));
-}
-
 function codexModelMatches(model: CodexModel, modelName: string): boolean {
   return model.model === modelName || model.id === modelName;
 }
@@ -132,15 +138,34 @@ function validateCodexReasoningEffort(config: ManagerAgentConfig, catalog: Codex
   }
 }
 
-async function validateConfigPatchWithCatalog(
+function validationError(error: unknown): ManagerAgentConfigValidationError {
+  if (error instanceof ManagerAgentConfigValidationError) return error;
+  return new ManagerAgentConfigValidationError(
+    error instanceof Error ? error.message : String(error),
+    error,
+  );
+}
+
+export async function validateAndSaveManagerAgentConfig(
   patch: Record<string, unknown>,
-  loadCodexModels: () => Promise<CodexModelCatalog>,
-): Promise<void> {
-  const next = patchedConfig(patch);
-  validateManagerConfig(next);
-  if (next.harness !== "codex_appserver") return;
-  const catalog = await loadCodexModels();
-  validateCodexReasoningEffort(next, catalog);
+  options: ManagerAgentConfigRoutesOptions = {},
+): Promise<ManagerAgentConfig> {
+  let next: ManagerAgentConfig;
+  try {
+    next = patchedConfig(patch);
+    validateManagerConfig(next);
+  } catch (error) {
+    throw validationError(error);
+  }
+  if (next.harness === "codex_appserver") {
+    const catalog = await (options.loadCodexModels ?? listCodexModels)();
+    try {
+      validateCodexReasoningEffort(next, catalog);
+    } catch (error) {
+      throw validationError(error);
+    }
+  }
+  return saveManagerAgentConfig(next as unknown as Record<string, unknown>);
 }
 
 export function managerAgentConfigRoutesHandler(
@@ -173,15 +198,15 @@ export function managerAgentConfigRoutesHandler(
     readJsonBody(req)
       .then(async (body) => {
         try {
-          await validateConfigPatchWithCatalog(body, options.loadCodexModels ?? listCodexModels);
+          const next = await validateAndSaveManagerAgentConfig(body, options);
+          ok(res, "Manager Agent config saved", next);
         } catch (err) {
-          badRequest(res, err instanceof Error ? err.message : String(err));
-          return;
+          const message = err instanceof Error ? err.message : String(err);
+          if (err instanceof ManagerAgentConfigValidationError) badRequest(res, message);
+          else serverError(res, message);
         }
-        const next = saveManagerAgentConfig(body);
-        ok(res, "Manager Agent config saved", next);
       })
-      .catch((err) => serverError(res, err instanceof Error ? err.message : String(err)));
+      .catch((err) => badRequest(res, err instanceof Error ? err.message : "Invalid JSON body"));
     return true;
   }
 

--- a/homerail_manager/src/server/manager-agent-config.ts
+++ b/homerail_manager/src/server/manager-agent-config.ts
@@ -1,8 +1,13 @@
 import * as http from "node:http";
 import {
+  hasManagerAgentConfig,
   readManagerAgentConfig,
   saveManagerAgentConfig,
 } from "../persistence/manager-agent-config.js";
+import {
+  findActiveClaudeSdkCompatibleSetting,
+  findActiveLlmRuntimeSetting,
+} from "../persistence/llm-settings.js";
 import { resolveManagerAgentConfig } from "./manager-agent-container.js";
 import { normalizeManagerAgentHarness } from "homerail-protocol";
 import { listCodexModels, type CodexModel, type CodexModelCatalog } from "./codex-models.js";
@@ -17,6 +22,7 @@ interface BaseResponse {
 
 export interface ManagerAgentConfigRoutesOptions {
   loadCodexModels?: () => Promise<CodexModelCatalog>;
+  autoDetectCodex?: boolean;
 }
 
 export class ManagerAgentConfigValidationError extends Error {
@@ -69,6 +75,10 @@ function _string(value: unknown): string | null | undefined {
 
 function isReasoningEffort(value: string): value is ManagerAgentConfig["reasoning_effort"] {
   return value === "minimal" || value === "low" || value === "medium" || value === "high" || value === "xhigh";
+}
+
+function autoDetectCodex(options: ManagerAgentConfigRoutesOptions): boolean {
+  return options.autoDetectCodex ?? process.env.NODE_ENV !== "test";
 }
 
 function validateManagerConfig(config: ReturnType<typeof readManagerAgentConfig>): void {
@@ -138,6 +148,24 @@ function validateCodexReasoningEffort(config: ManagerAgentConfig, catalog: Codex
   }
 }
 
+function preferredCodexConfig(catalog: CodexModelCatalog): Pick<ManagerAgentConfig, "model_name" | "reasoning_effort"> | null {
+  const candidates = catalog.models.flatMap((model) => {
+    const supported = model.supported_reasoning_efforts.filter(isReasoningEffort);
+    if (model.supported_reasoning_efforts.length > 0 && supported.length === 0) return [];
+    const defaultEffort = isReasoningEffort(model.default_reasoning_effort) &&
+      (supported.length === 0 || supported.includes(model.default_reasoning_effort))
+      ? model.default_reasoning_effort
+      : supported.includes("medium")
+        ? "medium"
+        : supported[0] ?? "medium";
+    return [{ model, reasoning_effort: defaultEffort }];
+  });
+  const selected = candidates.find(({ model }) => model.is_default) ?? candidates[0];
+  return selected
+    ? { model_name: selected.model.model, reasoning_effort: selected.reasoning_effort }
+    : null;
+}
+
 function validationError(error: unknown): ManagerAgentConfigValidationError {
   if (error instanceof ManagerAgentConfigValidationError) return error;
   return new ManagerAgentConfigValidationError(
@@ -168,6 +196,72 @@ export async function validateAndSaveManagerAgentConfig(
   return saveManagerAgentConfig(next as unknown as Record<string, unknown>);
 }
 
+export async function ensurePreferredManagerAgentConfig(
+  options: ManagerAgentConfigRoutesOptions = {},
+): Promise<ManagerAgentConfig> {
+  const current = readManagerAgentConfig();
+  if (hasManagerAgentConfig()) {
+    try {
+      validateManagerConfig(current);
+      return current;
+    } catch {
+      // Fall through to an available runtime when a stored config is stale.
+    }
+  }
+
+  const claudeSetting = findActiveClaudeSdkCompatibleSetting();
+  if (claudeSetting) {
+    const next = saveManagerAgentConfig({
+      harness: "claude_agent_sdk",
+      llm_setting_id: claudeSetting.id,
+      provider_name: claudeSetting.provider_id,
+      model_name: claudeSetting.model_name,
+    });
+    validateManagerConfig(next);
+    return next;
+  }
+
+  if (autoDetectCodex(options)) {
+    try {
+      const catalog = await (options.loadCodexModels ?? listCodexModels)();
+      const selected = preferredCodexConfig(catalog);
+      if (selected) {
+        return saveManagerAgentConfig({
+          harness: "codex_appserver",
+          llm_setting_id: null,
+          provider_name: null,
+          ...selected,
+        });
+      }
+    } catch {
+      // Codex is optional; continue to other configured runtimes.
+    }
+  }
+
+  const fallbackSetting = findActiveLlmRuntimeSetting();
+  if (fallbackSetting) {
+    try {
+      resolveManagerAgentConfig(
+        undefined,
+        fallbackSetting.provider_id,
+        fallbackSetting.model_name,
+        fallbackSetting.id,
+        "kimi_code",
+      );
+      return saveManagerAgentConfig({
+        harness: "kimi_code",
+        llm_setting_id: fallbackSetting.id,
+        provider_name: fallbackSetting.provider_id,
+        model_name: fallbackSetting.model_name,
+      });
+    } catch {
+      // No supported harness can execute this setting.
+    }
+  }
+
+  return current;
+}
+
 export function managerAgentConfigRoutesHandler(
   req: http.IncomingMessage,
   res: http.ServerResponse,
@@ -190,7 +284,9 @@ export function managerAgentConfigRoutesHandler(
   if (pathname !== "/api/manager-agent/config") return false;
 
   if (method === "GET") {
-    ok(res, "Manager Agent config loaded", readManagerAgentConfig());
+    void ensurePreferredManagerAgentConfig(options)
+      .then((config) => ok(res, "Manager Agent config loaded", config))
+      .catch((error) => serverError(res, error instanceof Error ? error.message : String(error)));
     return true;
   }
 

--- a/homerail_manager/src/server/manager-agent-config.ts
+++ b/homerail_manager/src/server/manager-agent-config.ts
@@ -73,10 +73,6 @@ function _string(value: unknown): string | null | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
-function isReasoningEffort(value: string): value is ManagerAgentConfig["reasoning_effort"] {
-  return value === "minimal" || value === "low" || value === "medium" || value === "high" || value === "xhigh";
-}
-
 function autoDetectCodex(options: ManagerAgentConfigRoutesOptions): boolean {
   return options.autoDetectCodex ?? process.env.NODE_ENV !== "test";
 }
@@ -90,7 +86,12 @@ function validateManagerConfig(config: ReturnType<typeof readManagerAgentConfig>
     config.llm_setting_id ?? undefined,
     config.harness,
     config.reasoning_effort,
+    config.service_tier,
   );
+}
+
+function normalizedServiceTier(value: string | null): string | null {
+  return value === "fast" ? "priority" : value;
 }
 
 function patchedConfig(patch: Record<string, unknown>): ManagerAgentConfig {
@@ -99,16 +100,15 @@ function patchedConfig(patch: Record<string, unknown>): ManagerAgentConfig {
   const providerName = _string(patch.provider_name);
   const modelName = _string(patch.model_name);
   const reasoningEffort = _string(patch.reasoning_effort);
-  if (reasoningEffort !== undefined && reasoningEffort !== null && !isReasoningEffort(reasoningEffort)) {
-    throw new Error(`Unsupported Manager Agent reasoning effort '${reasoningEffort}'. Supported values: minimal, low, medium, high, xhigh.`);
-  }
+  const serviceTier = _string(patch.service_tier);
   const harness = normalizeManagerAgentHarness(patch.harness) ?? current.harness;
   const mergedSettingId = settingId === undefined ? current.llm_setting_id : settingId;
   const mergedProviderName = providerName === undefined ? current.provider_name : providerName;
   const mergedModelName = modelName === undefined ? current.model_name : modelName;
-  const mergedReasoningEffort = reasoningEffort && isReasoningEffort(reasoningEffort)
-    ? reasoningEffort
-    : current.reasoning_effort;
+  const mergedReasoningEffort = reasoningEffort ?? current.reasoning_effort;
+  const mergedServiceTier = serviceTier === undefined
+    ? current.service_tier
+    : normalizedServiceTier(serviceTier);
   if (harness === "codex_appserver") {
     return {
       ...current,
@@ -117,6 +117,7 @@ function patchedConfig(patch: Record<string, unknown>): ManagerAgentConfig {
       provider_name: null,
       model_name: mergedSettingId || mergedProviderName ? "gpt-5.5" : mergedModelName ?? "gpt-5.5",
       reasoning_effort: mergedReasoningEffort,
+      service_tier: mergedServiceTier,
     };
   }
   return {
@@ -126,6 +127,7 @@ function patchedConfig(patch: Record<string, unknown>): ManagerAgentConfig {
     provider_name: mergedProviderName,
     model_name: mergedModelName,
     reasoning_effort: mergedReasoningEffort,
+    service_tier: mergedServiceTier,
   };
 }
 
@@ -148,11 +150,23 @@ function validateCodexReasoningEffort(config: ManagerAgentConfig, catalog: Codex
   }
 }
 
-function preferredCodexConfig(catalog: CodexModelCatalog): Pick<ManagerAgentConfig, "model_name" | "reasoning_effort"> | null {
+function validateCodexServiceTier(config: ManagerAgentConfig, catalog: CodexModelCatalog): void {
+  if (config.harness !== "codex_appserver" || !config.service_tier) return;
+  const modelName = config.model_name || "gpt-5.5";
+  const model = catalog.models.find((item) => codexModelMatches(item, modelName));
+  if (!model) return;
+  const supported = model.service_tiers.map((tier) => tier.id);
+  if (!supported.includes(config.service_tier)) {
+    throw new Error(
+      `Codex model '${modelName}' does not support service tier '${config.service_tier}'. Supported values: standard${supported.length ? `, ${supported.join(", ")}` : ""}.`,
+    );
+  }
+}
+
+function preferredCodexConfig(catalog: CodexModelCatalog): Pick<ManagerAgentConfig, "model_name" | "reasoning_effort" | "service_tier"> | null {
   const candidates = catalog.models.flatMap((model) => {
-    const supported = model.supported_reasoning_efforts.filter(isReasoningEffort);
-    if (model.supported_reasoning_efforts.length > 0 && supported.length === 0) return [];
-    const defaultEffort = isReasoningEffort(model.default_reasoning_effort) &&
+    const supported = model.supported_reasoning_efforts;
+    const defaultEffort = model.default_reasoning_effort &&
       (supported.length === 0 || supported.includes(model.default_reasoning_effort))
       ? model.default_reasoning_effort
       : supported.includes("medium")
@@ -162,7 +176,7 @@ function preferredCodexConfig(catalog: CodexModelCatalog): Pick<ManagerAgentConf
   });
   const selected = candidates.find(({ model }) => model.is_default) ?? candidates[0];
   return selected
-    ? { model_name: selected.model.model, reasoning_effort: selected.reasoning_effort }
+    ? { model_name: selected.model.model, reasoning_effort: selected.reasoning_effort, service_tier: null }
     : null;
 }
 
@@ -189,6 +203,7 @@ export async function validateAndSaveManagerAgentConfig(
     const catalog = await (options.loadCodexModels ?? listCodexModels)();
     try {
       validateCodexReasoningEffort(next, catalog);
+      validateCodexServiceTier(next, catalog);
     } catch (error) {
       throw validationError(error);
     }

--- a/homerail_manager/src/server/manager-agent-container.ts
+++ b/homerail_manager/src/server/manager-agent-container.ts
@@ -12,6 +12,7 @@ import {
   type ManagerAgentHarness,
   type ManagerAgentRuntimePlacement,
   type ManagerAgentReasoningEffort,
+  type ManagerAgentServiceTier,
 } from "homerail-protocol";
 
 export interface ManagerAgentRuntimeConfig {
@@ -26,6 +27,7 @@ export interface ManagerAgentRuntimeConfig {
   project_workspace?: string;
   /** 每轮实时生效的推理幅度，codex 传 model_reasoning_effort */
   reasoning_effort?: ManagerAgentReasoningEffort;
+  service_tier: ManagerAgentServiceTier;
 }
 
 export interface ManagerAgentContainerOptions {
@@ -293,11 +295,12 @@ export function resolveManagerAgentConfig(
   settingId?: string,
   harness?: ManagerAgentHarness | string | null,
   reasoningEffort?: ManagerAgentReasoningEffort | string | null,
+  serviceTier?: ManagerAgentServiceTier,
 ): ManagerAgentRuntimeConfig {
-  const effort = (reasoningEffort === "minimal" || reasoningEffort === "low" || reasoningEffort === "medium"
-    || reasoningEffort === "high" || reasoningEffort === "xhigh")
-    ? reasoningEffort
+  const effort = typeof reasoningEffort === "string" && reasoningEffort.trim()
+    ? reasoningEffort.trim()
     : undefined;
+  const normalizedServiceTier = serviceTier === "fast" ? "priority" : serviceTier ?? null;
   return {
     ...resolveAgentRuntimeConfig({
       surface: "manager_agent",
@@ -309,6 +312,7 @@ export function resolveManagerAgentConfig(
     project_id: projectId,
     project_workspace: resolveProjectWorkspace(projectId),
     reasoning_effort: effort ?? "low",
+    service_tier: normalizedServiceTier,
   };
 }
 

--- a/homerail_manager/src/server/manager-agent-readiness.ts
+++ b/homerail_manager/src/server/manager-agent-readiness.ts
@@ -3,7 +3,7 @@ import * as http from "node:http";
 import * as os from "node:os";
 import * as path from "node:path";
 import { getAllNodes, isDockerCapableNode } from "../node/registry.js";
-import { readManagerAgentConfig } from "../persistence/manager-agent-config.js";
+import { readManagerAgentConfig, type ManagerAgentConfig } from "../persistence/manager-agent-config.js";
 import { sendLifecycleRequest } from "../node/lifecycle-request.js";
 import { getHomerailHome } from "../config/env.js";
 import {
@@ -13,6 +13,10 @@ import {
 import { hostShellDiagnostics } from "./host-shell-manager-agent.js";
 import { readDagResourceStatus, type DagResourceStatus } from "./dag-resource-status.js";
 import { resolveCodexBinary, runCodexCommandSync } from "./codex-binary.js";
+import {
+  ensurePreferredManagerAgentConfig,
+  type ManagerAgentConfigRoutesOptions,
+} from "./manager-agent-config.js";
 
 interface ReadinessBlocker {
   code: string;
@@ -186,8 +190,9 @@ async function probeDockerWorkspaceMount(
 
 export function managerAgentReadiness(
   managerAgentOptions?: ManagerAgentContainerOptions,
+  effectiveConfig?: ManagerAgentConfig,
 ): ManagerAgentReadiness {
-  const config = readManagerAgentConfig();
+  const config = effectiveConfig ?? readManagerAgentConfig();
   const blockers: ReadinessBlocker[] = [];
   let runtimeConfig;
   try {
@@ -281,6 +286,7 @@ export function managerAgentReadinessRoutesHandler(
   req: http.IncomingMessage,
   res: http.ServerResponse,
   managerAgentOptions?: ManagerAgentContainerOptions,
+  managerAgentConfigOptions: ManagerAgentConfigRoutesOptions = {},
 ): boolean {
   const pathname = new URL(req.url || "/", "http://localhost").pathname;
   if (pathname === "/api/manager-agent/readiness") {
@@ -288,7 +294,12 @@ export function managerAgentReadinessRoutesHandler(
       methodNotAllowed(res);
       return true;
     }
-    ok(res, "Manager Agent readiness checked", managerAgentReadiness(managerAgentOptions));
+    void ensurePreferredManagerAgentConfig(managerAgentConfigOptions)
+      .then((config) => ok(res, "Manager Agent readiness checked", managerAgentReadiness(managerAgentOptions, config)))
+      .catch((error) => json(res, 500, {
+        success: false,
+        message: error instanceof Error ? error.message : String(error),
+      }));
     return true;
   }
   if (pathname === "/api/manager-agent/docker-workspace-probe") {

--- a/homerail_manager/src/server/manager-agent-readiness.ts
+++ b/homerail_manager/src/server/manager-agent-readiness.ts
@@ -203,6 +203,7 @@ export function managerAgentReadiness(
       config.llm_setting_id ?? undefined,
       config.harness,
       config.reasoning_effort,
+      config.service_tier,
     );
   } catch (err) {
     blockers.push({

--- a/homerail_manager/src/server/mutations.ts
+++ b/homerail_manager/src/server/mutations.ts
@@ -154,6 +154,7 @@ export function mutationRoutesHandler(
           requestedSettingId,
           savedManagerConfig.harness,
           savedManagerConfig.reasoning_effort,
+          savedManagerConfig.service_tier,
         );
         const parentSessionId = session && (existingSettingId || existingProvider || existingModel) &&
           (existingSettingId !== requestedSettingId || existingProvider !== agentConfig.provider_name || existingModel !== agentConfig.model)

--- a/homerail_manager/src/server/mutations.ts
+++ b/homerail_manager/src/server/mutations.ts
@@ -11,7 +11,10 @@ import {
   resolveManagerAgentConfig,
   type ManagerAgentContainerOptions,
 } from "./manager-agent-container.js";
-import { readManagerAgentConfig } from "../persistence/manager-agent-config.js";
+import {
+  ensurePreferredManagerAgentConfig,
+  type ManagerAgentConfigRoutesOptions,
+} from "./manager-agent-config.js";
 import { getSetting } from "../persistence/llm-settings.js";
 import { ManagerAgentRuntimeError, runManagerAgentTurn } from "./manager-agent-runtime.js";
 import { dagResourcesUnavailableForRun } from "./dag-resource-status.js";
@@ -92,6 +95,7 @@ export function mutationRoutesHandler(
   res: http.ServerResponse,
   changeOrchestrator: ChangeOrchestrator,
   managerAgentOptions?: ManagerAgentContainerOptions,
+  managerAgentConfigOptions: ManagerAgentConfigRoutesOptions = {},
 ): boolean {
   const pathname = new URL(req.url || "/", "http://localhost").pathname;
 
@@ -123,7 +127,7 @@ export function mutationRoutesHandler(
           : [];
         let sessionId = typeof b.session_id === "string" && b.session_id.trim() ? b.session_id.trim() : undefined;
         let session = sessionId ? loadSession(sessionId) : undefined;
-        const savedManagerConfig = readManagerAgentConfig();
+        const savedManagerConfig = await ensurePreferredManagerAgentConfig(managerAgentConfigOptions);
         const existingSettingId = typeof session?.metadata.manager_llm_setting_id === "string"
           ? session.metadata.manager_llm_setting_id
           : typeof session?.metadata.llm_setting_id === "string"

--- a/homerail_manager/src/server/voice-agent-bootstrap.ts
+++ b/homerail_manager/src/server/voice-agent-bootstrap.ts
@@ -6,7 +6,6 @@ import * as path from "node:path";
 import { getDataRoot } from "../config/env.js";
 import { encodeJson, getDb, parseJsonRow } from "../persistence/db.js";
 import { getProject } from "../persistence/projects-changes.js";
-import { readManagerAgentConfig } from "../persistence/manager-agent-config.js";
 import { normalizeStatus } from "../persistence/status.js";
 import {
   resolveManagerAgentConfig,
@@ -22,6 +21,7 @@ import {
 } from "./manager-agent-runtime.js";
 import {
   ManagerAgentConfigValidationError,
+  ensurePreferredManagerAgentConfig,
   validateAndSaveManagerAgentConfig,
   type ManagerAgentConfigRoutesOptions,
 } from "./manager-agent-config.js";
@@ -352,9 +352,10 @@ function voiceCompatConfig(config: Record<string, unknown>): Record<string, unkn
   return { ...DEFAULT_VOICE_AGENT_CONFIG, ...config };
 }
 
-function readConfig(): Record<string, unknown> {
+async function readConfig(options: ManagerAgentConfigRoutesOptions = {}): Promise<Record<string, unknown>> {
   try {
-    return voiceCompatConfig(readManagerAgentConfig() as unknown as Record<string, unknown>);
+    const config = await ensurePreferredManagerAgentConfig(options);
+    return voiceCompatConfig(config as unknown as Record<string, unknown>);
   } catch {
     return voiceCompatConfig(DEFAULT_VOICE_AGENT_CONFIG);
   }
@@ -1138,10 +1139,11 @@ async function processTurn(
   text: string,
   options?: ManagerAgentContainerOptions,
   realtimeHooks?: ManagerAgentRealtimeHooks,
+  managerAgentConfigOptions: ManagerAgentConfigRoutesOptions = {},
 ): Promise<VoiceTurnResult> {
   appendConversation(workspace, "user", text);
   ensureVoiceSessionTitle(workspace, text);
-  const config = readConfig();
+  const config = await readConfig(managerAgentConfigOptions);
 
   // 真实调用 Manager Agent：与文本模式 /api/manager/chat 走同一条链路。
   // voice agent 和 manager agent 是同一个主 Agent 的不同 I/O 表面。
@@ -1204,7 +1206,9 @@ export function voiceAgentBootstrapHandler(
   }
 
   if (method === "GET" && pathname === "/api/voice-agent/config") {
-    ok(res, "Voice Agent config loaded", readConfig());
+    void readConfig(managerAgentConfigOptions)
+      .then((config) => ok(res, "Voice Agent config loaded", config))
+      .catch((error) => serverError(res, error instanceof Error ? error.message : String(error)));
     return true;
   }
 
@@ -1391,7 +1395,7 @@ export function voiceAgentBootstrapHandler(
           if (projectIdPatch && !workspace.project_id) workspace.project_id = projectIdPatch;
           registerTurn(sessionId, "running");
           try {
-            const r = await processTurn(workspace, text, managerAgentOptions);
+            const r = await processTurn(workspace, text, managerAgentOptions, undefined, managerAgentConfigOptions);
             const saved = saveWorkspace(workspace);
             completeTurn(sessionId, saved.progress_brief?.status || "done");
             return { result: r, saved };
@@ -1455,7 +1459,7 @@ export function voiceAgentBootstrapHandler(
                 const saved = saveWorkspace(workspace);
                 streamLine(res, { type: "speech", event, workspace: saved });
               },
-            });
+            }, managerAgentConfigOptions);
             const saved = saveWorkspace(workspace);
             completeTurn(sessionId, saved.progress_brief?.status || "done");
             return { result: r, saved };
@@ -1500,7 +1504,7 @@ export function voiceAgentBootstrapHandler(
       .then(async (body) => {
         const sessionId = decodeURIComponent(confirmMatch[1]);
         const requested = typeof body.confirmation_id === "string" ? body.confirmation_id : "";
-        const config = readConfig();
+        const config = await readConfig(managerAgentConfigOptions);
         // workspace 在锁内重新读取，确保 confirm 基于最新 workspace。
         const result = await withSessionLock(sessionId, async () => {
           const workspace = loadWorkspace(sessionId);
@@ -1546,7 +1550,7 @@ export function voiceAgentBootstrapHandler(
     readJsonBody(req)
       .then(async () => {
         const sessionId = decodeURIComponent(confirmStreamMatch[1]);
-        const config = readConfig();
+        const config = await readConfig(managerAgentConfigOptions);
         res.writeHead(200, { "Content-Type": "application/x-ndjson" });
         // workspace 在锁内重新读取。
         const result = await withSessionLock(sessionId, async () => {

--- a/homerail_manager/src/server/voice-agent-bootstrap.ts
+++ b/homerail_manager/src/server/voice-agent-bootstrap.ts
@@ -1011,7 +1011,8 @@ async function submitVoiceWorkspaceToManagerAgent(
     const providerName = typeof config.provider_name === "string" ? config.provider_name : undefined;
     const modelName = typeof config.model_name === "string" ? config.model_name : undefined;
     const reasoningEffort = typeof config.reasoning_effort === "string" ? config.reasoning_effort : undefined;
-    agentConfig = resolveManagerAgentConfig(workspace.project_id ?? undefined, providerName, modelName, settingId, requestedHarness, reasoningEffort);
+    const serviceTier = typeof config.service_tier === "string" ? config.service_tier : null;
+    agentConfig = resolveManagerAgentConfig(workspace.project_id ?? undefined, providerName, modelName, settingId, requestedHarness, reasoningEffort, serviceTier);
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
     return markManagerAgentBlocker(workspace, "manager_config_error", detail);

--- a/homerail_manager/src/server/voice-agent-bootstrap.ts
+++ b/homerail_manager/src/server/voice-agent-bootstrap.ts
@@ -6,7 +6,7 @@ import * as path from "node:path";
 import { getDataRoot } from "../config/env.js";
 import { encodeJson, getDb, parseJsonRow } from "../persistence/db.js";
 import { getProject } from "../persistence/projects-changes.js";
-import { readManagerAgentConfig, saveManagerAgentConfig } from "../persistence/manager-agent-config.js";
+import { readManagerAgentConfig } from "../persistence/manager-agent-config.js";
 import { normalizeStatus } from "../persistence/status.js";
 import {
   resolveManagerAgentConfig,
@@ -20,7 +20,11 @@ import {
   runManagerAgentTurnStream,
   type RunManagerAgentTurnInput,
 } from "./manager-agent-runtime.js";
-import { validateConfigPatch } from "./manager-agent-config.js";
+import {
+  ManagerAgentConfigValidationError,
+  validateAndSaveManagerAgentConfig,
+  type ManagerAgentConfigRoutesOptions,
+} from "./manager-agent-config.js";
 import { resolveCodexBinary, runCodexCommandSync } from "./codex-binary.js";
 import { managerAgentRuntimePlacementForHarness, normalizeManagerAgentHarness } from "homerail-protocol";
 import {
@@ -356,9 +360,11 @@ function readConfig(): Record<string, unknown> {
   }
 }
 
-function saveConfig(patch: Record<string, unknown>): Record<string, unknown> {
-  validateConfigPatch(patch);
-  const saved = saveManagerAgentConfig(patch) as unknown as Record<string, unknown>;
+async function saveConfig(
+  patch: Record<string, unknown>,
+  options: ManagerAgentConfigRoutesOptions,
+): Promise<Record<string, unknown>> {
+  const saved = await validateAndSaveManagerAgentConfig(patch, options) as unknown as Record<string, unknown>;
   return voiceCompatConfig(saved);
 }
 
@@ -1187,6 +1193,7 @@ export function voiceAgentBootstrapHandler(
   req: http.IncomingMessage,
   res: http.ServerResponse,
   managerAgentOptions?: ManagerAgentContainerOptions,
+  managerAgentConfigOptions: ManagerAgentConfigRoutesOptions = {},
 ): boolean {
   const url = new URL(req.url || "/", "http://localhost");
   const pathname = url.pathname;
@@ -1256,8 +1263,17 @@ export function voiceAgentBootstrapHandler(
 
   if (method === "PUT" && pathname === "/api/voice-agent/config") {
     readJsonBody(req)
-      .then((body) => ok(res, "Voice Agent config saved", saveConfig(body)))
-      .catch((err) => serverError(res, err instanceof Error ? err.message : String(err)));
+      .then(async (body) => {
+        try {
+          const next = await saveConfig(body, managerAgentConfigOptions);
+          ok(res, "Voice Agent config saved", next);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          if (err instanceof ManagerAgentConfigValidationError) badRequest(res, message);
+          else serverError(res, message);
+        }
+      })
+      .catch((err) => badRequest(res, err instanceof Error ? err.message : "Invalid JSON body"));
     return true;
   }
 

--- a/homerail_manager/tests/codex-models.test.ts
+++ b/homerail_manager/tests/codex-models.test.ts
@@ -175,4 +175,74 @@ describe("Codex model catalog", () => {
     expect(response.status).toBe(200);
     expect(body).toMatchObject({ success: true, data: catalog });
   });
+
+  it("rejects unsupported Codex reasoning efforts before saving Manager Agent config", async () => {
+    const catalog: CodexModelCatalog = {
+      binary: "C:\\Codex\\codex.exe",
+      models: [{
+        id: "gpt-5.5",
+        model: "gpt-5.5",
+        display_name: "GPT-5.5",
+        description: "",
+        is_default: true,
+        default_reasoning_effort: "medium",
+        supported_reasoning_efforts: ["low", "medium", "high", "xhigh"],
+        service_tiers: [],
+      }],
+    };
+    server = http.createServer((req, res) => {
+      managerAgentConfigRoutesHandler(req, res, { loadCodexModels: async () => catalog });
+    });
+    await new Promise<void>((resolve) => server?.listen(0, "127.0.0.1", () => resolve()));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("Expected TCP server address");
+
+    const response = await fetch(`http://127.0.0.1:${address.port}/api/manager-agent/config`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ harness: "codex_appserver", model_name: "gpt-5.5", reasoning_effort: "minimal" }),
+    });
+    const body = await response.json() as Record<string, unknown>;
+
+    expect(response.status).toBe(400);
+    expect(body).toMatchObject({
+      success: false,
+      error: "Codex model 'gpt-5.5' does not support reasoning effort 'minimal'. Supported values: low, medium, high, xhigh.",
+    });
+  });
+
+  it("rejects legacy Codex reasoning effort values before they can fall back to config.toml", async () => {
+    const catalog: CodexModelCatalog = {
+      binary: "C:\\Codex\\codex.exe",
+      models: [{
+        id: "gpt-5.5",
+        model: "gpt-5.5",
+        display_name: "GPT-5.5",
+        description: "",
+        is_default: true,
+        default_reasoning_effort: "medium",
+        supported_reasoning_efforts: ["low", "medium", "high", "xhigh"],
+        service_tiers: [],
+      }],
+    };
+    server = http.createServer((req, res) => {
+      managerAgentConfigRoutesHandler(req, res, { loadCodexModels: async () => catalog });
+    });
+    await new Promise<void>((resolve) => server?.listen(0, "127.0.0.1", () => resolve()));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("Expected TCP server address");
+
+    const response = await fetch(`http://127.0.0.1:${address.port}/api/manager-agent/config`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ harness: "codex_appserver", model_name: "gpt-5.5", reasoning_effort: "max" }),
+    });
+    const body = await response.json() as Record<string, unknown>;
+
+    expect(response.status).toBe(400);
+    expect(body).toMatchObject({
+      success: false,
+      error: "Unsupported Manager Agent reasoning effort 'max'. Supported values: minimal, low, medium, high, xhigh.",
+    });
+  });
 });

--- a/homerail_manager/tests/codex-models.test.ts
+++ b/homerail_manager/tests/codex-models.test.ts
@@ -52,7 +52,10 @@ describe("Codex model catalog", () => {
                 hidden: false,
                 isDefault: true,
                 defaultReasoningEffort: "medium",
-                supportedReasoningEfforts: [{ reasoningEffort: "medium" }, { reasoningEffort: "high" }],
+                supportedReasoningEfforts: [
+                  { reasoningEffort: "medium", description: "Balanced reasoning" },
+                  { reasoningEffort: "high", description: "Deeper reasoning" },
+                ],
                 serviceTiers: [{ id: "priority", name: "Fast", description: "Faster responses" }],
               },
               {
@@ -117,6 +120,10 @@ describe("Codex model catalog", () => {
           is_default: true,
           default_reasoning_effort: "medium",
           supported_reasoning_efforts: ["medium", "high"],
+          reasoning_effort_options: [
+            { reasoning_effort: "medium", description: "Balanced reasoning" },
+            { reasoning_effort: "high", description: "Deeper reasoning" },
+          ],
           service_tiers: [{ id: "priority", name: "Fast", description: "Faster responses" }],
         },
         {
@@ -127,6 +134,7 @@ describe("Codex model catalog", () => {
           is_default: false,
           default_reasoning_effort: "",
           supported_reasoning_efforts: [],
+          reasoning_effort_options: [],
           service_tiers: [],
         },
       ],
@@ -211,7 +219,7 @@ describe("Codex model catalog", () => {
     });
   });
 
-  it("rejects legacy Codex reasoning effort values before they can fall back to config.toml", async () => {
+  it("rejects a reasoning effort that the selected Codex model does not advertise", async () => {
     const catalog: CodexModelCatalog = {
       binary: "C:\\Codex\\codex.exe",
       models: [{
@@ -242,7 +250,91 @@ describe("Codex model catalog", () => {
     expect(response.status).toBe(400);
     expect(body).toMatchObject({
       success: false,
-      error: "Unsupported Manager Agent reasoning effort 'max'. Supported values: minimal, low, medium, high, xhigh.",
+      error: "Codex model 'gpt-5.5' does not support reasoning effort 'max'. Supported values: low, medium, high, xhigh.",
+    });
+  });
+
+  it("accepts Sol ultra reasoning and OpenAI's priority service tier", async () => {
+    const catalog: CodexModelCatalog = {
+      binary: "C:\\Codex\\codex.exe",
+      models: [{
+        id: "gpt-5.6-sol",
+        model: "gpt-5.6-sol",
+        display_name: "GPT-5.6-Sol",
+        description: "",
+        is_default: true,
+        default_reasoning_effort: "low",
+        supported_reasoning_efforts: ["low", "medium", "high", "xhigh", "max", "ultra"],
+        service_tiers: [{ id: "priority", name: "Fast", description: "1.5x speed, increased usage" }],
+      }],
+    };
+    server = http.createServer((req, res) => {
+      managerAgentConfigRoutesHandler(req, res, { loadCodexModels: async () => catalog });
+    });
+    await new Promise<void>((resolve) => server?.listen(0, "127.0.0.1", () => resolve()));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("Expected TCP server address");
+
+    const response = await fetch(`http://127.0.0.1:${address.port}/api/manager-agent/config`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        harness: "codex_appserver",
+        model_name: "gpt-5.6-sol",
+        reasoning_effort: "ultra",
+        service_tier: "priority",
+      }),
+    });
+    const body = await response.json() as Record<string, unknown>;
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      success: true,
+      data: {
+        model_name: "gpt-5.6-sol",
+        reasoning_effort: "ultra",
+        service_tier: "priority",
+      },
+    });
+  });
+
+  it("rejects service tiers not advertised by the selected model", async () => {
+    const catalog: CodexModelCatalog = {
+      binary: "C:\\Codex\\codex.exe",
+      models: [{
+        id: "gpt-5.6-sol",
+        model: "gpt-5.6-sol",
+        display_name: "GPT-5.6-Sol",
+        description: "",
+        is_default: true,
+        default_reasoning_effort: "low",
+        supported_reasoning_efforts: ["low", "medium", "high", "xhigh", "max", "ultra"],
+        service_tiers: [{ id: "priority", name: "Fast", description: "1.5x speed, increased usage" }],
+      }],
+    };
+    server = http.createServer((req, res) => {
+      managerAgentConfigRoutesHandler(req, res, { loadCodexModels: async () => catalog });
+    });
+    await new Promise<void>((resolve) => server?.listen(0, "127.0.0.1", () => resolve()));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("Expected TCP server address");
+
+    const response = await fetch(`http://127.0.0.1:${address.port}/api/manager-agent/config`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        harness: "codex_appserver",
+        model_name: "gpt-5.6-sol",
+        reasoning_effort: "low",
+        service_tier: "flex",
+      }),
+    });
+    const body = await response.json() as Record<string, unknown>;
+
+    expect(response.status).toBe(400);
+    expect(body).toMatchObject({
+      success: false,
+      error: "Codex model 'gpt-5.6-sol' does not support service tier 'flex'. Supported values: standard, priority.",
     });
   });
 });

--- a/homerail_manager/tests/host-codex-appserver-protocol.test.ts
+++ b/homerail_manager/tests/host-codex-appserver-protocol.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  _buildCodexThreadStartParamsForTest,
+  _buildCodexTurnStartParamsForTest,
+} from "../src/server/host-codex-manager-agent.js";
+
+describe("Host Codex app-server protocol params", () => {
+  it("passes HomeRail reasoning effort through thread config instead of the removed legacy field", () => {
+    const params = _buildCodexThreadStartParamsForTest({
+      systemPrompt: "You are HomeRail.",
+      cwd: "/workspace",
+      model: "gpt-5.5",
+      serviceTier: "fast",
+      sandbox: "workspace-write",
+      dynamicTools: [{ name: "write_widget_file" }],
+      reasoningEffort: "xhigh",
+    });
+
+    expect(params).toMatchObject({
+      model: "gpt-5.5",
+      config: { model_reasoning_effort: "xhigh" },
+    });
+    expect(params).not.toHaveProperty("modelReasoningEffort");
+  });
+
+  it("passes HomeRail reasoning effort through turn/start effort", () => {
+    const params = _buildCodexTurnStartParamsForTest({
+      threadId: "thread-1",
+      prompt: "Run this task.",
+      cwd: "/workspace",
+      model: "gpt-5.5",
+      reasoningEffort: "xhigh",
+    });
+
+    expect(params).toMatchObject({
+      threadId: "thread-1",
+      model: "gpt-5.5",
+      effort: "xhigh",
+      input: [{ type: "text", text: "Run this task.", text_elements: [] }],
+    });
+    expect(params).not.toHaveProperty("modelReasoningEffort");
+  });
+});

--- a/homerail_manager/tests/host-codex-appserver-protocol.test.ts
+++ b/homerail_manager/tests/host-codex-appserver-protocol.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  _buildCodexAppServerArgsForTest,
   _buildCodexThreadStartParamsForTest,
   _buildCodexTurnStartParamsForTest,
 } from "../src/server/host-codex-manager-agent.js";
@@ -11,15 +12,15 @@ describe("Host Codex app-server protocol params", () => {
       systemPrompt: "You are HomeRail.",
       cwd: "/workspace",
       model: "gpt-5.5",
-      serviceTier: "fast",
       sandbox: "workspace-write",
       dynamicTools: [{ name: "write_widget_file" }],
-      reasoningEffort: "xhigh",
+      reasoningEffort: "ultra",
     });
 
     expect(params).toMatchObject({
       model: "gpt-5.5",
-      config: { model_reasoning_effort: "xhigh" },
+      config: { model_reasoning_effort: "ultra" },
+      serviceTier: null,
     });
     expect(params).not.toHaveProperty("modelReasoningEffort");
   });
@@ -30,15 +31,21 @@ describe("Host Codex app-server protocol params", () => {
       prompt: "Run this task.",
       cwd: "/workspace",
       model: "gpt-5.5",
-      reasoningEffort: "xhigh",
+      reasoningEffort: "max",
+      serviceTier: "priority",
     });
 
     expect(params).toMatchObject({
       threadId: "thread-1",
       model: "gpt-5.5",
-      effort: "xhigh",
+      effort: "max",
+      serviceTier: "priority",
       input: [{ type: "text", text: "Run this task.", text_elements: [] }],
     });
     expect(params).not.toHaveProperty("modelReasoningEffort");
+  });
+
+  it("starts app-server without a hidden Fast service-tier override", () => {
+    expect(_buildCodexAppServerArgsForTest()).toEqual(["app-server"]);
   });
 });

--- a/homerail_manager/tests/manager-chat.test.ts
+++ b/homerail_manager/tests/manager-chat.test.ts
@@ -830,15 +830,25 @@ describe("/api/manager/chat", () => {
   });
 
   it("resolves codex_appserver as a Manager Agent harness without an LLM setting", () => {
-    const config = resolveManagerAgentConfig(undefined, undefined, "gpt-5.5", undefined, "codex_appserver");
+    const config = resolveManagerAgentConfig(
+      undefined,
+      undefined,
+      "gpt-5.6-sol",
+      undefined,
+      "codex_appserver",
+      "ultra",
+      "priority",
+    );
 
     expect(config).toMatchObject({
       provider_name: "",
-      model: "gpt-5.5",
+      model: "gpt-5.6-sol",
       agent_type: "codex_appserver",
       runtime_placement: "host",
       api_key: "",
       base_url: "",
+      reasoning_effort: "ultra",
+      service_tier: "priority",
     });
   });
 

--- a/homerail_manager/tests/manager-chat.test.ts
+++ b/homerail_manager/tests/manager-chat.test.ts
@@ -32,6 +32,21 @@ import {
   managerAgentHostPort,
   registerFakeDockerNode,
 } from "./helpers/fake-manager-agent-node.js";
+import type { CodexModelCatalog } from "../src/server/codex-models.js";
+
+const TEST_CODEX_MODEL_CATALOG: CodexModelCatalog = {
+  binary: "codex",
+  models: [{
+    id: "gpt-5.5",
+    model: "gpt-5.5",
+    display_name: "GPT-5.5",
+    description: "",
+    is_default: true,
+    default_reasoning_effort: "medium",
+    supported_reasoning_efforts: ["low", "medium", "high", "xhigh"],
+    service_tiers: [],
+  }],
+};
 
 async function listen(server: http.Server): Promise<number> {
   await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
@@ -70,7 +85,9 @@ describe("/api/manager/chat", () => {
     _clearAllSessions();
     _clearNodes();
     clearLlmSettings();
-    server = createServer(0, undefined, undefined, false);
+    server = createServer(0, undefined, undefined, false, {
+      loadCodexModels: async () => TEST_CODEX_MODEL_CATALOG,
+    });
   });
 
   afterEach(async () => {

--- a/homerail_manager/tests/voice-bootstrap.test.ts
+++ b/homerail_manager/tests/voice-bootstrap.test.ts
@@ -22,6 +22,21 @@ import {
 } from "../src/server/host-codex-manager-agent.js";
 import { _clearNodes } from "../src/node/registry.js";
 import { managerAgentHostPort, registerFakeDockerNode } from "./helpers/fake-manager-agent-node.js";
+import type { CodexModelCatalog } from "../src/server/codex-models.js";
+
+const TEST_CODEX_MODEL_CATALOG: CodexModelCatalog = {
+  binary: "codex",
+  models: [{
+    id: "gpt-5.5",
+    model: "gpt-5.5",
+    display_name: "GPT-5.5",
+    description: "",
+    is_default: true,
+    default_reasoning_effort: "medium",
+    supported_reasoning_efforts: ["low", "medium", "high", "xhigh"],
+    service_tiers: [],
+  }],
+};
 
 async function listen(server: http.Server): Promise<number> {
   await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
@@ -83,7 +98,9 @@ describe("voice bootstrap routes", () => {
     _clearStoredVoiceSettings();
     _clearAllSettings();
     _clearNodes();
-    server = createServer(0, undefined, undefined, false);
+    server = createServer(0, undefined, undefined, false, {
+      loadCodexModels: async () => TEST_CODEX_MODEL_CATALOG,
+    });
   });
 
   afterEach(async () => {
@@ -131,6 +148,42 @@ describe("voice bootstrap routes", () => {
     expect(response.status).toBe(200);
     expect(body.success).toBe(true);
     expect(body.data.agent_type).toBe("manager_agent");
+  });
+
+  it("rejects unsupported Codex reasoning efforts through the legacy config route without persisting", async () => {
+    const port = await listen(server);
+    const baseUrl = `http://127.0.0.1:${port}`;
+
+    const response = await fetch(`${baseUrl}/api/voice-agent/config`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        harness: "codex_appserver",
+        model_name: "gpt-5.5",
+        reasoning_effort: "minimal",
+      }),
+    });
+    const body = await response.json() as { success: boolean; error: string };
+
+    expect(response.status).toBe(400);
+    expect(body).toMatchObject({
+      success: false,
+      error: "Codex model 'gpt-5.5' does not support reasoning effort 'minimal'. Supported values: low, medium, high, xhigh.",
+    });
+    expect(getDb()
+      .prepare("SELECT id FROM manager_agent_config WHERE id = ?")
+      .get("default"))
+      .toBeUndefined();
+
+    const stored = await fetch(`${baseUrl}/api/manager-agent/config`);
+    const storedBody = await stored.json() as {
+      data: { harness: string; model_name: string | null; reasoning_effort: string };
+    };
+    expect(storedBody.data).toMatchObject({
+      harness: "claude_agent_sdk",
+      model_name: null,
+      reasoning_effort: "low",
+    });
   });
 
   it("stores and returns the current-session pointer for cross-device sync", async () => {

--- a/homerail_manager/tests/voice-bootstrap.test.ts
+++ b/homerail_manager/tests/voice-bootstrap.test.ts
@@ -100,6 +100,7 @@ describe("voice bootstrap routes", () => {
     _clearNodes();
     server = createServer(0, undefined, undefined, false, {
       loadCodexModels: async () => TEST_CODEX_MODEL_CATALOG,
+      autoDetectCodex: true,
     });
   });
 
@@ -143,11 +144,54 @@ describe("voice bootstrap routes", () => {
   it("keeps voice-agent config readable without creating workspaces", async () => {
     const port = await listen(server);
     const response = await fetch(`http://127.0.0.1:${port}/api/voice-agent/config`);
-    const body = await response.json() as { success: boolean; data: { agent_type: string } };
+    const body = await response.json() as {
+      success: boolean;
+      data: { agent_type: string; harness: string; model_name: string; reasoning_effort: string };
+    };
 
     expect(response.status).toBe(200);
     expect(body.success).toBe(true);
-    expect(body.data.agent_type).toBe("manager_agent");
+    expect(body.data).toMatchObject({
+      agent_type: "manager_agent",
+      harness: "codex_appserver",
+      model_name: "gpt-5.5",
+      reasoning_effort: "medium",
+    });
+  });
+
+  it("keeps an available user-configured Claude SDK runtime ahead of Codex auto-detection", async () => {
+    upsertProvider({
+      id: "claude-priority",
+      name: "Claude Priority",
+      default_model: "claude-priority-model",
+      base_url: "https://claude-priority.example/v1",
+      anthropic_base_url: "https://claude-priority.example/v1",
+    });
+    const setting = createSetting({
+      provider_id: "claude-priority",
+      endpoint_id: "custom",
+      model_name: "claude-priority-model",
+      api_key: "sk-claude-priority",
+      protocol: "anthropic_compatible",
+      base_url: "https://claude-priority.example/v1",
+      anthropic_base_url: "https://claude-priority.example/v1",
+      supports_llm: true,
+      is_active: true,
+      is_default: true,
+    });
+    const port = await listen(server);
+
+    const response = await fetch(`http://127.0.0.1:${port}/api/manager-agent/config`);
+    const body = await response.json() as {
+      data: { harness: string; llm_setting_id: string; model_name: string };
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.data).toMatchObject({
+      harness: "claude_agent_sdk",
+      llm_setting_id: setting.id,
+      model_name: "claude-priority-model",
+    });
   });
 
   it("rejects unsupported Codex reasoning efforts through the legacy config route without persisting", async () => {
@@ -174,16 +218,6 @@ describe("voice bootstrap routes", () => {
       .prepare("SELECT id FROM manager_agent_config WHERE id = ?")
       .get("default"))
       .toBeUndefined();
-
-    const stored = await fetch(`${baseUrl}/api/manager-agent/config`);
-    const storedBody = await stored.json() as {
-      data: { harness: string; model_name: string | null; reasoning_effort: string };
-    };
-    expect(storedBody.data).toMatchObject({
-      harness: "claude_agent_sdk",
-      model_name: null,
-      reasoning_effort: "low",
-    });
   });
 
   it("stores and returns the current-session pointer for cross-device sync", async () => {
@@ -367,6 +401,8 @@ describe("voice bootstrap routes", () => {
   });
 
   it("creates and processes a voice-agent workspace", async () => {
+    await close(server);
+    server = createServer(0, undefined, undefined, false, { autoDetectCodex: false });
     const port = await listen(server);
     const response = await fetch(`http://127.0.0.1:${port}/api/voice-agent/sessions`, {
       method: "POST",
@@ -713,6 +749,8 @@ describe("voice bootstrap routes", () => {
   });
 
   it("keeps project_id from stream turns when the workspace was created without one", async () => {
+    await close(server);
+    server = createServer(0, undefined, undefined, false, { autoDetectCodex: false });
     const port = await listen(server);
     const baseUrl = `http://127.0.0.1:${port}`;
     const created = await fetch(`${baseUrl}/api/voice-agent/sessions`, {

--- a/homerail_protocol/src/manager-agent.ts
+++ b/homerail_protocol/src/manager-agent.ts
@@ -23,7 +23,9 @@ export type ManagerAgentRuntimePlacement =
 // variants, but these canonical values should not be renamed casually.
 export type ManagerAgentRuntimeAgentType = "claude-sdk" | "codex_appserver" | "kimi_code";
 
-export type ManagerAgentReasoningEffort = "minimal" | "low" | "medium" | "high" | "xhigh";
+// app-server advertises model-specific, forward-compatible effort strings via model/list.
+export type ManagerAgentReasoningEffort = string;
+export type ManagerAgentServiceTier = string | null;
 
 export interface ManagerAgentHarnessDefinition {
   harness: ManagerAgentHarness;


### PR DESCRIPTION
## Context

Windows real-package validation found a Codex app-server protocol compatibility issue independent of the Windows console-window fix. HomeRail saved `reasoning_effort: xhigh`, but Codex 0.144.1 ignored the legacy `modelReasoningEffort` field and inherited `model_reasoning_effort = "max"` from the user config, causing `gpt-5.5` requests to fail with HTTP 400.

## Changes

- Send `thread/start` reasoning through `config.model_reasoning_effort`.
- Send `turn/start` reasoning through `effort`.
- Remove the old `modelReasoningEffort` request field from both app-server requests.
- Reject unsupported Manager Agent reasoning values such as `max` before saving.
- Validate Codex model/reasoning-effort combinations against `model/list` `supportedReasoningEfforts` before runtime.
- Add focused tests for app-server params and Codex model reasoning validation.

## Mac validation

- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run ci`
- Passed on macOS: typecheck, build:packages, and all package tests.
- Test totals: protocol 93, manager 228, node 158 passed / 1 skipped, worker 167 passed / 1 skipped, cli 177, agent-ui 56.

## Windows validation

Pending real-machine validation by the Homerail Win Build session.