### PR TITLE
ci: add GitHub-hosted validation workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,128 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  core-linux:
+    name: Core (Linux, Node 24)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: |
+            homerail_protocol/package-lock.json
+            homerail_manager/package-lock.json
+            homerail_node/package-lock.json
+            homerail_worker/package-lock.json
+            homerail_cli/package-lock.json
+            agent-ui/package-lock.json
+
+      - name: Install dependencies
+        run: npm run install:all
+
+      - name: Typecheck, build, and test
+        run: npm run ci
+
+  core-windows:
+    name: Core (Windows, Node 24)
+    runs-on: windows-latest
+    timeout-minutes: 25
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: |
+            homerail_protocol/package-lock.json
+            homerail_manager/package-lock.json
+            homerail_node/package-lock.json
+            homerail_worker/package-lock.json
+            homerail_cli/package-lock.json
+            agent-ui/package-lock.json
+
+      - name: Install dependencies
+        run: npm run install:all
+
+      - name: Typecheck, build, and test
+        run: npm run ci
+
+  agent-ui-coverage:
+    name: Agent UI coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: |
+            homerail_protocol/package-lock.json
+            agent-ui/package-lock.json
+
+      - name: Install dependencies
+        run: |
+          npm --prefix homerail_protocol ci
+          npm --prefix agent-ui ci
+
+      - name: Run full-source coverage
+        run: npm --prefix agent-ui run test:coverage
+
+  docker-smoke:
+    name: Docker smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: homerail_node/package-lock.json
+
+      - name: Install Node dependencies
+        run: npm --prefix homerail_node ci
+
+      - name: Run real Docker lifecycle test
+        env:
+          DOCKER_TEST: "1"
+        run: npm --prefix homerail_node test -- src/providers/__tests__/docker-cli-provider.integration.test.ts
+
+      - name: Build Worker image
+        run: docker build -t homerail-worker:ci -f homerail_worker/Dockerfile .

--- a/README.md
+++ b/README.md
@@ -84,6 +84,18 @@ npm run install:all
 npm run build
 ```
 
+Run the deterministic checks directly with `npm run ci`. To execute the Linux
+GitHub Actions jobs locally, install Docker, [`act`](https://github.com/nektos/act),
+and [`actionlint`](https://github.com/rhysd/actionlint), then run:
+
+```bash
+npm run ci:local
+npm run ci:local -- core-linux  # run one job
+```
+
+The local runner covers the Linux core, UI coverage, and Docker smoke jobs. The
+Windows job remains on GitHub's `windows-latest` runner.
+
 The CLI is exposed as `hr`. Link it locally so the rest of this guide works as
 written:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -49,6 +49,18 @@ npm run install:all
 npm run build
 ```
 
+直接运行确定性检查可使用 `npm run ci`。若要在本地执行 GitHub Actions 的
+Linux jobs，请先安装 Docker、[`act`](https://github.com/nektos/act) 和
+[`actionlint`](https://github.com/rhysd/actionlint)，然后运行：
+
+```bash
+npm run ci:local
+npm run ci:local -- core-linux  # 只运行一个 job
+```
+
+本地 Runner 覆盖 Linux 核心检查、UI 覆盖率和 Docker smoke；Windows job
+仍由 GitHub 的 `windows-latest` Runner 执行。
+
 CLI 通过 `hr` 暴露。先在本地 link 一下，后面的命令才能直接写成 `hr`：
 
 ```bash

--- a/agent-ui/src/api/agent/agent-evidence-api.test.ts
+++ b/agent-ui/src/api/agent/agent-evidence-api.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { http } from '../clients/http-client'
+import { agentEvidenceApi, getChange, getRun } from './agent-evidence-api'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('agent evidence API', () => {
+  it('encodes project, change, and run identifiers in raw requests', async () => {
+    const get = vi.spyOn(http, 'get').mockResolvedValue({ success: true, data: {} })
+
+    await getChange('project/a b', 'change/a b')
+    await getRun('run/a b')
+
+    expect(get).toHaveBeenNthCalledWith(1, '/api/projects/project%2Fa%20b/changes/change%2Fa%20b')
+    expect(get).toHaveBeenNthCalledWith(2, '/api/runs/run%2Fa%20b')
+  })
+
+  it('normalizes change evidence without leaking transport response fields', async () => {
+    vi.spyOn(http, 'get').mockResolvedValue({
+      success: true,
+      data: {
+        id: 'change-1',
+        project_id: 'project-1',
+        title: 'CI foundation',
+        status: 'ready',
+        diff_summary: 'Adds deterministic checks',
+        created_at: 'created'
+      },
+      message: 'ignored transport message'
+    })
+
+    await expect(agentEvidenceApi.getChangeEvidence('project-1', 'change-1')).resolves.toEqual({
+      id: 'change-1',
+      project_id: 'project-1',
+      title: 'CI foundation',
+      status: 'ready',
+      diff_summary: 'Adds deterministic checks',
+      created_at: 'created'
+    })
+  })
+
+  it('uses the same normalized run contract for summaries and details', async () => {
+    vi.spyOn(http, 'get')
+      .mockResolvedValueOnce({
+        success: true,
+        data: { run_id: 'run-1', status: 'completed', created_at: 'created' }
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        data: { id: 'run-2', status: 'failed', completed_at: 'completed' }
+      })
+
+    await expect(agentEvidenceApi.getRunSummary('run-1')).resolves.toEqual({
+      id: 'run-1',
+      status: 'completed',
+      created_at: 'created',
+      completed_at: undefined
+    })
+    await expect(agentEvidenceApi.getRunDetail('run-2')).resolves.toEqual({
+      id: 'run-2',
+      status: 'failed',
+      created_at: '',
+      completed_at: 'completed'
+    })
+  })
+})

--- a/agent-ui/src/api/agent/agent-runtime-api.test.ts
+++ b/agent-ui/src/api/agent/agent-runtime-api.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { http } from '../clients/http-client'
+import {
+  agentRuntimeApi,
+  getManagerAgentConfig,
+  getRunAuditSummary,
+  invokeManagerAgent,
+  managerChat,
+  updateManagerAgentConfig
+} from './agent-runtime-api'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('agent runtime API', () => {
+  it('routes raw runtime operations and preserves abort signals', async () => {
+    const get = vi.spyOn(http, 'get').mockResolvedValue({ success: true, data: {} })
+    const post = vi.spyOn(http, 'post').mockResolvedValue({ success: true, data: {} })
+    const put = vi.spyOn(http, 'put').mockResolvedValue({ success: true, data: {} })
+    const controller = new AbortController()
+
+    await managerChat({ message: 'hello' }, controller.signal)
+    await managerChat({ message: 'without signal' })
+    await getManagerAgentConfig()
+    await updateManagerAgentConfig({ model_name: 'test-model' })
+    await invokeManagerAgent('run/a b', { prompt: 'review' })
+    await getRunAuditSummary('run/a b')
+
+    expect(post).toHaveBeenNthCalledWith(
+      1,
+      '/api/manager/chat',
+      { message: 'hello' },
+      { signal: controller.signal }
+    )
+    expect(post).toHaveBeenNthCalledWith(
+      2,
+      '/api/manager/chat',
+      { message: 'without signal' },
+      undefined
+    )
+    expect(get).toHaveBeenNthCalledWith(1, '/api/manager-agent/config')
+    expect(put).toHaveBeenCalledWith('/api/manager-agent/config', { model_name: 'test-model' })
+    expect(post).toHaveBeenNthCalledWith(3, '/api/runs/run%2Fa%20b/invoke', { prompt: 'review' })
+    expect(get).toHaveBeenNthCalledWith(2, '/api/runs/run%2Fa%20b/audit/summary')
+  })
+
+  it('normalizes Manager chat request and response fields', async () => {
+    const post = vi.spyOn(http, 'post').mockResolvedValue({
+      success: true,
+      data: { text: 'done', session_id: 'session-1' }
+    })
+    const controller = new AbortController()
+
+    await expect(
+      agentRuntimeApi.agentChat(
+        {
+          project_id: 'project-1',
+          message: 'review this',
+          session_id: 'session-1',
+          context: { harness: 'codex_appserver' }
+        },
+        controller.signal
+      )
+    ).resolves.toEqual({
+      reply: 'done',
+      session_id: 'session-1',
+      status: 'ok'
+    })
+    expect(post).toHaveBeenCalledWith(
+      '/api/manager/chat',
+      {
+        message: 'review this',
+        project_id: 'project-1',
+        session_id: 'session-1',
+        manager_agent_config: { harness: 'codex_appserver' }
+      },
+      { signal: controller.signal }
+    )
+  })
+
+  it('marks unsuccessful Manager chat responses as errors', async () => {
+    vi.spyOn(http, 'post').mockResolvedValue({
+      success: false,
+      data: { text: 'failed', session_id: 'session-2' }
+    })
+
+    await expect(
+      agentRuntimeApi.agentChat({
+        project_id: 'project-1',
+        message: 'fail'
+      })
+    ).resolves.toEqual({
+      reply: 'failed',
+      session_id: 'session-2',
+      status: 'error'
+    })
+  })
+
+  it('normalizes invoked Agent responses and defaults unknown status', async () => {
+    const post = vi
+      .spyOn(http, 'post')
+      .mockResolvedValueOnce({
+        success: true,
+        data: { prompt: 'implemented', instance_id: 'agent-1', status: 'completed' }
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        data: { prompt: 'queued', instance_id: 'agent-2' }
+      })
+
+    await expect(agentRuntimeApi.invokeAgent('run-1', { prompt: 'implement' })).resolves.toEqual({
+      reply: 'implemented',
+      session_id: 'agent-1',
+      status: 'completed'
+    })
+    await expect(agentRuntimeApi.invokeAgent('run-2', { prompt: 'queue' })).resolves.toEqual({
+      reply: 'queued',
+      session_id: 'agent-2',
+      status: 'unknown'
+    })
+  })
+
+  it('normalizes string and object audit summaries', async () => {
+    const get = vi
+      .spyOn(http, 'get')
+      .mockResolvedValueOnce({ success: true, data: 'plain summary' })
+      .mockResolvedValueOnce({ success: true, data: { summary: 'detailed', findings: 2 } })
+
+    await expect(agentRuntimeApi.getAuditSummary('run-1')).resolves.toEqual({
+      run_id: 'run-1',
+      summary: 'plain summary',
+      details: {}
+    })
+    await expect(agentRuntimeApi.getAuditSummary('run-2')).resolves.toEqual({
+      run_id: 'run-2',
+      summary: 'detailed',
+      details: { summary: 'detailed', findings: 2 }
+    })
+  })
+})

--- a/agent-ui/src/api/agent/agent-session-api.test.ts
+++ b/agent-ui/src/api/agent/agent-session-api.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { http } from '../clients/http-client'
+import {
+  agentSessionApi,
+  closeManagerSession,
+  deleteManagerSession,
+  getManagerSession,
+  getManagerSessionMessages,
+  listManagerSessions
+} from './agent-session-api'
+
+const rawSession = {
+  session_id: 'session/one',
+  project_id: 'project-1',
+  status: 'active',
+  created_at: 'created',
+  updated_at: 'updated',
+  metadata: { source: 'test' }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('agent session API', () => {
+  it('routes raw Manager session operations with encoded IDs and limits', async () => {
+    const get = vi.spyOn(http, 'get').mockResolvedValue({ success: true, data: {} })
+    const post = vi.spyOn(http, 'post').mockResolvedValue({ success: true, data: {} })
+    const remove = vi.spyOn(http, 'delete').mockResolvedValue({ success: true, data: {} })
+
+    await listManagerSessions('project-1', 12)
+    await getManagerSession('session/a b')
+    await getManagerSessionMessages('session/a b', 45)
+    await closeManagerSession('session/a b')
+    await deleteManagerSession('session/a b')
+
+    expect(get).toHaveBeenNthCalledWith(1, '/api/manager/sessions', {
+      params: { project_id: 'project-1', limit: 12 }
+    })
+    expect(get).toHaveBeenNthCalledWith(2, '/api/manager/sessions/session%2Fa%20b')
+    expect(get).toHaveBeenNthCalledWith(3, '/api/manager/sessions/session%2Fa%20b/messages', {
+      params: { limit: 45 }
+    })
+    expect(post).toHaveBeenCalledWith('/api/manager/sessions/session%2Fa%20b/close')
+    expect(remove).toHaveBeenCalledWith('/api/manager/sessions/session%2Fa%20b')
+  })
+
+  it('creates native sessions and normalizes native text turns', async () => {
+    const post = vi
+      .spyOn(http, 'post')
+      .mockResolvedValueOnce({ success: true, data: rawSession })
+      .mockResolvedValueOnce({
+        success: true,
+        data: {
+          session_id: 'session/one',
+          run_id: 'run-1',
+          turn_id: 'turn-1',
+          user_message: { type: 'user', content: 'hello', run_id: 'run-1' },
+          assistant_message: {
+            role: 'assistant',
+            content: { answer: 'world' },
+            evidence_id: 'evidence-1'
+          }
+        }
+      })
+
+    await expect(
+      agentSessionApi.createNativeSession({ session_id: 'session/one' })
+    ).resolves.toMatchObject({ id: 'session/one', metadata: { source: 'test' } })
+    await expect(
+      agentSessionApi.submitNativeTextTurn('session/one', { message: 'hello' })
+    ).resolves.toEqual({
+      session_id: 'session/one',
+      run_id: 'run-1',
+      turn_id: 'turn-1',
+      user_message: {
+        role: 'user',
+        content: 'hello',
+        timestamp: '',
+        run_id: 'run-1',
+        evidence_id: undefined
+      },
+      assistant_message: {
+        role: 'assistant',
+        content: '{"answer":"world"}',
+        timestamp: '',
+        run_id: undefined,
+        evidence_id: 'evidence-1'
+      }
+    })
+    expect(post).toHaveBeenNthCalledWith(1, '/api/agent/sessions', {
+      session_id: 'session/one'
+    })
+    expect(post).toHaveBeenNthCalledWith(2, '/api/agent/sessions/session%2Fone/turns', {
+      message: 'hello'
+    })
+  })
+
+  it('normalizes native session details and messages', async () => {
+    const get = vi
+      .spyOn(http, 'get')
+      .mockResolvedValueOnce({ success: true, data: rawSession })
+      .mockResolvedValueOnce({
+        success: true,
+        data: { messages: [{ role: 'assistant', content: 'ready' }] }
+      })
+
+    await expect(agentSessionApi.getNativeSession('session/one')).resolves.toMatchObject({
+      id: 'session/one',
+      project_id: 'project-1'
+    })
+    await expect(agentSessionApi.getNativeSessionMessages('session/one')).resolves.toEqual([
+      {
+        role: 'assistant',
+        content: 'ready',
+        timestamp: '',
+        run_id: undefined,
+        evidence_id: undefined
+      }
+    ])
+    expect(get).toHaveBeenNthCalledWith(1, '/api/agent/sessions/session%2Fone')
+    expect(get).toHaveBeenNthCalledWith(2, '/api/agent/sessions/session%2Fone/messages')
+  })
+
+  it('supports wrapped and direct Manager session collections', async () => {
+    vi.spyOn(http, 'get')
+      .mockResolvedValueOnce({ success: true, data: { sessions: [rawSession] } })
+      .mockResolvedValueOnce({ success: true, data: [rawSession] })
+      .mockResolvedValueOnce({ success: true, data: rawSession })
+      .mockResolvedValueOnce({
+        success: true,
+        data: { messages: [{ role: 'user', content: 'wrapped' }] }
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        data: [{ role: 'assistant', content: 'direct' }]
+      })
+
+    await expect(agentSessionApi.listSessions('project-1')).resolves.toHaveLength(1)
+    await expect(agentSessionApi.listSessions('project-1', 4)).resolves.toHaveLength(1)
+    await expect(agentSessionApi.getSession('session/one')).resolves.toMatchObject({
+      id: 'session/one'
+    })
+    await expect(agentSessionApi.getSessionMessages('session/one')).resolves.toEqual([
+      expect.objectContaining({ content: 'wrapped' })
+    ])
+    await expect(agentSessionApi.getSessionMessages('session/one', 5)).resolves.toEqual([
+      expect.objectContaining({ content: 'direct' })
+    ])
+  })
+
+  it('closes and deletes sessions without returning transport responses', async () => {
+    const post = vi.spyOn(http, 'post').mockResolvedValue({ success: true, data: {} })
+    const remove = vi.spyOn(http, 'delete').mockResolvedValue({ success: true, data: {} })
+
+    await expect(agentSessionApi.closeSession('session/one')).resolves.toBeUndefined()
+    await expect(agentSessionApi.deleteSession('session/one')).resolves.toBeUndefined()
+    expect(post).toHaveBeenCalledOnce()
+    expect(remove).toHaveBeenCalledOnce()
+  })
+})

--- a/agent-ui/src/api/agent/agent-voice-bridge.test.ts
+++ b/agent-ui/src/api/agent/agent-voice-bridge.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { agentSessionApi } from './agent-session-api'
+import { createVoiceModeSession, runVoiceTextTurn, submitVoiceTextTurn } from './agent-voice-bridge'
+
+const session = {
+  id: 'session-1',
+  project_id: '',
+  status: 'active',
+  created_at: 'created',
+  updated_at: 'updated'
+}
+
+const turn = {
+  session_id: 'session-1',
+  run_id: 'run-1',
+  turn_id: 'turn-1',
+  user_message: { role: 'user', content: 'Review' },
+  assistant_message: { role: 'assistant', content: 'Done' }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('Agent voice-text bridge', () => {
+  it('creates a native session and merges caller-provided voice metadata', async () => {
+    const create = vi.spyOn(agentSessionApi, 'createNativeSession').mockResolvedValue(session)
+
+    await expect(
+      createVoiceModeSession({ source: 'attempted-override', locale: 'zh-CN' })
+    ).resolves.toBe(session)
+    expect(create).toHaveBeenCalledWith({
+      metadata: {
+        voice_mode: true,
+        source: 'attempted-override',
+        locale: 'zh-CN'
+      }
+    })
+  })
+
+  it('submits voice text through the native session turn endpoint', async () => {
+    const submit = vi.spyOn(agentSessionApi, 'submitNativeTextTurn').mockResolvedValue(turn)
+
+    await expect(submitVoiceTextTurn('session-1', 'Review')).resolves.toBe(turn)
+    expect(submit).toHaveBeenCalledWith('session-1', { message: 'Review' })
+  })
+
+  it('creates a session before submitting the convenience text turn', async () => {
+    const create = vi.spyOn(agentSessionApi, 'createNativeSession').mockResolvedValue(session)
+    const submit = vi.spyOn(agentSessionApi, 'submitNativeTextTurn').mockResolvedValue(turn)
+
+    await expect(runVoiceTextTurn('Review')).resolves.toEqual({ session, turn })
+    expect(create).toHaveBeenCalledBefore(submit)
+    expect(submit).toHaveBeenCalledWith('session-1', { message: 'Review' })
+  })
+})

--- a/agent-ui/src/api/agent/agent.types.test.ts
+++ b/agent-ui/src/api/agent/agent.types.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  asAgentRecord,
+  getAgentArray,
+  getAgentDataPayload,
+  normalizeChatMessage,
+  normalizeProject,
+  normalizeRunSummary,
+  normalizeSession
+} from './agent.types'
+
+describe('agent facade normalization', () => {
+  it('rejects arrays and primitives as records and arrays only real arrays', () => {
+    expect(asAgentRecord(null)).toEqual({})
+    expect(asAgentRecord(['not', 'a', 'record'])).toEqual({})
+    expect(asAgentRecord({ id: 'record' })).toEqual({ id: 'record' })
+    expect(getAgentArray({ 0: 'not-an-array' })).toEqual([])
+    expect(getAgentArray(['message'])).toEqual(['message'])
+  })
+
+  it('unwraps data payloads without discarding unwrapped responses', () => {
+    expect(getAgentDataPayload({ data: { id: 'wrapped' } })).toEqual({ id: 'wrapped' })
+    expect(getAgentDataPayload({ id: 'direct' })).toEqual({ id: 'direct' })
+  })
+
+  it('normalizes projects and sessions with stable empty defaults', () => {
+    expect(normalizeProject({ id: 'p1', name: 'HomeRail', status: 'active' })).toEqual({
+      id: 'p1',
+      name: 'HomeRail',
+      description: '',
+      status: 'active',
+      created_at: '',
+      updated_at: ''
+    })
+    expect(normalizeSession({ session_id: 's1', metadata: null })).toEqual({
+      id: 's1',
+      project_id: '',
+      status: '',
+      created_at: '',
+      updated_at: '',
+      metadata: {}
+    })
+  })
+
+  it('normalizes text and structured chat content without losing evidence fields', () => {
+    expect(
+      normalizeChatMessage({
+        type: 'assistant',
+        content: { answer: 42 },
+        created_at: '2026-07-10T00:00:00Z',
+        run_id: 'run-1',
+        evidence_id: 'evidence-1'
+      })
+    ).toEqual({
+      role: 'assistant',
+      content: '{"answer":42}',
+      timestamp: '2026-07-10T00:00:00Z',
+      run_id: 'run-1',
+      evidence_id: 'evidence-1'
+    })
+  })
+
+  it('accepts both run_id and id when normalizing run summaries', () => {
+    expect(normalizeRunSummary({ run_id: 'run-1', status: 'completed' })).toEqual({
+      id: 'run-1',
+      status: 'completed',
+      created_at: '',
+      completed_at: undefined
+    })
+    expect(normalizeRunSummary({ id: 'run-2', completed_at: 'later' }).id).toBe('run-2')
+  })
+})

--- a/agent-ui/src/api/clients/http-client.test.ts
+++ b/agent-ui/src/api/clients/http-client.test.ts
@@ -1,0 +1,151 @@
+import axios, {
+  AxiosError,
+  type AxiosAdapter,
+  type AxiosResponse,
+  type InternalAxiosRequestConfig
+} from 'axios'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import HttpClient from './http-client'
+
+const originalAdapter = axios.defaults.adapter
+
+function response(config: InternalAxiosRequestConfig, data: unknown, status = 200): AxiosResponse {
+  return {
+    config,
+    data,
+    headers: {},
+    status,
+    statusText: status >= 400 ? 'Error' : 'OK'
+  }
+}
+
+function clientWithAdapter(adapter: AxiosAdapter): HttpClient {
+  axios.defaults.adapter = adapter
+  return new HttpClient({ baseURL: 'https://manager.test', timeout: 1234 })
+}
+
+function rejectingAdapter(status: number, data: unknown): AxiosAdapter {
+  return async config => {
+    throw new AxiosError(
+      'Request failed',
+      'ERR_BAD_RESPONSE',
+      config,
+      {},
+      response(config, data, status)
+    )
+  }
+}
+
+afterEach(() => {
+  axios.defaults.adapter = originalAdapter
+  localStorage.clear()
+})
+
+describe('HttpClient', () => {
+  it('sends every HTTP verb through Axios and injects the auth token', async () => {
+    const requests: InternalAxiosRequestConfig[] = []
+    const adapter: AxiosAdapter = async config => {
+      requests.push(config)
+      return response(config, {
+        success: true,
+        data: { method: config.method, url: config.url }
+      })
+    }
+    const client = clientWithAdapter(adapter)
+    client.setToken('test-token')
+
+    await client.get('/items', { params: { page: 2 } })
+    await client.post('/items', { name: 'created' })
+    await client.put('/items/1', { name: 'replaced' })
+    await client.patch('/items/1', { name: 'patched' })
+    await client.delete('/items/1')
+
+    expect(requests.map(request => request.method)).toEqual([
+      'get',
+      'post',
+      'put',
+      'patch',
+      'delete'
+    ])
+    expect(requests[0]?.headers.get('Authorization')).toBe('Bearer test-token')
+    expect(requests[0]?.params).toEqual({ page: 2 })
+    expect(JSON.parse(String(requests[1]?.data))).toEqual({ name: 'created' })
+  })
+
+  it('updates the base URL used by later requests', async () => {
+    const requests: InternalAxiosRequestConfig[] = []
+    const client = clientWithAdapter(async config => {
+      requests.push(config)
+      return response(config, { success: true, data: null })
+    })
+
+    expect(client.getBaseURL()).toBe('https://manager.test')
+    client.setBaseURL('https://manager-2.test')
+    await client.get('/health')
+
+    expect(client.getBaseURL()).toBe('https://manager-2.test')
+    expect(requests[0]?.baseURL).toBe('https://manager-2.test')
+  })
+
+  it('turns a 200 business failure into a structured API error', async () => {
+    const client = clientWithAdapter(async config =>
+      response(config, {
+        success: false,
+        error: 'Model is unavailable',
+        data: { provider: 'test' }
+      })
+    )
+
+    await expect(client.get('/models')).rejects.toEqual({
+      message: 'Model is unavailable',
+      code: 400,
+      details: { provider: 'test' }
+    })
+  })
+
+  it('clears the stored token after an unauthorized response', async () => {
+    const client = clientWithAdapter(rejectingAdapter(401, { message: 'expired' }))
+    client.setToken('expired-token')
+
+    await expect(client.get('/private')).rejects.toEqual({
+      message: 'Authentication required',
+      code: 401
+    })
+    expect(localStorage.getItem('omni_auth_token')).toBeNull()
+  })
+
+  it.each([
+    [403, { message: 'ignored' }, 'Access forbidden'],
+    [404, { error: { message: 'Missing run' } }, 'Missing run'],
+    [409, { message: 'Run is active' }, 'Run is active'],
+    [422, { detail: 'Invalid field', details: { field: 'name' } }, 'Invalid field'],
+    [400, { error: 'Bad input' }, 'Bad input'],
+    [500, { message: 'Manager failed' }, 'Manager failed'],
+    [418, {}, 'HTTP Error: 418']
+  ])('maps HTTP %i responses to a stable API error', async (status, data, message) => {
+    const client = clientWithAdapter(rejectingAdapter(status, data))
+
+    await expect(client.get('/failure')).rejects.toMatchObject({
+      message,
+      code: status
+    })
+  })
+
+  it('distinguishes network failures from request configuration failures', async () => {
+    const networkClient = clientWithAdapter(async config => {
+      throw new AxiosError('offline', 'ERR_NETWORK', config, {})
+    })
+    await expect(networkClient.get('/health')).rejects.toEqual({
+      message: 'Network error - no response received',
+      code: 0
+    })
+
+    const configClient = clientWithAdapter(async config => {
+      throw new AxiosError('Invalid adapter configuration', 'ERR_BAD_OPTION', config)
+    })
+    await expect(configClient.get('/health')).rejects.toEqual({
+      message: 'Invalid adapter configuration'
+    })
+  })
+})

--- a/agent-ui/src/api/services/dag-api.test.ts
+++ b/agent-ui/src/api/services/dag-api.test.ts
@@ -1,0 +1,240 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { http } from '../clients/http-client'
+import {
+  getDagEvents,
+  getDagExperienceIngestStatus,
+  getDagManagerChat,
+  getDagNodeChat,
+  getDagNodeDetail,
+  getDagRunMetrics,
+  getDagStatus,
+  retryDagExperienceIngest
+} from './dag-api'
+
+function backendDag(overrides: Record<string, unknown> = {}) {
+  return {
+    instance_id: 'run-1',
+    graph: {
+      nodes: [
+        { node_id: 'plan', name: 'Plan' },
+        { node_id: 'review', name: 'Review' }
+      ],
+      edges: [
+        { from_node: 'plan', to_node: 'review', condition: 'success' },
+        { from_node: 'review', to_node: '', condition: '' }
+      ]
+    },
+    execution: {
+      complete: false,
+      active_nodes: ['plan'],
+      completed_nodes: [],
+      failed_nodes: [],
+      ready_nodes: [],
+      node_count: 2,
+      nodes: {
+        plan: {
+          status: 'running',
+          retry_count: 1,
+          started_at: '2026-07-10T00:00:00Z',
+          completed_at: null,
+          token_usage: { input_tokens: 12, output_tokens: 4 },
+          context_limit: 1000,
+          context_usage_pct: 1.6,
+          latest_todos: [{ content: 'Inspect', status: 'in_progress' }]
+        }
+      },
+      ...overrides
+    }
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('DAG API', () => {
+  it('transforms graph and execution state into the UI DAG contract', async () => {
+    vi.spyOn(http, 'get').mockResolvedValue({ success: true, data: backendDag() })
+
+    await expect(getDagStatus('run-1')).resolves.toEqual({
+      dag_run_id: 'run-1',
+      status: 'running',
+      nodes: [
+        expect.objectContaining({
+          id: 'plan',
+          name: 'Plan',
+          status: 'running',
+          dependencies: [],
+          retry_count: 1,
+          started_at: '2026-07-10T00:00:00Z',
+          completed_at: undefined,
+          token_usage: {
+            input_tokens: 12,
+            output_tokens: 4,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0
+          },
+          context_limit: 1000,
+          context_usage_pct: 1.6,
+          latest_todos: [{ content: 'Inspect', status: 'in_progress' }]
+        }),
+        expect.objectContaining({
+          id: 'review',
+          status: 'pending',
+          dependencies: ['plan'],
+          token_usage: undefined
+        })
+      ],
+      edges: [
+        {
+          id: 'e-0',
+          source: 'plan',
+          target: 'review',
+          condition: 'success'
+        }
+      ]
+    })
+  })
+
+  it.each([
+    [{ complete: true, failed_nodes: [] }, 'completed'],
+    [{ complete: true, failed_nodes: ['review'] }, 'failed'],
+    [{ complete: false, active_nodes: [], ready_nodes: ['review'] }, 'running'],
+    [{ complete: false, active_nodes: [], ready_nodes: [] }, 'pending']
+  ])('derives the overall DAG status from execution state', async (execution, status) => {
+    vi.spyOn(http, 'get').mockResolvedValue({
+      success: true,
+      data: backendDag(execution)
+    })
+
+    await expect(getDagStatus('run-1')).resolves.toMatchObject({ status })
+  })
+
+  it('returns null for failed, empty, or malformed DAG responses', async () => {
+    vi.spyOn(http, 'get')
+      .mockResolvedValueOnce({ success: false, data: null })
+      .mockResolvedValueOnce({ success: true, data: null })
+      .mockResolvedValueOnce({ success: true, data: { graph: {} } })
+
+    await expect(getDagStatus('failed')).resolves.toBeNull()
+    await expect(getDagStatus('empty')).resolves.toBeNull()
+    await expect(getDagStatus('malformed')).resolves.toBeNull()
+  })
+
+  it('returns node details from the transport payload', async () => {
+    const detail = { id: 'plan', status: 'running' }
+    const get = vi.spyOn(http, 'get').mockResolvedValue({ success: true, data: detail })
+
+    await expect(getDagNodeDetail('run-1', 'plan')).resolves.toBe(detail)
+    expect(get).toHaveBeenCalledWith('/api/dag-status/run-1/node/plan')
+  })
+
+  it('converts worker chat events and filters diagnostic entries', async () => {
+    vi.spyOn(http, 'get').mockResolvedValue({
+      success: true,
+      data: {
+        messages: [
+          null,
+          { content: 'not-an-event' },
+          {
+            timestamp: '2026-07-10T00:00:00Z',
+            targetId: 'worker-1',
+            content: { event: 'text', text: 'Implemented' }
+          },
+          {
+            timestamp: '2026-07-10T00:00:01Z',
+            targetId: 'worker-1',
+            content: { type: 'content', content: 'Verified' }
+          },
+          {
+            targetId: 'worker-1',
+            content: { event: 'thinking', summary: 'Checking behavior' }
+          },
+          {
+            targetId: 'worker-1',
+            content: {
+              event: 'tool_use',
+              tool_id: 'tool-1',
+              tool_name: 'mcp__dag-tools__handoff',
+              tool_input: { artifact: 'review' }
+            }
+          },
+          {
+            targetId: 'worker-1',
+            content: {
+              event: 'tool_result',
+              tool_use_id: 'tool-1',
+              result_preview: 'done',
+              is_error: true
+            }
+          },
+          { content: { event: 'agent_debug', message: 'ignored' } }
+        ]
+      }
+    })
+
+    const messages = await getDagNodeChat('run-1', 'plan')
+
+    expect(messages).toHaveLength(5)
+    expect(messages[0]).toMatchObject({
+      type: 'text',
+      content: 'Implemented',
+      worker_id: 'worker-1'
+    })
+    expect(messages[1]).toMatchObject({ type: 'text', content: 'Verified' })
+    expect(messages[2]).toMatchObject({ type: 'thinking', content: 'Checking behavior' })
+    expect(messages[3]).toMatchObject({
+      type: 'tool_use',
+      message_id: 'tool-1',
+      tool_name: 'handoff',
+      tool_input: { artifact: 'review' }
+    })
+    expect(messages[4]).toMatchObject({
+      type: 'tool_result',
+      message_id: 'tool-1',
+      tool_result: 'done',
+      is_error: true
+    })
+  })
+
+  it('uses empty chat arrays when the backend omits messages', async () => {
+    vi.spyOn(http, 'get').mockResolvedValue({ success: true, data: {} })
+
+    await expect(getDagNodeChat('run-1', 'plan')).resolves.toEqual([])
+    await expect(getDagManagerChat('run-1')).resolves.toEqual([])
+  })
+
+  it('returns Manager chat and event history payloads', async () => {
+    const get = vi
+      .spyOn(http, 'get')
+      .mockResolvedValueOnce({ success: true, data: { messages: [{ type: 'text' }] } })
+      .mockResolvedValueOnce({ success: true, data: { events: [{ event_type: 'node_started' }] } })
+
+    await expect(getDagManagerChat('run-1')).resolves.toEqual([{ type: 'text' }])
+    await expect(getDagEvents('run-1')).resolves.toEqual([{ event_type: 'node_started' }])
+    expect(get).toHaveBeenNthCalledWith(1, '/api/dag-status/run-1/manager/chat')
+    expect(get).toHaveBeenNthCalledWith(2, '/api/dag-status/run-1/events/history')
+  })
+
+  it('handles optional metrics and experience-ingest payloads', async () => {
+    const get = vi
+      .spyOn(http, 'get')
+      .mockResolvedValueOnce({ success: false, data: null })
+      .mockResolvedValueOnce({ success: true, data: { total_tokens: 42 } })
+      .mockResolvedValueOnce({ success: true, data: null })
+      .mockResolvedValueOnce({ success: true, data: { status: 'completed' } })
+    const post = vi
+      .spyOn(http, 'post')
+      .mockResolvedValueOnce({ success: false, data: null })
+      .mockResolvedValueOnce({ success: true, data: { status: 'queued' } })
+
+    await expect(getDagRunMetrics('missing')).resolves.toBeNull()
+    await expect(getDagRunMetrics('run-1')).resolves.toEqual({ total_tokens: 42 })
+    await expect(getDagExperienceIngestStatus('missing')).resolves.toBeNull()
+    await expect(getDagExperienceIngestStatus('run-1')).resolves.toEqual({ status: 'completed' })
+    await expect(retryDagExperienceIngest('missing')).resolves.toBeNull()
+    await expect(retryDagExperienceIngest('run-1')).resolves.toEqual({ status: 'queued' })
+    expect(post).toHaveBeenLastCalledWith('/api/dag-status/run-1/experience-ingest/retry')
+  })
+})

--- a/agent-ui/src/stores/agent/message-mapper.test.ts
+++ b/agent-ui/src/stores/agent/message-mapper.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+
+import { mapManagerSessionMessages } from './message-mapper'
+
+describe('Manager session message mapper', () => {
+  it('maps conversation, thinking, tool, error, and fallback records', () => {
+    const mapped = mapManagerSessionMessages(
+      [
+        { message_type: 'user', content: { text: 'Review this PR' }, timestamp: 't1' },
+        { message_type: 'text', content: { content: 'Starting review' }, timestamp: 't2' },
+        { message_type: 'thinking', content: {}, timestamp: 't3' },
+        {
+          message_type: 'tool_usage',
+          content: {
+            tool_id: 'tool-1',
+            name: 'mcp__dag-tools__handoff',
+            input: { run_id: 'run-1', artifact: 'review', extra: true }
+          },
+          timestamp: 't4'
+        },
+        {
+          message_type: 'tool_result',
+          content: { tool_id: 'tool-1', output: { ok: true }, is_error: true },
+          timestamp: 't5'
+        },
+        {
+          message_type: 'tool_result',
+          content: { tool_id: 'orphan', tool_name: 'mcp__tools__read', content: 'fallback' },
+          timestamp: 't6'
+        },
+        { message_type: 'error', content: { message: 'Manager failed' }, timestamp: 't7' },
+        { message_type: 'unknown', content: { state: 'custom' }, timestamp: 't8' }
+      ],
+      'session-1'
+    )
+
+    expect(mapped).toHaveLength(7)
+    expect(mapped[0]).toMatchObject({ role: 'user', content: 'Review this PR', type: 'text' })
+    expect(mapped[1]).toMatchObject({ role: 'assistant', content: 'Starting review' })
+    expect(mapped[2]).toMatchObject({ type: 'thinking', content: 'Manager Agent 已分析请求' })
+    expect(mapped[3]).toMatchObject({
+      id: 'db-session-1-3',
+      type: 'tool_call',
+      toolId: 'tool-1',
+      toolName: 'handoff',
+      toolSummary: 'run_id, artifact, extra',
+      toolResult: '{\n  "ok": true\n}',
+      status: 'failed'
+    })
+    expect(mapped[4]).toMatchObject({
+      type: 'tool_call',
+      toolId: 'orphan',
+      toolName: 'read',
+      toolResult: 'fallback',
+      status: 'completed'
+    })
+    expect(mapped[5]).toMatchObject({ type: 'status', content: 'Manager failed' })
+    expect(mapped[6]).toMatchObject({ content: '{"state":"custom"}' })
+  })
+
+  it('supports string content and supplies timestamps when records omit them', () => {
+    const mapped = mapManagerSessionMessages(
+      [
+        { message_type: 'user', content: 'hello' },
+        { message_type: 'thinking', content: 'reasoning' },
+        { message_type: 'error', content: 'failed' }
+      ],
+      'session-2'
+    )
+
+    expect(mapped.map(message => message.content)).toEqual(['hello', 'reasoning', 'failed'])
+    expect(mapped.every(message => typeof message.timestamp === 'string')).toBe(true)
+  })
+})

--- a/agent-ui/src/stores/agent/persistence.test.ts
+++ b/agent-ui/src/stores/agent/persistence.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { clearAgentSession, loadAgentSession, saveAgentSession } from './persistence'
+
+afterEach(() => {
+  localStorage.clear()
+  vi.restoreAllMocks()
+})
+
+describe('Agent session persistence', () => {
+  it('saves and loads the current run, session, project, and Manager model', () => {
+    saveAgentSession({
+      runId: 'run-1',
+      sessionId: 'session-1',
+      projectId: 'project-1',
+      managerProviderName: 'openrouter',
+      managerModelName: 'hy3:free'
+    })
+
+    expect(loadAgentSession()).toEqual({
+      runId: 'run-1',
+      sessionId: 'session-1',
+      projectId: 'project-1',
+      managerProviderName: 'openrouter',
+      managerModelName: 'hy3:free'
+    })
+  })
+
+  it('normalizes invalid persisted fields and removes legacy messages', () => {
+    localStorage.setItem(
+      'omni-agent-session',
+      JSON.stringify({
+        runId: 42,
+        sessionId: 'session-1',
+        projectId: null,
+        managerProviderName: false,
+        managerModelName: 'model-1',
+        messages: [{ content: 'legacy payload' }]
+      })
+    )
+
+    expect(loadAgentSession()).toEqual({
+      runId: null,
+      sessionId: 'session-1',
+      projectId: null,
+      managerProviderName: null,
+      managerModelName: 'model-1'
+    })
+    expect(JSON.parse(localStorage.getItem('omni-agent-session') || '{}')).not.toHaveProperty(
+      'messages'
+    )
+  })
+
+  it('returns null for missing or corrupt storage', () => {
+    expect(loadAgentSession()).toBeNull()
+    localStorage.setItem('omni-agent-session', '{invalid json')
+    expect(loadAgentSession()).toBeNull()
+  })
+
+  it('ignores storage quota failures and clears persisted state', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('quota exceeded', 'QuotaExceededError')
+    })
+    expect(() => saveAgentSession({ runId: null, sessionId: null, projectId: null })).not.toThrow()
+
+    vi.restoreAllMocks()
+    localStorage.setItem('omni-agent-session', '{}')
+    clearAgentSession()
+    expect(localStorage.getItem('omni-agent-session')).toBeNull()
+  })
+})

--- a/agent-ui/vitest.config.ts
+++ b/agent-ui/vitest.config.ts
@@ -22,10 +22,10 @@ export default defineConfig({
         'coverage/'
       ],
       thresholds: {
-        branches: 6,
-        functions: 5,
-        lines: 8,
-        statements: 8
+        branches: 9,
+        functions: 9,
+        lines: 11,
+        statements: 11
       }
     },
     testTimeout: 30000,

--- a/agent-ui/vitest.config.ts
+++ b/agent-ui/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
+      include: ['src/**/*.{ts,vue}'],
       exclude: [
         'node_modules/',
         'src/tests/',
@@ -21,12 +22,10 @@ export default defineConfig({
         'coverage/'
       ],
       thresholds: {
-        global: {
-          branches: 80,
-          functions: 80,
-          lines: 80,
-          statements: 80
-        }
+        branches: 6,
+        functions: 5,
+        lines: 8,
+        statements: 8
       }
     },
     testTimeout: 30000,

--- a/homerail_manager/tests/agent-sessions.test.ts
+++ b/homerail_manager/tests/agent-sessions.test.ts
@@ -12,7 +12,7 @@ import {
   loadMessages,
   loadSession,
 } from "../src/persistence/agent-sessions.js";
-import { getDb } from "../src/persistence/db.js";
+import { closeDb, getDb } from "../src/persistence/db.js";
 import { _clearAllPersistence } from "../src/persistence/store.js";
 import { _clearActiveRuns, createActiveRun, getActiveRunCount } from "../src/runtime/active-runs.js";
 import { createServer } from "../src/server/http.js";
@@ -72,6 +72,7 @@ describe("/api/agent/sessions/:session_id/turns", () => {
     } else {
       process.env.HOMERAIL_HOME = oldHome;
     }
+    closeDb();
     fs.rmSync(tmpHome, { recursive: true, force: true });
   });
 

--- a/homerail_manager/tests/audit-summary.test.ts
+++ b/homerail_manager/tests/audit-summary.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { parseDAGYaml } from "../src/orchestration/yaml-loader.js";
+import { closeDb } from "../src/persistence/db.js";
 import { _clearAllPersistence } from "../src/persistence/store.js";
 import { _clearActiveRuns, createActiveRun } from "../src/runtime/active-runs.js";
 import { createServer } from "../src/server/http.js";
@@ -62,6 +63,7 @@ describe("audit summary", () => {
     } else {
       process.env.HOMERAIL_HOME = oldHome;
     }
+    closeDb();
     fs.rmSync(tmpHome, { recursive: true, force: true });
   });
 

--- a/homerail_manager/tests/helpers/fake-manager-agent-node.ts
+++ b/homerail_manager/tests/helpers/fake-manager-agent-node.ts
@@ -7,7 +7,22 @@ async function close(server: http.Server): Promise<void> {
   await new Promise<void>((resolve) => server.close(() => resolve()));
 }
 
+export async function findAvailableManagerAgentPort(): Promise<number> {
+  const server = http.createServer();
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    await close(server);
+    throw new Error("failed to allocate Manager Agent test port");
+  }
+  const port = address.port;
+  await close(server);
+  return port;
+}
+
 export function managerAgentHostPort(projectId?: string): number {
+  const fixed = process.env.HOMERAIL_MANAGER_AGENT_PORT;
+  if (fixed) return Number(fixed);
   const canonical = (projectId ?? "").trim().replace(/[^A-Za-z0-9_.-]/g, "-") || "__default__";
   const digest = createHash("sha256").update(canonical).digest("hex");
   return 39000 + (Number.parseInt(digest.slice(0, 8), 16) % 20000);

--- a/homerail_manager/tests/llm-providers.test.ts
+++ b/homerail_manager/tests/llm-providers.test.ts
@@ -12,7 +12,7 @@ import {
   resolveClaudeSdkBaseUrlForSetting,
   updateSetting,
 } from "../src/persistence/llm-settings.js";
-import { getDb } from "../src/persistence/db.js";
+import { closeDb, getDb } from "../src/persistence/db.js";
 import { createServer } from "../src/server/http.js";
 
 async function listen(server: http.Server): Promise<number> {
@@ -51,6 +51,7 @@ describe("custom LLM providers", () => {
     } else {
       process.env.HOMERAIL_HOME = oldHome;
     }
+    closeDb();
     fs.rmSync(tmpHome, { recursive: true, force: true });
   });
 

--- a/homerail_manager/tests/manager-chat.test.ts
+++ b/homerail_manager/tests/manager-chat.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { _clearActiveRuns } from "../src/runtime/active-runs.js";
 import { createServer } from "../src/server/http.js";
 import { _clearAllSessions, createSession as createAgentSession } from "../src/persistence/agent-sessions.js";
+import { closeDb } from "../src/persistence/db.js";
 import { createSetting, upsertProvider, _clearAllSettings as clearLlmSettings } from "../src/persistence/llm-settings.js";
 import { createProject } from "../src/persistence/projects-changes.js";
 import { ensureDefaultWorkspacePath } from "../src/config/env.js";
@@ -91,6 +92,7 @@ describe("/api/manager/chat", () => {
     else process.env.HOMERAIL_MANAGER_AGENT_HOST_ENTRY = oldHostEntry;
     if (oldHostShell === undefined) delete process.env.HOMERAIL_MANAGER_AGENT_SHELL;
     else process.env.HOMERAIL_MANAGER_AGENT_SHELL = oldHostShell;
+    closeDb();
     fs.rmSync(tmpHome, { recursive: true, force: true });
   });
 

--- a/homerail_manager/tests/manager-chat.test.ts
+++ b/homerail_manager/tests/manager-chat.test.ts
@@ -26,7 +26,11 @@ import {
   _voiceMemoPathForTest,
   _workspaceFromConfigForTest,
 } from "../src/server/host-codex-manager-agent.js";
-import { managerAgentHostPort, registerFakeDockerNode } from "./helpers/fake-manager-agent-node.js";
+import {
+  findAvailableManagerAgentPort,
+  managerAgentHostPort,
+  registerFakeDockerNode,
+} from "./helpers/fake-manager-agent-node.js";
 
 async function listen(server: http.Server): Promise<number> {
   await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
@@ -45,19 +49,22 @@ describe("/api/manager/chat", () => {
   let oldHome: string | undefined;
   let oldLocalNodeAutostart: string | undefined;
   let oldManagerRuntime: string | undefined;
+  let oldManagerAgentPort: string | undefined;
   let oldHostEntry: string | undefined;
   let oldHostShell: string | undefined;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     oldHome = process.env.HOMERAIL_HOME;
     oldLocalNodeAutostart = process.env.HOMERAIL_LOCAL_NODE_AUTOSTART;
     oldManagerRuntime = process.env.HOMERAIL_MANAGER_AGENT_RUNTIME;
+    oldManagerAgentPort = process.env.HOMERAIL_MANAGER_AGENT_PORT;
     oldHostEntry = process.env.HOMERAIL_MANAGER_AGENT_HOST_ENTRY;
     oldHostShell = process.env.HOMERAIL_MANAGER_AGENT_SHELL;
     tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-manager-chat-"));
     process.env.HOMERAIL_HOME = tmpHome;
     process.env.HOMERAIL_LOCAL_NODE_AUTOSTART = "0";
     process.env.HOMERAIL_MANAGER_AGENT_RUNTIME = "container";
+    process.env.HOMERAIL_MANAGER_AGENT_PORT = String(await findAvailableManagerAgentPort());
     _clearActiveRuns();
     _clearAllSessions();
     _clearNodes();
@@ -78,6 +85,8 @@ describe("/api/manager/chat", () => {
     else process.env.HOMERAIL_LOCAL_NODE_AUTOSTART = oldLocalNodeAutostart;
     if (oldManagerRuntime === undefined) delete process.env.HOMERAIL_MANAGER_AGENT_RUNTIME;
     else process.env.HOMERAIL_MANAGER_AGENT_RUNTIME = oldManagerRuntime;
+    if (oldManagerAgentPort === undefined) delete process.env.HOMERAIL_MANAGER_AGENT_PORT;
+    else process.env.HOMERAIL_MANAGER_AGENT_PORT = oldManagerAgentPort;
     if (oldHostEntry === undefined) delete process.env.HOMERAIL_MANAGER_AGENT_HOST_ENTRY;
     else process.env.HOMERAIL_MANAGER_AGENT_HOST_ENTRY = oldHostEntry;
     if (oldHostShell === undefined) delete process.env.HOMERAIL_MANAGER_AGENT_SHELL;

--- a/homerail_manager/tests/projects-contract.test.ts
+++ b/homerail_manager/tests/projects-contract.test.ts
@@ -4,7 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { getDb } from "../src/persistence/db.js";
+import { closeDb, getDb } from "../src/persistence/db.js";
 import { upsertDagSessionIndex } from "../src/persistence/dag-session-index.js";
 import { _clearAllChanges, _clearAllProjects } from "../src/persistence/projects-changes.js";
 import { createServer } from "../src/server/http.js";
@@ -42,6 +42,7 @@ describe("project settings API contract", () => {
     await close(server);
     if (oldHome === undefined) delete process.env.HOMERAIL_HOME;
     else process.env.HOMERAIL_HOME = oldHome;
+    closeDb();
     fs.rmSync(tmpHome, { recursive: true, force: true });
     fs.rmSync(workspaceDir, { recursive: true, force: true });
   });

--- a/homerail_manager/tests/secret-storage.test.ts
+++ b/homerail_manager/tests/secret-storage.test.ts
@@ -16,7 +16,7 @@ import {
   listServers as listMcpServers,
   toPublicServer,
 } from "../src/persistence/mcp-servers.js";
-import { getDb } from "../src/persistence/db.js";
+import { closeDb, getDb } from "../src/persistence/db.js";
 import { createServer as createHttpServer } from "../src/server/http.js";
 
 async function listen(server: http.Server): Promise<number> {
@@ -58,6 +58,7 @@ describe("Manager encrypted secret storage", () => {
     restoreEnv("HOMERAIL_HOME", oldHome);
     restoreEnv("HOMERAIL_MANAGER_SECRET_KEY", oldManagerSecretKey);
     restoreEnv("HOMERAIL_SECRET_KEY", oldSecretKey);
+    closeDb();
     fs.rmSync(tmpHome, { recursive: true, force: true });
   });
 

--- a/homerail_manager/tests/settings-bootstrap.test.ts
+++ b/homerail_manager/tests/settings-bootstrap.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { parseDAGYaml } from "../src/orchestration/yaml-loader.js";
+import { closeDb } from "../src/persistence/db.js";
 import { _clearAllPersistence } from "../src/persistence/store.js";
 import { _clearActiveRuns, createActiveRun } from "../src/runtime/active-runs.js";
 import { createServer } from "../src/server/http.js";
@@ -70,6 +71,7 @@ describe("settings bootstrap routes", () => {
     } else {
       process.env.HOMERAIL_ASSET_DIR = oldAssetDir;
     }
+    closeDb();
     fs.rmSync(tmpHome, { recursive: true, force: true });
   });
 

--- a/homerail_manager/tests/voice-session-registry.test.ts
+++ b/homerail_manager/tests/voice-session-registry.test.ts
@@ -14,7 +14,7 @@ import {
 } from "../src/server/voice-session-registry.js";
 import { _clearStoredConfig } from "../src/server/voice-agent-bootstrap.js";
 import { _clearStoredVoiceSettings } from "../src/server/voice.js";
-import { getDb } from "../src/persistence/db.js";
+import { closeDb, getDb } from "../src/persistence/db.js";
 import { _clearAllSettings } from "../src/persistence/llm-settings.js";
 import { _clearNodes } from "../src/node/registry.js";
 
@@ -58,6 +58,7 @@ describe("voice session registry", () => {
     _clearStoredVoiceSettings();
     _clearAllSettings();
     _clearNodes();
+    closeDb();
     fs.rmSync(tmpHome, { recursive: true, force: true });
   });
 

--- a/homerail_manager/tests/widget-file-protocol.test.ts
+++ b/homerail_manager/tests/widget-file-protocol.test.ts
@@ -3,6 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { closeDb } from "../src/persistence/db.js";
 
 import {
   readWidgetFile,
@@ -34,6 +35,7 @@ describe("Widget File Protocol", () => {
   afterEach(() => {
     if (oldHome === undefined) delete process.env.HOMERAIL_HOME;
     else process.env.HOMERAIL_HOME = oldHome;
+    closeDb();
     fs.rmSync(tmpHome, { recursive: true, force: true });
   });
 

--- a/homerail_node/src/control-plane/__tests__/lifecycle-handler.test.ts
+++ b/homerail_node/src/control-plane/__tests__/lifecycle-handler.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { normalizePath } from "../../platform/paths.js";
 import { MockProvider } from "../../providers/mock-provider.js";
 import {
   handleLifecycleRequest,
@@ -381,6 +382,7 @@ describe("handleLifecycleRequest", () => {
     });
 
     it("create worker accepts isolated workspace mode", async () => {
+      const previousHome = process.env.HOMERAIL_HOME;
       const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-node-isolated-"));
       process.env["HOMERAIL_HOME"] = tempHome;
       const provider = new MockProvider();
@@ -398,6 +400,11 @@ describe("handleLifecycleRequest", () => {
           send,
         );
       } finally {
+        if (previousHome === undefined) {
+          delete process.env.HOMERAIL_HOME;
+        } else {
+          process.env.HOMERAIL_HOME = previousHome;
+        }
         fs.rmSync(tempHome, { recursive: true, force: true });
       }
 
@@ -406,7 +413,9 @@ describe("handleLifecycleRequest", () => {
       expect(provider.containers.size).toBe(1);
       const data = responses[0]!.resource_data!;
       const container = provider.containers.get(String(data.id));
-      expect(container!.config.mounts![0]!.host).toBe(path.join(tempHome, "workspace", "run-isolated"));
+      expect(container!.config.mounts![0]!.host).toBe(
+        normalizePath(path.join(tempHome, "workspace", "run-isolated")),
+      );
     });
 
     it("create worker rejects unsupported workspace preparation modes", async () => {

--- a/homerail_node/src/providers/__tests__/docker-cli-provider.integration.test.ts
+++ b/homerail_node/src/providers/__tests__/docker-cli-provider.integration.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { DockerCliProvider } from "../docker-cli-provider.js";
+
+describe("DockerCliProvider (integration, real Docker)", () => {
+  const provider = new DockerCliProvider();
+  let containerId: string | null = null;
+
+  afterEach(async () => {
+    if (!containerId) return;
+    await provider.remove(containerId).catch(() => undefined);
+    containerId = null;
+  });
+
+  it.runIf(process.env["DOCKER_TEST"] === "1")(
+    "completes the container lifecycle",
+    async () => {
+      const created = await provider.create({
+        image: "node:22-alpine",
+        name: `homerail-smoke-test-${process.pid}`,
+        command: [
+          "/bin/sh",
+          "-c",
+          "while true; do sleep 3600; done",
+        ],
+      });
+      expect(created.status).toBe("created");
+      containerId = created.id;
+
+      await provider.start(containerId);
+
+      const result = await provider.exec(containerId, [
+        "node",
+        "-e",
+        "console.log('ok')",
+      ]);
+      expect(result.stdout.trim()).toBe("ok");
+      expect(result.exitCode).toBe(0);
+
+      await provider.stop(containerId);
+      await provider.remove(containerId);
+      containerId = null;
+    },
+    60_000,
+  );
+});

--- a/homerail_node/src/providers/__tests__/docker-cli-provider.test.ts
+++ b/homerail_node/src/providers/__tests__/docker-cli-provider.test.ts
@@ -492,36 +492,3 @@ describe("DockerCliProvider (unit, mocked)", () => {
     });
   });
 });
-
-describe("DockerCliProvider (integration — real Docker)", () => {
-  const provider = new DockerCliProvider();
-  const IMAGE = "node:20-alpine";
-  let containerId: string | null = null;
-
-  it.runIf(Boolean(process.env["CI"] || process.env["DOCKER_TEST"]))(
-    "full lifecycle: create -> start -> exec -> stop -> remove",
-    async () => {
-      const created = await provider.create({
-        image: IMAGE,
-        name: "homerail-smoke-test-it",
-      });
-      expect(created.status).toBe("created");
-      containerId = created.id;
-
-      await provider.start(containerId);
-
-      const result = await provider.exec(containerId, [
-        "node",
-        "-e",
-        "console.log('ok')",
-      ]);
-      expect(result.stdout.trim()).toBe("ok");
-      expect(result.exitCode).toBe(0);
-
-      await provider.stop(containerId);
-      await provider.remove(containerId);
-      containerId = null;
-    },
-    30000,
-  );
-});

--- a/homerail_node/src/storage/__tests__/workspace-prepare.test.ts
+++ b/homerail_node/src/storage/__tests__/workspace-prepare.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { normalizePath } from "../../platform/paths.js";
 import { prepareWorkerWorkspace } from "../workspace-prepare.js";
 
 describe("prepareWorkerWorkspace", () => {
@@ -19,9 +20,10 @@ describe("prepareWorkerWorkspace", () => {
 
   it("does nothing when no workspace spec is provided", async () => {
     const result = await prepareWorkerWorkspace("run-1/triage", undefined);
+    const expectedRoot = normalizePath(path.join(homerailHome, "workspace", "run-1", "triage"));
 
     expect(result).toEqual({
-      root: path.join(homerailHome, "workspace", "run-1", "triage"),
+      root: expectedRoot,
       prepared: false,
     });
     expect(fs.existsSync(result.root)).toBe(false);
@@ -29,6 +31,8 @@ describe("prepareWorkerWorkspace", () => {
 
   it("clones git workspace into repo under the worker workspace root", async () => {
     const calls: Array<{ command: string; args: string[]; cwd: string }> = [];
+    const expectedRoot = normalizePath(path.join(homerailHome, "workspace", "run-1", "triage"));
+    const expectedRepoPath = path.join(expectedRoot, "repo");
 
     const result = await prepareWorkerWorkspace(
       "run-1/triage",
@@ -45,8 +49,8 @@ describe("prepareWorkerWorkspace", () => {
     );
 
     expect(result.prepared).toBe(true);
-    expect(result.root).toBe(path.join(homerailHome, "workspace", "run-1", "triage"));
-    expect(result.repoPath).toBe(path.join(result.root, "repo"));
+    expect(result.root).toBe(expectedRoot);
+    expect(result.repoPath).toBe(expectedRepoPath);
     expect(calls).toEqual([
       {
         command: "git",
@@ -56,18 +60,19 @@ describe("prepareWorkerWorkspace", () => {
           "dev",
           "--single-branch",
           "https://example.com/acme/project.git",
-          path.join(result.root, "repo"),
+          expectedRepoPath,
         ],
-        cwd: result.root,
+        cwd: expectedRoot,
       },
     ]);
   });
 
   it("creates an empty workspace for isolated mode", async () => {
     const result = await prepareWorkerWorkspace("run-1", { mode: "isolated" });
+    const expectedRoot = normalizePath(path.join(homerailHome, "workspace", "run-1"));
 
     expect(result).toEqual({
-      root: path.join(homerailHome, "workspace", "run-1"),
+      root: expectedRoot,
       prepared: true,
     });
     expect(fs.existsSync(result.root)).toBe(true);
@@ -92,7 +97,10 @@ describe("prepareWorkerWorkspace", () => {
       );
 
       expect(result.prepared).toBe(true);
-      expect(result.repoPath).toBe(path.join(homerailHome, "workspace", "run-local-copy", "repo"));
+      expect(result.repoPath).toBe(path.join(
+        normalizePath(path.join(homerailHome, "workspace", "run-local-copy")),
+        "repo",
+      ));
       expect(fs.readFileSync(path.join(result.repoPath!, "src", "index.ts"), "utf-8")).toContain("value");
       expect(fs.existsSync(path.join(result.repoPath!, ".git", "HEAD"))).toBe(true);
       expect(fs.existsSync(path.join(result.repoPath!, "node_modules"))).toBe(false);
@@ -120,7 +128,7 @@ describe("prepareWorkerWorkspace", () => {
   });
 
   it("does not reclone an existing git workspace", async () => {
-    const root = path.join(homerailHome, "workspace", "run-1");
+    const root = normalizePath(path.join(homerailHome, "workspace", "run-1"));
     const repoPath = path.join(root, "repo");
     fs.mkdirSync(path.join(repoPath, ".git"), { recursive: true });
     const calls: Array<{ command: string; args: string[]; cwd: string }> = [];

--- a/homerail_worker/src/__tests__/codex-appserver.test.ts
+++ b/homerail_worker/src/__tests__/codex-appserver.test.ts
@@ -167,6 +167,15 @@ describe("CodexAppServerAdapter", () => {
     await expect(adapter.resume("s1")).rejects.toThrow("transcript resume is not implemented");
   });
 
+  it("uses a shell only for Windows command shims", async () => {
+    const { _codexWindowsCommandNeedsShellForTest } = await import("../agent/codex-appserver.js");
+
+    expect(_codexWindowsCommandNeedsShellForTest("C:\\Tools\\codex.cmd", "win32")).toBe(true);
+    expect(_codexWindowsCommandNeedsShellForTest("C:\\Tools\\codex.bat", "win32")).toBe(true);
+    expect(_codexWindowsCommandNeedsShellForTest("C:\\Tools\\codex.exe", "win32")).toBe(false);
+    expect(_codexWindowsCommandNeedsShellForTest("/usr/bin/codex.cmd", "linux")).toBe(false);
+  });
+
   it("emits error when codex binary not found", async () => {
     vi.doMock("node:fs", async () => {
       const actual = await vi.importActual<typeof import("node:fs")>("node:fs");

--- a/homerail_worker/src/__tests__/harness-simple-dag.test.ts
+++ b/homerail_worker/src/__tests__/harness-simple-dag.test.ts
@@ -72,6 +72,17 @@ function writeExecutable(dir: string, name: string, source: string): string {
   return file;
 }
 
+function writeCodexFixture(dir: string): string {
+  if (process.platform !== "win32") {
+    return writeExecutable(dir, "codex", codexFixtureSource());
+  }
+
+  const script = writeExecutable(dir, "codex-fixture.js", codexFixtureSource());
+  const shim = join(dir, "codex.cmd");
+  writeFileSync(shim, `@echo off\r\n"${process.execPath}" "${script}" %*\r\n`, "utf8");
+  return join(dir, "codex");
+}
+
 function kimiFixtureSource(): string {
   return `#!/usr/bin/env node
 const { spawn } = require("node:child_process");
@@ -245,7 +256,7 @@ describe.sequential("release harness simple DAG handoff", () => {
 
   it("runs a simple DAG handoff through codex_appserver", async () => {
     tempDir = mkdtempSync(join(tmpdir(), "homerail-codex-fixture-"));
-    const codexBin = writeExecutable(tempDir, "codex", codexFixtureSource());
+    const codexBin = writeCodexFixture(tempDir);
     vi.stubEnv("HOMERAIL_HOME", tempDir);
     registerAgentBackend("fixture-codex-appserver", () => new CodexAppServerAdapter(codexBin));
 

--- a/homerail_worker/src/agent/codex-appserver.ts
+++ b/homerail_worker/src/agent/codex-appserver.ts
@@ -53,8 +53,32 @@ function spawnProcess(bin: string, args: string[], env: Record<string, string | 
   return spawn(bin, args, {
     stdio: ["pipe", "pipe", "pipe"],
     env,
+    shell: windowsCommandNeedsShell(bin),
     windowsHide: true,
   });
+}
+
+function windowsCommandNeedsShell(command: string, platform = process.platform): boolean {
+  return platform === "win32" && /\.(cmd|bat)$/i.test(command);
+}
+
+function isPathLike(command: string): boolean {
+  return path.isAbsolute(command) || command.includes("/") || command.includes("\\");
+}
+
+function executableCandidates(command: string, platform = process.platform): string[] {
+  if (platform !== "win32" || /\.(exe|cmd|bat)$/i.test(command)) return [command];
+  const parsed = path.win32.parse(command);
+  return [".exe", ".cmd", ".bat"]
+    .map((extension) => path.win32.join(parsed.dir, `${parsed.base}${extension}`))
+    .concat(command);
+}
+
+function findExistingBinary(command: string): string | null {
+  for (const candidate of executableCandidates(command)) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return null;
 }
 
 export class CodexAppServerAdapter implements AgentClient {
@@ -585,15 +609,21 @@ export class CodexAppServerAdapter implements AgentClient {
   }
 
   private async validateBinary(): Promise<void> {
-    if (this.codexBin !== DEFAULT_CODEX_BIN && this.codexBin.includes(path.sep)) {
-      if (!fs.existsSync(this.codexBin)) {
+    if (isPathLike(this.codexBin)) {
+      const found = findExistingBinary(this.codexBin);
+      if (!found) {
         throw new Error(`Codex binary not found at: ${this.codexBin}`);
       }
+      this.codexBin = found;
       return;
     }
 
     // Check default codex path
-    if (fs.existsSync(DEFAULT_CODEX_BIN)) return;
+    const localBinary = findExistingBinary(this.codexBin);
+    if (localBinary) {
+      this.codexBin = localBinary;
+      return;
+    }
 
     // Check common alternative locations
     const alternatives = [
@@ -602,8 +632,9 @@ export class CodexAppServerAdapter implements AgentClient {
       "/usr/bin/codex",
     ];
     for (const alt of alternatives) {
-      if (fs.existsSync(alt)) {
-        this.codexBin = alt;
+      const found = findExistingBinary(alt);
+      if (found) {
+        this.codexBin = found;
         return;
       }
     }
@@ -632,8 +663,12 @@ function findExecutableOnPath(command: string): string | null {
   const pathEnv = process.env.PATH ?? "";
   for (const dir of pathEnv.split(path.delimiter)) {
     if (!dir) continue;
-    const candidate = path.join(dir, command);
-    if (fs.existsSync(candidate)) return candidate;
+    for (const name of executableCandidates(command)) {
+      const candidate = path.join(dir, name);
+      if (fs.existsSync(candidate)) return candidate;
+    }
   }
   return null;
 }
+
+export const _codexWindowsCommandNeedsShellForTest = windowsCommandNeedsShell;

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "e2e:agent-ui": "npm --prefix agent-ui run e2e",
     "audit": "npm --registry=https://registry.npmjs.org --prefix homerail_protocol audit --audit-level=high && npm --registry=https://registry.npmjs.org --prefix homerail_manager audit --audit-level=high && npm --registry=https://registry.npmjs.org --prefix homerail_node audit --audit-level=high && npm --registry=https://registry.npmjs.org --prefix homerail_worker audit --audit-level=high && npm --registry=https://registry.npmjs.org --prefix homerail_cli audit --audit-level=high && npm --registry=https://registry.npmjs.org --prefix agent-ui audit --audit-level=high",
     "ci": "npm run typecheck && npm run build:packages && npm run test:packages",
+    "ci:local": "bash scripts/ci-local.sh",
     "smoke": "npm run ci"
   },
   "engines": {

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKFLOW="${ROOT_DIR}/.github/workflows/ci.yml"
+RUNNER_IMAGE="${HOMERAIL_ACT_IMAGE:-ghcr.io/catthehacker/ubuntu@sha256:2362bb12b0c61438d334b9ed3686809981796a864ab89d93b5ee657652774eb7}"
+DEFAULT_JOBS=(core-linux agent-ui-coverage docker-smoke)
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    printf 'Required command not found: %s\n' "$1" >&2
+    exit 1
+  fi
+}
+
+require_command actionlint
+require_command act
+require_command docker
+
+docker info >/dev/null
+actionlint "${WORKFLOW}"
+
+if (( $# > 0 )); then
+  jobs=("$@")
+else
+  jobs=("${DEFAULT_JOBS[@]}")
+fi
+
+cd "${ROOT_DIR}"
+for job in "${jobs[@]}"; do
+  case "${job}" in
+    core-linux|agent-ui-coverage|docker-smoke) ;;
+    *)
+      printf 'Unsupported local job: %s\n' "${job}" >&2
+      printf 'Supported jobs: %s\n' "${DEFAULT_JOBS[*]}" >&2
+      exit 1
+      ;;
+  esac
+
+  act pull_request \
+    --job "${job}" \
+    --workflows "${WORKFLOW}" \
+    --platform "ubuntu-latest=${RUNNER_IMAGE}" \
+    --container-architecture linux/amd64 \
+    --pull=false
+done


### PR DESCRIPTION
## Summary

- add GitHub-hosted Linux and Windows typecheck, build, and test jobs
- enforce honest full-source Agent UI coverage baselines
- add 50 behavior tests for HTTP errors, Agent session/runtime/evidence facades, DAG transforms, voice-text bridging, and session persistence
- add a real Docker lifecycle test and Worker image build smoke job
- close Manager SQLite databases before temporary-home cleanup so the suite is valid on Windows
- make Node workspace and mount-path assertions honor HomeRail's normalized cross-platform path contract
- support Windows `codex.cmd`/`codex.bat` discovery and startup in the Worker Codex AppServer adapter, covered by a protocol-level DAG handoff fixture
- isolate Manager Agent tests from fixed host-port collisions
- add a pinned local `act` runner entry point and contributor documentation

## Why

The repository had no GitHub Actions workflow. The existing UI coverage configuration only counted loaded files and used a threshold shape that Vitest did not enforce. The Docker integration case also lived in a globally mocked unit-test file, while Manager Agent tests could collide with a live HomeRail port.

GitHub-hosted Windows runs exposed three real cross-platform gaps: test suites deleted temporary SQLite homes before closing database handles, workspace tests expected platform-native separators despite HomeRail's normalized mount-path contract, and the Worker Codex AppServer adapter could not discover or start npm `.cmd` shims.

## Validation

- `npm run ci:local`
  - Core Linux: 926 tests passed, 2 skipped
  - Agent UI: 106 tests passed, up from 56
  - Agent UI full-source coverage:
    - statements: 11.04% (from 8.67%)
    - branches: 9.14% (from 6.78%)
    - functions: 9.01% (from 5.88%)
    - lines: 11.61% (from 8.98%)
  - Docker lifecycle test passed
  - Worker image build passed
- GitHub Actions run `29070201911`
  - Core (Linux, Node 24): passed
  - Core (Windows, Node 24): passed
  - Agent UI coverage: passed
  - Docker smoke: passed
- `actionlint .github/workflows/ci.yml`
- `shellcheck scripts/ci-local.sh`

Coverage thresholds are ratcheted to statements 11%, branches 9%, functions 9%, and lines 11%. No repository secrets or live HomeRail data are used.