### PR TITLE
feat: add reusable DAG pattern library and Manager Agent skills

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - homerail-live-112

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ on:
         description: Wake the Qwen model host when it is offline
         type: boolean
         default: true
+      patterns:
+        description: Optional comma-separated pattern IDs (empty runs the full catalog)
+        type: string
+        required: false
 
 permissions:
   contents: read
@@ -167,6 +171,7 @@ jobs:
       HOMERAIL_PATTERN_MODEL_BASE_URL: http://192.168.100.10:5000
       HOMERAIL_PATTERN_MODEL: qwen3.6
       HOMERAIL_WAKE_MODEL: ${{ inputs.wake_model && '1' || '0' }}
+      HOMERAIL_LIVE_PATTERNS: ${{ inputs.patterns }}
       HOMERAIL_LIVE_RUN_KEY: ${{ github.run_id }}-${{ github.run_attempt }}
       HOMERAIL_LIVE_REPORT_PATH: ${{ github.workspace }}/artifacts/dag-patterns-live.json
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,17 +5,31 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      live_patterns:
+        description: Run model-backed DAG pattern validation on homerail-live-112
+        type: boolean
+        default: false
+      target_ref:
+        description: Branch, tag, or commit to validate (defaults to the selected workflow ref)
+        type: string
+        required: false
+      wake_model:
+        description: Wake the Qwen model host when it is offline
+        type: boolean
+        default: true
 
 permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.event.pull_request.number || github.ref }}
+  group: ci-${{ github.event_name == 'workflow_dispatch' && inputs.live_patterns && 'dag-live-112' || github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   core-linux:
     name: Core (Linux, Node ${{ matrix.node-version }})
+    if: github.event_name != 'workflow_dispatch' || !inputs.live_patterns
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
@@ -51,6 +65,7 @@ jobs:
 
   core-windows:
     name: Core (Windows, Node 24)
+    if: github.event_name != 'workflow_dispatch' || !inputs.live_patterns
     runs-on: windows-latest
     timeout-minutes: 25
     steps:
@@ -82,6 +97,7 @@ jobs:
 
   agent-ui-coverage:
     name: Agent UI coverage
+    if: github.event_name != 'workflow_dispatch' || !inputs.live_patterns
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -109,6 +125,7 @@ jobs:
 
   docker-smoke:
     name: Docker smoke
+    if: github.event_name != 'workflow_dispatch' || !inputs.live_patterns
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
@@ -134,3 +151,58 @@ jobs:
 
       - name: Build Worker image
         run: docker build -t homerail-worker:ci -f homerail_worker/Dockerfile .
+
+  live-dag-patterns:
+    name: Live DAG patterns (.112 to Qwen3.6)
+    if: github.event_name == 'workflow_dispatch' && inputs.live_patterns && github.actor == 'xiaotianfotos'
+    runs-on: [self-hosted, Linux, X64, homerail-live-112]
+    timeout-minutes: 90
+    env:
+      HOMERAIL_RUNNER_BASE: /vol1/1000/homerail_runners
+      HOMERAIL_LIVE_HOME_BASE: /vol1/1000/homerail_runners/homerail_home
+      HOMERAIL_LIVE_ARTIFACTS: /vol1/1000/homerail_runners/artifacts
+      HOMERAIL_MANAGER_PORT: "29191"
+      HOMERAIL_MANAGER_URL: http://127.0.0.1:29191
+      HOMERAIL_LIVE_WORKER_IMAGE_PREFIX: homerail-worker:dag-live
+      HOMERAIL_PATTERN_MODEL_BASE_URL: http://192.168.100.10:5000
+      HOMERAIL_PATTERN_MODEL: qwen3.6
+      HOMERAIL_WAKE_MODEL: ${{ inputs.wake_model && '1' || '0' }}
+      HOMERAIL_LIVE_RUN_KEY: ${{ github.run_id }}-${{ github.run_attempt }}
+      HOMERAIL_LIVE_REPORT_PATH: ${{ github.workspace }}/artifacts/dag-patterns-live.json
+    steps:
+      - name: Check out target revision
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.target_ref || github.ref }}
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: |
+            homerail_protocol/package-lock.json
+            homerail_manager/package-lock.json
+            homerail_node/package-lock.json
+            homerail_worker/package-lock.json
+            homerail_cli/package-lock.json
+            agent-ui/package-lock.json
+
+      - name: Install dependencies
+        run: npm run install:all
+
+      - name: Build packages
+        run: npm run build:packages
+
+      - name: Run isolated live DAG pattern validation
+        run: npm run validate:dag-patterns-runner
+
+      - name: Upload validation evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: dag-patterns-live-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,15 @@ concurrency:
 
 jobs:
   core-linux:
-    name: Core (Linux, Node 24)
+    name: Core (Linux, Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20, 24]
+    env:
+      HOMERAIL_HOME: ${{ runner.temp }}/homerail-ci-node-${{ matrix.node-version }}
     steps:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -27,7 +33,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 24
+          node-version: ${{ matrix.node-version }}
           cache: npm
           cache-dependency-path: |
             homerail_protocol/package-lock.json
@@ -47,6 +53,8 @@ jobs:
     name: Core (Windows, Node 24)
     runs-on: windows-latest
     timeout-minutes: 25
+    env:
+      HOMERAIL_HOME: ${{ runner.temp }}/homerail-ci
     steps:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,14 +185,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          cache: npm
-          cache-dependency-path: |
-            homerail_protocol/package-lock.json
-            homerail_manager/package-lock.json
-            homerail_node/package-lock.json
-            homerail_worker/package-lock.json
-            homerail_cli/package-lock.json
-            agent-ui/package-lock.json
 
       - name: Install dependencies
         run: npm run install:all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [20, 24]
-    env:
-      HOMERAIL_HOME: ${{ runner.temp }}/homerail-ci-node-${{ matrix.node-version }}
     steps:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -47,14 +45,14 @@ jobs:
         run: npm run install:all
 
       - name: Typecheck, build, and test
+        env:
+          HOMERAIL_HOME: ${{ runner.temp }}/homerail-ci-node-${{ matrix.node-version }}
         run: npm run ci
 
   core-windows:
     name: Core (Windows, Node 24)
     runs-on: windows-latest
     timeout-minutes: 25
-    env:
-      HOMERAIL_HOME: ${{ runner.temp }}/homerail-ci
     steps:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -78,6 +76,8 @@ jobs:
         run: npm run install:all
 
       - name: Typecheck, build, and test
+        env:
+          HOMERAIL_HOME: ${{ runner.temp }}/homerail-ci
         run: npm run ci
 
   agent-ui-coverage:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,8 +157,14 @@ jobs:
         run: docker build -t homerail-worker:ci -f homerail_worker/Dockerfile .
 
   live-dag-patterns:
-    name: Live DAG patterns (.112 to Qwen3.6)
-    if: github.event_name == 'workflow_dispatch' && inputs.live_patterns && github.actor == 'xiaotianfotos'
+    name: Live DAG patterns (.112 model-backed)
+    if: >-
+      (github.event_name == 'workflow_dispatch' &&
+       inputs.live_patterns &&
+       github.actor == 'xiaotianfotos') ||
+      (github.event_name == 'pull_request' &&
+       github.actor == 'xiaotianfotos' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: [self-hosted, Linux, X64, homerail-live-112]
     timeout-minutes: 90
     env:
@@ -168,17 +174,15 @@ jobs:
       HOMERAIL_MANAGER_PORT: "29191"
       HOMERAIL_MANAGER_URL: http://127.0.0.1:29191
       HOMERAIL_LIVE_WORKER_IMAGE_PREFIX: homerail-worker:dag-live
-      HOMERAIL_PATTERN_MODEL_BASE_URL: http://192.168.100.10:5000
-      HOMERAIL_PATTERN_MODEL: qwen3.6
-      HOMERAIL_WAKE_MODEL: ${{ inputs.wake_model && '1' || '0' }}
-      HOMERAIL_LIVE_PATTERNS: ${{ inputs.patterns }}
+      HOMERAIL_WAKE_MODEL: ${{ github.event_name == 'pull_request' && '1' || inputs.wake_model && '1' || '0' }}
+      HOMERAIL_LIVE_PATTERNS: ${{ github.event_name == 'workflow_dispatch' && inputs.patterns || '' }}
       HOMERAIL_LIVE_RUN_KEY: ${{ github.run_id }}-${{ github.run_attempt }}
       HOMERAIL_LIVE_REPORT_PATH: ${{ github.workspace }}/artifacts/dag-patterns-live.json
     steps:
       - name: Check out target revision
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ inputs.target_ref || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.target_ref || github.ref }}
           persist-credentials: false
 
       - name: Set up Node.js

--- a/README.md
+++ b/README.md
@@ -184,6 +184,16 @@ hr run assets/orchestrations/public-two-node.yaml.template \
   --prompt "Draft a short checklist for a backend release"
 ```
 
+HomeRail also ships a Manager-backed [DAG pattern library](docs/dag-patterns.md)
+for reusable control-flow designs such as quorum, bounded ratchets, standing
+goal verification, and planner/worker fan-out:
+
+```bash
+hr patterns list
+hr patterns show quorum
+hr patterns instantiate quorum --set workflow_id=release-quorum --set threshold=2
+```
+
 ## Drive the CLI from a coding agent
 
 There is a second way to use HomeRail, beyond speaking to the Manager Agent or

--- a/README.md
+++ b/README.md
@@ -194,6 +194,13 @@ hr patterns show quorum
 hr patterns instantiate quorum --set workflow_id=release-quorum --set threshold=2
 ```
 
+Manager Agent discovers every `SKILL.md` directory under
+`${HOMERAIL_HOME:-$HOME/.homerail}/skills` on each turn and installs missing
+built-in `homerail-*` skills there as links. A pattern request can therefore be
+handled without shell commands: Manager Agent reads `homerail-dag-patterns`,
+selects and instantiates a catalog pattern, syncs it, and starts the returned
+workflow through Manager tools.
+
 ## Drive the CLI from a coding agent
 
 There is a second way to use HomeRail, beyond speaking to the Manager Agent or

--- a/assets/orchestrations/README.md
+++ b/assets/orchestrations/README.md
@@ -36,6 +36,19 @@ node homerail_cli/dist/cli.js run assets/orchestrations/public-two-node.yaml.tem
   --prompt "Draft a short checklist for a backend release"
 ```
 
+The concrete offline pattern instances exercise the Manager's built-in gateway
+semantics without a model provider:
+
+```bash
+node homerail_cli/dist/cli.js run assets/orchestrations/pattern-quorum-offline.yaml \
+  --profile offline-deterministic --prompt "verify quorum routing"
+node homerail_cli/dist/cli.js run assets/orchestrations/pattern-ratchet-exhaustion-offline.yaml \
+  --profile offline-deterministic --prompt "verify bounded feedback"
+```
+
+Use `hr patterns list` and `hr patterns show <id>` for the abstract catalog;
+these files are concrete examples, not the catalog source of truth.
+
 The five-node smoke writes its standard example artifacts to the shared
 run-level workspace:
 

--- a/assets/orchestrations/pattern-quorum-offline.yaml
+++ b/assets/orchestrations/pattern-quorum-offline.yaml
@@ -1,0 +1,100 @@
+name: pattern-quorum-offline
+workflow_id: pattern-quorum-offline
+description: "Concrete offline instance of the built-in quorum pattern: two act votes out of three admit one action."
+
+workspace:
+  mode: isolated
+
+pattern:
+  id: quorum
+  version: 1.0.0
+  source: https://x.com/i/status/2074169173178212621
+  parameters:
+    threshold: 2
+
+runtime_profiles:
+  offline-deterministic:
+    agents:
+      "*":
+        agent_type: deterministic
+
+agents:
+  signal:
+    system: "HANDOFF port=collected content=normalized-signal"
+  voter_one:
+    system: "HANDOFF port=vote content=act"
+  voter_two:
+    system: "HANDOFF port=vote content=act"
+  voter_three:
+    system: "HANDOFF port=vote content=stop"
+  conductor:
+    system: "HANDOFF port=decided content=quorum-action-admitted"
+  reporter:
+    system: "HANDOFF port=done content=quorum-pattern-complete"
+
+nodes:
+  collect_signal:
+    agent: signal
+    outputs:
+      collected:
+        to:
+          - voter_one.in:signal
+          - voter_two.in:signal
+          - voter_three.in:signal
+
+  voter_one:
+    agent: voter_one
+    after: [collect_signal]
+    outputs:
+      vote:
+        to: quorum.in:one
+
+  voter_two:
+    agent: voter_two
+    after: [collect_signal]
+    outputs:
+      vote:
+        to: quorum.in:two
+
+  voter_three:
+    agent: voter_three
+    after: [collect_signal]
+    outputs:
+      vote:
+        to: quorum.in:three
+
+  quorum:
+    type: join_gateway
+    gateway_config:
+      mode: n_of_m
+      threshold: 2
+      success_values: [act]
+      passed_port: act
+      failed_port: stop
+    after: [voter_one, voter_two, voter_three]
+    outputs:
+      act:
+        to: conduct.in:votes
+      stop:
+        to: stopped.in:votes
+
+  conduct:
+    agent: conductor
+    after: [quorum]
+    outputs:
+      decided:
+        to: acted.in:result
+
+  acted:
+    agent: reporter
+    after: [conduct]
+    outputs:
+      done:
+        to: ""
+
+  stopped:
+    agent: reporter
+    after: [quorum]
+    outputs:
+      done:
+        to: ""

--- a/assets/orchestrations/pattern-ratchet-exhaustion-offline.yaml
+++ b/assets/orchestrations/pattern-ratchet-exhaustion-offline.yaml
@@ -1,0 +1,76 @@
+name: pattern-ratchet-exhaustion-offline
+workflow_id: pattern-ratchet-exhaustion-offline
+description: "Concrete offline instance of the built-in ratchet pattern: bounded feedback stops after two unsuccessful attempts."
+
+workspace:
+  mode: isolated
+
+pattern:
+  id: ratchet
+  version: 1.0.0
+  source: https://x.com/i/status/2074169173178212621
+  parameters:
+    target: done
+    max_iterations: 2
+
+runtime_profiles:
+  offline-deterministic:
+    agents:
+      "*":
+        agent_type: deterministic
+
+agents:
+  measurer:
+    system: "HANDOFF port=measured content=not-done"
+  improver:
+    system: "HANDOFF port=measured content=not-done"
+  reporter:
+    system: "HANDOFF port=done content=ratchet-stopped-at-bounded-limit"
+
+nodes:
+  baseline:
+    agent: measurer
+    outputs:
+      measured:
+        to: target_gate.in:measurement
+
+  target_gate:
+    type: while_gateway
+    gateway_config:
+      operator: eq
+      value: done
+      max_iterations: 2
+      continue_port: improve
+      done_port: reached
+      exhausted_port: exhausted
+    after: [baseline]
+    outputs:
+      improve:
+        to: improve.in:measurement
+      reached:
+        to: achieved.in:result
+      exhausted:
+        to: stopped.in:result
+
+  improve:
+    agent: improver
+    after: [target_gate]
+    outputs:
+      measured:
+        to: target_gate.in:measurement
+        retry_policy:
+          max_retries: 2
+
+  achieved:
+    agent: reporter
+    after: [target_gate]
+    outputs:
+      done:
+        to: ""
+
+  stopped:
+    agent: reporter
+    after: [target_gate]
+    outputs:
+      done:
+        to: ""

--- a/docs/dag-patterns.md
+++ b/docs/dag-patterns.md
@@ -1,0 +1,121 @@
+# DAG Pattern Library
+
+HomeRail's pattern library separates reusable orchestration knowledge into four
+layers. A pattern describes a control-flow invariant; it is not tied to one
+model, provider, repository, or task prompt.
+
+## Four Layers
+
+1. **Runtime primitives**: nodes, typed handoffs, terminal edges, condition and
+   finite-loop gateways, `join_gateway`, `while_gateway`, and bounded feedback
+   edges.
+2. **Abstract patterns**: parameterized, provider-independent workflow
+   definitions built into Manager.
+3. **Skill guidance**: selection, adaptation, composition, and validation rules
+   in `skills/homerail-dag-patterns/SKILL.md`.
+4. **Concrete instances**: task-specific YAML with prompts and runtime profiles,
+   such as `pattern-quorum-offline.yaml` and
+   `pattern-ratchet-exhaustion-offline.yaml`.
+
+The Manager catalog is the source of truth for abstract definitions. Skills and
+concrete instances reference the catalog instead of duplicating it.
+
+## Runtime Primitives
+
+### Join Gateway
+
+`join_gateway` waits for its normal `after` dependencies, collects all input
+mailboxes, and emits one aggregate payload. Configure:
+
+- `mode`: `all`, `any`, or `n_of_m`.
+- `field`: optional dotted field read from each input.
+- `success_values`: values counted as successful.
+- `threshold`: required count for `n_of_m`.
+- `passed_port` and `failed_port`: output names; defaults are `passed` and
+  `failed`.
+
+The aggregate payload includes `total`, `successes`, `failures`, `threshold`,
+`passed`, and the original `values`. It does not cancel slow upstream work or
+finish early; use it when every declared dependency must report.
+
+### Finite Loop Gateway
+
+`loop_gateway` can set `result_port` to collect one result from each finite-loop
+iteration. Its terminal `done` payload contains the ordered `results` array, so
+downstream reporters and AI agents receive evidence from every item rather than
+only a completion count.
+
+### While Gateway
+
+`while_gateway` evaluates the latest feedback value before each attempt.
+
+Configure:
+
+- `field`: optional dotted field containing the metric or status.
+- `operator`: `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `truthy`, or `falsy`.
+- `value`: expected value for comparison operators.
+- `max_iterations`: maximum number of continue passes.
+- `continue_port`, `done_port`, and `exhausted_port`.
+
+The feedback edge must return directly to the while gateway. Add
+`retry_policy.max_retries` to that edge so the local feedback bound is explicit
+in addition to the run-wide traversal limit.
+
+## Built-in Patterns
+
+| Pattern | Invariant |
+| --- | --- |
+| `heartbeat` | Cheap quiet exit, one selected action, independent verdict. |
+| `orchestrator-workers` | One planner, independent workers, aggregate, fresh verifier. |
+| `budget-gate` | Explicit budget admission before expensive work. |
+| `trust-ledger` | Autonomy is granted per recurring skill from measured history. |
+| `standing-goal-sentinel` | Completed goals become repeatedly checked invariants. |
+| `quorum` | Independent n-of-m agreement before action. |
+| `sparring` | Breaker, builder, and verifier remain separate. |
+| `ratchet` | Bounded measured attempts until a target or exhaustion. |
+| `compost` | Repeated failures become bounded proposals behind human review. |
+
+List and inspect the live catalog:
+
+```bash
+hr patterns list
+hr --json patterns show quorum
+```
+
+Instantiate without changing Manager state:
+
+```bash
+hr patterns instantiate quorum \
+  --set workflow_id=release-quorum \
+  --set threshold=2 \
+  --output /tmp/release-quorum.yaml
+```
+
+Add `--sync` only after reviewing the generated YAML. Runtime model selection
+still comes from HomeRail database settings and profiles.
+
+The same operations are available to AI clients through:
+
+- `GET /api/dag/patterns`
+- `GET /api/dag/patterns/:id`
+- `POST /api/dag/patterns/:id/instantiate`
+
+Instantiation validates parameter types, rejects unknown parameters, preserves
+numeric and boolean values, substitutes all placeholders, parses the generated
+YAML, and validates the resulting graph before returning it.
+
+## External State Boundaries
+
+Some patterns need state or triggers outside the DAG graph. Schedules, cost
+records, trust history, standing-goal ledgers, and human approvals remain
+explicit inputs or surrounding services. The pattern encodes how that evidence
+is routed; it does not claim that a DAG alone provides a cron scheduler, billing
+source, durable policy database, or interactive human pause.
+
+## Inspiration
+
+This library is inspired by Avid's article
+[How to Build An Agentic OS using Fable 5 (Builder's Guide)](https://x.com/i/status/2074169173178212621).
+HomeRail adapts the article's orchestration ideas into generic DAG primitives
+and provider-independent patterns; it does not copy the article's model,
+pricing, shell, or cron assumptions.

--- a/docs/dag-patterns.md
+++ b/docs/dag-patterns.md
@@ -100,6 +100,14 @@ The same operations are available to AI clients through:
 - `GET /api/dag/patterns/:id`
 - `POST /api/dag/patterns/:id/instantiate`
 
+The HomeRail Manager Agent receives all Skill metadata discovered under
+`${HOMERAIL_HOME}/skills` on every turn. For pattern work it loads
+`homerail-dag-patterns` through `read_skill`, then uses
+`list_dag_patterns`, `get_dag_pattern`, `instantiate_dag_pattern`, and
+`create_and_run`. This works identically for host Codex, host-shell, and
+container Manager Agent runtimes; it does not depend on the native Codex or
+Claude skill search path.
+
 Instantiation validates parameter types, rejects unknown parameters, preserves
 numeric and boolean values, substitutes all placeholders, parses the generated
 YAML, and validates the resulting graph before returning it.

--- a/homerail_cli/src/commands/patterns.ts
+++ b/homerail_cli/src/commands/patterns.ts
@@ -1,0 +1,190 @@
+import type { Command } from "commander";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { getClient } from "../index.js";
+
+interface GlobalOpts {
+  baseUrl?: string;
+  json?: boolean;
+  requestTimeout?: number;
+}
+
+interface PatternSummary {
+  id: string;
+  version: string;
+  name: string;
+  summary: string;
+  required_primitives: string[];
+  node_count: number;
+}
+
+interface PatternDetail extends PatternSummary {
+  intent: string;
+  roles: Array<{ id: string; responsibility: string }>;
+  typical_uses: string[];
+  avoid_when: string[];
+  parameters: Record<string, { type: string; description: string; default: unknown }>;
+  source: { title: string; author: string; url: string };
+}
+
+interface InstantiateResponse {
+  success?: boolean;
+  message?: string;
+  data?: {
+    pattern?: PatternDetail;
+    parameters?: Record<string, unknown>;
+    workflow?: { workflow_id?: string; name?: string };
+    yaml_text?: string;
+    validation?: { valid?: boolean };
+  };
+}
+
+interface InstantiateOptions {
+  set: string[];
+  output?: string;
+  sync?: boolean;
+}
+
+function collect(value: string, previous: string[]): string[] {
+  return [...previous, value];
+}
+
+export function parsePatternParameters(values: string[]): Record<string, unknown> {
+  const parameters: Record<string, unknown> = {};
+  for (const value of values) {
+    const separator = value.indexOf("=");
+    if (separator <= 0) throw new Error(`Invalid --set value '${value}'. Expected key=value.`);
+    const key = value.slice(0, separator).trim();
+    const raw = value.slice(separator + 1).trim();
+    if (!/^[A-Za-z0-9_]+$/.test(key)) throw new Error(`Invalid pattern parameter name: ${key}`);
+    if (raw === "true") parameters[key] = true;
+    else if (raw === "false") parameters[key] = false;
+    else if (raw !== "" && Number.isFinite(Number(raw))) parameters[key] = Number(raw);
+    else parameters[key] = raw;
+  }
+  return parameters;
+}
+
+function printPattern(detail: PatternDetail): void {
+  console.log(`${detail.name} (${detail.id}@${detail.version})`);
+  console.log(detail.summary);
+  console.log(`Intent: ${detail.intent}`);
+  console.log("Roles:");
+  for (const role of detail.roles) console.log(`  ${role.id}: ${role.responsibility}`);
+  console.log("Typical uses:");
+  for (const use of detail.typical_uses) console.log(`  - ${use}`);
+  console.log("Avoid when:");
+  for (const item of detail.avoid_when) console.log(`  - ${item}`);
+  console.log("Parameters:");
+  for (const [name, parameter] of Object.entries(detail.parameters)) {
+    console.log(`  ${name} (${parameter.type}, default=${String(parameter.default)}): ${parameter.description}`);
+  }
+  console.log(`Source: ${detail.source.title} by ${detail.source.author}`);
+  console.log(detail.source.url);
+}
+
+export function registerPatternsCommand(program: Command): void {
+  const patterns = program
+    .command("patterns")
+    .description("Built-in DAG design pattern catalog");
+
+  patterns
+    .command("list")
+    .description("List built-in DAG patterns from Manager")
+    .action(async () => {
+      const globalOpts = program.opts<GlobalOpts>();
+      const client = getClient(globalOpts);
+      try {
+        const response = await client.get("/api/dag/patterns") as {
+          data?: { patterns?: PatternSummary[] };
+        };
+        const items = response.data?.patterns ?? [];
+        if (globalOpts.json) {
+          console.log(JSON.stringify(items));
+          return;
+        }
+        if (items.length === 0) {
+          console.log("No built-in DAG patterns found.");
+          return;
+        }
+        console.log(`${"Pattern".padEnd(28)} ${"Nodes".padEnd(7)} Summary`);
+        console.log("-".repeat(90));
+        for (const item of items) {
+          console.log(`${item.id.padEnd(28)} ${String(item.node_count).padEnd(7)} ${item.summary}`);
+        }
+      } catch (err) {
+        console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+        process.exitCode = 1;
+      }
+    });
+
+  patterns
+    .command("show <id>")
+    .description("Show AI-readable guidance and the abstract workflow template")
+    .action(async (id: string) => {
+      const globalOpts = program.opts<GlobalOpts>();
+      const client = getClient(globalOpts);
+      try {
+        const response = await client.get(`/api/dag/patterns/${encodeURIComponent(id)}`) as { data?: PatternDetail };
+        if (!response.data) throw new Error(`DAG pattern not found: ${id}`);
+        if (globalOpts.json) console.log(JSON.stringify(response.data));
+        else printPattern(response.data);
+      } catch (err) {
+        console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+        process.exitCode = 1;
+      }
+    });
+
+  patterns
+    .command("instantiate <id>")
+    .description("Instantiate a built-in pattern as validated DAG YAML")
+    .option("--set <key=value>", "Override a typed pattern parameter; repeat for multiple values", collect, [])
+    .option("--output <file>", "Write the generated YAML to a file")
+    .option("--sync", "Sync the generated workflow into Manager after validation")
+    .action(async (id: string, opts: InstantiateOptions) => {
+      const globalOpts = program.opts<GlobalOpts>();
+      const client = getClient(globalOpts);
+      try {
+        const parameters = parsePatternParameters(opts.set);
+        const response = await client.post(
+          `/api/dag/patterns/${encodeURIComponent(id)}/instantiate`,
+          { parameters },
+        ) as InstantiateResponse;
+        const yamlText = response.data?.yaml_text;
+        if (!yamlText || response.data?.validation?.valid !== true) {
+          throw new Error("Manager did not return a valid instantiated DAG.");
+        }
+
+        let outputPath: string | undefined;
+        if (opts.output) {
+          outputPath = path.resolve(opts.output);
+          fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+          fs.writeFileSync(outputPath, yamlText, "utf8");
+        }
+
+        let syncResponse: unknown;
+        if (opts.sync) {
+          syncResponse = await client.post("/api/dag/workflows/sync", {
+            yaml_text: yamlText,
+            source_path: outputPath ?? `builtin:${id}`,
+          });
+        }
+
+        if (globalOpts.json) {
+          console.log(JSON.stringify({ ...response.data, output_path: outputPath, sync: syncResponse }));
+          return;
+        }
+        if (!outputPath && !opts.sync) {
+          process.stdout.write(yamlText);
+          return;
+        }
+        const workflowId = response.data?.workflow?.workflow_id ?? id;
+        if (outputPath) console.log(`Pattern instantiated: ${workflowId} -> ${outputPath}`);
+        if (opts.sync) console.log(`Workflow synced: ${workflowId}`);
+      } catch (err) {
+        console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+        process.exitCode = 1;
+      }
+    });
+}

--- a/homerail_cli/src/index.ts
+++ b/homerail_cli/src/index.ts
@@ -16,6 +16,7 @@ import { registerDoctorCommand } from "./commands/doctor.js";
 import { registerSmokeCommand } from "./commands/smoke.js";
 import { registerConfigCommand } from "./commands/config.js";
 import { registerRuntimeCommands } from "./commands/runtime.js";
+import { registerPatternsCommand } from "./commands/patterns.js";
 import { DEFAULT_MANAGER_URL } from "./local-config.js";
 
 export { HomeRailClient } from "./client.js";
@@ -32,6 +33,7 @@ export function createProgram(): Command {
     .option("--json", "Output as JSON");
 
   registerTemplatesCommand(program);
+  registerPatternsCommand(program);
   registerRunCommand(program);
   registerRunsCommand(program);
   registerStatusCommand(program);

--- a/homerail_cli/tests/patterns.test.ts
+++ b/homerail_cli/tests/patterns.test.ts
@@ -1,0 +1,118 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { parsePatternParameters } from "../src/commands/patterns.js";
+import { createProgram } from "../src/index.js";
+
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+  } as Response;
+}
+
+describe("patterns command", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-cli-patterns-"));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("parses repeated typed parameter overrides", () => {
+    expect(parsePatternParameters([
+      "workflow_id=release-quorum",
+      "threshold=3",
+      "enabled=true",
+      "label=three voters",
+    ])).toEqual({
+      workflow_id: "release-quorum",
+      threshold: 3,
+      enabled: true,
+      label: "three voters",
+    });
+    expect(() => parsePatternParameters(["missing-separator"])).toThrow("Expected key=value");
+  });
+
+  it("lists AI-readable built-in patterns from Manager", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({
+      success: true,
+      data: {
+        patterns: [{
+          id: "quorum",
+          version: "1.0.0",
+          name: "Quorum",
+          summary: "Require independent agreement.",
+          required_primitives: ["join_gateway n_of_m mode"],
+          node_count: 8,
+        }],
+      },
+    }));
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await createProgram().parseAsync(["node", "hr", "--json", "patterns", "list"]);
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "http://localhost:19191/api/dag/patterns",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(JSON.parse(String(log.mock.calls[0][0]))).toMatchObject([{ id: "quorum" }]);
+  });
+
+  it("instantiates, writes, and syncs the same validated workflow", async () => {
+    const yamlText = "name: Release Quorum\nworkflow_id: release-quorum\npattern:\n  id: quorum\nnodes:\n  one:\n    outputs:\n      done:\n        to: \"\"\n";
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse({
+        success: true,
+        data: {
+          pattern: { id: "quorum" },
+          parameters: { workflow_id: "release-quorum", threshold: 3 },
+          workflow: { workflow_id: "release-quorum", name: "Release Quorum" },
+          yaml_text: yamlText,
+          validation: { valid: true },
+        },
+      }))
+      .mockResolvedValueOnce(jsonResponse({
+        success: true,
+        data: { workflow: { workflow_id: "release-quorum" }, created: true },
+      }));
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const output = path.join(tmpDir, "release-quorum.yaml");
+
+    await createProgram().parseAsync([
+      "node",
+      "hr",
+      "patterns",
+      "instantiate",
+      "quorum",
+      "--set",
+      "workflow_id=release-quorum",
+      "--set",
+      "threshold=3",
+      "--output",
+      output,
+      "--sync",
+    ]);
+
+    expect(fs.readFileSync(output, "utf8")).toBe(yamlText);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][0]).toBe("http://localhost:19191/api/dag/patterns/quorum/instantiate");
+    expect(JSON.parse(String((fetchMock.mock.calls[0][1] as RequestInit).body))).toEqual({
+      parameters: { workflow_id: "release-quorum", threshold: 3 },
+    });
+    expect(JSON.parse(String((fetchMock.mock.calls[1][1] as RequestInit).body))).toMatchObject({
+      yaml_text: yamlText,
+      source_path: output,
+    });
+  });
+});

--- a/homerail_manager/src/orchestration/dag-engine.ts
+++ b/homerail_manager/src/orchestration/dag-engine.ts
@@ -143,6 +143,7 @@ function _skipUntakenSatisfiedBranches(run: DAGRun, nodeId: string): void {
   });
   if (hasUntakenRequiredInput) {
     run.nodeStates.set(nodeId, "SKIPPED");
+    _skipDependentNodes(run, nodeId);
   }
 }
 
@@ -209,7 +210,8 @@ function _wakeLoopSource(run: DAGRun, nodeId: string): void {
 }
 
 function _isLoopGateway(run: DAGRun, nodeId: string): boolean {
-  return run.graph.nodes.find((node) => node.node_id === nodeId)?.node_type === "loop_gateway";
+  const nodeType = run.graph.nodes.find((node) => node.node_id === nodeId)?.node_type;
+  return nodeType === "loop_gateway" || nodeType === "while_gateway";
 }
 
 function _wakeLoopGatewayReceiver(run: DAGRun, fromNode: string, nodeId: string): void {

--- a/homerail_manager/src/orchestration/dag-engine.ts
+++ b/homerail_manager/src/orchestration/dag-engine.ts
@@ -143,7 +143,7 @@ function _skipUntakenSatisfiedBranches(run: DAGRun, nodeId: string): void {
   });
   if (hasUntakenRequiredInput) {
     run.nodeStates.set(nodeId, "SKIPPED");
-    _skipDependentNodes(run, nodeId);
+    _skipDependentNodes(run, nodeId, true);
   }
 }
 
@@ -181,15 +181,15 @@ function _hasAlternativePath(run: DAGRun, nodeId: string, excludePred: string): 
   return false;
 }
 
-function _skipDependentNodes(run: DAGRun, failedNodeId: string): void {
+function _skipDependentNodes(run: DAGRun, unavailableNodeId: string, sourceWasSkipped = false): void {
   for (const edge of run.graph.edges) {
-    if (edge.from_node !== failedNodeId) continue;
-    if (edge.condition !== "on_success") continue;
+    if (edge.from_node !== unavailableNodeId) continue;
+    if (!sourceWasSkipped && edge.condition !== "on_success") continue;
     if (!edge.to_node) continue;
     if (run.nodeStates.get(edge.to_node) !== "PENDING") continue;
-    if (_hasAlternativePath(run, edge.to_node, failedNodeId)) continue;
+    if (_hasAlternativePath(run, edge.to_node, unavailableNodeId)) continue;
     run.nodeStates.set(edge.to_node, "SKIPPED");
-    _skipDependentNodes(run, edge.to_node);
+    _skipDependentNodes(run, edge.to_node, true);
   }
 }
 

--- a/homerail_manager/src/orchestration/dag-patterns.ts
+++ b/homerail_manager/src/orchestration/dag-patterns.ts
@@ -541,7 +541,7 @@ const ratchet: DAGPatternDefinition = {
 
 const compost: DAGPatternDefinition = {
   id: "compost",
-  version: "1.0.2",
+  version: "1.0.3",
   name: "Compost",
   summary: "Turn repeated failures into a small set of proposed laws, skill changes, or standing goals.",
   intent: "Let operational evidence improve the system while keeping policy changes behind explicit review.",
@@ -573,7 +573,7 @@ const compost: DAGPatternDefinition = {
     agents: {
       collector: { system: "Collect recent failures, trust demotions, violated goals, and rejected changes with evidence." },
       proposer: { system: "Produce at most {{max_proposals}} proposals. Each must be a law, skill change, or standing goal grounded in incidents. Return exactly one JSON object with top-level status (proposed or no_change) and top-level proposals array. A status nested inside an individual proposal does not satisfy the contract." },
-      reviewer: { system: "You are a review boundary, not the human decision maker. Present proposals for explicit human acceptance, then finish by calling the handoff tool on done with exactly one JSON object. Its top-level key must be named status and its literal value must be awaiting_human_review; do not rename, nest, or substitute that value. Include the proposals and no approval decision. Never approve, reject, sign, apply, or simulate a human decision." },
+      reviewer: { system: "You are a review boundary, not the human decision maker. Present proposals for explicit human acceptance, then finish by calling the handoff tool on done with one JSON object. Prefer top-level status awaiting_human_review. An equivalent per-proposal form is allowed only when top-level review_boundary is human_review and every proposal has status awaiting_human_review. Include no approval decision. Never emit approved, rejected, signed, or applied status, and never simulate a human decision." },
     },
     nodes: {
       collect: { agent: "collector", outputs: { evidence: { to: "propose.in:evidence" } } },

--- a/homerail_manager/src/orchestration/dag-patterns.ts
+++ b/homerail_manager/src/orchestration/dag-patterns.ts
@@ -1,0 +1,732 @@
+import YAML from "yaml";
+
+import { assertGraphValid, validateGraph, type GraphValidationResult } from "./graph-validator.js";
+import type { ParsedDAG } from "./graph.js";
+import { parseDAGYaml } from "./yaml-loader.js";
+
+export const DAG_PATTERN_SOURCE = {
+  title: "How to Build An Agentic OS using Fable 5 (Builder's Guide)",
+  author: "Avid (@Av1dlive)",
+  url: "https://x.com/i/status/2074169173178212621",
+  relationship: "inspiration",
+} as const;
+
+export type DAGPatternParameterType = "string" | "number" | "boolean";
+
+export interface DAGPatternParameter {
+  type: DAGPatternParameterType;
+  description: string;
+  default: string | number | boolean;
+  minimum?: number;
+  maximum?: number;
+  integer?: boolean;
+  values?: Array<string | number | boolean>;
+}
+
+export interface DAGPatternRole {
+  id: string;
+  responsibility: string;
+}
+
+export interface DAGPatternDefinition {
+  id: string;
+  version: string;
+  name: string;
+  summary: string;
+  intent: string;
+  roles: DAGPatternRole[];
+  typical_uses: string[];
+  avoid_when: string[];
+  required_primitives: string[];
+  parameters: Record<string, DAGPatternParameter>;
+  source: typeof DAG_PATTERN_SOURCE;
+  workflow_template: Record<string, unknown>;
+}
+
+export interface DAGPatternSummary extends Omit<DAGPatternDefinition, "workflow_template"> {
+  node_count: number;
+}
+
+export interface InstantiatedDAGPattern {
+  pattern: DAGPatternDefinition;
+  parameters: Record<string, string | number | boolean>;
+  workflow: Record<string, unknown>;
+  yaml_text: string;
+  parsed: ParsedDAG;
+  validation: GraphValidationResult;
+}
+
+const identityParameters = (id: string, name: string): Record<string, DAGPatternParameter> => ({
+  workflow_id: {
+    type: "string",
+    description: "Stable workflow identity used when syncing the instance.",
+    default: `pattern-${id}`,
+  },
+  name: {
+    type: "string",
+    description: "Display name for the instantiated workflow.",
+    default: name,
+  },
+});
+
+const terminalNode = (agent: string, after: string): Record<string, unknown> => ({
+  agent,
+  after: [after],
+  outputs: { done: { to: "" } },
+});
+
+const heartbeat: DAGPatternDefinition = {
+  id: "heartbeat",
+  version: "1.0.0",
+  name: "Heartbeat",
+  summary: "Triage one signal, route one actionable item, execute it, and independently verify the result.",
+  intent: "Keep periodic autonomous work bounded by a quiet-path exit, a single selected action, and a separate verifier.",
+  roles: [
+    { id: "triage", responsibility: "Reduce raw signals to actionable or quiet status." },
+    { id: "conductor", responsibility: "Select exactly one item and issue a bounded work order." },
+    { id: "worker", responsibility: "Execute only the selected work order." },
+    { id: "verifier", responsibility: "Judge the result against explicit completion criteria." },
+  ],
+  typical_uses: ["scheduled repository maintenance", "issue triage", "bounded operational automation"],
+  avoid_when: ["the input cannot be classified reliably", "multiple actions must commit atomically"],
+  required_primitives: ["condition_gateway", "success/failure routing", "independent agent roles"],
+  parameters: identityParameters("heartbeat", "Heartbeat Pattern"),
+  source: DAG_PATTERN_SOURCE,
+  workflow_template: {
+    name: "{{name}}",
+    workflow_id: "{{workflow_id}}",
+    description: "Heartbeat pattern: quiet exit, one bounded action, independent verification.",
+    workspace: { mode: "isolated" },
+    agents: {
+      triage: { system: "Classify the supplied signals. Hand off JSON with status actionable or quiet and evidence." },
+      conductor: { system: "Select exactly one highest-value actionable item. Emit a bounded work order with verifiable done_when criteria." },
+      worker: { system: "Execute only the supplied work order. Return status success or failure with evidence." },
+      verifier: { system: "Independently verify every done_when criterion. Return verdict pass or fail with evidence." },
+      reporter: { system: "Report the terminal outcome without claiming unverified work." },
+    },
+    nodes: {
+      triage: { agent: "triage", outputs: { classified: { to: "signal_gate.in:signal" } } },
+      signal_gate: {
+        type: "condition_gateway",
+        gateway_config: {
+          field: "status",
+          routes: { actionable: "act", quiet: "quiet" },
+          default_port: "quiet",
+        },
+        after: ["triage"],
+        outputs: {
+          act: { to: "conduct.in:signal" },
+          quiet: { to: "quiet.in:result" },
+        },
+      },
+      conduct: { agent: "conductor", after: ["signal_gate"], outputs: { ordered: { to: "execute.in:order" } } },
+      execute: { agent: "worker", after: ["conduct"], outputs: { completed: { to: "verify.in:result" } } },
+      verify: { agent: "verifier", after: ["execute"], outputs: { verdict: { to: "verdict_gate.in:verdict" } } },
+      verdict_gate: {
+        type: "condition_gateway",
+        gateway_config: { field: "verdict", routes: { pass: "passed", fail: "failed" }, default_port: "failed" },
+        after: ["verify"],
+        outputs: {
+          passed: { to: "done.in:result" },
+          failed: { to: "review.in:result" },
+        },
+      },
+      quiet: terminalNode("reporter", "signal_gate"),
+      done: terminalNode("reporter", "verdict_gate"),
+      review: terminalNode("reporter", "verdict_gate"),
+    },
+  },
+};
+
+const orchestratorWorkers: DAGPatternDefinition = {
+  id: "orchestrator-workers",
+  version: "1.0.0",
+  name: "Orchestrator and Workers",
+  summary: "Separate planning from parallel execution, then aggregate and verify all worker results.",
+  intent: "Give one planner ownership of decomposition while independent workers execute bounded parts in parallel.",
+  roles: [
+    { id: "orchestrator", responsibility: "Decompose the objective into non-overlapping work orders." },
+    { id: "worker", responsibility: "Complete one work order and report structured status." },
+    { id: "verifier", responsibility: "Verify the aggregate rather than trusting worker self-assessment." },
+  ],
+  typical_uses: ["parallel research", "multi-module implementation", "independent evidence collection"],
+  avoid_when: ["workers must edit the same state concurrently", "the objective is too small to decompose"],
+  required_primitives: ["fan-out edges", "join_gateway all mode", "independent verification"],
+  parameters: identityParameters("orchestrator-workers", "Orchestrator and Workers Pattern"),
+  source: DAG_PATTERN_SOURCE,
+  workflow_template: {
+    name: "{{name}}",
+    workflow_id: "{{workflow_id}}",
+    description: "Planner-led fan-out, deterministic all-result aggregation, and fresh verification.",
+    workspace: { mode: "isolated" },
+    agents: {
+      orchestrator: { system: "Produce three non-overlapping work orders with explicit acceptance criteria." },
+      worker: { system: "Execute the assigned work order only. Return JSON with status success or failure and evidence." },
+      verifier: { system: "Verify the combined worker evidence against the original objective." },
+      reporter: { system: "Summarize the verified aggregate or the failed worker set." },
+    },
+    nodes: {
+      plan: {
+        agent: "orchestrator",
+        outputs: {
+          planned: { to: ["worker_one.in:order", "worker_two.in:order", "worker_three.in:order"] },
+        },
+      },
+      worker_one: { agent: "worker", after: ["plan"], outputs: { result: { to: "join.in:one" } } },
+      worker_two: { agent: "worker", after: ["plan"], outputs: { result: { to: "join.in:two" } } },
+      worker_three: { agent: "worker", after: ["plan"], outputs: { result: { to: "join.in:three" } } },
+      join: {
+        type: "join_gateway",
+        gateway_config: { mode: "all", field: "status", success_values: ["success"] },
+        after: ["worker_one", "worker_two", "worker_three"],
+        outputs: {
+          passed: { to: "verify.in:aggregate" },
+          failed: { to: "review.in:aggregate" },
+        },
+      },
+      verify: { agent: "verifier", after: ["join"], outputs: { verified: { to: "done.in:result" } } },
+      done: terminalNode("reporter", "verify"),
+      review: terminalNode("reporter", "join"),
+    },
+  },
+};
+
+const budgetGate: DAGPatternDefinition = {
+  id: "budget-gate",
+  version: "1.0.0",
+  name: "Budget Gate",
+  summary: "Measure expected or accumulated cost before execution and route over-budget work to a stop path.",
+  intent: "Make budget approval an explicit routing decision before expensive work starts.",
+  roles: [
+    { id: "accountant", responsibility: "Calculate usage against the configured budget and emit a status." },
+    { id: "worker", responsibility: "Execute only work admitted by the gate." },
+    { id: "auditor", responsibility: "Record final usage and outcome." },
+  ],
+  typical_uses: ["metered model workflows", "bounded batch processing", "daily automation budgets"],
+  avoid_when: ["usage cannot be measured", "the operation must run regardless of cost"],
+  required_primitives: ["condition_gateway", "structured budget status", "terminal stop branch"],
+  parameters: {
+    ...identityParameters("budget-gate", "Budget Gate Pattern"),
+    budget_limit: {
+      type: "number",
+      description: "Maximum budget admitted by the accounting role.",
+      default: 5,
+      minimum: 0,
+    },
+  },
+  source: DAG_PATTERN_SOURCE,
+  workflow_template: {
+    name: "{{name}}",
+    workflow_id: "{{workflow_id}}",
+    description: "Explicit budget admission before execution.",
+    workspace: { mode: "isolated" },
+    agents: {
+      accountant: { system: "Calculate current and projected usage. The budget limit is {{budget_limit}}. Return status within_budget or exceeded with evidence." },
+      worker: { system: "Execute the admitted work and report measured usage." },
+      auditor: { system: "Record the budget decision, measured usage, and terminal outcome." },
+    },
+    nodes: {
+      assess_budget: { agent: "accountant", outputs: { assessed: { to: "budget_gate.in:assessment" } } },
+      budget_gate: {
+        type: "condition_gateway",
+        gateway_config: {
+          field: "status",
+          routes: { within_budget: "admit", exceeded: "block" },
+          default_port: "block",
+        },
+        after: ["assess_budget"],
+        outputs: {
+          admit: { to: "execute.in:budget" },
+          block: { to: "blocked.in:budget" },
+        },
+      },
+      execute: { agent: "worker", after: ["budget_gate"], outputs: { completed: { to: "audited.in:result" } } },
+      audited: terminalNode("auditor", "execute"),
+      blocked: terminalNode("auditor", "budget_gate"),
+    },
+  },
+};
+
+const trustLedger: DAGPatternDefinition = {
+  id: "trust-ledger",
+  version: "1.0.0",
+  name: "Trust Ledger",
+  summary: "Route each recurring skill according to measured pass history: auto, queue, or watch.",
+  intent: "Grant autonomy per skill from evidence instead of assigning one global automation level.",
+  roles: [
+    { id: "assessor", responsibility: "Read the skill's run history and assign a trust tier." },
+    { id: "worker", responsibility: "Produce a candidate result regardless of tier." },
+    { id: "verifier", responsibility: "Emit the pass/fail evidence used to update trust." },
+  ],
+  typical_uses: ["recurring maintenance skills", "graduated autonomy", "automatic demotion after failures"],
+  avoid_when: ["tasks do not repeat", "pass/fail cannot be measured consistently"],
+  required_primitives: ["condition_gateway", "persistent external ledger", "per-skill identity"],
+  parameters: identityParameters("trust-ledger", "Trust Ledger Pattern"),
+  source: DAG_PATTERN_SOURCE,
+  workflow_template: {
+    name: "{{name}}",
+    workflow_id: "{{workflow_id}}",
+    description: "Per-skill evidence routes verified work to auto, queue, or watch outcomes.",
+    workspace: { mode: "isolated" },
+    agents: {
+      assessor: { system: "Read the supplied skill history and return tier auto, queue, or watch with the measured rate." },
+      worker: { system: "Execute the recurring skill and return evidence." },
+      verifier: { system: "Independently grade the result and update the supplied trust ledger record. Return JSON with top-level tier (auto, queue, or watch), independent_grade, evidence, and ledger_update." },
+      reporter: { system: "Report the resulting autonomy decision and evidence." },
+    },
+    nodes: {
+      assess: { agent: "assessor", outputs: { tiered: { to: "execute.in:tier" } } },
+      execute: { agent: "worker", after: ["assess"], outputs: { completed: { to: "verify.in:result" } } },
+      verify: { agent: "verifier", after: ["execute"], outputs: { recorded: { to: "tier_gate.in:record" } } },
+      tier_gate: {
+        type: "condition_gateway",
+        gateway_config: {
+          field: "tier",
+          routes: { auto: "ship", queue: "queue", watch: "watch" },
+          default_port: "watch",
+        },
+        after: ["verify"],
+        outputs: {
+          ship: { to: "auto.in:result" },
+          queue: { to: "queued.in:result" },
+          watch: { to: "watched.in:result" },
+        },
+      },
+      auto: terminalNode("reporter", "tier_gate"),
+      queued: terminalNode("reporter", "tier_gate"),
+      watched: terminalNode("reporter", "tier_gate"),
+    },
+  },
+};
+
+const standingGoalSentinel: DAGPatternDefinition = {
+  id: "standing-goal-sentinel",
+  version: "1.0.0",
+  name: "Standing Goal Sentinel",
+  summary: "Iterate over previously satisfied goals, re-run their predicates, and report violations.",
+  intent: "Turn completed goals into continuously checked invariants instead of one-time claims.",
+  roles: [
+    { id: "loader", responsibility: "Load active goal predicates as a finite item list." },
+    { id: "verifier", responsibility: "Evaluate one predicate and emit structured evidence." },
+    { id: "reporter", responsibility: "Summarize all current violations without silently fixing them." },
+  ],
+  typical_uses: ["regression sentinels", "operational invariants", "periodic acceptance checks"],
+  avoid_when: ["predicates mutate production state", "verification cannot finish within a bounded time"],
+  required_primitives: ["loop_gateway", "structured item handoff", "persistent goal ledger"],
+  parameters: identityParameters("standing-goal-sentinel", "Standing Goal Sentinel Pattern"),
+  source: DAG_PATTERN_SOURCE,
+  workflow_template: {
+    name: "{{name}}",
+    workflow_id: "{{workflow_id}}",
+    description: "Finite re-verification of standing goals with a violation report.",
+    workspace: { mode: "isolated" },
+    agents: {
+      loader: { system: "Load all active standing goals and hand off an array of predicate records." },
+      verifier: { system: "Evaluate exactly one supplied goal predicate. A boolean predicate is already evaluated: return it directly without tools or workspace inspection. For command predicates, run only the supplied command. Return JSON with top-level result (pass or fail) and evidence; do not expand scope or auto-fix." },
+      reporter: { system: "Summarize verified goals and violations, including likely changes since the last pass." },
+    },
+    nodes: {
+      load_goals: { agent: "loader", outputs: { goals: { to: "goal_loop.in:items" } } },
+      goal_loop: {
+        type: "loop_gateway",
+        gateway_config: { item_port: "next_goal", result_port: "result", done_port: "done" },
+        after: ["load_goals"],
+        outputs: {
+          next_goal: { to: "verify_goal.in:goal" },
+          done: { to: "report.in:summary" },
+        },
+      },
+      verify_goal: {
+        agent: "verifier",
+        after: ["goal_loop"],
+        outputs: { verified: { to: "goal_loop.in:result" } },
+      },
+      report: terminalNode("reporter", "goal_loop"),
+    },
+  },
+};
+
+const quorum: DAGPatternDefinition = {
+  id: "quorum",
+  version: "1.0.0",
+  name: "Quorum",
+  summary: "Collect independent votes and continue only when an n-of-m threshold is met.",
+  intent: "Reduce false wake-ups or risky decisions by requiring independent agreement before expensive action.",
+  roles: [
+    { id: "signal", responsibility: "Provide one shared evidence bundle to all voters." },
+    { id: "voter", responsibility: "Vote independently without seeing other votes." },
+    { id: "conductor", responsibility: "Act only on a passing aggregate." },
+  ],
+  typical_uses: ["actionability filtering", "high-cost wake-up gates", "independent review consensus"],
+  avoid_when: ["voters share the same failure mode", "latency matters more than decision confidence"],
+  required_primitives: ["fan-out edges", "join_gateway n_of_m mode", "structured independent votes"],
+  parameters: {
+    ...identityParameters("quorum", "Quorum Pattern"),
+    threshold: {
+      type: "number",
+      description: "Number of passing votes required out of three voters.",
+      default: 2,
+      minimum: 1,
+      maximum: 3,
+      integer: true,
+    },
+  },
+  source: DAG_PATTERN_SOURCE,
+  workflow_template: {
+    name: "{{name}}",
+    workflow_id: "{{workflow_id}}",
+    description: "Three independent votes aggregated by a configurable n-of-m threshold.",
+    workspace: { mode: "isolated" },
+    agents: {
+      signal: { system: "Collect and normalize the supplied evidence bundle without discarding concrete facts. Return JSON with top-level evidence and status; do not make the final decision." },
+      voter: { system: "Evaluate the supplied evidence independently. Return JSON with top-level vote (act or stop) and evidence. Do not inspect or infer other voters' decisions." },
+      conductor: { system: "Receive the quorum aggregate and create one bounded action." },
+      reporter: { system: "Report the aggregate vote and why action did or did not proceed." },
+    },
+    nodes: {
+      collect_signal: {
+        agent: "signal",
+        outputs: { collected: { to: ["voter_one.in:signal", "voter_two.in:signal", "voter_three.in:signal"] } },
+      },
+      voter_one: { agent: "voter", after: ["collect_signal"], outputs: { vote: { to: "quorum.in:one" } } },
+      voter_two: { agent: "voter", after: ["collect_signal"], outputs: { vote: { to: "quorum.in:two" } } },
+      voter_three: { agent: "voter", after: ["collect_signal"], outputs: { vote: { to: "quorum.in:three" } } },
+      quorum: {
+        type: "join_gateway",
+        gateway_config: {
+          mode: "n_of_m",
+          threshold: "{{threshold}}",
+          field: "vote",
+          success_values: ["act"],
+          passed_port: "act",
+          failed_port: "stop",
+        },
+        after: ["voter_one", "voter_two", "voter_three"],
+        outputs: {
+          act: { to: "conduct.in:votes" },
+          stop: { to: "stopped.in:votes" },
+        },
+      },
+      conduct: { agent: "conductor", after: ["quorum"], outputs: { decided: { to: "acted.in:result" } } },
+      acted: terminalNode("reporter", "conduct"),
+      stopped: terminalNode("reporter", "quorum"),
+    },
+  },
+};
+
+const sparring: DAGPatternDefinition = {
+  id: "sparring",
+  version: "1.0.0",
+  name: "Sparring",
+  summary: "A breaker creates a concrete challenge, a builder addresses it, and a fresh verifier settles the result.",
+  intent: "Separate adversarial discovery from repair so neither role grades its own output.",
+  roles: [
+    { id: "breaker", responsibility: "Produce one reproducible failing challenge without fixing it." },
+    { id: "builder", responsibility: "Fix the implementation without weakening the challenge." },
+    { id: "verifier", responsibility: "Judge the challenge and repair from fresh context." },
+  ],
+  typical_uses: ["regression test generation", "security review", "specification hardening"],
+  avoid_when: ["the breaker cannot produce reproducible evidence", "the challenged surface is unsafe for autonomous edits"],
+  required_primitives: ["sequential role isolation", "condition_gateway", "dispute terminal"],
+  parameters: identityParameters("sparring", "Sparring Pattern"),
+  source: DAG_PATTERN_SOURCE,
+  workflow_template: {
+    name: "{{name}}",
+    workflow_id: "{{workflow_id}}",
+    description: "Breaker, builder, and fresh verifier with an explicit dispute path.",
+    workspace: { mode: "isolated" },
+    agents: {
+      breaker: { system: "Provide one reproducible failing challenge and JSON evidence. Do not fix it. If the task supplies a self-contained validation case, use it directly without tools or workspace inspection." },
+      builder: { system: "Fix only the supplied challenge and return JSON evidence. Do not weaken or delete the check. For a self-contained validation case, return the corrected value without tools or workspace changes." },
+      verifier: { system: "Run or evaluate the original challenge and acceptance checks from fresh context. For a self-contained validation case, compare the supplied values without tools or workspace inspection. Return JSON with top-level lowercase verdict (pass or fail) and evidence." },
+      reporter: { system: "Report verified success or queue a concrete dispute for human review." },
+    },
+    nodes: {
+      break: { agent: "breaker", outputs: { challenge: { to: "build.in:challenge" } } },
+      build: { agent: "builder", after: ["break"], outputs: { repaired: { to: "verify.in:repair" } } },
+      verify: { agent: "verifier", after: ["build"], outputs: { verdict: { to: "verdict_gate.in:verdict" } } },
+      verdict_gate: {
+        type: "condition_gateway",
+        gateway_config: { field: "verdict", routes: { pass: "passed", fail: "disputed" }, default_port: "disputed" },
+        after: ["verify"],
+        outputs: {
+          passed: { to: "done.in:result" },
+          disputed: { to: "dispute.in:result" },
+        },
+      },
+      done: terminalNode("reporter", "verdict_gate"),
+      dispute: terminalNode("reporter", "verdict_gate"),
+    },
+  },
+};
+
+const ratchet: DAGPatternDefinition = {
+  id: "ratchet",
+  version: "1.0.0",
+  name: "Ratchet",
+  summary: "Repeat measured improvements until a target is reached or a bounded iteration limit is exhausted.",
+  intent: "Make progress monotonic and bounded by checking the metric before every additional attempt.",
+  roles: [
+    { id: "measurer", responsibility: "Establish and report the current metric." },
+    { id: "improver", responsibility: "Make one bounded change and re-measure without gaming the metric." },
+    { id: "reporter", responsibility: "Record target achievement or bounded exhaustion." },
+  ],
+  typical_uses: ["warning reduction", "performance improvement", "coverage or quality targets"],
+  avoid_when: ["the metric is noisy or gameable", "individual attempts cannot be reverted safely"],
+  required_primitives: ["while_gateway", "comparison predicate", "edge retry limit"],
+  parameters: {
+    ...identityParameters("ratchet", "Ratchet Pattern"),
+    target: {
+      type: "number",
+      description: "Metric value at or below which the goal is complete.",
+      default: 0,
+    },
+    max_iterations: {
+      type: "number",
+      description: "Maximum improvement attempts before routing to exhaustion.",
+      default: 3,
+      minimum: 1,
+      maximum: 100,
+      integer: true,
+    },
+  },
+  source: DAG_PATTERN_SOURCE,
+  workflow_template: {
+    name: "{{name}}",
+    workflow_id: "{{workflow_id}}",
+    description: "Measured bounded improvement until the configured target is reached.",
+    workspace: { mode: "isolated" },
+    agents: {
+      measurer: { system: "Measure only the current objective metric without changing the system. If a starting metric N is supplied, return exactly that current value N. Do not plan, simulate, or perform any improvement; the improver owns all changes. Return JSON with top-level numeric metric and evidence, then hand off immediately." },
+      improver: { system: "Read the previous top-level numeric metric, make one bounded improvement, and return JSON with a strictly lower top-level numeric metric and evidence. Revert changes that worsen or preserve the metric; never claim the target without the numeric value." },
+      reporter: { system: "Report target achievement or bounded exhaustion with the metric history." },
+    },
+    nodes: {
+      baseline: { agent: "measurer", outputs: { measured: { to: "target_gate.in:measurement" } } },
+      target_gate: {
+        type: "while_gateway",
+        gateway_config: {
+          field: "metric",
+          operator: "lte",
+          value: "{{target}}",
+          max_iterations: "{{max_iterations}}",
+          continue_port: "improve",
+          done_port: "reached",
+          exhausted_port: "exhausted",
+        },
+        after: ["baseline"],
+        outputs: {
+          improve: { to: "improve.in:measurement" },
+          reached: { to: "achieved.in:result" },
+          exhausted: { to: "stopped.in:result" },
+        },
+      },
+      improve: {
+        agent: "improver",
+        after: ["target_gate"],
+        outputs: {
+          measured: {
+            to: "target_gate.in:measurement",
+            retry_policy: { max_retries: "{{max_iterations}}" },
+          },
+        },
+      },
+      achieved: terminalNode("reporter", "target_gate"),
+      stopped: terminalNode("reporter", "target_gate"),
+    },
+  },
+};
+
+const compost: DAGPatternDefinition = {
+  id: "compost",
+  version: "1.0.0",
+  name: "Compost",
+  summary: "Turn repeated failures into a small set of proposed laws, skill changes, or standing goals.",
+  intent: "Let operational evidence improve the system while keeping policy changes behind explicit review.",
+  roles: [
+    { id: "collector", responsibility: "Collect recent failures and rejected work with evidence." },
+    { id: "proposer", responsibility: "Produce a bounded set of system-improvement proposals." },
+    { id: "reviewer", responsibility: "Present proposals for explicit human acceptance; never auto-apply policy." },
+  ],
+  typical_uses: ["weekly process review", "recurring failure analysis", "guardrail evolution"],
+  avoid_when: ["there is too little evidence", "policy changes may be applied without human ownership"],
+  required_primitives: ["condition_gateway", "bounded proposal contract", "human-review terminal"],
+  parameters: {
+    ...identityParameters("compost", "Compost Pattern"),
+    max_proposals: {
+      type: "number",
+      description: "Maximum number of proposals emitted in one run.",
+      default: 3,
+      minimum: 1,
+      maximum: 10,
+      integer: true,
+    },
+  },
+  source: DAG_PATTERN_SOURCE,
+  workflow_template: {
+    name: "{{name}}",
+    workflow_id: "{{workflow_id}}",
+    description: "Evidence-driven process proposals with an explicit human-review boundary.",
+    workspace: { mode: "isolated" },
+    agents: {
+      collector: { system: "Collect recent failures, trust demotions, violated goals, and rejected changes with evidence." },
+      proposer: { system: "Produce at most {{max_proposals}} proposals. Each must be a law, skill change, or standing goal grounded in incidents. Return exactly one JSON object with top-level status (proposed or no_change) and top-level proposals array. A status nested inside an individual proposal does not satisfy the contract." },
+      reviewer: { system: "Present proposals for explicit human acceptance. Return JSON with top-level status awaiting_human_review and the proposals. Never approve, reject, sign, apply, or simulate a human decision." },
+    },
+    nodes: {
+      collect: { agent: "collector", outputs: { evidence: { to: "propose.in:evidence" } } },
+      propose: { agent: "proposer", after: ["collect"], outputs: { recommendation: { to: "proposal_gate.in:recommendation" } } },
+      proposal_gate: {
+        type: "condition_gateway",
+        gateway_config: {
+          field: "status",
+          routes: { proposed: "review", no_change: "quiet" },
+          default_port: "quiet",
+        },
+        after: ["propose"],
+        outputs: {
+          review: { to: "human_review.in:proposal" },
+          quiet: { to: "no_change.in:result" },
+        },
+      },
+      human_review: terminalNode("reviewer", "proposal_gate"),
+      no_change: terminalNode("reviewer", "proposal_gate"),
+    },
+  },
+};
+
+const definitions = [
+  heartbeat,
+  orchestratorWorkers,
+  budgetGate,
+  trustLedger,
+  standingGoalSentinel,
+  quorum,
+  sparring,
+  ratchet,
+  compost,
+] as const;
+
+const definitionById = new Map(definitions.map((definition) => [definition.id, definition]));
+
+function clone<T>(value: T): T {
+  return structuredClone(value);
+}
+
+function publicDefinition(definition: DAGPatternDefinition): DAGPatternDefinition {
+  return clone(definition);
+}
+
+export function listDAGPatterns(): DAGPatternSummary[] {
+  return definitions.map((definition) => ({
+    id: definition.id,
+    version: definition.version,
+    name: definition.name,
+    summary: definition.summary,
+    intent: definition.intent,
+    roles: clone(definition.roles),
+    typical_uses: [...definition.typical_uses],
+    avoid_when: [...definition.avoid_when],
+    required_primitives: [...definition.required_primitives],
+    parameters: clone(definition.parameters),
+    source: clone(definition.source),
+    node_count: Object.keys(definition.workflow_template.nodes as Record<string, unknown>).length,
+  }));
+}
+
+export function getDAGPattern(id: string): DAGPatternDefinition | undefined {
+  const definition = definitionById.get(id);
+  return definition ? publicDefinition(definition) : undefined;
+}
+
+function validateParameter(name: string, definition: DAGPatternParameter, value: unknown): string | number | boolean {
+  if (definition.type === "string") {
+    if (typeof value !== "string" || !value.trim()) {
+      throw new Error(`Pattern parameter '${name}' must be a non-empty string.`);
+    }
+  } else if (definition.type === "number") {
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+      throw new Error(`Pattern parameter '${name}' must be a finite number.`);
+    }
+    if (definition.integer && !Number.isInteger(value)) {
+      throw new Error(`Pattern parameter '${name}' must be an integer.`);
+    }
+    if (definition.minimum !== undefined && value < definition.minimum) {
+      throw new Error(`Pattern parameter '${name}' must be at least ${definition.minimum}.`);
+    }
+    if (definition.maximum !== undefined && value > definition.maximum) {
+      throw new Error(`Pattern parameter '${name}' must be at most ${definition.maximum}.`);
+    }
+  } else if (typeof value !== "boolean") {
+    throw new Error(`Pattern parameter '${name}' must be a boolean.`);
+  }
+  if (definition.values && !definition.values.includes(value as never)) {
+    throw new Error(`Pattern parameter '${name}' must be one of: ${definition.values.join(", ")}.`);
+  }
+  return value as string | number | boolean;
+}
+
+function resolveParameters(
+  definition: DAGPatternDefinition,
+  supplied: Record<string, unknown>,
+): Record<string, string | number | boolean> {
+  for (const name of Object.keys(supplied)) {
+    if (!definition.parameters[name]) throw new Error(`Unknown pattern parameter: ${name}`);
+  }
+  const resolved: Record<string, string | number | boolean> = {};
+  for (const [name, parameter] of Object.entries(definition.parameters)) {
+    const value = Object.prototype.hasOwnProperty.call(supplied, name) ? supplied[name] : parameter.default;
+    resolved[name] = validateParameter(name, parameter, value);
+  }
+  return resolved;
+}
+
+const wholePlaceholder = /^\{\{([A-Za-z0-9_]+)\}\}$/;
+const inlinePlaceholder = /\{\{([A-Za-z0-9_]+)\}\}/g;
+
+function interpolate(value: unknown, parameters: Record<string, string | number | boolean>): unknown {
+  if (Array.isArray(value)) return value.map((item) => interpolate(item, parameters));
+  if (typeof value === "object" && value !== null) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [key, interpolate(item, parameters)]),
+    );
+  }
+  if (typeof value !== "string") return value;
+  const whole = value.match(wholePlaceholder);
+  if (whole) {
+    if (!(whole[1] in parameters)) throw new Error(`Missing pattern parameter: ${whole[1]}`);
+    return parameters[whole[1]];
+  }
+  return value.replace(inlinePlaceholder, (_match, name: string) => {
+    if (!(name in parameters)) throw new Error(`Missing pattern parameter: ${name}`);
+    return String(parameters[name]);
+  });
+}
+
+export function instantiateDAGPattern(
+  id: string,
+  supplied: Record<string, unknown> = {},
+): InstantiatedDAGPattern {
+  const definition = definitionById.get(id);
+  if (!definition) throw new Error(`DAG pattern not found: ${id}`);
+  const parameters = resolveParameters(definition, supplied);
+  const workflow = interpolate(definition.workflow_template, parameters) as Record<string, unknown>;
+  workflow.pattern = {
+    id: definition.id,
+    version: definition.version,
+    source: definition.source.url,
+    parameters,
+  };
+  const yamlText = YAML.stringify(workflow, { lineWidth: 0 });
+  const parsed = parseDAGYaml(yamlText);
+  const validation = validateGraph(parsed.graph);
+  assertGraphValid(parsed.graph);
+  return {
+    pattern: publicDefinition(definition),
+    parameters,
+    workflow,
+    yaml_text: yamlText,
+    parsed,
+    validation,
+  };
+}

--- a/homerail_manager/src/orchestration/dag-patterns.ts
+++ b/homerail_manager/src/orchestration/dag-patterns.ts
@@ -142,7 +142,7 @@ const heartbeat: DAGPatternDefinition = {
 
 const orchestratorWorkers: DAGPatternDefinition = {
   id: "orchestrator-workers",
-  version: "1.0.0",
+  version: "1.0.1",
   name: "Orchestrator and Workers",
   summary: "Separate planning from parallel execution, then aggregate and verify all worker results.",
   intent: "Give one planner ownership of decomposition while independent workers execute bounded parts in parallel.",
@@ -162,8 +162,8 @@ const orchestratorWorkers: DAGPatternDefinition = {
     description: "Planner-led fan-out, deterministic all-result aggregation, and fresh verification.",
     workspace: { mode: "isolated" },
     agents: {
-      orchestrator: { system: "Produce three non-overlapping work orders with explicit acceptance criteria." },
-      worker: { system: "Execute the assigned work order only. Return JSON with status success or failure and evidence." },
+      orchestrator: { system: "Produce exactly three non-overlapping work orders with explicit acceptance criteria. Return one JSON object whose top-level work_orders object is keyed worker_one, worker_two, and worker_three; each value must be one self-contained work order. Finish with one handoff on planned so the same indexed plan can fan out to all workers." },
+      worker: { system: "Input order is the shared indexed plan and may arrive as a JSON string. Parse it, identify the current DAG node id, and execute only work_orders[current_node_id]. Do not execute another worker's order or inspect unrelated workspace state. Finish by calling the handoff tool on result with one JSON object containing top-level status success or failure and top-level evidence." },
       verifier: { system: "Verify the combined worker evidence against the original objective." },
       reporter: { system: "Summarize the verified aggregate or the failed worker set." },
     },
@@ -541,7 +541,7 @@ const ratchet: DAGPatternDefinition = {
 
 const compost: DAGPatternDefinition = {
   id: "compost",
-  version: "1.0.0",
+  version: "1.0.1",
   name: "Compost",
   summary: "Turn repeated failures into a small set of proposed laws, skill changes, or standing goals.",
   intent: "Let operational evidence improve the system while keeping policy changes behind explicit review.",
@@ -573,7 +573,7 @@ const compost: DAGPatternDefinition = {
     agents: {
       collector: { system: "Collect recent failures, trust demotions, violated goals, and rejected changes with evidence." },
       proposer: { system: "Produce at most {{max_proposals}} proposals. Each must be a law, skill change, or standing goal grounded in incidents. Return exactly one JSON object with top-level status (proposed or no_change) and top-level proposals array. A status nested inside an individual proposal does not satisfy the contract." },
-      reviewer: { system: "Present proposals for explicit human acceptance. Return JSON with top-level status awaiting_human_review and the proposals. Never approve, reject, sign, apply, or simulate a human decision." },
+      reviewer: { system: "You are a review boundary, not the human decision maker. Present proposals for explicit human acceptance, then finish by calling the handoff tool on done with exactly one JSON object containing top-level status awaiting_human_review and the proposals. Never approve, reject, sign, apply, or simulate a human decision." },
     },
     nodes: {
       collect: { agent: "collector", outputs: { evidence: { to: "propose.in:evidence" } } },

--- a/homerail_manager/src/orchestration/dag-patterns.ts
+++ b/homerail_manager/src/orchestration/dag-patterns.ts
@@ -464,7 +464,7 @@ const sparring: DAGPatternDefinition = {
 
 const ratchet: DAGPatternDefinition = {
   id: "ratchet",
-  version: "1.0.0",
+  version: "1.0.1",
   name: "Ratchet",
   summary: "Repeat measured improvements until a target is reached or a bounded iteration limit is exhausted.",
   intent: "Make progress monotonic and bounded by checking the metric before every additional attempt.",
@@ -500,7 +500,7 @@ const ratchet: DAGPatternDefinition = {
     workspace: { mode: "isolated" },
     agents: {
       measurer: { system: "Measure only the current objective metric without changing the system. If a starting metric N is supplied, return exactly that current value N. Do not plan, simulate, or perform any improvement; the improver owns all changes. Return JSON with top-level numeric metric and evidence, then hand off immediately." },
-      improver: { system: "Read the previous top-level numeric metric, make one bounded improvement, and return JSON with a strictly lower top-level numeric metric and evidence. Revert changes that worsen or preserve the metric; never claim the target without the numeric value." },
+      improver: { system: "Read the previous top-level numeric metric and preserve the scope declared by the upstream evidence. If the input is synthetic or in-memory, transform only the supplied metric and never inspect or modify the workspace or call builtin tools. Otherwise make one bounded improvement within the declared scope. Return JSON with a strictly lower top-level numeric metric and evidence. Revert changes that worsen or preserve the metric; never claim the target without the numeric value." },
       reporter: { system: "Report target achievement or bounded exhaustion with the metric history." },
     },
     nodes: {

--- a/homerail_manager/src/orchestration/dag-patterns.ts
+++ b/homerail_manager/src/orchestration/dag-patterns.ts
@@ -541,7 +541,7 @@ const ratchet: DAGPatternDefinition = {
 
 const compost: DAGPatternDefinition = {
   id: "compost",
-  version: "1.0.1",
+  version: "1.0.2",
   name: "Compost",
   summary: "Turn repeated failures into a small set of proposed laws, skill changes, or standing goals.",
   intent: "Let operational evidence improve the system while keeping policy changes behind explicit review.",
@@ -573,7 +573,7 @@ const compost: DAGPatternDefinition = {
     agents: {
       collector: { system: "Collect recent failures, trust demotions, violated goals, and rejected changes with evidence." },
       proposer: { system: "Produce at most {{max_proposals}} proposals. Each must be a law, skill change, or standing goal grounded in incidents. Return exactly one JSON object with top-level status (proposed or no_change) and top-level proposals array. A status nested inside an individual proposal does not satisfy the contract." },
-      reviewer: { system: "You are a review boundary, not the human decision maker. Present proposals for explicit human acceptance, then finish by calling the handoff tool on done with exactly one JSON object containing top-level status awaiting_human_review and the proposals. Never approve, reject, sign, apply, or simulate a human decision." },
+      reviewer: { system: "You are a review boundary, not the human decision maker. Present proposals for explicit human acceptance, then finish by calling the handoff tool on done with exactly one JSON object. Its top-level key must be named status and its literal value must be awaiting_human_review; do not rename, nest, or substitute that value. Include the proposals and no approval decision. Never approve, reject, sign, apply, or simulate a human decision." },
     },
     nodes: {
       collect: { agent: "collector", outputs: { evidence: { to: "propose.in:evidence" } } },

--- a/homerail_manager/src/orchestration/dag-patterns.ts
+++ b/homerail_manager/src/orchestration/dag-patterns.ts
@@ -77,7 +77,7 @@ const terminalNode = (agent: string, after: string): Record<string, unknown> => 
 
 const heartbeat: DAGPatternDefinition = {
   id: "heartbeat",
-  version: "1.0.0",
+  version: "1.0.1",
   name: "Heartbeat",
   summary: "Triage one signal, route one actionable item, execute it, and independently verify the result.",
   intent: "Keep periodic autonomous work bounded by a quiet-path exit, a single selected action, and a separate verifier.",
@@ -101,7 +101,9 @@ const heartbeat: DAGPatternDefinition = {
       triage: { system: "Classify the supplied signals. Hand off JSON with status actionable or quiet and evidence." },
       conductor: { system: "Select exactly one highest-value actionable item. Emit a bounded work order with verifiable done_when criteria." },
       worker: { system: "Execute only the supplied work order. Return status success or failure with evidence." },
-      verifier: { system: "Independently verify every done_when criterion. Return verdict pass or fail with evidence." },
+      verifier: {
+        system: "Independently verify every done_when criterion. Hand off one JSON object with top-level verdict set to pass or fail and top-level evidence. Never nest verdict inside another object.",
+      },
       reporter: { system: "Report the terminal outcome without claiming unverified work." },
     },
     nodes: {

--- a/homerail_manager/src/orchestration/graph-executor.ts
+++ b/homerail_manager/src/orchestration/graph-executor.ts
@@ -16,7 +16,16 @@ export class GraphExecutor {
   }
 
   tick(runId: string): number {
-    return dispatchReadyNodes(runId, this.dispatcher);
+    const run = getActiveRun(runId);
+    if (!run) return 0;
+    const maxPasses = Math.max(1, run.dagRun.graph.nodes.length * 2);
+    let total = 0;
+    for (let pass = 0; pass < maxPasses; pass++) {
+      const advanced = dispatchReadyNodes(runId, this.dispatcher);
+      total += advanced;
+      if (advanced === 0) break;
+    }
+    return total;
   }
 
   getRun(runId: string): ActiveRun | undefined {

--- a/homerail_manager/src/orchestration/graph-validator.ts
+++ b/homerail_manager/src/orchestration/graph-validator.ts
@@ -20,7 +20,10 @@ function _isTerminalEdge(edge: DAGEdge): boolean {
 
 function _isLoopFeedbackEdge(graph: DAGGraphData, edge: DAGEdge): boolean {
   if (_isTerminalEdge(edge)) return false;
-  return graph.nodes.find((node) => node.node_id === edge.to_node)?.node_type === "loop_gateway";
+  const target = graph.nodes.find((node) => node.node_id === edge.to_node);
+  if (target?.node_type !== "loop_gateway" && target?.node_type !== "while_gateway") return false;
+  const source = graph.nodes.find((node) => node.node_id === edge.from_node);
+  return source?.after.includes(target.node_id) ?? false;
 }
 
 function _nodeIds(graph: DAGGraphData): string[] {
@@ -131,17 +134,58 @@ function _maxRetries(edge: DAGEdge): number | undefined {
   return typeof raw === "number" && Number.isFinite(raw) ? raw : undefined;
 }
 
+const JOIN_MODES = new Set(["all", "any", "n_of_m"]);
+const WHILE_OPERATORS = new Set(["eq", "ne", "gt", "gte", "lt", "lte", "truthy", "falsy"]);
+
+function _validateGatewayConfigs(graph: DAGGraphData, errors: string[]): void {
+  for (const node of graph.nodes) {
+    const config = node.gateway_config;
+    if (node.node_type === "join_gateway") {
+      const mode = config?.mode ?? "all";
+      if (!JOIN_MODES.has(mode)) {
+        errors.push(`Join gateway ${node.node_id} has unsupported mode: ${mode}`);
+      }
+      if (mode === "n_of_m") {
+        const threshold = config?.threshold;
+        if (!Number.isInteger(threshold) || (threshold ?? 0) < 1) {
+          errors.push(`Join gateway ${node.node_id} requires a positive integer threshold for n_of_m mode`);
+        }
+      }
+    }
+    if (node.node_type === "while_gateway") {
+      const operator = config?.operator ?? "eq";
+      if (!WHILE_OPERATORS.has(operator)) {
+        errors.push(`While gateway ${node.node_id} has unsupported operator: ${operator}`);
+      }
+      const maxIterations = config?.max_iterations ?? 3;
+      if (!Number.isInteger(maxIterations) || maxIterations < 1) {
+        errors.push(`While gateway ${node.node_id} requires max_iterations to be a positive integer`);
+      }
+    }
+  }
+}
+
 export function validateGraph(graph: DAGGraphData): GraphValidationResult {
   const errors: string[] = [];
   const warnings: string[] = [];
   const ids = _nodeIds(graph);
   const idSet = new Set(ids);
 
+  _validateGatewayConfigs(graph, errors);
+
   if (ids.length === 0) {
     errors.push("Graph has no nodes");
   }
 
   for (const edge of graph.edges) {
+    if (
+      edge.retry_policy?.max_retries !== undefined &&
+      (!Number.isInteger(edge.retry_policy.max_retries) || edge.retry_policy.max_retries < 0)
+    ) {
+      errors.push(
+        `Edge ${edge.from_node}.${edge.from_port} -> ${edge.to_node}.${edge.to_port} requires max_retries to be a non-negative integer`,
+      );
+    }
     if (!idSet.has(edge.from_node)) {
       errors.push(`Edge references unknown from_node: ${edge.from_node}`);
     }

--- a/homerail_manager/src/orchestration/graph-validator.ts
+++ b/homerail_manager/src/orchestration/graph-validator.ts
@@ -141,6 +141,27 @@ function _validateGatewayConfigs(graph: DAGGraphData, errors: string[]): void {
   for (const node of graph.nodes) {
     const config = node.gateway_config;
     if (node.node_type === "join_gateway") {
+      const dependencies = new Set(node.after);
+      const routedSources = new Set(
+        graph.edges
+          .filter((edge) => edge.to_node === node.node_id && edge.label !== "after_dep")
+          .map((edge) => edge.from_node),
+      );
+      if (dependencies.size === 0) {
+        errors.push(`Join gateway ${node.node_id} requires at least one after dependency`);
+      }
+      const missingInputs = Array.from(dependencies).filter((dependency) => !routedSources.has(dependency));
+      if (missingInputs.length > 0) {
+        errors.push(
+          `Join gateway ${node.node_id} is missing routed input from after dependencies: ${missingInputs.sort().join(", ")}`,
+        );
+      }
+      const unawaitedInputs = Array.from(routedSources).filter((source) => !dependencies.has(source));
+      if (unawaitedInputs.length > 0) {
+        errors.push(
+          `Join gateway ${node.node_id} has routed input from undeclared after dependencies: ${unawaitedInputs.sort().join(", ")}`,
+        );
+      }
       const mode = config?.mode ?? "all";
       if (!JOIN_MODES.has(mode)) {
         errors.push(`Join gateway ${node.node_id} has unsupported mode: ${mode}`);
@@ -149,6 +170,10 @@ function _validateGatewayConfigs(graph: DAGGraphData, errors: string[]): void {
         const threshold = config?.threshold;
         if (!Number.isInteger(threshold) || (threshold ?? 0) < 1) {
           errors.push(`Join gateway ${node.node_id} requires a positive integer threshold for n_of_m mode`);
+        } else if ((threshold ?? 0) > dependencies.size) {
+          errors.push(
+            `Join gateway ${node.node_id} threshold ${threshold} exceeds its ${dependencies.size} after dependencies`,
+          );
         }
       }
     }

--- a/homerail_manager/src/orchestration/graph.ts
+++ b/homerail_manager/src/orchestration/graph.ts
@@ -24,15 +24,33 @@ export interface DAGNodeRequirements {
 }
 
 export interface DAGGatewayConfig {
-  type?: "loop" | "condition" | string;
-  kind?: "loop" | "condition" | string;
+  type?: "loop" | "condition" | "join" | "while" | string;
+  kind?: "loop" | "condition" | "join" | "while" | string;
+  mode?: "all" | "any" | "n_of_m" | string;
   field?: string;
   routes?: Record<string, string>;
   cases?: Record<string, string>;
   default_port?: string;
   items?: unknown[];
   item_port?: string;
+  result_port?: string;
   done_port?: string;
+  passed_port?: string;
+  failed_port?: string;
+  continue_port?: string;
+  exhausted_port?: string;
+  threshold?: number;
+  success_values?: unknown[];
+  operator?: "eq" | "ne" | "gt" | "gte" | "lt" | "lte" | "truthy" | "falsy" | string;
+  value?: unknown;
+  max_iterations?: number;
+}
+
+export interface DAGPatternInstanceMeta {
+  id: string;
+  version: string;
+  source?: string;
+  parameters?: Record<string, unknown>;
 }
 
 export interface DAGNodeConfig {
@@ -126,6 +144,7 @@ export interface ResolvedWorkflowMeta {
   runtime_profiles?: Record<string, RuntimeProfile>;
   provider_policy?: ProviderPolicyConfig;
   scorecard?: ScorecardPolicyConfig;
+  pattern?: DAGPatternInstanceMeta;
   image?: string;
   limits?: Record<string, unknown>;
   git?: Record<string, unknown>;

--- a/homerail_manager/src/orchestration/yaml-loader.ts
+++ b/homerail_manager/src/orchestration/yaml-loader.ts
@@ -82,15 +82,22 @@ function _normalizeNodeType(cfg: DAGNodeConfig): string {
   const type = rawType || (gateway ? "gateway" : "agent");
   if (type === "loop" || type === "loop_gateway") return "loop_gateway";
   if (type === "condition" || type === "condition_gateway") return "condition_gateway";
+  if (type === "join" || type === "join_gateway") return "join_gateway";
+  if (type === "while" || type === "while_gateway") return "while_gateway";
   if (type === "gateway") {
     if (kind === "loop") return "loop_gateway";
     if (kind === "condition") return "condition_gateway";
+    if (kind === "join") return "join_gateway";
+    if (kind === "while") return "while_gateway";
   }
   return type || "agent";
 }
 
 function _isGatewayNodeType(nodeType: string): boolean {
-  return nodeType === "loop_gateway" || nodeType === "condition_gateway";
+  return nodeType === "loop_gateway" ||
+    nodeType === "condition_gateway" ||
+    nodeType === "join_gateway" ||
+    nodeType === "while_gateway";
 }
 
 export function _detectLoopSources(
@@ -158,8 +165,15 @@ export function _detectLoopSources(
   }
 
   const loopSources = new Set<string>();
+  const nodeById = new Map(nodes.map((node) => [node.node_id, node]));
   for (const e of edges) {
     if (e.label === "after_dep" || e.to_node === "") continue;
+    const target = nodeById.get(e.to_node);
+    const source = nodeById.get(e.from_node);
+    if (target?.node_type === "loop_gateway" || target?.node_type === "while_gateway") {
+      if (source?.after.includes(target.node_id)) loopSources.add(target.node_id);
+      continue;
+    }
     const fromIdx = topoIndex.get(e.from_node);
     const toIdx = topoIndex.get(e.to_node);
     if (fromIdx !== undefined && toIdx !== undefined && fromIdx > toIdx) {
@@ -184,6 +198,7 @@ export function parseDAGYaml(yamlString: string): ParsedDAG {
     runtime_profiles: raw.runtime_profiles,
     provider_policy: raw.provider_policy,
     scorecard: raw.scorecard,
+    pattern: raw.pattern,
     image: raw.image,
     limits: raw.limits,
     git: raw.git,

--- a/homerail_manager/src/persistence/store.ts
+++ b/homerail_manager/src/persistence/store.ts
@@ -8,7 +8,7 @@ import type {
   PersistedGraphData,
   NodeUsageRecord,
 } from "./types.js";
-import type { DAGGraphData, ScorecardPolicyConfig } from "../orchestration/graph.js";
+import type { DAGGraphData, DAGPatternInstanceMeta, ScorecardPolicyConfig } from "../orchestration/graph.js";
 import { DAG_EVENT_TYPES, subscribe, type DAGEventPayload } from "../events/bus.js";
 import type { DAGRunCounters, DAGRunLimits } from "../runtime/active-runs.js";
 import { assertStatus, type DagRunStatus } from "./status.js";
@@ -24,6 +24,7 @@ interface SerializableRun {
   agents?: Record<string, { agent_type?: string; model?: string; system?: string; description?: string; skills?: string[]; extra?: Record<string, unknown> }>;
   workspace?: Record<string, unknown>;
   scorecard?: ScorecardPolicyConfig;
+  pattern?: DAGPatternInstanceMeta;
   createdAt: number;
   status: DagRunStatus;
   completedAt?: number;
@@ -187,6 +188,7 @@ export function serializeRunMetadata(run: SerializableRun): PersistedRunMetadata
     agents: run.agents,
     workspace: run.workspace,
     scorecard: run.scorecard,
+    pattern: run.pattern,
     createdAt: run.createdAt,
     status: run.status,
     completedAt: run.completedAt,

--- a/homerail_manager/src/persistence/types.ts
+++ b/homerail_manager/src/persistence/types.ts
@@ -1,5 +1,10 @@
 import type { DAGEventType, DAGEventPayload } from "../events/bus.js";
-import type { DAGGatewayConfig, DAGNodeRequirements, ScorecardPolicyConfig } from "../orchestration/graph.js";
+import type {
+  DAGGatewayConfig,
+  DAGNodeRequirements,
+  DAGPatternInstanceMeta,
+  ScorecardPolicyConfig,
+} from "../orchestration/graph.js";
 import type { DAGRunCounters, DAGRunLimits } from "../runtime/active-runs.js";
 import type { DagRunStatus } from "./status.js";
 
@@ -41,6 +46,7 @@ export interface PersistedRunMetadata {
   agents?: Record<string, { agent_type?: string; model?: string; system?: string; description?: string; skills?: string[]; extra?: Record<string, unknown> }>;
   workspace?: Record<string, unknown>;
   scorecard?: ScorecardPolicyConfig;
+  pattern?: DAGPatternInstanceMeta;
   createdAt: number;
   status: DagRunStatus;
   completedAt?: number;

--- a/homerail_manager/src/runtime/active-runs.ts
+++ b/homerail_manager/src/runtime/active-runs.ts
@@ -13,7 +13,7 @@ import {
   isRunTerminal,
   startNode,
 } from "../orchestration/dag-engine.js";
-import type { DAGAgentConfig, DAGEdge, DAGGatewayConfig, DAGGraphNode, DAGOutputRoute, ParsedDAG, ScorecardPolicyConfig } from "../orchestration/graph.js";
+import type { DAGAgentConfig, DAGEdge, DAGGatewayConfig, DAGGraphNode, DAGOutputRoute, DAGPatternInstanceMeta, ParsedDAG, ScorecardPolicyConfig } from "../orchestration/graph.js";
 import { _normalizeOutputsToEdges } from "../orchestration/yaml-loader.js";
 import { assertGraphValid } from "../orchestration/graph-validator.js";
 import { findDispatchTarget } from "../orchestration/dispatch-tracker.js";
@@ -66,6 +66,7 @@ export interface ActiveRun {
   agents?: Record<string, DAGAgentConfig>;
   workspace?: Record<string, unknown>;
   scorecard?: ScorecardPolicyConfig;
+  pattern?: DAGPatternInstanceMeta;
   dagRun: DAGRun;
   createdAt: number;
   status: "active" | "completed" | "failed" | "cancelled";
@@ -122,6 +123,7 @@ export interface DAGRunCounters {
   corrections: Record<string, number>;
   dispatch_retries: Record<string, number>;
   gateway_iterations: Record<string, number>;
+  gateway_results: Record<string, unknown[]>;
   abort_reason?: string;
 }
 
@@ -189,6 +191,21 @@ function _initialCounters(): DAGRunCounters {
     corrections: {},
     dispatch_retries: {},
     gateway_iterations: {},
+    gateway_results: {},
+  };
+}
+
+function _restoreCounters(counters: DAGRunCounters | undefined): DAGRunCounters {
+  const defaults = _initialCounters();
+  if (!counters) return defaults;
+  return {
+    ...defaults,
+    ...counters,
+    edge_traversals: { ...(counters.edge_traversals ?? {}) },
+    corrections: { ...(counters.corrections ?? {}) },
+    dispatch_retries: { ...(counters.dispatch_retries ?? {}) },
+    gateway_iterations: { ...(counters.gateway_iterations ?? {}) },
+    gateway_results: { ...(counters.gateway_results ?? {}) },
   };
 }
 
@@ -354,6 +371,9 @@ export function createActiveRun(
     scorecard: parsedDAG.meta.scorecard
       ? { ...parsedDAG.meta.scorecard }
       : undefined,
+    pattern: parsedDAG.meta.pattern
+      ? { ...parsedDAG.meta.pattern, parameters: { ...(parsedDAG.meta.pattern.parameters ?? {}) } }
+      : undefined,
     dagRun,
     createdAt: Date.now(),
     status: "active",
@@ -431,7 +451,9 @@ function _graphFromPersisted(data: PersistedGraphData): {
   const nodes = data.nodes.map((node): DAGGraphNode => ({ ...node }));
   const edges = data.edges.map((edge): DAGEdge => ({ ...edge }));
   const loopSources = new Set(
-    nodes.filter((n) => n.node_type === "loop_gateway").map((n) => n.node_id),
+    nodes
+      .filter((n) => n.node_type === "loop_gateway" || n.node_type === "while_gateway")
+      .map((n) => n.node_id),
   );
   return { nodes, edges, loopSources };
 }
@@ -550,11 +572,14 @@ export function restoreActiveRun(
       : undefined,
     workspace: metadata.workspace ? { ...metadata.workspace } : undefined,
     scorecard: metadata.scorecard ? { ...metadata.scorecard } : undefined,
+    pattern: metadata.pattern
+      ? { ...metadata.pattern, parameters: { ...(metadata.pattern.parameters ?? {}) } }
+      : undefined,
     dagRun,
     createdAt: metadata.createdAt,
     status: "active",
     limits: metadata.limits ?? { ...DEFAULT_LIMITS },
-    counters: metadata.counters ?? _initialCounters(),
+    counters: _restoreCounters(metadata.counters),
     nodeIndex: _buildNodeIndex(nodes),
     nodeSessions: new Map(),
   };
@@ -951,9 +976,10 @@ export function handoffActiveRun(
     const key = `${edge.from_node}/${edge.from_port}->${edge.to_node}/${edge.to_port}`;
     const nextCount = (run.counters.edge_traversals[key] ?? 0) + 1;
     run.counters.edge_traversals[key] = nextCount;
-    if (nextCount > run.limits.max_edge_traversals) {
-      abortActiveRun(runId, `max_edge_traversals (${run.limits.max_edge_traversals}) exceeded for ${key}`, fromNode);
-      throw new Error(`max_edge_traversals (${run.limits.max_edge_traversals}) exceeded for ${key}`);
+    const edgeLimit = edge.retry_policy?.max_retries ?? run.limits.max_edge_traversals;
+    if (nextCount > edgeLimit) {
+      abortActiveRun(runId, `edge retry limit (${edgeLimit}) exceeded for ${key}`, fromNode);
+      throw new Error(`edge retry limit (${edgeLimit}) exceeded for ${key}`);
     }
   }
 
@@ -1009,6 +1035,11 @@ function _afterDepEdges(node: DAGGraphNode): DAGEdge[] {
 }
 
 function _isBackwardEdge(run: ActiveRun, edge: DAGEdge): boolean {
+  const target = run.dagRun.graph.nodes.find((node) => node.node_id === edge.to_node);
+  if (target?.node_type === "loop_gateway" || target?.node_type === "while_gateway") {
+    const source = run.dagRun.graph.nodes.find((node) => node.node_id === edge.from_node);
+    return source?.after.includes(target.node_id) ?? false;
+  }
   const fromIndex = run.nodeIndex.get(edge.from_node);
   const toIndex = run.nodeIndex.get(edge.to_node);
   return fromIndex !== undefined && toIndex !== undefined && fromIndex > toIndex;
@@ -1179,7 +1210,10 @@ function _nodeInputs(
 }
 
 function _isGatewayNode(node: DAGGraphNode): boolean {
-  return node.node_type === "loop_gateway" || node.node_type === "condition_gateway";
+  return node.node_type === "loop_gateway" ||
+    node.node_type === "condition_gateway" ||
+    node.node_type === "join_gateway" ||
+    node.node_type === "while_gateway";
 }
 
 function _firstInputValue(inputs: Record<string, unknown[]>): unknown {
@@ -1189,9 +1223,20 @@ function _firstInputValue(inputs: Record<string, unknown[]>): unknown {
   return undefined;
 }
 
+function _structuredGatewayValue(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return value;
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch {
+    return value;
+  }
+}
+
 function _fieldValue(value: unknown, field: string | undefined): unknown {
-  if (!field) return value;
-  let current = value;
+  let current = _structuredGatewayValue(value);
+  if (!field) return current;
   for (const part of field.split(".").map((item) => item.trim()).filter(Boolean)) {
     if (typeof current !== "object" || current === null || Array.isArray(current)) return undefined;
     current = (current as Record<string, unknown>)[part];
@@ -1214,10 +1259,98 @@ function _conditionGatewayPort(config: DAGGatewayConfig | undefined, input: unkn
 
 function _loopGatewayItems(config: DAGGatewayConfig | undefined, inputs: Record<string, unknown[]>): unknown[] {
   if (Array.isArray(config?.items)) return config.items;
-  const fromItemsPort = inputs.items?.find((value) => Array.isArray(value));
+  const fromItemsPort = inputs.items
+    ?.map(_structuredGatewayValue)
+    .find((value) => Array.isArray(value));
   if (Array.isArray(fromItemsPort)) return fromItemsPort;
-  const first = _firstInputValue(inputs);
+  const first = _structuredGatewayValue(_firstInputValue(inputs));
   return Array.isArray(first) ? first : [];
+}
+
+function _gatewayComparison(actual: unknown, operator: string | undefined, expected: unknown): boolean {
+  switch (operator ?? "eq") {
+    case "eq":
+      return actual === expected;
+    case "ne":
+      return actual !== expected;
+    case "gt":
+      return typeof actual === "number" && typeof expected === "number" && actual > expected;
+    case "gte":
+      return typeof actual === "number" && typeof expected === "number" && actual >= expected;
+    case "lt":
+      return typeof actual === "number" && typeof expected === "number" && actual < expected;
+    case "lte":
+      return typeof actual === "number" && typeof expected === "number" && actual <= expected;
+    case "truthy":
+      return Boolean(actual);
+    case "falsy":
+      return !actual;
+    default:
+      return false;
+  }
+}
+
+function _joinGatewayResult(config: DAGGatewayConfig | undefined, inputs: Record<string, unknown[]>): {
+  port: string;
+  payload: Record<string, unknown>;
+} {
+  const values = Object.values(inputs).flat();
+  const successValues = config?.success_values ?? [true, "pass", "passed", "success", "approved", "yes", "act", "actionable"];
+  const votes = values.map((value) => {
+    const selected = _fieldValue(value, config?.field);
+    return successValues.some((candidate) => selected === candidate);
+  });
+  const successes = votes.filter(Boolean).length;
+  const mode = config?.mode === "any" || config?.mode === "n_of_m" ? config.mode : "all";
+  const threshold = mode === "any"
+    ? 1
+    : mode === "n_of_m"
+      ? Math.max(1, Math.floor(config?.threshold ?? Math.ceil(values.length / 2)))
+      : values.length;
+  const passed = values.length > 0 && successes >= threshold;
+  return {
+    port: passed ? config?.passed_port || "passed" : config?.failed_port || "failed",
+    payload: {
+      mode,
+      total: values.length,
+      successes,
+      failures: values.length - successes,
+      threshold,
+      passed,
+      values,
+    },
+  };
+}
+
+function _whileGatewayResult(
+  run: ActiveRun,
+  node: DAGGraphNode,
+  input: unknown,
+): { port: string; payload: Record<string, unknown> } {
+  const config = node.gateway_config;
+  const selected = _fieldValue(input, config?.field);
+  const matched = _gatewayComparison(selected, config?.operator, config?.value);
+  const iteration = run.counters.gateway_iterations[node.node_id] ?? 0;
+  const maxIterations = Math.max(1, Math.floor(config?.max_iterations ?? 3));
+  if (matched) {
+    run.dagRun.loopSources.delete(node.node_id);
+    return {
+      port: config?.done_port || "done",
+      payload: { input, iteration, max_iterations: maxIterations, matched: true },
+    };
+  }
+  if (iteration >= maxIterations) {
+    run.dagRun.loopSources.delete(node.node_id);
+    return {
+      port: config?.exhausted_port || "exhausted",
+      payload: { input, iteration, max_iterations: maxIterations, matched: false, exhausted: true },
+    };
+  }
+  run.counters.gateway_iterations[node.node_id] = iteration + 1;
+  return {
+    port: config?.continue_port || "continue",
+    payload: { input, iteration: iteration + 1, max_iterations: maxIterations, matched: false },
+  };
 }
 
 function _executeGatewayNode(runId: string, run: ActiveRun, node: DAGGraphNode): boolean {
@@ -1241,11 +1374,18 @@ function _executeGatewayNode(runId: string, run: ActiveRun, node: DAGGraphNode):
     const items = _loopGatewayItems(node.gateway_config, inputs);
     const index = run.counters.gateway_iterations[node.node_id] ?? 0;
     const itemPort = node.gateway_config?.item_port || "next_item";
+    const resultPort = node.gateway_config?.result_port || "result";
     const donePort = node.gateway_config?.done_port || "done";
+    const results = run.counters.gateway_results[node.node_id] ?? [];
+    const resultValues = inputs[resultPort];
+    if (index > 0 && resultValues && resultValues.length > 0) {
+      results.push(_structuredGatewayValue(resultValues[resultValues.length - 1]));
+      run.counters.gateway_results[node.node_id] = results;
+    }
     const port = index < items.length ? itemPort : donePort;
     const payload = index < items.length
-      ? { item: items[index], index, total: items.length }
-      : { total: items.length, completed: true };
+      ? { item: items[index], index, total: items.length, completed_results: [...results] }
+      : { total: items.length, completed: true, results: [...results] };
     if (index < items.length) {
       run.counters.gateway_iterations[node.node_id] = index + 1;
     } else {
@@ -1258,6 +1398,33 @@ function _executeGatewayNode(runId: string, run: ActiveRun, node: DAGGraphNode):
       nodeId: node.node_id,
       gatewayType: node.node_type,
       port,
+    });
+    return true;
+  }
+
+  if (node.node_type === "join_gateway") {
+    const result = _joinGatewayResult(node.gateway_config, _nodeInputs(run.dagRun, node.node_id));
+    const next = handoffActiveRun(runId, node.node_id, result.port, result.payload);
+    if (!next) return false;
+    emit("dag:gateway_executed", {
+      runId,
+      nodeId: node.node_id,
+      gatewayType: node.node_type,
+      port: result.port,
+    });
+    return true;
+  }
+
+  if (node.node_type === "while_gateway") {
+    const inputs = _nodeInputs(run.dagRun, node.node_id);
+    const result = _whileGatewayResult(run, node, _firstInputValue(inputs));
+    const next = handoffActiveRun(runId, node.node_id, result.port, result.payload);
+    if (!next) return false;
+    emit("dag:gateway_executed", {
+      runId,
+      nodeId: node.node_id,
+      gatewayType: node.node_type,
+      port: result.port,
     });
     return true;
   }

--- a/homerail_manager/src/runtime/active-runs.ts
+++ b/homerail_manager/src/runtime/active-runs.ts
@@ -1322,6 +1322,11 @@ function _joinGatewayResult(config: DAGGatewayConfig | undefined, inputs: Record
   };
 }
 
+function _terminateLoopSource(run: ActiveRun, nodeId: string): void {
+  // loopSources is run-local execution state; removal makes this gateway terminal for the rest of this run.
+  run.dagRun.loopSources.delete(nodeId);
+}
+
 function _whileGatewayResult(
   run: ActiveRun,
   node: DAGGraphNode,
@@ -1333,14 +1338,14 @@ function _whileGatewayResult(
   const iteration = run.counters.gateway_iterations[node.node_id] ?? 0;
   const maxIterations = Math.max(1, Math.floor(config?.max_iterations ?? 3));
   if (matched) {
-    run.dagRun.loopSources.delete(node.node_id);
+    _terminateLoopSource(run, node.node_id);
     return {
       port: config?.done_port || "done",
       payload: { input, iteration, max_iterations: maxIterations, matched: true },
     };
   }
   if (iteration >= maxIterations) {
-    run.dagRun.loopSources.delete(node.node_id);
+    _terminateLoopSource(run, node.node_id);
     return {
       port: config?.exhausted_port || "exhausted",
       payload: { input, iteration, max_iterations: maxIterations, matched: false, exhausted: true },
@@ -1389,7 +1394,7 @@ function _executeGatewayNode(runId: string, run: ActiveRun, node: DAGGraphNode):
     if (index < items.length) {
       run.counters.gateway_iterations[node.node_id] = index + 1;
     } else {
-      run.dagRun.loopSources.delete(node.node_id);
+      _terminateLoopSource(run, node.node_id);
     }
     const next = handoffActiveRun(runId, node.node_id, port, payload);
     if (!next) return false;

--- a/homerail_manager/src/server/dag-workflows.ts
+++ b/homerail_manager/src/server/dag-workflows.ts
@@ -6,6 +6,11 @@ import {
   upsertDagRuntimeProfileFromYaml,
   upsertDagWorkflowFromYaml,
 } from "../persistence/dag-workflows.js";
+import {
+  getDAGPattern,
+  instantiateDAGPattern,
+  listDAGPatterns,
+} from "../orchestration/dag-patterns.js";
 
 interface BaseResponse {
   success: boolean;
@@ -66,9 +71,65 @@ function workflowIdFromPath(pathname: string): string | undefined {
   return id && !id.includes("/") ? decodeURIComponent(id) : undefined;
 }
 
+function patternPath(pathname: string): { id: string; action?: "instantiate" } | undefined {
+  const prefix = "/api/dag/patterns/";
+  if (!pathname.startsWith(prefix)) return undefined;
+  const parts = pathname.slice(prefix.length).split("/").filter(Boolean);
+  if (parts.length === 1) return { id: decodeURIComponent(parts[0]) };
+  if (parts.length === 2 && parts[1] === "instantiate") {
+    return { id: decodeURIComponent(parts[0]), action: "instantiate" };
+  }
+  return undefined;
+}
+
+function objectField(body: Record<string, unknown>, name: string): Record<string, unknown> | undefined {
+  const value = body[name];
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
 export function dagWorkflowRoutesHandler(req: http.IncomingMessage, res: http.ServerResponse): boolean {
   const url = new URL(req.url || "/", "http://localhost");
   const pathname = url.pathname;
+
+  if (pathname === "/api/dag/patterns" && req.method === "GET") {
+    const patterns = listDAGPatterns();
+    ok(res, `Found ${patterns.length} built-in DAG pattern(s)`, { patterns, total: patterns.length });
+    return true;
+  }
+
+  const patternRoute = patternPath(pathname);
+  if (patternRoute && !patternRoute.action && req.method === "GET") {
+    const pattern = getDAGPattern(patternRoute.id);
+    if (!pattern) notFound(res, `DAG pattern not found: ${patternRoute.id}`);
+    else ok(res, "DAG pattern retrieved", pattern);
+    return true;
+  }
+
+  if (patternRoute?.action === "instantiate" && req.method === "POST") {
+    readJsonBody(req)
+      .then((body) => {
+        const parameters = objectField(body, "parameters");
+        if (body.parameters !== undefined && !parameters) {
+          throw new Error("Field 'parameters' must be an object.");
+        }
+        const instance = instantiateDAGPattern(patternRoute.id, parameters ?? {});
+        ok(res, "DAG pattern instantiated", {
+          pattern: instance.pattern,
+          parameters: instance.parameters,
+          workflow: instance.workflow,
+          yaml_text: instance.yaml_text,
+          validation: instance.validation,
+        });
+      })
+      .catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        if (message.startsWith("DAG pattern not found:")) notFound(res, message);
+        else badRequest(res, message);
+      });
+    return true;
+  }
 
   if (pathname === "/api/dag/workflows" && req.method === "GET") {
     const workflows = listDagWorkflows();

--- a/homerail_manager/src/server/host-codex-manager-agent.ts
+++ b/homerail_manager/src/server/host-codex-manager-agent.ts
@@ -24,6 +24,7 @@ import {
   type ManagerAgentWidgetFileToolResult,
   type ManagerAgentToolName,
   type ManagerAgentReasoningEffort,
+  type ManagerAgentPromptSkill,
 } from "homerail-protocol";
 
 type ToolHandlerResult = {
@@ -124,6 +125,7 @@ export interface HostCodexManagerAgentInput {
   managerRestUrl?: string | (() => string);
   response_mode?: "chat" | "voice";
   voice_ui_rules?: VoiceUiRules;
+  manager_skills?: ManagerAgentPromptSkill[];
 }
 
 export type HostCodexManagerAgentRunner = (
@@ -497,6 +499,22 @@ function createManagerTools(state: {
       },
     },
     {
+      ...managerAgentToolSpec("list_skills"),
+      async handler() {
+        const body = await requestManager(state.restUrl, "/skills");
+        return { content: [{ type: "text", text: short(body, 12000) }] };
+      },
+    },
+    {
+      ...managerAgentToolSpec("read_skill"),
+      async handler(args) {
+        const skillId = String(args.skill_id || "").trim();
+        if (!skillId) throw new Error("read_skill requires skill_id");
+        const body = await requestManager(state.restUrl, `/skills/${encodeURIComponent(skillId)}`);
+        return { content: [{ type: "text", text: short(body, 30000) }] };
+      },
+    },
+    {
       name: "list_orchestrations",
       description: "List repo-local orchestration YAML templates available to create runs.",
       input_schema: { type: "object", properties: {}, additionalProperties: false },
@@ -511,6 +529,75 @@ function createManagerTools(state: {
             text: JSON.stringify({ root: "assets/orchestrations", files }),
           }],
         };
+      },
+    },
+    {
+      ...managerAgentToolSpec("list_dag_patterns"),
+      async handler() {
+        const body = await requestManager(state.restUrl, "/dag/patterns");
+        return { content: [{ type: "text", text: short(body, 20000) }] };
+      },
+    },
+    {
+      ...managerAgentToolSpec("get_dag_pattern"),
+      async handler(args) {
+        const patternId = String(args.pattern_id || "").trim();
+        if (!patternId) throw new Error("get_dag_pattern requires pattern_id");
+        const body = await requestManager(state.restUrl, `/dag/patterns/${encodeURIComponent(patternId)}`);
+        return { content: [{ type: "text", text: short(body, 30000) }] };
+      },
+    },
+    {
+      ...managerAgentToolSpec("instantiate_dag_pattern"),
+      async handler(args) {
+        const patternId = String(args.pattern_id || "").trim();
+        if (!patternId) throw new Error("instantiate_dag_pattern requires pattern_id");
+        try {
+          const instantiated = await requestManager(
+            state.restUrl,
+            `/dag/patterns/${encodeURIComponent(patternId)}/instantiate`,
+            {
+              method: "POST",
+              body: JSON.stringify({
+                parameters: args.parameters && typeof args.parameters === "object" && !Array.isArray(args.parameters)
+                  ? args.parameters
+                  : {},
+              }),
+            },
+          ) as Record<string, unknown>;
+          const data = instantiated.data as Record<string, unknown> | undefined;
+          const yamlText = typeof data?.yaml_text === "string" ? data.yaml_text : "";
+          const shouldSync = args.sync !== false;
+          let syncResult: unknown = null;
+          if (shouldSync) {
+            if (!yamlText) throw new Error("Pattern instantiation did not return yaml_text");
+            syncResult = await requestManager(state.restUrl, "/dag/workflows/sync", {
+              method: "POST",
+              body: JSON.stringify({ yaml_text: yamlText, source_path: `builtin:${patternId}` }),
+            });
+          }
+          state.objectiveToolCalls.push({ name: "instantiate_dag_pattern", success: true });
+          return {
+            content: [{
+              type: "text",
+              text: short({
+                pattern_id: patternId,
+                parameters: data?.parameters,
+                workflow: data?.workflow,
+                validation: data?.validation,
+                synced: shouldSync,
+                sync: syncResult,
+              }, 16000),
+            }],
+          };
+        } catch (error) {
+          state.objectiveToolCalls.push({
+            name: "instantiate_dag_pattern",
+            success: false,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          throw error;
+        }
       },
     },
     {
@@ -773,11 +860,11 @@ export function _hostCodexVoiceToolCatalogForTest(): Array<{ name: string; descr
 export async function _invokeHostCodexVoiceToolForTest(
   name: string,
   args: Record<string, unknown>,
-  options: { projectId?: string; sessionId?: string } = {},
+  options: { projectId?: string; sessionId?: string; managerRestUrl?: string } = {},
 ): Promise<{ result: ToolHandlerResult; voiceSurface: VoiceSurfaceState }> {
   const voiceSurface = emptyVoiceSurface();
   const tools = createManagerTools({
-    restUrl: "http://127.0.0.1:0/api",
+    restUrl: options.managerRestUrl ?? "http://127.0.0.1:0/api",
     workspace: process.cwd(),
     projectId: options.projectId ?? "test-project",
     sessionId: options.sessionId ?? "test-session",
@@ -982,6 +1069,7 @@ function systemPrompt(
   responseMode: "chat" | "voice" = "chat",
   voiceUiRules?: VoiceUiRules,
   voiceSystemContract?: VoiceSystemContract,
+  skills?: ManagerAgentPromptSkill[],
 ): string {
   return buildManagerAgentSystemPrompt({
     responseMode,
@@ -992,6 +1080,7 @@ function systemPrompt(
     },
     voiceUiRules: responseMode === "voice" ? voiceUiRules ?? loadVoiceUiRules() : undefined,
     voiceSystem: responseMode === "voice" ? voiceSystemContract ?? loadVoiceSystemContract() : undefined,
+    skills,
   });
 }
 
@@ -1000,8 +1089,9 @@ export function _systemPromptForTest(
   responseMode: "chat" | "voice" = "chat",
   voiceUiRules?: VoiceUiRules,
   voiceSystemContract?: VoiceSystemContract,
+  skills?: ManagerAgentPromptSkill[],
 ): string {
-  return systemPrompt(config, responseMode, voiceUiRules, voiceSystemContract);
+  return systemPrompt(config, responseMode, voiceUiRules, voiceSystemContract, skills);
 }
 
 function buildPrompt(
@@ -1028,6 +1118,14 @@ function toolCallCommentary(name: string): string | undefined {
   switch (name) {
     case "list_orchestrations":
       return "正在查看可用的 DAG 编排。";
+    case "list_skills":
+    case "read_skill":
+      return "正在加载 HomeRail Skill。";
+    case "list_dag_patterns":
+    case "get_dag_pattern":
+      return "正在选择合适的 DAG 模式。";
+    case "instantiate_dag_pattern":
+      return "正在生成并同步 DAG 模式。";
     case "create_and_run":
       return "正在启动 DAG。";
     case "invoke_run":
@@ -1160,7 +1258,7 @@ async function* runHostCodexManagerAgentTurnEvents(
       buildPrompt(input.history, message, input.continue_chat !== false),
       createManagerTools(state, responseMode),
       {
-        systemPrompt: systemPrompt(config, responseMode, voiceUiRules, voiceSystemContract),
+        systemPrompt: systemPrompt(config, responseMode, voiceUiRules, voiceSystemContract, input.manager_skills),
         provider: config.provider_name || undefined,
         model: config.model || "codex",
         apiKey: config.api_key || "",

--- a/homerail_manager/src/server/manager-agent-runtime.ts
+++ b/homerail_manager/src/server/manager-agent-runtime.ts
@@ -14,6 +14,7 @@ import {
   runHostCodexManagerAgentTurnStream,
   type VoiceUiRules,
 } from "./host-codex-manager-agent.js";
+import { listManagerSkills, type ManagerSkillSummary } from "./manager-skills.js";
 import {
   managerAgentRuntimePlacementForHarness,
   normalizeManagerAgentHarness,
@@ -33,6 +34,7 @@ export interface RunManagerAgentTurnInput {
   required_tool_calls?: string[];
   agent_config: ManagerAgentRuntimeConfig;
   voice_ui_rules?: VoiceUiRules;
+  manager_skills?: ManagerSkillSummary[];
 }
 
 export interface RunManagerAgentTurnResult {
@@ -79,6 +81,7 @@ export async function runManagerAgentTurn(
   options?: ManagerAgentContainerOptions,
 ): Promise<RunManagerAgentTurnResult> {
   const runtimePlacement = managerAgentRuntimePlacement(input.agent_config);
+  const managerSkills = input.manager_skills ?? listManagerSkills();
   if (runtimePlacement === "host") {
     try {
       const result = await runHostCodexManagerAgentTurn({
@@ -92,6 +95,7 @@ export async function runManagerAgentTurn(
         managerRestUrl: options?.managerRestUrl,
         response_mode: input.response_mode,
         voice_ui_rules: input.voice_ui_rules,
+        manager_skills: managerSkills,
       });
       return {
         result,
@@ -144,6 +148,7 @@ export async function runManagerAgentTurn(
         agent_config: input.agent_config,
         voice_ui_rules: input.voice_ui_rules,
         voice_system_contract: input.response_mode === "voice" ? loadVoiceSystemContract() : undefined,
+        manager_skills: managerSkills,
       });
       return {
         result,
@@ -185,6 +190,7 @@ export async function runManagerAgentTurn(
       agent_config: input.agent_config,
       voice_ui_rules: input.voice_ui_rules,
       voice_system_contract: input.response_mode === "voice" ? loadVoiceSystemContract() : undefined,
+      manager_skills: managerSkills,
     });
     return {
       result,
@@ -217,6 +223,7 @@ export async function* runManagerAgentTurnStream(
   }
 
   try {
+    const managerSkills = input.manager_skills ?? listManagerSkills();
     for await (const event of runHostCodexManagerAgentTurnStream({
       message: input.message,
       project_id: input.project_id ?? undefined,
@@ -228,6 +235,7 @@ export async function* runManagerAgentTurnStream(
       managerRestUrl: options?.managerRestUrl,
       response_mode: input.response_mode,
       voice_ui_rules: input.voice_ui_rules,
+      manager_skills: managerSkills,
     })) {
       if (event.type === "commentary") {
         yield { type: "commentary", text: event.text };

--- a/homerail_manager/src/server/manager-skills.ts
+++ b/homerail_manager/src/server/manager-skills.ts
@@ -1,0 +1,149 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import YAML from "yaml";
+
+import { repoRoot } from "../assets/root.js";
+import { getHomerailHome } from "../config/env.js";
+
+export interface ManagerSkillSummary {
+  id: string;
+  name: string;
+  description: string;
+  relative_path: string;
+  source: "home" | "repo";
+  enabled: true;
+}
+
+export interface ManagerSkillDetail extends ManagerSkillSummary {
+  content: string;
+}
+
+export interface ManagerSkillInstallResult {
+  root: string;
+  installed: string[];
+  existing: string[];
+  errors: Array<{ id: string; message: string }>;
+}
+
+const MAX_SKILL_BYTES = 256 * 1024;
+
+function skillDescription(content: string): { name?: string; description?: string } {
+  if (!content.startsWith("---")) return {};
+  const end = content.indexOf("\n---", 3);
+  if (end < 0) return {};
+  try {
+    const parsed = YAML.parse(content.slice(3, end)) as Record<string, unknown> | null;
+    const name = typeof parsed?.name === "string" ? parsed.name.trim() : undefined;
+    const description = typeof parsed?.description === "string"
+      ? parsed.description.replace(/\s+/g, " ").trim()
+      : undefined;
+    return { name, description };
+  } catch {
+    return {};
+  }
+}
+
+function readSkillFile(file: string): string | undefined {
+  try {
+    const stat = fs.statSync(file);
+    if (!stat.isFile() || stat.size > MAX_SKILL_BYTES) return undefined;
+    return fs.readFileSync(file, "utf8");
+  } catch {
+    return undefined;
+  }
+}
+
+function scanSkills(root: string, source: ManagerSkillSummary["source"]): ManagerSkillDetail[] {
+  if (!fs.existsSync(root)) return [];
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(root, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((entry) => entry.isDirectory() || entry.isSymbolicLink())
+    .flatMap((entry) => {
+      const file = path.join(root, entry.name, "SKILL.md");
+      const content = readSkillFile(file);
+      if (content === undefined) return [];
+      const metadata = skillDescription(content);
+      return [{
+        id: entry.name,
+        name: metadata.name || entry.name,
+        description: metadata.description || "HomeRail Manager Agent skill",
+        relative_path: path.posix.join("skills", entry.name, "SKILL.md"),
+        source,
+        enabled: true as const,
+        content,
+      }];
+    })
+    .sort((a, b) => a.id.localeCompare(b.id));
+}
+
+export function getManagerSkillsRoot(): string {
+  return path.join(getHomerailHome(), "skills");
+}
+
+export function ensureManagerSkillsInstalled(): ManagerSkillInstallResult {
+  const destinationRoot = getManagerSkillsRoot();
+  const sourceRoot = path.join(repoRoot(), "skills");
+  const result: ManagerSkillInstallResult = { root: destinationRoot, installed: [], existing: [], errors: [] };
+  fs.mkdirSync(destinationRoot, { recursive: true });
+  if (!fs.existsSync(sourceRoot)) return result;
+
+  for (const entry of fs.readdirSync(sourceRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory() || !entry.name.startsWith("homerail-")) continue;
+    const source = path.join(sourceRoot, entry.name);
+    if (!fs.existsSync(path.join(source, "SKILL.md"))) continue;
+    const destination = path.join(destinationRoot, entry.name);
+    try {
+      const existing = fs.lstatSync(destination);
+      if (existing.isSymbolicLink() && !fs.existsSync(destination)) {
+        fs.unlinkSync(destination);
+      } else {
+        result.existing.push(entry.name);
+        continue;
+      }
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT") {
+        result.errors.push({ id: entry.name, message: error instanceof Error ? error.message : String(error) });
+        continue;
+      }
+    }
+    try {
+      fs.symlinkSync(source, destination, process.platform === "win32" ? "junction" : "dir");
+      result.installed.push(entry.name);
+    } catch (error) {
+      result.errors.push({
+        id: entry.name,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  return result;
+}
+
+export function listManagerSkills(): ManagerSkillSummary[] {
+  ensureManagerSkillsInstalled();
+  const homeSkills = scanSkills(getManagerSkillsRoot(), "home");
+  const byId = new Map(homeSkills.map((skill) => [skill.id, skill]));
+  for (const skill of scanSkills(path.join(repoRoot(), "skills"), "repo")) {
+    if (!byId.has(skill.id)) byId.set(skill.id, skill);
+  }
+  return Array.from(byId.values())
+    .sort((a, b) => a.id.localeCompare(b.id))
+    .map(({ content: _content, ...summary }) => summary);
+}
+
+export function readManagerSkill(id: string): ManagerSkillDetail | undefined {
+  const normalized = id.trim();
+  if (!normalized || normalized.includes("/") || normalized.includes("\\") || normalized === "." || normalized === "..") {
+    return undefined;
+  }
+  ensureManagerSkillsInstalled();
+  const home = scanSkills(getManagerSkillsRoot(), "home").find((skill) => skill.id === normalized);
+  if (home) return home;
+  return scanSkills(path.join(repoRoot(), "skills"), "repo").find((skill) => skill.id === normalized);
+}

--- a/homerail_manager/src/server/settings-bootstrap.ts
+++ b/homerail_manager/src/server/settings-bootstrap.ts
@@ -5,6 +5,11 @@ import { runtimeStatusHandler } from "../runtime/status.js";
 import { getExperienceDir, listExperienceGraphFromDb } from "./experience.js";
 import { listPersistedRunIds, loadRunMetadata } from "../persistence/store.js";
 import { repoRoot, resolveAssetRoot } from "../assets/root.js";
+import {
+  ensureManagerSkillsInstalled,
+  listManagerSkills,
+  readManagerSkill,
+} from "./manager-skills.js";
 
 interface BaseResponse {
   success: boolean;
@@ -52,21 +57,9 @@ function readJsonBody(req: http.IncomingMessage): Promise<Record<string, unknown
 }
 
 function readSkillsCatalog() {
-  const root = repoRoot();
-  const skillsDir = path.join(root, "skills");
-  const skills = fs.existsSync(skillsDir)
-    ? fs.readdirSync(skillsDir, { withFileTypes: true })
-      .filter((entry) => entry.isDirectory())
-      .filter((entry) => fs.existsSync(path.join(skillsDir, entry.name, "SKILL.md")))
-      .map((entry) => ({
-        id: entry.name,
-        name: entry.name,
-        relative_path: path.posix.join("skills", entry.name, "SKILL.md"),
-        source: "repo",
-      }))
-      .sort((a, b) => a.id.localeCompare(b.id))
-    : [];
-  return { skills, total: skills.length };
+  const install = ensureManagerSkillsInstalled();
+  const skills = listManagerSkills();
+  return { skills, total: skills.length, root: install.root, install };
 }
 
 function buildAssetDiagnostics() {
@@ -521,6 +514,24 @@ export function settingsBootstrapHandler(
 
   if (pathname === "/api/skills" && req.method === "GET") {
     _ok(res, "Skills retrieved", readSkillsCatalog());
+    return true;
+  }
+
+  const skillMatch = pathname.match(/^\/api\/skills\/([^/]+)$/);
+  if (skillMatch && req.method === "GET") {
+    let skillId = "";
+    try {
+      skillId = decodeURIComponent(skillMatch[1]);
+    } catch {
+      json(res, 400, { success: false, message: "Invalid skill id", error: "Invalid skill id" });
+      return true;
+    }
+    const skill = readManagerSkill(skillId);
+    if (!skill) {
+      json(res, 404, { success: false, message: "Skill not found", error: "Skill not found" });
+    } else {
+      _ok(res, "Skill retrieved", skill);
+    }
     return true;
   }
 

--- a/homerail_manager/tests/cold-recovery.test.ts
+++ b/homerail_manager/tests/cold-recovery.test.ts
@@ -44,6 +44,12 @@ function singleNodeDag() {
   return parseDAGYaml(`
 name: cold-recovery
 workflow_id: cold-recovery
+pattern:
+  id: heartbeat
+  version: 1.0.0
+  source: https://x.com/i/status/2074169173178212621
+  parameters:
+    workflow_id: cold-recovery
 workspace:
   project_id: project-a
 agents:
@@ -127,6 +133,12 @@ describe("manager cold recovery", () => {
     expect(run!.limits.max_dispatches).toBeGreaterThan(0);
     expect(run!.dagRun.graph.nodes).toHaveLength(1);
     expect(run!.nodeIndex.has("work")).toBe(true);
+    expect(run!.pattern).toEqual({
+      id: "heartbeat",
+      version: "1.0.0",
+      source: "https://x.com/i/status/2074169173178212621",
+      parameters: { workflow_id: "cold-recovery" },
+    });
   });
 
   it("replays handoff history so a downstream node receives upstream output in its mailbox", () => {
@@ -295,6 +307,23 @@ describe("manager cold recovery", () => {
     if (result.status === "restored") {
       expect(result.run.runId).toBe("run-direct");
       expect(result.demotedFromRunning).toEqual(["work"]);
+    }
+  });
+
+  it("fills newly added counter collections when restoring older metadata", () => {
+    createActiveRun("run-old-counters", singleNodeDag());
+    const metadata = loadRunMetadata("run-old-counters")!;
+    if (metadata.counters) {
+      delete (metadata.counters as Partial<typeof metadata.counters> & { gateway_results?: unknown }).gateway_results;
+    }
+    writeRunMetadata("run-old-counters", metadata);
+    _clearActiveRuns();
+
+    const result = restoreActiveRun(loadRunMetadata("run-old-counters")!);
+
+    expect(result.status).toBe("restored");
+    if (result.status === "restored") {
+      expect(result.run.counters.gateway_results).toEqual({});
     }
   });
 

--- a/homerail_manager/tests/dag-gateway.test.ts
+++ b/homerail_manager/tests/dag-gateway.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { DAGDispatcher, DispatchEnvelope, DispatchResult } from "../src/orchestration/dag-dispatcher.js";
 import { FakeDAGDispatcher } from "../src/orchestration/dag-dispatcher.js";
+import { GraphExecutor } from "../src/orchestration/graph-executor.js";
 import { parseDAGYaml } from "../src/orchestration/yaml-loader.js";
 import { _clearListeners } from "../src/events/bus.js";
 import { closeDb } from "../src/persistence/db.js";
@@ -71,18 +72,124 @@ nodes:
     gateway_config:
       items: [alpha, beta]
       item_port: next_item
+      result_port: worker_done
       done_port: done
     outputs:
       next_item:
         to: worker.in:task
       done:
-        to: ""
+        to: summary.in:result
   worker:
     agent: worker
     after: [loop]
     outputs:
       done:
         to: loop.in:worker_done
+  summary:
+    agent: worker
+    after: [loop]
+    outputs:
+      done:
+        to: ""
+`;
+}
+
+function joinGatewayYaml(mode = "n_of_m", threshold = 2): string {
+  return `
+name: join-gateway
+agents:
+  worker:
+    agent_type: deterministic
+nodes:
+  voter_one:
+    agent: worker
+    outputs:
+      vote:
+        to: join.in:one
+  voter_two:
+    agent: worker
+    outputs:
+      vote:
+        to: join.in:two
+  voter_three:
+    agent: worker
+    outputs:
+      vote:
+        to: join.in:three
+  join:
+    type: join_gateway
+    gateway_config:
+      mode: ${mode}
+      threshold: ${threshold}
+      field: decision
+      success_values: [approve]
+      passed_port: accepted
+      failed_port: rejected
+    after: [voter_one, voter_two, voter_three]
+    outputs:
+      accepted:
+        to: accepted.in:result
+      rejected:
+        to: rejected.in:result
+  accepted:
+    agent: worker
+    after: [join]
+    outputs:
+      done:
+        to: ""
+  rejected:
+    agent: worker
+    after: [join]
+    outputs:
+      done:
+        to: ""
+`;
+}
+
+function whileGatewayYaml(maxIterations = 2, maxRetries = 2): string {
+  return `
+name: while-gateway
+agents:
+  worker:
+    agent_type: deterministic
+nodes:
+  gate:
+    type: while_gateway
+    gateway_config:
+      field: score
+      operator: gte
+      value: 3
+      max_iterations: ${maxIterations}
+      continue_port: improve
+      done_port: reached
+      exhausted_port: stopped
+    outputs:
+      improve:
+        to: worker.in:task
+      reached:
+        to: success.in:result
+      stopped:
+        to: exhausted.in:result
+  worker:
+    agent: worker
+    after: [gate]
+    outputs:
+      measured:
+        to: gate.in:measurement
+        retry_policy:
+          max_retries: ${maxRetries}
+  success:
+    agent: worker
+    after: [gate]
+    outputs:
+      done:
+        to: ""
+  exhausted:
+    agent: worker
+    after: [gate]
+    outputs:
+      done:
+        to: ""
 `;
 }
 
@@ -135,6 +242,121 @@ describe("DAG gateway nodes", () => {
     expect(run?.dagRun.nodeStates.get("bad")).toBe("SKIPPED");
   });
 
+  it("accepts JSON-string handoffs from model-backed agents at gateway boundaries", () => {
+    const parsed = parseDAGYaml(conditionGatewayYaml());
+    createActiveRun("run-condition-json-string", parsed);
+    handoffActiveRun("run-condition-json-string", "start", "done", JSON.stringify({ status: "pass" }));
+
+    expect(dispatchReadyNodes("run-condition-json-string", new FakeDAGDispatcher())).toBe(1);
+    const run = getActiveRun("run-condition-json-string");
+    expect(run?.dagRun.nodeStates.get("good")).toBe("READY");
+    expect(run?.dagRun.nodeStates.get("bad")).toBe("SKIPPED");
+  });
+
+  it("iterates a JSON-string item array emitted by a model-backed loader", () => {
+    const parsed = parseDAGYaml(`
+name: loop-json-string
+agents:
+  worker:
+    agent_type: deterministic
+nodes:
+  load:
+    agent: worker
+    outputs:
+      items:
+        to: loop.in:items
+  loop:
+    type: loop_gateway
+    after: [load]
+    outputs:
+      next_item:
+        to: worker.in:task
+      done:
+        to: ""
+  worker:
+    agent: worker
+    after: [loop]
+    outputs:
+      done:
+        to: loop.in:result
+`);
+    createActiveRun("run-loop-json-string", parsed);
+    handoffActiveRun("run-loop-json-string", "load", "items", JSON.stringify(["alpha", "beta"]));
+
+    expect(dispatchReadyNodes("run-loop-json-string", new FakeDAGDispatcher())).toBe(1);
+    expect(getActiveRun("run-loop-json-string")?.dagRun.mailboxes.get("worker")?.get("task")?.[0]).toMatchObject({
+      item: "alpha",
+      index: 0,
+      total: 2,
+    });
+  });
+
+  it("drains a gateway transition and dispatches the newly opened agent in one executor tick", () => {
+    const parsed = parseDAGYaml(conditionGatewayYaml());
+    const dispatcher = new CollectingDispatcher();
+    const executor = new GraphExecutor(dispatcher);
+    executor.createRun("run-condition-drain", parsed);
+    handoffActiveRun("run-condition-drain", "start", "done", { status: "pass" });
+
+    expect(executor.tick("run-condition-drain")).toBe(2);
+    expect(dispatcher.dispatched.map((item) => item.nodeId)).toEqual(["good"]);
+    expect(getActiveRun("run-condition-drain")?.dagRun.nodeStates.get("good")).toBe("RUNNING");
+  });
+
+  it("recursively skips descendants of an untaken gateway branch", () => {
+    const parsed = parseDAGYaml(`
+name: branch-skip-propagation
+agents:
+  worker:
+    agent_type: deterministic
+nodes:
+  start:
+    agent: worker
+    outputs:
+      done:
+        to: gate.in:decision
+  gate:
+    type: condition_gateway
+    gateway_config:
+      field: status
+      routes:
+        pass: approved
+        fail: rejected
+    after: [start]
+    outputs:
+      approved:
+        to: approved.in:task
+      rejected:
+        to: rejected.in:task
+  approved:
+    agent: worker
+    after: [gate]
+    outputs:
+      done:
+        to: approved_terminal.in:result
+  approved_terminal:
+    agent: worker
+    after: [approved]
+    outputs:
+      done:
+        to: ""
+  rejected:
+    agent: worker
+    after: [gate]
+    outputs:
+      done:
+        to: ""
+`);
+    createActiveRun("run-branch-skip-propagation", parsed);
+    handoffActiveRun("run-branch-skip-propagation", "start", "done", { status: "fail" });
+
+    expect(dispatchReadyNodes("run-branch-skip-propagation", new FakeDAGDispatcher())).toBe(1);
+    const run = getActiveRun("run-branch-skip-propagation");
+    expect(run?.dagRun.nodeStates.get("approved")).toBe("SKIPPED");
+    expect(run?.dagRun.nodeStates.get("approved_terminal")).toBe("SKIPPED");
+    expect(run?.dagRun.nodeStates.get("rejected")).toBe("READY");
+  });
+
   it("iterates loop gateways over configured items and then opens the done branch", () => {
     const parsed = parseDAGYaml(loopGatewayYaml());
     createActiveRun("run-loop-gateway", parsed);
@@ -145,15 +367,121 @@ describe("DAG gateway nodes", () => {
 
     expect(dispatchReadyNodes("run-loop-gateway", dispatcher)).toBe(1);
     expect(dispatcher.dispatched[0].inputs.task[0]).toMatchObject({ item: "alpha", index: 0, total: 2 });
-    handoffActiveRun("run-loop-gateway", "worker", "done", "first complete");
+    handoffActiveRun("run-loop-gateway", "worker", "done", JSON.stringify({ item: "alpha", result: "pass" }));
 
     expect(dispatchReadyNodes("run-loop-gateway", dispatcher)).toBe(1);
     expect(dispatchReadyNodes("run-loop-gateway", dispatcher)).toBe(1);
     expect(dispatcher.dispatched[1].inputs.task[0]).toMatchObject({ item: "beta", index: 1, total: 2 });
-    handoffActiveRun("run-loop-gateway", "worker", "done", "second complete");
+    handoffActiveRun("run-loop-gateway", "worker", "done", JSON.stringify({ item: "beta", result: "pass" }));
 
     expect(dispatchReadyNodes("run-loop-gateway", dispatcher)).toBe(1);
     const run = getActiveRun("run-loop-gateway");
     expect(run?.dagRun.nodeStates.get("loop")).toBe("COMPLETED");
+    expect(run?.dagRun.nodeStates.get("summary")).toBe("READY");
+    const expectedResults = [
+      { item: "alpha", result: "pass" },
+      { item: "beta", result: "pass" },
+    ];
+    expect(run?.counters.gateway_results.loop).toEqual(expectedResults);
+    expect(run?.dagRun.mailboxes.get("summary")?.get("result")?.[0]).toEqual({
+      total: 2,
+      completed: true,
+      results: expectedResults,
+    });
+  });
+
+  it("aggregates n-of-m join inputs and opens the passing branch", () => {
+    const parsed = parseDAGYaml(joinGatewayYaml());
+    createActiveRun("run-join-passed", parsed);
+
+    handoffActiveRun("run-join-passed", "voter_one", "vote", { decision: "approve" });
+    handoffActiveRun("run-join-passed", "voter_two", "vote", { decision: "reject" });
+    handoffActiveRun("run-join-passed", "voter_three", "vote", { decision: "approve" });
+
+    expect(dispatchReadyNodes("run-join-passed", new FakeDAGDispatcher())).toBe(1);
+    const run = getActiveRun("run-join-passed");
+    expect(run?.dagRun.nodeStates.get("join")).toBe("COMPLETED");
+    expect(run?.dagRun.nodeStates.get("accepted")).toBe("READY");
+    expect(run?.dagRun.nodeStates.get("rejected")).toBe("SKIPPED");
+    expect(run?.dagRun.mailboxes.get("accepted")?.get("result")?.[0]).toMatchObject({
+      mode: "n_of_m",
+      total: 3,
+      successes: 2,
+      threshold: 2,
+      passed: true,
+    });
+  });
+
+  it("opens the failing join branch when the quorum is not met", () => {
+    const parsed = parseDAGYaml(joinGatewayYaml());
+    createActiveRun("run-join-failed", parsed);
+
+    handoffActiveRun("run-join-failed", "voter_one", "vote", { decision: "approve" });
+    handoffActiveRun("run-join-failed", "voter_two", "vote", { decision: "reject" });
+    handoffActiveRun("run-join-failed", "voter_three", "vote", { decision: "reject" });
+
+    expect(dispatchReadyNodes("run-join-failed", new FakeDAGDispatcher())).toBe(1);
+    const run = getActiveRun("run-join-failed");
+    expect(run?.dagRun.nodeStates.get("accepted")).toBe("SKIPPED");
+    expect(run?.dagRun.nodeStates.get("rejected")).toBe("READY");
+  });
+
+  it("repeats a while gateway until its completion predicate matches", () => {
+    const parsed = parseDAGYaml(whileGatewayYaml());
+    createActiveRun("run-while-complete", parsed);
+    const dispatcher = new CollectingDispatcher();
+
+    expect(dispatchReadyNodes("run-while-complete", dispatcher)).toBe(1);
+    expect(dispatchReadyNodes("run-while-complete", dispatcher)).toBe(1);
+    handoffActiveRun("run-while-complete", "worker", "measured", { score: 1 });
+
+    expect(dispatchReadyNodes("run-while-complete", dispatcher)).toBe(1);
+    expect(dispatchReadyNodes("run-while-complete", dispatcher)).toBe(1);
+    handoffActiveRun("run-while-complete", "worker", "measured", { score: 3 });
+
+    expect(dispatchReadyNodes("run-while-complete", dispatcher)).toBe(1);
+    const run = getActiveRun("run-while-complete");
+    expect(run?.dagRun.nodeStates.get("gate")).toBe("COMPLETED");
+    expect(run?.dagRun.nodeStates.get("success")).toBe("READY");
+    expect(run?.dagRun.nodeStates.get("exhausted")).toBe("SKIPPED");
+    expect(run?.counters.gateway_iterations.gate).toBe(2);
+  });
+
+  it("routes a while gateway to exhausted after its iteration limit", () => {
+    const parsed = parseDAGYaml(whileGatewayYaml());
+    createActiveRun("run-while-exhausted", parsed);
+    const dispatcher = new CollectingDispatcher();
+
+    expect(dispatchReadyNodes("run-while-exhausted", dispatcher)).toBe(1);
+    expect(dispatchReadyNodes("run-while-exhausted", dispatcher)).toBe(1);
+    handoffActiveRun("run-while-exhausted", "worker", "measured", { score: 1 });
+    expect(dispatchReadyNodes("run-while-exhausted", dispatcher)).toBe(1);
+    expect(dispatchReadyNodes("run-while-exhausted", dispatcher)).toBe(1);
+    handoffActiveRun("run-while-exhausted", "worker", "measured", { score: 2 });
+
+    expect(dispatchReadyNodes("run-while-exhausted", dispatcher)).toBe(1);
+    const run = getActiveRun("run-while-exhausted");
+    expect(run?.dagRun.nodeStates.get("success")).toBe("SKIPPED");
+    expect(run?.dagRun.nodeStates.get("exhausted")).toBe("READY");
+  });
+
+  it("enforces an edge-specific retry limit on feedback edges", () => {
+    const parsed = parseDAGYaml(whileGatewayYaml(5, 1));
+    createActiveRun("run-while-retry-limit", parsed);
+    const dispatcher = new CollectingDispatcher();
+
+    expect(dispatchReadyNodes("run-while-retry-limit", dispatcher)).toBe(1);
+    expect(dispatchReadyNodes("run-while-retry-limit", dispatcher)).toBe(1);
+    handoffActiveRun("run-while-retry-limit", "worker", "measured", { score: 1 });
+    expect(dispatchReadyNodes("run-while-retry-limit", dispatcher)).toBe(1);
+    expect(dispatchReadyNodes("run-while-retry-limit", dispatcher)).toBe(1);
+
+    expect(() => handoffActiveRun(
+      "run-while-retry-limit",
+      "worker",
+      "measured",
+      { score: 2 },
+    )).toThrow("edge retry limit (1) exceeded");
+    expect(getActiveRun("run-while-retry-limit")?.status).toBe("failed");
   });
 });

--- a/homerail_manager/tests/dag-gateway.test.ts
+++ b/homerail_manager/tests/dag-gateway.test.ts
@@ -334,7 +334,15 @@ nodes:
     outputs:
       done:
         to: approved_terminal.in:result
+      failed:
+        to: approved_failure_terminal.in:error
   approved_terminal:
+    agent: worker
+    after: [approved]
+    outputs:
+      done:
+        to: ""
+  approved_failure_terminal:
     agent: worker
     after: [approved]
     outputs:
@@ -354,6 +362,7 @@ nodes:
     const run = getActiveRun("run-branch-skip-propagation");
     expect(run?.dagRun.nodeStates.get("approved")).toBe("SKIPPED");
     expect(run?.dagRun.nodeStates.get("approved_terminal")).toBe("SKIPPED");
+    expect(run?.dagRun.nodeStates.get("approved_failure_terminal")).toBe("SKIPPED");
     expect(run?.dagRun.nodeStates.get("rejected")).toBe("READY");
   });
 

--- a/homerail_manager/tests/dag-graph-validator.test.ts
+++ b/homerail_manager/tests/dag-graph-validator.test.ts
@@ -183,4 +183,77 @@ nodes:
       "Feedback-loop risk: on_failure edge second.error -> first.retry has max_retries 11",
     );
   });
+
+  it("allows a bounded feedback cycle that targets a while gateway", () => {
+    const parsed = parseDAGYaml(`
+name: valid-while-cycle
+nodes:
+  work:
+    agent: worker
+    after: [gate]
+    outputs:
+      measured:
+        to: gate.in:measurement
+        retry_policy:
+          max_retries: 2
+  gate:
+    type: while_gateway
+    gateway_config:
+      operator: eq
+      value: done
+      max_iterations: 2
+    outputs:
+      continue:
+        to: work.in:task
+      done:
+        to: ""
+      exhausted:
+        to: ""
+`);
+
+    const result = validateGraph(parsed.graph);
+    expect(result.valid).toBe(true);
+    expect(result.entry_nodes).toEqual(["gate"]);
+    expect(parsed.loop_sources).toContain("gate");
+  });
+
+  it("rejects invalid join, while, and retry configurations before runtime", () => {
+    expect(() => parseDAGYaml(`
+name: invalid-join
+nodes:
+  join:
+    type: join_gateway
+    gateway_config:
+      mode: n_of_m
+      threshold: 0
+    outputs:
+      passed:
+        to: ""
+`)).toThrow(/positive integer threshold/);
+
+    expect(() => parseDAGYaml(`
+name: invalid-while
+nodes:
+  gate:
+    type: while_gateway
+    gateway_config:
+      operator: approximately
+      max_iterations: 0
+    outputs:
+      done:
+        to: ""
+`)).toThrow(/unsupported operator/);
+
+    expect(() => parseDAGYaml(`
+name: invalid-retry
+nodes:
+  start:
+    agent: worker
+    outputs:
+      done:
+        to: ""
+        retry_policy:
+          max_retries: -1
+`)).toThrow(/non-negative integer/);
+  });
 });

--- a/homerail_manager/tests/dag-graph-validator.test.ts
+++ b/homerail_manager/tests/dag-graph-validator.test.ts
@@ -220,12 +220,21 @@ nodes:
   it("rejects invalid join, while, and retry configurations before runtime", () => {
     expect(() => parseDAGYaml(`
 name: invalid-join
+agents:
+  worker:
+    agent_type: deterministic
 nodes:
+  voter:
+    agent: worker
+    outputs:
+      vote:
+        to: join.in:vote
   join:
     type: join_gateway
     gateway_config:
       mode: n_of_m
       threshold: 0
+    after: [voter]
     outputs:
       passed:
         to: ""
@@ -255,5 +264,92 @@ nodes:
         retry_policy:
           max_retries: -1
 `)).toThrow(/non-negative integer/);
+  });
+
+  it("rejects join gateways without a complete dependency input contract", () => {
+    expect(() => parseDAGYaml(`
+name: join-without-dependencies
+nodes:
+  join:
+    type: join_gateway
+    outputs:
+      passed:
+        to: ""
+`)).toThrow(/requires at least one after dependency/);
+
+    expect(() => parseDAGYaml(`
+name: join-with-missing-input
+agents:
+  worker:
+    agent_type: deterministic
+nodes:
+  voter_one:
+    agent: worker
+    outputs:
+      vote:
+        to: join.in:one
+  voter_two:
+    agent: worker
+    outputs:
+      done:
+        to: ""
+  join:
+    type: join_gateway
+    after: [voter_one, voter_two]
+    outputs:
+      passed:
+        to: ""
+`)).toThrow(/missing routed input from after dependencies: voter_two/);
+
+    expect(() => parseDAGYaml(`
+name: join-with-unawaited-input
+agents:
+  worker:
+    agent_type: deterministic
+nodes:
+  awaited_voter:
+    agent: worker
+    outputs:
+      vote:
+        to: join.in:awaited
+  unawaited_voter:
+    agent: worker
+    outputs:
+      vote:
+        to: join.in:unawaited
+  join:
+    type: join_gateway
+    after: [awaited_voter]
+    outputs:
+      passed:
+        to: ""
+`)).toThrow(/routed input from undeclared after dependencies: unawaited_voter/);
+
+    expect(() => parseDAGYaml(`
+name: join-with-impossible-threshold
+agents:
+  worker:
+    agent_type: deterministic
+nodes:
+  voter_one:
+    agent: worker
+    outputs:
+      vote:
+        to: join.in:one
+  voter_two:
+    agent: worker
+    outputs:
+      vote:
+        to: join.in:two
+  join:
+    type: join_gateway
+    gateway_config:
+      mode: n_of_m
+      threshold: 3
+    after: [voter_one, voter_two]
+    outputs:
+      passed:
+        to: ""
+`)).toThrow(/threshold 3 exceeds its 2 after dependencies/);
   });
 });

--- a/homerail_manager/tests/dag-patterns-api.test.ts
+++ b/homerail_manager/tests/dag-patterns-api.test.ts
@@ -1,0 +1,113 @@
+import * as fs from "node:fs";
+import * as http from "node:http";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { closeDb } from "../src/persistence/db.js";
+import { createServer } from "../src/server/http.js";
+
+async function listen(server: http.Server): Promise<number> {
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address !== "object") throw new Error("server did not bind");
+  return address.port;
+}
+
+async function close(server: http.Server): Promise<void> {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+describe("DAG patterns API", () => {
+  let server: http.Server;
+  let baseUrl: string;
+  let tmpHome: string;
+  let oldHome: string | undefined;
+
+  beforeEach(async () => {
+    oldHome = process.env.HOMERAIL_HOME;
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-dag-pattern-api-"));
+    process.env.HOMERAIL_HOME = tmpHome;
+    closeDb();
+    server = createServer(0, undefined, undefined, false);
+    baseUrl = `http://127.0.0.1:${await listen(server)}`;
+  });
+
+  afterEach(async () => {
+    await close(server);
+    closeDb();
+    if (oldHome === undefined) delete process.env.HOMERAIL_HOME;
+    else process.env.HOMERAIL_HOME = oldHome;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("lists and describes built-in patterns for AI clients", async () => {
+    const listResponse = await fetch(`${baseUrl}/api/dag/patterns`);
+    const listBody = await listResponse.json() as {
+      success: boolean;
+      data: { total: number; patterns: Array<{ id: string; typical_uses: string[] }> };
+    };
+    expect(listResponse.status).toBe(200);
+    expect(listBody.success).toBe(true);
+    expect(listBody.data.total).toBe(9);
+    expect(listBody.data.patterns.find((pattern) => pattern.id === "quorum")?.typical_uses.length).toBeGreaterThan(0);
+
+    const detailResponse = await fetch(`${baseUrl}/api/dag/patterns/ratchet`);
+    const detailBody = await detailResponse.json() as {
+      data: { required_primitives: string[]; workflow_template: { nodes: Record<string, unknown> } };
+    };
+    expect(detailResponse.status).toBe(200);
+    expect(detailBody.data.required_primitives).toContain("while_gateway");
+    expect(detailBody.data.workflow_template.nodes).toHaveProperty("target_gate");
+  });
+
+  it("instantiates a typed pattern and returns validated YAML without persisting it", async () => {
+    const response = await fetch(`${baseUrl}/api/dag/patterns/quorum/instantiate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ parameters: { workflow_id: "api-quorum", threshold: 3 } }),
+    });
+    const body = await response.json() as {
+      success: boolean;
+      data: {
+        parameters: { threshold: number };
+        workflow: { workflow_id: string; pattern: { id: string } };
+        yaml_text: string;
+        validation: { valid: boolean };
+      };
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data.parameters.threshold).toBe(3);
+    expect(body.data.workflow).toMatchObject({ workflow_id: "api-quorum", pattern: { id: "quorum" } });
+    expect(body.data.yaml_text).toContain("threshold: 3");
+    expect(body.data.validation.valid).toBe(true);
+  });
+
+  it("reports invalid parameters and unknown patterns with API status codes", async () => {
+    const invalid = await fetch(`${baseUrl}/api/dag/patterns/quorum/instantiate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ parameters: { threshold: 4 } }),
+    });
+    expect(invalid.status).toBe(400);
+
+    const invalidContainer = await fetch(`${baseUrl}/api/dag/patterns/quorum/instantiate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ parameters: ["threshold=2"] }),
+    });
+    expect(invalidContainer.status).toBe(400);
+
+    const missing = await fetch(`${baseUrl}/api/dag/patterns/unknown`);
+    expect(missing.status).toBe(404);
+
+    const missingInstance = await fetch(`${baseUrl}/api/dag/patterns/unknown/instantiate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+    expect(missingInstance.status).toBe(404);
+  });
+});

--- a/homerail_manager/tests/dag-patterns.test.ts
+++ b/homerail_manager/tests/dag-patterns.test.ts
@@ -106,9 +106,10 @@ describe("built-in DAG patterns", () => {
 
     expect(reviewer?.system).toContain("not the human decision maker");
     expect(reviewer?.system).toContain("handoff tool on done");
-    expect(reviewer?.system).toContain("key must be named status");
-    expect(reviewer?.system).toContain("literal value must be awaiting_human_review");
-    expect(reviewer?.system).toContain("do not rename, nest, or substitute");
+    expect(reviewer?.system).toContain("top-level status awaiting_human_review");
+    expect(reviewer?.system).toContain("review_boundary is human_review");
+    expect(reviewer?.system).toContain("every proposal has status awaiting_human_review");
+    expect(reviewer?.system).toContain("Never emit approved, rejected, signed, or applied status");
   });
 
   it("requires ratchet improvers to preserve an upstream synthetic scope", () => {

--- a/homerail_manager/tests/dag-patterns.test.ts
+++ b/homerail_manager/tests/dag-patterns.test.ts
@@ -82,6 +82,33 @@ describe("built-in DAG patterns", () => {
     expect(verdictGate?.gateway_config?.field).toBe("verdict");
   });
 
+  it("fans out one indexed plan while requiring each worker to select only its own work order", () => {
+    const pattern = instantiateDAGPattern("orchestrator-workers");
+    const planEdges = pattern.parsed.graph.edges.filter(
+      (edge) => edge.from_node === "plan" && edge.from_port === "planned" && edge.label !== "after_dep",
+    );
+
+    expect(planEdges.map((edge) => [edge.from_port, edge.to_node, edge.to_port])).toEqual([
+      ["planned", "worker_one", "order"],
+      ["planned", "worker_two", "order"],
+      ["planned", "worker_three", "order"],
+    ]);
+    expect(pattern.parsed.meta.agents.orchestrator?.system).toContain("work_orders object is keyed");
+    expect(pattern.parsed.meta.agents.worker?.system).toContain("may arrive as a JSON string");
+    expect(pattern.parsed.meta.agents.worker?.system).toContain("work_orders[current_node_id]");
+    expect(pattern.parsed.meta.agents.worker?.system).toContain("handoff tool on result");
+    expect(pattern.parsed.meta.agents.worker?.system).toContain("top-level status");
+  });
+
+  it("keeps compost proposals behind an explicit human-review handoff", () => {
+    const pattern = instantiateDAGPattern("compost");
+    const reviewer = pattern.parsed.meta.agents.reviewer;
+
+    expect(reviewer?.system).toContain("not the human decision maker");
+    expect(reviewer?.system).toContain("handoff tool on done");
+    expect(reviewer?.system).toContain("top-level status awaiting_human_review");
+  });
+
   it("rejects unknown, incorrectly typed, and out-of-range parameters", () => {
     expect(() => instantiateDAGPattern("missing")).toThrow("DAG pattern not found");
     expect(() => instantiateDAGPattern("quorum", { surprise: true })).toThrow("Unknown pattern parameter");

--- a/homerail_manager/tests/dag-patterns.test.ts
+++ b/homerail_manager/tests/dag-patterns.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import * as path from "node:path";
+
+import {
+  DAG_PATTERN_SOURCE,
+  getDAGPattern,
+  instantiateDAGPattern,
+  listDAGPatterns,
+} from "../src/orchestration/dag-patterns.js";
+import { parseDAGYamlFile } from "../src/orchestration/yaml-loader.js";
+
+describe("built-in DAG patterns", () => {
+  it("ships the complete pattern catalog with AI-readable guidance", () => {
+    const patterns = listDAGPatterns();
+
+    expect(patterns.map((pattern) => pattern.id)).toEqual([
+      "heartbeat",
+      "orchestrator-workers",
+      "budget-gate",
+      "trust-ledger",
+      "standing-goal-sentinel",
+      "quorum",
+      "sparring",
+      "ratchet",
+      "compost",
+    ]);
+    for (const pattern of patterns) {
+      expect(pattern.roles.length).toBeGreaterThan(1);
+      expect(pattern.typical_uses.length).toBeGreaterThan(0);
+      expect(pattern.avoid_when.length).toBeGreaterThan(0);
+      expect(pattern.required_primitives.length).toBeGreaterThan(0);
+      expect(pattern.node_count).toBeGreaterThan(1);
+      expect(pattern.source).toEqual(DAG_PATTERN_SOURCE);
+    }
+  });
+
+  it("instantiates every built-in pattern as valid provider-independent YAML", () => {
+    for (const summary of listDAGPatterns()) {
+      const instance = instantiateDAGPattern(summary.id);
+
+      expect(instance.validation.valid).toBe(true);
+      expect(instance.validation.errors).toEqual([]);
+      expect(instance.parsed.meta.workflow_id).toBe(`pattern-${summary.id}`);
+      expect(instance.parsed.meta.workspace).toEqual({ mode: "isolated" });
+      expect(instance.parsed.meta.pattern).toMatchObject({
+        id: summary.id,
+        version: summary.version,
+        source: DAG_PATTERN_SOURCE.url,
+      });
+      expect(instance.yaml_text).not.toMatch(/provider:|model:|api_key:/);
+      expect(instance.yaml_text).not.toContain("{{");
+    }
+  });
+
+  it("preserves numeric parameter types in gateway configuration", () => {
+    const quorum = instantiateDAGPattern("quorum", {
+      workflow_id: "release-quorum",
+      threshold: 3,
+    });
+    const join = quorum.parsed.graph.nodes.find((node) => node.node_id === "quorum");
+    expect(join?.gateway_config?.threshold).toBe(3);
+    expect(quorum.parsed.meta.pattern?.parameters).toMatchObject({
+      workflow_id: "release-quorum",
+      threshold: 3,
+    });
+
+    const ratchet = instantiateDAGPattern("ratchet", { target: 2, max_iterations: 5 });
+    const gate = ratchet.parsed.graph.nodes.find((node) => node.node_id === "target_gate");
+    expect(gate?.gateway_config).toMatchObject({ value: 2, max_iterations: 5 });
+    expect(ratchet.parsed.graph.edges.find(
+      (edge) => edge.from_node === "improve" && edge.to_node === "target_gate",
+    )?.retry_policy?.max_retries).toBe(5);
+  });
+
+  it("rejects unknown, incorrectly typed, and out-of-range parameters", () => {
+    expect(() => instantiateDAGPattern("missing")).toThrow("DAG pattern not found");
+    expect(() => instantiateDAGPattern("quorum", { surprise: true })).toThrow("Unknown pattern parameter");
+    expect(() => instantiateDAGPattern("quorum", { threshold: "2" })).toThrow("must be a finite number");
+    expect(() => instantiateDAGPattern("quorum", { threshold: 2.5 })).toThrow("must be an integer");
+    expect(() => instantiateDAGPattern("quorum", { threshold: 4 })).toThrow("must be at most 3");
+    expect(() => instantiateDAGPattern("heartbeat", { workflow_id: "" })).toThrow("must be a non-empty string");
+  });
+
+  it("returns defensive copies of pattern definitions", () => {
+    const first = getDAGPattern("quorum");
+    expect(first).toBeDefined();
+    first!.roles[0].responsibility = "mutated";
+
+    expect(getDAGPattern("quorum")?.roles[0].responsibility).not.toBe("mutated");
+  });
+
+  it("keeps concrete offline pattern instances valid and isolated", () => {
+    const assets = [
+      ["pattern-quorum-offline.yaml", "quorum"],
+      ["pattern-ratchet-exhaustion-offline.yaml", "ratchet"],
+    ] as const;
+    for (const [file, patternId] of assets) {
+      const parsed = parseDAGYamlFile(path.resolve("..", "assets", "orchestrations", file));
+      expect(parsed.meta.pattern?.id).toBe(patternId);
+      expect(parsed.meta.workspace).toEqual({ mode: "isolated" });
+    }
+  });
+});

--- a/homerail_manager/tests/dag-patterns.test.ts
+++ b/homerail_manager/tests/dag-patterns.test.ts
@@ -109,6 +109,15 @@ describe("built-in DAG patterns", () => {
     expect(reviewer?.system).toContain("top-level status awaiting_human_review");
   });
 
+  it("requires ratchet improvers to preserve an upstream synthetic scope", () => {
+    const pattern = instantiateDAGPattern("ratchet");
+    const improver = pattern.parsed.meta.agents.improver;
+
+    expect(improver?.system).toContain("preserve the scope declared by the upstream evidence");
+    expect(improver?.system).toContain("synthetic or in-memory");
+    expect(improver?.system).toContain("never inspect or modify the workspace");
+  });
+
   it("rejects unknown, incorrectly typed, and out-of-range parameters", () => {
     expect(() => instantiateDAGPattern("missing")).toThrow("DAG pattern not found");
     expect(() => instantiateDAGPattern("quorum", { surprise: true })).toThrow("Unknown pattern parameter");

--- a/homerail_manager/tests/dag-patterns.test.ts
+++ b/homerail_manager/tests/dag-patterns.test.ts
@@ -72,6 +72,16 @@ describe("built-in DAG patterns", () => {
     )?.retry_policy?.max_retries).toBe(5);
   });
 
+  it("makes the heartbeat verifier emit the top-level field consumed by its gateway", () => {
+    const heartbeat = instantiateDAGPattern("heartbeat");
+    const verifier = heartbeat.parsed.meta.agents.verifier;
+    const verdictGate = heartbeat.parsed.graph.nodes.find((node) => node.node_id === "verdict_gate");
+
+    expect(verifier?.system).toContain("top-level verdict");
+    expect(verifier?.system).toContain("Never nest verdict");
+    expect(verdictGate?.gateway_config?.field).toBe("verdict");
+  });
+
   it("rejects unknown, incorrectly typed, and out-of-range parameters", () => {
     expect(() => instantiateDAGPattern("missing")).toThrow("DAG pattern not found");
     expect(() => instantiateDAGPattern("quorum", { surprise: true })).toThrow("Unknown pattern parameter");

--- a/homerail_manager/tests/dag-patterns.test.ts
+++ b/homerail_manager/tests/dag-patterns.test.ts
@@ -106,7 +106,9 @@ describe("built-in DAG patterns", () => {
 
     expect(reviewer?.system).toContain("not the human decision maker");
     expect(reviewer?.system).toContain("handoff tool on done");
-    expect(reviewer?.system).toContain("top-level status awaiting_human_review");
+    expect(reviewer?.system).toContain("key must be named status");
+    expect(reviewer?.system).toContain("literal value must be awaiting_human_review");
+    expect(reviewer?.system).toContain("do not rename, nest, or substitute");
   });
 
   it("requires ratchet improvers to preserve an upstream synthetic scope", () => {

--- a/homerail_manager/tests/manager-chat.test.ts
+++ b/homerail_manager/tests/manager-chat.test.ts
@@ -241,6 +241,9 @@ describe("/api/manager/chat", () => {
           model: "qwen3.6",
           base_url: "http://127.0.0.1:5000",
         },
+        manager_skills: expect.arrayContaining([
+          expect.objectContaining({ id: "homerail-dag-patterns", source: "home" }),
+        ]),
       });
       expect(fakeNode.requests.map((item) => `${item.resource_type}:${item.operation}`)).toEqual([
         "container:list",
@@ -979,9 +982,11 @@ describe("/api/manager/chat", () => {
   it("routes codex_appserver Manager Agent chat through host Codex without a container", async () => {
     let seenMessage = "";
     let seenAgentType = "";
+    let seenSkills: Array<{ id: string; source?: string }> = [];
     _setHostCodexManagerAgentRunnerForTest(async (input) => {
       seenMessage = input.message;
       seenAgentType = input.agent_config.agent_type;
+      seenSkills = input.manager_skills ?? [];
       return {
         text: "host codex handled",
         session_id: input.session_id,
@@ -1029,6 +1034,10 @@ describe("/api/manager/chat", () => {
     expect(body.data.manager_agent_config.runtime_placement).toBe("host");
     expect(seenMessage).toBe("启动一个 DAG");
     expect(seenAgentType).toBe("codex_appserver");
+    expect(seenSkills).toContainEqual(expect.objectContaining({
+      id: "homerail-dag-patterns",
+      source: "home",
+    }));
   });
 
   it("normalizes container-only manager URLs for host Codex tools", () => {
@@ -1145,6 +1154,11 @@ describe("/api/manager/chat", () => {
     const names = tools.map((tool) => tool.name);
 
     expect(names).toEqual(expect.arrayContaining([
+      "list_skills",
+      "read_skill",
+      "list_dag_patterns",
+      "get_dag_pattern",
+      "instantiate_dag_pattern",
       "update_voice_memo",
       "validate_widget_file",
       "write_widget_file",
@@ -1156,6 +1170,54 @@ describe("/api/manager/chat", () => {
       const tool = tools.find((item) => item.name === name);
       expect(tool?.description).toContain("Manager-internal");
     }
+  });
+
+  it("exposes skill and DAG pattern operations through host Codex tools", async () => {
+    const port = await listen(server);
+    const managerRestUrl = `http://127.0.0.1:${port}/api`;
+
+    const listedSkills = await _invokeHostCodexVoiceToolForTest(
+      "list_skills",
+      {},
+      { managerRestUrl },
+    );
+    expect(listedSkills.result.content[0].text).toContain("homerail-dag-patterns");
+
+    const skill = await _invokeHostCodexVoiceToolForTest(
+      "read_skill",
+      { skill_id: "homerail-dag-patterns" },
+      { managerRestUrl },
+    );
+    expect(skill.result.content[0].text).toContain("Manager Agent Native Path");
+
+    const patterns = await _invokeHostCodexVoiceToolForTest(
+      "list_dag_patterns",
+      {},
+      { managerRestUrl },
+    );
+    expect(patterns.result.content[0].text).toContain("heartbeat");
+
+    const pattern = await _invokeHostCodexVoiceToolForTest(
+      "get_dag_pattern",
+      { pattern_id: "heartbeat" },
+      { managerRestUrl },
+    );
+    expect(pattern.result.content[0].text).toContain("condition_gateway");
+
+    const instantiated = await _invokeHostCodexVoiceToolForTest(
+      "instantiate_dag_pattern",
+      {
+        pattern_id: "heartbeat",
+        parameters: { workflow_id: "host-skill-heartbeat", name: "Host Skill Heartbeat" },
+        sync: true,
+      },
+      { managerRestUrl },
+    );
+    expect(instantiated.result.is_error).toBeFalsy();
+    expect(instantiated.result.content[0].text).toContain('"synced":true');
+
+    const workflow = await fetch(`http://127.0.0.1:${port}/api/dag/workflows/host-skill-heartbeat`);
+    expect(workflow.status).toBe(200);
   });
 
   it("writes voice widgets only after TOML validation succeeds", async () => {

--- a/homerail_manager/tests/manager-skills.test.ts
+++ b/homerail_manager/tests/manager-skills.test.ts
@@ -1,0 +1,84 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  ensureManagerSkillsInstalled,
+  getManagerSkillsRoot,
+  listManagerSkills,
+  readManagerSkill,
+} from "../src/server/manager-skills.js";
+
+function writeSkill(root: string, id: string, name: string, description: string, body = "Use this skill."): void {
+  const dir = path.join(root, "skills", id);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "SKILL.md"), [
+    "---",
+    `name: ${name}`,
+    `description: ${description}`,
+    "---",
+    "",
+    `# ${name}`,
+    "",
+    body,
+    "",
+  ].join("\n"), "utf8");
+}
+
+describe("Manager Agent skill discovery", () => {
+  let tmpHome: string;
+  let oldHome: string | undefined;
+
+  beforeEach(() => {
+    oldHome = process.env.HOMERAIL_HOME;
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-manager-skills-"));
+    process.env.HOMERAIL_HOME = tmpHome;
+  });
+
+  afterEach(() => {
+    if (oldHome === undefined) delete process.env.HOMERAIL_HOME;
+    else process.env.HOMERAIL_HOME = oldHome;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("installs missing built-in skills as links under HOMERAIL_HOME", () => {
+    const result = ensureManagerSkillsInstalled();
+
+    expect(result.root).toBe(path.join(tmpHome, "skills"));
+    expect(result.errors).toEqual([]);
+    expect(result.installed).toContain("homerail-dag-patterns");
+    expect(fs.realpathSync(path.join(getManagerSkillsRoot(), "homerail-dag-patterns")))
+      .toBe(fs.realpathSync(path.resolve(process.cwd(), "..", "skills", "homerail-dag-patterns")));
+  });
+
+  it("discovers every home skill and lets home content override a built-in id", () => {
+    writeSkill(tmpHome, "custom-operator", "custom-operator", "Custom operator workflow");
+    writeSkill(
+      tmpHome,
+      "homerail-dag-patterns",
+      "homerail-dag-patterns",
+      "User-owned pattern guidance",
+      "Always inspect local policy before choosing a pattern.",
+    );
+
+    const skills = listManagerSkills();
+
+    expect(skills.find((skill) => skill.id === "custom-operator")).toMatchObject({
+      description: "Custom operator workflow",
+      source: "home",
+      enabled: true,
+    });
+    expect(skills.find((skill) => skill.id === "homerail-dag-patterns")).toMatchObject({
+      description: "User-owned pattern guidance",
+      source: "home",
+    });
+    expect(readManagerSkill("homerail-dag-patterns")?.content)
+      .toContain("Always inspect local policy");
+  });
+
+  it("rejects path traversal and missing skill ids", () => {
+    expect(readManagerSkill("../secrets")).toBeUndefined();
+    expect(readManagerSkill("missing-skill")).toBeUndefined();
+  });
+});

--- a/homerail_manager/tests/settings-bootstrap.test.ts
+++ b/homerail_manager/tests/settings-bootstrap.test.ts
@@ -75,19 +75,43 @@ describe("settings bootstrap routes", () => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
   });
 
-  it("returns the real repository skill catalog", async () => {
+  it("returns the merged HomeRail skill catalog and skill contents", async () => {
+    const customDir = path.join(tmpHome, "skills", "custom-runtime-skill");
+    fs.mkdirSync(customDir, { recursive: true });
+    fs.writeFileSync(path.join(customDir, "SKILL.md"), [
+      "---",
+      "name: custom-runtime-skill",
+      "description: Runtime custom skill",
+      "---",
+      "",
+      "# Runtime custom skill",
+    ].join("\n"));
     const port = await listen(server);
     const response = await fetch(`http://127.0.0.1:${port}/api/skills`);
     const body = await response.json() as {
       success: boolean;
-      data: { total: number; skills: Array<{ id: string; relative_path: string }> };
+      data: { total: number; root: string; skills: Array<{ id: string; relative_path: string; source: string }> };
     };
 
     expect(response.status).toBe(200);
     expect(body.success).toBe(true);
     expect(body.data.total).toBeGreaterThan(0);
     expect(body.data.skills.map((skill) => skill.id)).toContain("homerail-dag-ops");
+    expect(body.data.skills).toContainEqual(expect.objectContaining({
+      id: "custom-runtime-skill",
+      source: "home",
+    }));
+    expect(body.data.root).toBe(path.join(tmpHome, "skills"));
     expect(body.data.skills.every((skill) => !path.isAbsolute(skill.relative_path))).toBe(true);
+
+    const detailResponse = await fetch(`http://127.0.0.1:${port}/api/skills/custom-runtime-skill`);
+    const detail = await detailResponse.json() as { data: { content: string; description: string } };
+    expect(detailResponse.status).toBe(200);
+    expect(detail.data.description).toBe("Runtime custom skill");
+    expect(detail.data.content).toContain("# Runtime custom skill");
+
+    const traversal = await fetch(`http://127.0.0.1:${port}/api/skills/%2E%2E%5Csecrets`);
+    expect(traversal.status).toBe(404);
   });
 
   it("returns asset diagnostics with concrete checks", async () => {

--- a/homerail_protocol/src/manager-agent-prompt.ts
+++ b/homerail_protocol/src/manager-agent-prompt.ts
@@ -20,11 +20,19 @@ export interface ManagerAgentPromptVoiceSystem {
   source?: string;
 }
 
+export interface ManagerAgentPromptSkill {
+  id: string;
+  name?: string;
+  description?: string;
+  source?: string;
+}
+
 export interface ManagerAgentPromptInput {
   runtime?: ManagerAgentPromptRuntime;
   responseMode?: "chat" | "voice";
   voiceUiRules?: ManagerAgentPromptVoiceRules;
   voiceSystem?: ManagerAgentPromptVoiceSystem;
+  skills?: ManagerAgentPromptSkill[];
 }
 
 export function buildManagerAgentSystemPrompt(input: ManagerAgentPromptInput = {}): string {
@@ -39,7 +47,8 @@ export function buildManagerAgentSystemPrompt(input: ManagerAgentPromptInput = {
   const lines = [
     `You are the HomeRail Manager Agent running as ${placement}.`,
     "Your job is to convert user requests into real HomeRail Manager actions using the provided tools.",
-    "For DAG work, inspect available orchestration templates with list_orchestrations when you need one, then call create_and_run with the repo-local yamlPath selected from the user's request and template names.",
+    "HomeRail skills are available through the skill catalog below. When a request matches a skill, call read_skill before acting and follow its instructions. Skill metadata is always available; load full bodies only when relevant.",
+    "For reusable DAG work, read homerail-dag-patterns, inspect list_dag_patterns, inspect the selected pattern with get_dag_pattern, then call instantiate_dag_pattern and create_and_run. Use list_orchestrations for concrete repo-local templates. Do not force a design pattern when a simple linear DAG is clearer.",
     "Never claim a DAG started unless create_and_run or invoke_run returned a real run id.",
     "Do not use shell, curl, npm, node, or a locally started manager server to create DAG runs; those do not count as Manager Agent tool execution.",
     "Do not edit files, commit, push, or call external services unless the user explicitly requests it.",
@@ -47,6 +56,19 @@ export function buildManagerAgentSystemPrompt(input: ManagerAgentPromptInput = {
     "Call finish once with a concise final summary after the required action is started or clearly blocked.",
     `Current runtime provider/model: ${provider}/${model}.`,
   ];
+  const skills = (input.skills ?? []).filter((skill) => skill.id?.trim());
+  if (skills.length > 0) {
+    lines.push(
+      "## Available HomeRail Skills",
+      "These enabled skills are refreshed from HOMERAIL_HOME/skills on every Manager Agent turn; built-in HomeRail skills are installed there when missing.",
+      ...skills.map((skill) => `- ${skill.id}: ${skill.description || skill.name || "HomeRail skill"} [${skill.source || "unknown"}]`),
+    );
+  } else {
+    lines.push(
+      "## Available HomeRail Skills",
+      "No HomeRail skills were discovered. Use list_skills to refresh diagnostics before DAG work.",
+    );
+  }
   if (responseMode === "voice") {
     const voiceSystem = input.voiceSystem;
     const uiRules = input.voiceUiRules;

--- a/homerail_protocol/src/manager-agent-tools.ts
+++ b/homerail_protocol/src/manager-agent-tools.ts
@@ -20,7 +20,12 @@ export type ManagerAgentResponseMode = "chat" | "voice";
 
 export const MANAGER_AGENT_COMMON_TOOL_NAMES = [
   "list_projects",
+  "list_skills",
+  "read_skill",
   "list_orchestrations",
+  "list_dag_patterns",
+  "get_dag_pattern",
+  "instantiate_dag_pattern",
   "create_change",
   "create_and_run",
   "invoke_run",
@@ -193,10 +198,54 @@ export const MANAGER_AGENT_TOOL_SPECS: Record<ManagerAgentToolName, AgentToolDef
     description: "List projects known by the HomeRail Manager.",
     input_schema: emptyObjectSchema,
   },
+  list_skills: {
+    name: "list_skills",
+    description: "List all enabled HomeRail skills discovered from HOMERAIL_HOME/skills with built-in fallbacks.",
+    input_schema: emptyObjectSchema,
+  },
+  read_skill: {
+    name: "read_skill",
+    description: "Load the complete SKILL.md instructions for one HomeRail skill before applying it.",
+    input_schema: {
+      type: "object",
+      properties: { skill_id: { type: "string" } },
+      required: ["skill_id"],
+      additionalProperties: false,
+    },
+  },
   list_orchestrations: {
     name: "list_orchestrations",
     description: "List repo-local orchestration YAML templates available to create runs.",
     input_schema: emptyObjectSchema,
+  },
+  list_dag_patterns: {
+    name: "list_dag_patterns",
+    description: "List built-in abstract DAG design patterns, roles, intended uses, avoid conditions, primitives, and parameters.",
+    input_schema: emptyObjectSchema,
+  },
+  get_dag_pattern: {
+    name: "get_dag_pattern",
+    description: "Get one built-in DAG design pattern including its abstract workflow template.",
+    input_schema: {
+      type: "object",
+      properties: { pattern_id: { type: "string" } },
+      required: ["pattern_id"],
+      additionalProperties: false,
+    },
+  },
+  instantiate_dag_pattern: {
+    name: "instantiate_dag_pattern",
+    description: "Instantiate a built-in DAG pattern with typed parameters and sync the validated workflow to Manager by default.",
+    input_schema: {
+      type: "object",
+      properties: {
+        pattern_id: { type: "string" },
+        parameters: { type: "object", additionalProperties: true },
+        sync: { type: "boolean" },
+      },
+      required: ["pattern_id"],
+      additionalProperties: false,
+    },
   },
   create_change: {
     name: "create_change",

--- a/homerail_protocol/tests/manager-agent.test.ts
+++ b/homerail_protocol/tests/manager-agent.test.ts
@@ -105,6 +105,13 @@ describe("Manager Agent harness contract", () => {
     const chatNames = managerAgentCommonToolCatalog("chat").map((tool) => tool.name);
     const voiceNames = managerAgentCommonToolCatalog("voice").map((tool) => tool.name);
     expect(chatNames).toContain("create_and_run");
+    expect(chatNames).toEqual(expect.arrayContaining([
+      "list_skills",
+      "read_skill",
+      "list_dag_patterns",
+      "get_dag_pattern",
+      "instantiate_dag_pattern",
+    ]));
     expect(chatNames).not.toContain("write_widget_file");
     expect(voiceNames).toContain("write_widget_file");
     expect(voiceNames).toContain("update_voice_memo");
@@ -119,6 +126,11 @@ describe("Manager Agent harness contract", () => {
       { required: ["workflowId"] },
       { required: ["yamlPath"] },
     ]);
+    expect(managerAgentToolSpec("instantiate_dag_pattern").input_schema.properties).toMatchObject({
+      pattern_id: { type: "string" },
+      parameters: { type: "object", additionalProperties: true },
+      sync: { type: "boolean" },
+    });
     expect(managerAgentToolSpec("write_widget_file").input_schema.properties).toMatchObject({
       widget_type: { type: "string", enum: MANAGER_AGENT_WIDGET_FILE_TYPES },
     });
@@ -192,6 +204,30 @@ describe("Manager Agent harness contract", () => {
     expect(prompt).toContain("Voice UI rules hash: abc123");
     expect(prompt).toContain("VOICE_RULES");
     expect(prompt).toContain("Use tool-created widgets for generated UI");
+  });
+
+  it("renders HomeRail skill metadata and the pattern-first DAG workflow", () => {
+    const prompt = buildManagerAgentSystemPrompt({
+      runtime: { placement: "host", provider: "codex", model: "gpt-5.5" },
+      skills: [
+        {
+          id: "homerail-dag-patterns",
+          description: "Select and instantiate reusable DAG patterns.",
+          source: "home",
+        },
+        {
+          id: "custom-operator",
+          description: "Apply local operations policy.",
+          source: "home",
+        },
+      ],
+    });
+
+    expect(prompt).toContain("Available HomeRail Skills");
+    expect(prompt).toContain("homerail-dag-patterns: Select and instantiate reusable DAG patterns. [home]");
+    expect(prompt).toContain("custom-operator: Apply local operations policy. [home]");
+    expect(prompt).toContain("call read_skill before acting");
+    expect(prompt).toContain("instantiate_dag_pattern and create_and_run");
   });
 
   it("describes host-shell manager agents separately from containers", () => {

--- a/homerail_worker/src/__tests__/manager-agent-server.test.ts
+++ b/homerail_worker/src/__tests__/manager-agent-server.test.ts
@@ -40,6 +40,61 @@ function makeManagerApiServer(createAndRunBodies: Record<string, unknown>[] = []
   });
 }
 
+function makePatternManagerApiServer(observed: Array<{ method: string; path: string; body?: Record<string, unknown> }>): http.Server {
+  return http.createServer((req, res) => {
+    const pathname = new URL(req.url || "/", "http://localhost").pathname;
+    const finish = (status: number, data: unknown) => {
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ success: status < 400, data }));
+    };
+    if (req.method === "GET") {
+      observed.push({ method: "GET", path: pathname });
+      if (pathname === "/api/skills") {
+        finish(200, { skills: [{ id: "homerail-dag-patterns", description: "Pattern guidance" }], total: 1 });
+        return;
+      }
+      if (pathname === "/api/skills/homerail-dag-patterns") {
+        finish(200, { id: "homerail-dag-patterns", content: "# HomeRail DAG Patterns\nUse heartbeat." });
+        return;
+      }
+      if (pathname === "/api/dag/patterns") {
+        finish(200, { patterns: [{ id: "heartbeat", summary: "One bounded action" }], total: 1 });
+        return;
+      }
+      if (pathname === "/api/dag/patterns/heartbeat") {
+        finish(200, { id: "heartbeat", parameters: { workflow_id: { type: "string" } } });
+        return;
+      }
+      finish(404, { error: "not found" });
+      return;
+    }
+    let raw = "";
+    req.on("data", (chunk) => { raw += chunk; });
+    req.on("end", () => {
+      const body = raw ? JSON.parse(raw) as Record<string, unknown> : {};
+      observed.push({ method: req.method || "POST", path: pathname, body });
+      if (pathname === "/api/dag/patterns/heartbeat/instantiate") {
+        finish(200, {
+          parameters: { workflow_id: "manager-heartbeat" },
+          workflow: { workflow_id: "manager-heartbeat", name: "Manager heartbeat" },
+          yaml_text: "name: Manager heartbeat\nworkflow_id: manager-heartbeat\nnodes: {}\n",
+          validation: { valid: true },
+        });
+        return;
+      }
+      if (pathname === "/api/dag/workflows/sync") {
+        finish(200, { workflow_id: "manager-heartbeat" });
+        return;
+      }
+      if (pathname === "/api/runs/create-and-run") {
+        finish(201, { runId: "run-pattern-skill-123" });
+        return;
+      }
+      finish(404, { error: "not found" });
+    });
+  });
+}
+
 function writeOrchestrationFiles(workspace: string): void {
   const dir = path.join(workspace, "assets", "orchestrations");
   fs.mkdirSync(dir, { recursive: true });
@@ -142,6 +197,47 @@ class ToolCatalogAgent implements AgentClient {
     this.toolNames = tools.map((tool) => tool.name).sort();
     this.systemPrompt = context.systemPrompt ?? "";
     yield { type: "text", text: "catalog captured" };
+    yield { type: "done" };
+  }
+}
+
+class PatternSkillAgent implements AgentClient {
+  systemPrompt = "";
+
+  async *run(
+    _prompt: string,
+    tools: DagToolDefinition[],
+    context: AgentRunContext,
+  ): AsyncIterable<AgentEvent> {
+    this.systemPrompt = context.systemPrompt ?? "";
+    const calls: Array<{ name: string; input: Record<string, unknown> }> = [
+      { name: "list_skills", input: {} },
+      { name: "read_skill", input: { skill_id: "homerail-dag-patterns" } },
+      { name: "list_dag_patterns", input: {} },
+      { name: "get_dag_pattern", input: { pattern_id: "heartbeat" } },
+      {
+        name: "instantiate_dag_pattern",
+        input: { pattern_id: "heartbeat", parameters: { workflow_id: "manager-heartbeat" }, sync: true },
+      },
+      {
+        name: "create_and_run",
+        input: { workflow_id: "manager-heartbeat", prompt: "Inspect one bounded signal" },
+      },
+    ];
+    for (const [index, call] of calls.entries()) {
+      const tool = tools.find((item) => item.name === call.name);
+      if (!tool) throw new Error(`${call.name} tool missing`);
+      const id = `pattern-tool-${index + 1}`;
+      yield { type: "tool_use", id, name: call.name, input: call.input };
+      const result = await tool.handler(call.input);
+      yield {
+        type: "tool_result",
+        tool_use_id: id,
+        content: result.content.map((item) => item.text).join(""),
+        is_error: result.is_error,
+      };
+    }
+    yield { type: "text", text: "pattern skill run started" };
     yield { type: "done" };
   }
 }
@@ -531,6 +627,72 @@ describe("manager-agent server", () => {
       expect(agent.systemPrompt).toContain("VOICE_SYSTEM_CONTRACT_TEST");
       expect(agent.systemPrompt).toContain("Voice UI rules hash: rules-hash");
       expect(agent.systemPrompt).toContain("VOICE_RULES_TEST");
+    } finally {
+      await close(server);
+      await close(managerApi);
+    }
+  });
+
+  it("loads a HomeRail skill, instantiates its DAG pattern, syncs it, and starts a run", async () => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-manager-agent-workspace-"));
+    tmpDirs.push(workspace);
+    const agent = new PatternSkillAgent();
+    registerAgentBackend("manager-agent-pattern-skill-test", () => agent);
+    vi.stubEnv("PROJECT_WORKSPACE", workspace);
+
+    const observed: Array<{ method: string; path: string; body?: Record<string, unknown> }> = [];
+    const managerApi = makePatternManagerApiServer(observed);
+    const managerPort = await listen(managerApi);
+    vi.stubEnv("MANAGER_REST_URL", `http://127.0.0.1:${managerPort}/api`);
+
+    const server = startManagerAgentServer(0);
+    await new Promise<void>((resolve) => server.once("listening", () => resolve()));
+    const addr = server.address();
+    const port = typeof addr === "object" && addr ? addr.port : 0;
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/chat`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          message: "用 Skill 启动一个周期检查 DAG",
+          required_tool_calls: ["instantiate_dag_pattern", "create_and_run"],
+          manager_skills: [{
+            id: "homerail-dag-patterns",
+            description: "Select reusable DAG patterns",
+            source: "home",
+          }],
+          agent_config: { agent_type: "manager-agent-pattern-skill-test", model: "test" },
+        }),
+      });
+      const body = await response.json() as {
+        run_id?: string;
+        objective?: { satisfied?: boolean };
+        tool_calls?: Array<{ name: string }>;
+      };
+
+      expect(response.status).toBe(200);
+      expect(body.run_id).toBe("run-pattern-skill-123");
+      expect(body.objective?.satisfied).toBe(true);
+      expect(body.tool_calls?.map((call) => call.name)).toEqual([
+        "list_skills",
+        "read_skill",
+        "list_dag_patterns",
+        "get_dag_pattern",
+        "instantiate_dag_pattern",
+        "create_and_run",
+      ]);
+      expect(agent.systemPrompt).toContain("homerail-dag-patterns: Select reusable DAG patterns [home]");
+      expect(observed).toContainEqual(expect.objectContaining({
+        method: "POST",
+        path: "/api/dag/workflows/sync",
+        body: expect.objectContaining({ source_path: "builtin:heartbeat" }),
+      }));
+      expect(observed).toContainEqual(expect.objectContaining({
+        method: "POST",
+        path: "/api/runs/create-and-run",
+        body: expect.objectContaining({ workflow_id: "manager-heartbeat" }),
+      }));
     } finally {
       await close(server);
       await close(managerApi);

--- a/homerail_worker/src/manager-agent/server.ts
+++ b/homerail_worker/src/manager-agent/server.ts
@@ -14,6 +14,7 @@ import {
   type ManagerAgentWidgetFileToolAdapter,
   type ManagerAgentWidgetFileToolResult,
   type ManagerAgentToolName,
+  type ManagerAgentPromptSkill,
 } from "homerail-protocol";
 
 interface ManagerAgentConfig {
@@ -37,6 +38,7 @@ interface ChatRequest {
   agent_config?: ManagerAgentConfig;
   voice_ui_rules?: { prompt?: string; hash?: string; sources?: string[] };
   voice_system_contract?: { prompt?: string; source?: string };
+  manager_skills?: ManagerAgentPromptSkill[];
 }
 
 interface ChatSession {
@@ -344,6 +346,22 @@ function createManagerTools(state: {
       },
     },
     {
+      ...managerAgentToolSpec("list_skills"),
+      async handler() {
+        const body = await requestManager("/skills");
+        return { content: [{ type: "text", text: short(body, 12000) }] };
+      },
+    },
+    {
+      ...managerAgentToolSpec("read_skill"),
+      async handler(args) {
+        const skillId = String(args.skill_id || "").trim();
+        if (!skillId) throw new Error("read_skill requires skill_id");
+        const body = await requestManager(`/skills/${encodeURIComponent(skillId)}`);
+        return { content: [{ type: "text", text: short(body, 30000) }] };
+      },
+    },
+    {
       name: "list_orchestrations",
       description: "List repo-local orchestration YAML templates available to create runs.",
       input_schema: { type: "object", properties: {}, additionalProperties: false },
@@ -361,6 +379,74 @@ function createManagerTools(state: {
             }),
           }],
         };
+      },
+    },
+    {
+      ...managerAgentToolSpec("list_dag_patterns"),
+      async handler() {
+        const body = await requestManager("/dag/patterns");
+        return { content: [{ type: "text", text: short(body, 20000) }] };
+      },
+    },
+    {
+      ...managerAgentToolSpec("get_dag_pattern"),
+      async handler(args) {
+        const patternId = String(args.pattern_id || "").trim();
+        if (!patternId) throw new Error("get_dag_pattern requires pattern_id");
+        const body = await requestManager(`/dag/patterns/${encodeURIComponent(patternId)}`);
+        return { content: [{ type: "text", text: short(body, 30000) }] };
+      },
+    },
+    {
+      ...managerAgentToolSpec("instantiate_dag_pattern"),
+      async handler(args) {
+        const patternId = String(args.pattern_id || "").trim();
+        if (!patternId) throw new Error("instantiate_dag_pattern requires pattern_id");
+        try {
+          const instantiated = await requestManager(
+            `/dag/patterns/${encodeURIComponent(patternId)}/instantiate`,
+            {
+              method: "POST",
+              body: JSON.stringify({
+                parameters: args.parameters && typeof args.parameters === "object" && !Array.isArray(args.parameters)
+                  ? args.parameters
+                  : {},
+              }),
+            },
+          ) as Record<string, unknown>;
+          const data = instantiated.data as Record<string, unknown> | undefined;
+          const yamlText = typeof data?.yaml_text === "string" ? data.yaml_text : "";
+          const shouldSync = args.sync !== false;
+          let syncResult: unknown = null;
+          if (shouldSync) {
+            if (!yamlText) throw new Error("Pattern instantiation did not return yaml_text");
+            syncResult = await requestManager("/dag/workflows/sync", {
+              method: "POST",
+              body: JSON.stringify({ yaml_text: yamlText, source_path: `builtin:${patternId}` }),
+            });
+          }
+          state.objectiveToolCalls.push({ name: "instantiate_dag_pattern", success: true });
+          return {
+            content: [{
+              type: "text",
+              text: short({
+                pattern_id: patternId,
+                parameters: data?.parameters,
+                workflow: data?.workflow,
+                validation: data?.validation,
+                synced: shouldSync,
+                sync: syncResult,
+              }, 16000),
+            }],
+          };
+        } catch (error) {
+          state.objectiveToolCalls.push({
+            name: "instantiate_dag_pattern",
+            success: false,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          throw error;
+        }
       },
     },
     {
@@ -617,6 +703,7 @@ function systemPrompt(
   responseMode: "chat" | "voice" = "chat",
   voiceUiRules?: ChatRequest["voice_ui_rules"],
   voiceSystemContract?: ChatRequest["voice_system_contract"],
+  skills?: ManagerAgentPromptSkill[],
 ): string {
   const placement = process.env.HOMERAIL_MANAGER_AGENT_RUNTIME_PLACEMENT === "host_shell"
     ? "host_shell"
@@ -641,6 +728,7 @@ function systemPrompt(
           source: voiceSystemContract.source,
         }
       : undefined,
+    skills,
   });
 }
 
@@ -704,7 +792,7 @@ async function handleChat(body: ChatRequest): Promise<Record<string, unknown>> {
     timeout.unref?.();
   }
   const context: AgentRunContext = {
-    systemPrompt: systemPrompt(config, responseMode, body.voice_ui_rules, body.voice_system_contract),
+    systemPrompt: systemPrompt(config, responseMode, body.voice_ui_rules, body.voice_system_contract, body.manager_skills),
     provider: config.provider_name,
     model,
     apiKey: String(config.api_key || ""),

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "npm run build:packages && npm run test:packages",
     "typecheck": "npm --prefix homerail_protocol run typecheck && npm --prefix homerail_manager run typecheck && npm --prefix homerail_node run typecheck && npm --prefix homerail_worker run typecheck && npm --prefix homerail_cli run typecheck && npm --prefix agent-ui run typecheck",
     "e2e:agent-ui": "npm --prefix agent-ui run e2e",
+    "validate:dag-patterns-live": "node scripts/validate-dag-patterns-live.mjs",
     "audit": "npm --registry=https://registry.npmjs.org --prefix homerail_protocol audit --audit-level=high && npm --registry=https://registry.npmjs.org --prefix homerail_manager audit --audit-level=high && npm --registry=https://registry.npmjs.org --prefix homerail_node audit --audit-level=high && npm --registry=https://registry.npmjs.org --prefix homerail_worker audit --audit-level=high && npm --registry=https://registry.npmjs.org --prefix homerail_cli audit --audit-level=high && npm --registry=https://registry.npmjs.org --prefix agent-ui audit --audit-level=high",
     "ci": "npm run typecheck && npm run build:packages && npm run test:packages",
     "ci:local": "bash scripts/ci-local.sh",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "typecheck": "npm --prefix homerail_protocol run typecheck && npm --prefix homerail_manager run typecheck && npm --prefix homerail_node run typecheck && npm --prefix homerail_worker run typecheck && npm --prefix homerail_cli run typecheck && npm --prefix agent-ui run typecheck",
     "e2e:agent-ui": "npm --prefix agent-ui run e2e",
     "validate:dag-patterns-live": "node scripts/validate-dag-patterns-live.mjs",
+    "validate:dag-patterns-runner": "bash scripts/run-dag-patterns-live-runner.sh",
     "audit": "npm --registry=https://registry.npmjs.org --prefix homerail_protocol audit --audit-level=high && npm --registry=https://registry.npmjs.org --prefix homerail_manager audit --audit-level=high && npm --registry=https://registry.npmjs.org --prefix homerail_node audit --audit-level=high && npm --registry=https://registry.npmjs.org --prefix homerail_worker audit --audit-level=high && npm --registry=https://registry.npmjs.org --prefix homerail_cli audit --audit-level=high && npm --registry=https://registry.npmjs.org --prefix agent-ui audit --audit-level=high",
     "ci": "npm run typecheck && npm run build:packages && npm run test:packages",
     "ci:local": "bash scripts/ci-local.sh",

--- a/scripts/cleanup-dag-patterns-live-runner.sh
+++ b/scripts/cleanup-dag-patterns-live-runner.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RUNNER_BASE="${HOMERAIL_RUNNER_BASE:-/vol1/1000/homerail_runners}"
+HOME_BASE="${HOMERAIL_LIVE_HOME_BASE:-$RUNNER_BASE/homerail_home}"
+LOCK_FILE="$RUNNER_BASE/dag-patterns-live.lock"
+
+mkdir -p "$RUNNER_BASE" "$HOME_BASE"
+if [ "${HOMERAIL_CLEANUP_LOCK_HELD:-0}" != "1" ]; then
+  exec 9>"$LOCK_FILE"
+  flock -n 9 || exit 0
+fi
+
+mapfile -t containers < <(docker ps -aq --filter "label=org.homerail.live_run")
+if [ "${#containers[@]}" -gt 0 ]; then
+  docker rm -f "${containers[@]}" >/dev/null
+fi
+
+mapfile -t images < <(docker images --filter "label=org.homerail.live_run" --format "{{.ID}}" | sort -u)
+if [ "${#images[@]}" -gt 0 ]; then
+  docker image rm -f "${images[@]}" >/dev/null
+fi
+
+find "$HOME_BASE" -mindepth 1 -maxdepth 1 -type d -name 'run-*' -exec rm -rf -- {} +

--- a/scripts/configure-live-pattern-model.mjs
+++ b/scripts/configure-live-pattern-model.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+const managerUrl = (process.env.HOMERAIL_MANAGER_URL ?? "http://127.0.0.1:29191").replace(/\/+$/, "");
+const modelBaseUrl = (process.env.HOMERAIL_PATTERN_MODEL_BASE_URL ?? "http://192.168.100.10:5000")
+  .replace(/\/+$/, "");
+const modelName = process.env.HOMERAIL_PATTERN_MODEL ?? "qwen3.6";
+const providerId = "homerail-runner-qwen36";
+
+async function request(path, init) {
+  const response = await fetch(`${managerUrl}${path}`, init);
+  const body = await response.json();
+  if (!response.ok || body.success === false) {
+    throw new Error(`${init?.method ?? "GET"} ${path}: ${body.error ?? body.message ?? `HTTP ${response.status}`}`);
+  }
+  return body.data;
+}
+
+await request("/api/llm/providers", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    id: providerId,
+    name: "HomeRail Runner Qwen3.6",
+    status: "active",
+    default_model: modelName,
+    base_url: modelBaseUrl,
+    anthropic_base_url: modelBaseUrl,
+    supports_llm: true,
+  }),
+});
+
+const setting = await request("/api/llm/settings", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    provider_id: providerId,
+    endpoint_id: `${providerId}_custom`,
+    model_name: modelName,
+    api_key: "local-no-key",
+    protocol: "anthropic_compatible",
+    base_url: modelBaseUrl,
+    anthropic_base_url: modelBaseUrl,
+    is_active: true,
+    is_default: true,
+    supports_llm: true,
+  }),
+});
+
+if (!setting?.id) throw new Error("Manager did not return an LLM setting id");
+process.stdout.write(String(setting.id));

--- a/scripts/configure-live-pattern-model.mjs
+++ b/scripts/configure-live-pattern-model.mjs
@@ -4,7 +4,16 @@ const managerUrl = (process.env.HOMERAIL_MANAGER_URL ?? "http://127.0.0.1:29191"
 const modelBaseUrl = (process.env.HOMERAIL_PATTERN_MODEL_BASE_URL ?? "http://192.168.100.10:5000")
   .replace(/\/+$/, "");
 const modelName = process.env.HOMERAIL_PATTERN_MODEL ?? "qwen3.6";
-const providerId = "homerail-runner-qwen36";
+const providerId = process.env.HOMERAIL_PATTERN_PROVIDER_ID ?? "homerail-runner-live";
+const providerName = process.env.HOMERAIL_PATTERN_PROVIDER_NAME ?? `HomeRail Runner ${modelName}`;
+const modelApiKey = process.env.HOMERAIL_PATTERN_MODEL_API_KEY ?? "local-no-key";
+const modelProtocol = process.env.HOMERAIL_PATTERN_MODEL_PROTOCOL ?? "anthropic_compatible";
+
+if (modelProtocol !== "anthropic_compatible") {
+  throw new Error(
+    `Live DAG validation requires an Anthropic-compatible endpoint; received ${modelProtocol}`,
+  );
+}
 
 async function request(path, init) {
   const response = await fetch(`${managerUrl}${path}`, init);
@@ -20,7 +29,7 @@ await request("/api/llm/providers", {
   headers: { "Content-Type": "application/json" },
   body: JSON.stringify({
     id: providerId,
-    name: "HomeRail Runner Qwen3.6",
+    name: providerName,
     status: "active",
     default_model: modelName,
     base_url: modelBaseUrl,
@@ -36,8 +45,8 @@ const setting = await request("/api/llm/settings", {
     provider_id: providerId,
     endpoint_id: `${providerId}_custom`,
     model_name: modelName,
-    api_key: "local-no-key",
-    protocol: "anthropic_compatible",
+    api_key: modelApiKey,
+    protocol: modelProtocol,
     base_url: modelBaseUrl,
     anthropic_base_url: modelBaseUrl,
     is_active: true,

--- a/scripts/run-dag-patterns-live-runner.sh
+++ b/scripts/run-dag-patterns-live-runner.sh
@@ -24,12 +24,14 @@ REPORT_PATH="$PERSISTENT_ARTIFACT_DIR/dag-patterns-live.json"
 UPLOAD_REPORT_PATH="${HOMERAIL_LIVE_REPORT_PATH:-$REPO_ROOT/artifacts/dag-patterns-live.json}"
 LOCK_FILE="$RUNNER_BASE/dag-patterns-live.lock"
 
-mkdir -p "$HOMERAIL_HOME" "$PERSISTENT_ARTIFACT_DIR" "$(dirname "$UPLOAD_REPORT_PATH")"
+mkdir -p "$RUNNER_BASE" "$HOME_BASE" "$PERSISTENT_ARTIFACT_DIR" "$(dirname "$UPLOAD_REPORT_PATH")"
 exec 9>"$LOCK_FILE"
-if ! flock -n 9; then
+if ! flock -w 60 9; then
   echo "Another HomeRail live validation is already running on this runner." >&2
   exit 1
 fi
+HOMERAIL_CLEANUP_LOCK_HELD=1 "$REPO_ROOT/scripts/cleanup-dag-patterns-live-runner.sh"
+mkdir -p "$HOMERAIL_HOME"
 
 cleanup() {
   local exit_code=$?
@@ -37,11 +39,14 @@ cleanup() {
   if [ -x "$REPO_ROOT/homerail_cli/dist/cli.js" ] || [ -f "$REPO_ROOT/homerail_cli/dist/cli.js" ]; then
     node "$REPO_ROOT/homerail_cli/dist/cli.js" runtime stop >/dev/null 2>&1
   fi
-  mapfile -t containers < <(docker ps -aq --filter "ancestor=$HOMERAIL_WORKER_IMAGE" 2>/dev/null)
+  mapfile -t containers < <(docker ps -aq --filter "label=org.homerail.live_run=$RUN_KEY" 2>/dev/null)
   if [ "${#containers[@]}" -gt 0 ]; then
     docker rm -f "${containers[@]}" >/dev/null 2>&1
   fi
-  docker image rm -f "$HOMERAIL_WORKER_IMAGE" >/dev/null 2>&1
+  mapfile -t images < <(docker images --filter "label=org.homerail.live_run=$RUN_KEY" --format "{{.ID}}" | sort -u)
+  if [ "${#images[@]}" -gt 0 ]; then
+    docker image rm -f "${images[@]}" >/dev/null 2>&1
+  fi
   if [ -d "$HOMERAIL_HOME/logs" ]; then
     tar -czf "$PERSISTENT_ARTIFACT_DIR/homerail-logs.tgz" -C "$HOMERAIL_HOME" logs >/dev/null 2>&1
   fi
@@ -116,7 +121,7 @@ docker build \
   -f "$REPO_ROOT/homerail_worker/Dockerfile" \
   "$REPO_ROOT"
 
-node "$REPO_ROOT/homerail_cli/dist/cli.js" start --no-build-worker-image
+node "$REPO_ROOT/homerail_cli/dist/cli.js" start --host 0.0.0.0 --no-build-worker-image
 SETTING_ID="$(node "$REPO_ROOT/scripts/configure-live-pattern-model.mjs")"
 
 node "$REPO_ROOT/scripts/validate-dag-patterns-live.mjs" \

--- a/scripts/run-dag-patterns-live-runner.sh
+++ b/scripts/run-dag-patterns-live-runner.sh
@@ -124,12 +124,24 @@ docker build \
 node "$REPO_ROOT/homerail_cli/dist/cli.js" start --host 0.0.0.0 --no-build-worker-image
 SETTING_ID="$(node "$REPO_ROOT/scripts/configure-live-pattern-model.mjs")"
 
-node "$REPO_ROOT/scripts/validate-dag-patterns-live.mjs" \
-  --base-url "$HOMERAIL_MANAGER_URL" \
-  --setting-id "$SETTING_ID" \
-  --expected-model "$MODEL_NAME" \
-  --timeout-ms 360000 \
+validation_args=(
+  --base-url "$HOMERAIL_MANAGER_URL"
+  --setting-id "$SETTING_ID"
+  --expected-model "$MODEL_NAME"
+  --timeout-ms 360000
   --output "$REPORT_PATH"
+)
+if [ -n "${HOMERAIL_LIVE_PATTERNS:-}" ]; then
+  IFS=',' read -ra requested_patterns <<<"$HOMERAIL_LIVE_PATTERNS"
+  for pattern in "${requested_patterns[@]}"; do
+    pattern="${pattern//[[:space:]]/}"
+    if [ -n "$pattern" ]; then
+      validation_args+=(--pattern "$pattern")
+    fi
+  done
+fi
+
+node "$REPO_ROOT/scripts/validate-dag-patterns-live.mjs" "${validation_args[@]}"
 
 cp "$REPORT_PATH" "$UPLOAD_REPORT_PATH"
 echo "Live DAG pattern report: $REPORT_PATH"

--- a/scripts/run-dag-patterns-live-runner.sh
+++ b/scripts/run-dag-patterns-live-runner.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+RUNNER_BASE="${HOMERAIL_RUNNER_BASE:-/vol1/1000/homerail_runners}"
+HOME_BASE="${HOMERAIL_LIVE_HOME_BASE:-$RUNNER_BASE/homerail_home}"
+ARTIFACT_BASE="${HOMERAIL_LIVE_ARTIFACTS:-$RUNNER_BASE/artifacts}"
+MANAGER_PORT="${HOMERAIL_MANAGER_PORT:-29191}"
+MODEL_BASE_URL="${HOMERAIL_PATTERN_MODEL_BASE_URL:-http://192.168.100.10:5000}"
+MODEL_NAME="${HOMERAIL_PATTERN_MODEL:-qwen3.6}"
+MODEL_MAC="${HOMERAIL_PATTERN_MODEL_MAC:-}"
+WAKE_MODEL="${HOMERAIL_WAKE_MODEL:-1}"
+RUN_KEY="${HOMERAIL_LIVE_RUN_KEY:-${GITHUB_RUN_ID:-manual}-${GITHUB_RUN_ATTEMPT:-1}}"
+RUN_KEY="$(printf '%s' "$RUN_KEY" | tr -c 'A-Za-z0-9_.-' '-')"
+
+export HOMERAIL_HOME="$HOME_BASE/run-$RUN_KEY"
+export HOMERAIL_MANAGER_PORT="$MANAGER_PORT"
+export HOMERAIL_MANAGER_URL="http://127.0.0.1:$MANAGER_PORT"
+export HOMERAIL_WORKER_IMAGE="${HOMERAIL_LIVE_WORKER_IMAGE_PREFIX:-homerail-worker:dag-live}-$RUN_KEY"
+export HOMERAIL_MANAGER_AGENT_IMAGE="$HOMERAIL_WORKER_IMAGE"
+
+PERSISTENT_ARTIFACT_DIR="$ARTIFACT_BASE/$RUN_KEY"
+REPORT_PATH="$PERSISTENT_ARTIFACT_DIR/dag-patterns-live.json"
+UPLOAD_REPORT_PATH="${HOMERAIL_LIVE_REPORT_PATH:-$REPO_ROOT/artifacts/dag-patterns-live.json}"
+LOCK_FILE="$RUNNER_BASE/dag-patterns-live.lock"
+
+mkdir -p "$HOMERAIL_HOME" "$PERSISTENT_ARTIFACT_DIR" "$(dirname "$UPLOAD_REPORT_PATH")"
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
+  echo "Another HomeRail live validation is already running on this runner." >&2
+  exit 1
+fi
+
+cleanup() {
+  local exit_code=$?
+  set +e
+  if [ -x "$REPO_ROOT/homerail_cli/dist/cli.js" ] || [ -f "$REPO_ROOT/homerail_cli/dist/cli.js" ]; then
+    node "$REPO_ROOT/homerail_cli/dist/cli.js" runtime stop >/dev/null 2>&1
+  fi
+  mapfile -t containers < <(docker ps -aq --filter "ancestor=$HOMERAIL_WORKER_IMAGE" 2>/dev/null)
+  if [ "${#containers[@]}" -gt 0 ]; then
+    docker rm -f "${containers[@]}" >/dev/null 2>&1
+  fi
+  docker image rm -f "$HOMERAIL_WORKER_IMAGE" >/dev/null 2>&1
+  if [ -d "$HOMERAIL_HOME/logs" ]; then
+    tar -czf "$PERSISTENT_ARTIFACT_DIR/homerail-logs.tgz" -C "$HOMERAIL_HOME" logs >/dev/null 2>&1
+  fi
+  if [ -f "$REPORT_PATH" ] && [ "$REPORT_PATH" != "$UPLOAD_REPORT_PATH" ]; then
+    cp "$REPORT_PATH" "$UPLOAD_REPORT_PATH"
+  fi
+  case "$HOMERAIL_HOME" in
+    "$HOME_BASE"/run-*) rm -rf "$HOMERAIL_HOME" ;;
+    *) echo "Refusing to remove unexpected HOMERAIL_HOME: $HOMERAIL_HOME" >&2 ;;
+  esac
+  exit "$exit_code"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+model_ready() {
+  curl -fsS --connect-timeout 3 --max-time 10 "$MODEL_BASE_URL/v1/models" 2>/dev/null \
+    | MODEL_NAME="$MODEL_NAME" python3 -c 'import json, os, sys; data=json.load(sys.stdin); raise SystemExit(0 if any(item.get("id") == os.environ["MODEL_NAME"] for item in data.get("data", [])) else 1)'
+}
+
+wake_model() {
+  if [ -z "$MODEL_MAC" ]; then
+    echo "Model host is offline and HOMERAIL_PATTERN_MODEL_MAC is not configured." >&2
+    return 1
+  fi
+  python3 - "$MODEL_MAC" <<'PY'
+import socket
+import sys
+
+mac = bytes.fromhex(sys.argv[1].replace(":", "").replace("-", ""))
+packet = b"\xff" * 6 + mac * 16
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+for address in ("255.255.255.255", "192.168.100.255"):
+    sock.sendto(packet, (address, 9))
+sock.close()
+PY
+}
+
+if ! model_ready; then
+  if [ "$WAKE_MODEL" != "1" ]; then
+    echo "Model $MODEL_NAME is unavailable at $MODEL_BASE_URL and wake_model is disabled." >&2
+    exit 1
+  fi
+  echo "Waking model host for $MODEL_NAME..."
+  wake_model
+  ready=0
+  for _ in $(seq 1 60); do
+    if model_ready; then
+      ready=1
+      break
+    fi
+    sleep 10
+  done
+  if [ "$ready" -ne 1 ]; then
+    echo "Model $MODEL_NAME did not become ready within 10 minutes." >&2
+    exit 1
+  fi
+fi
+
+if curl -fsS --max-time 3 "$HOMERAIL_MANAGER_URL/health" >/dev/null 2>&1 \
+  || ss -H -ltn "sport = :$MANAGER_PORT" | grep -q .; then
+  echo "Runner Manager port $MANAGER_PORT is already serving another process; refusing to interfere." >&2
+  exit 1
+fi
+
+echo "Building isolated worker image $HOMERAIL_WORKER_IMAGE"
+docker build \
+  --label "org.homerail.live_run=$RUN_KEY" \
+  -t "$HOMERAIL_WORKER_IMAGE" \
+  -f "$REPO_ROOT/homerail_worker/Dockerfile" \
+  "$REPO_ROOT"
+
+node "$REPO_ROOT/homerail_cli/dist/cli.js" start --no-build-worker-image
+SETTING_ID="$(node "$REPO_ROOT/scripts/configure-live-pattern-model.mjs")"
+
+node "$REPO_ROOT/scripts/validate-dag-patterns-live.mjs" \
+  --base-url "$HOMERAIL_MANAGER_URL" \
+  --setting-id "$SETTING_ID" \
+  --expected-model "$MODEL_NAME" \
+  --timeout-ms 360000 \
+  --output "$REPORT_PATH"
+
+cp "$REPORT_PATH" "$UPLOAD_REPORT_PATH"
+echo "Live DAG pattern report: $REPORT_PATH"

--- a/scripts/validate-dag-patterns-live.mjs
+++ b/scripts/validate-dag-patterns-live.mjs
@@ -104,6 +104,25 @@ function matchingHandoffs(handoffs, node, port) {
   return handoffs.filter((handoff) => handoffNode(handoff) === node && handoff.port === port);
 }
 
+function preservesHumanReviewBoundary(value) {
+  if (typeof value !== "object" || value === null) return false;
+  const forbidden = new Set(["approved", "rejected", "signed", "applied"]);
+  const proposals = Array.isArray(value.proposals) ? value.proposals : [];
+  const statuses = [value.status, value.decision, value.approval, value.outcome]
+    .concat(proposals.map((proposal) =>
+      typeof proposal === "object" && proposal !== null ? proposal.status : undefined
+    ))
+    .filter((status) => typeof status === "string")
+    .map((status) => status.toLowerCase());
+  if (statuses.some((status) => forbidden.has(status))) return false;
+  if (value.status === "awaiting_human_review") return true;
+  return value.review_boundary === "human_review"
+    && proposals.length > 0
+    && proposals.every((proposal) =>
+      typeof proposal === "object" && proposal !== null && proposal.status === "awaiting_human_review"
+    );
+}
+
 function semanticFailures(patternId, handoffs) {
   const failures = [];
   for (const requirement of semanticRequirements[patternId]) {
@@ -136,7 +155,7 @@ function semanticFailures(patternId, handoffs) {
   }
   if (patternId === "compost") {
     const review = parseContent(matchingHandoffs(handoffs, "human_review", "done").at(-1)?.content);
-    if (typeof review !== "object" || review === null || review.status !== "awaiting_human_review") {
+    if (!preservesHumanReviewBoundary(review)) {
       failures.push("compost terminal did not preserve the awaiting_human_review boundary");
     }
   }

--- a/scripts/validate-dag-patterns-live.mjs
+++ b/scripts/validate-dag-patterns-live.mjs
@@ -1,0 +1,292 @@
+#!/usr/bin/env node
+
+import * as fs from "node:fs";
+
+const args = process.argv.slice(2);
+
+function option(name, fallback) {
+  const index = args.indexOf(name);
+  return index >= 0 && args[index + 1] ? args[index + 1] : fallback;
+}
+
+function repeatedOption(name) {
+  const values = [];
+  for (let index = 0; index < args.length; index++) {
+    if (args[index] === name && args[index + 1]) values.push(args[index + 1]);
+  }
+  return values;
+}
+
+const baseUrl = option("--base-url", process.env.HOMERAIL_MANAGER_URL ?? "http://127.0.0.1:19191").replace(/\/+$/, "");
+const settingId = option("--setting-id", process.env.HOMERAIL_PATTERN_SETTING_ID);
+const expectedModel = option("--expected-model", process.env.HOMERAIL_PATTERN_EXPECTED_MODEL ?? "");
+const profileId = option("--profile-id", "live-pattern-validation");
+const timeoutMs = Number(option("--timeout-ms", "360000"));
+const outputPath = option("--output", "");
+const requestedPatterns = repeatedOption("--pattern");
+
+if (!settingId) {
+  console.error("Missing --setting-id or HOMERAIL_PATTERN_SETTING_ID.");
+  process.exit(2);
+}
+if (!Number.isFinite(timeoutMs) || timeoutMs < 1_000) {
+  console.error("--timeout-ms must be at least 1000.");
+  process.exit(2);
+}
+
+async function request(path, init) {
+  const response = await fetch(`${baseUrl}${path}`, init);
+  const body = await response.json();
+  if (!response.ok || body.success === false) {
+    throw new Error(`${init?.method ?? "GET"} ${path}: ${body.error ?? body.message ?? `HTTP ${response.status}`}`);
+  }
+  return body.data;
+}
+
+function patternParameters(pattern) {
+  const parameters = {
+    workflow_id: `live-${pattern.id}`,
+    name: `Live ${pattern.name} Validation`,
+  };
+  if (pattern.id === "budget-gate") parameters.budget_limit = 100;
+  if (pattern.id === "quorum") parameters.threshold = 2;
+  if (pattern.id === "ratchet") {
+    parameters.target = 0;
+    parameters.max_iterations = 2;
+  }
+  if (pattern.id === "compost") parameters.max_proposals = 3;
+  return parameters;
+}
+
+const prompts = {
+  heartbeat: "Treat this as one actionable signal. Execute one bounded action and verify it. Use structured object handoffs and declared ports.",
+  "orchestrator-workers": "Split validation into three independent checks. Every worker must return status success with evidence, then verify the aggregate.",
+  "budget-gate": "Projected usage is 1 unit against a budget limit of 100. Return status within_budget, execute one bounded check, and audit it.",
+  "trust-ledger": "The validation skill has 20 runs and 20 passes. Assign tier auto, execute one check, verify it, and preserve the measured evidence.",
+  "standing-goal-sentinel": "Load exactly this JSON array and do not add descriptions: [{\"id\":\"goal-a\",\"predicate\":true},{\"id\":\"goal-b\",\"predicate\":true}]. Treat each predicate as an already evaluated literal boolean. Do not inspect the workspace or use tools.",
+  quorum: "Preserve this concrete evidence: health_check=passed, regression_count=0, risk=low. Each independent voter should return top-level vote act with evidence. Continue only after the configured quorum.",
+  sparring: "Use this self-contained synthetic case only and do not inspect or modify the workspace: input 1+1, broken output 3, expected output 2. Breaker returns the challenge, builder returns repaired output 2, and fresh verifier returns top-level verdict pass with evidence.",
+  ratchet: "Use an in-memory synthetic metric only; do not inspect or modify the workspace. The baseline measurer must return current top-level metric 2 unchanged and stop; it must not simulate improvements. Each later improver returns metric reduced by exactly 1 until target 0.",
+  compost: "Use only these two synthetic repeated failures and do not inspect the workspace: missing top-level verdict twice; missing bounded retry twice. Propose no more than three grounded improvements with top-level status proposed. The terminal reviewer must return status awaiting_human_review and must not approve or apply them.",
+};
+
+const semanticRequirements = {
+  heartbeat: [{ node: "signal_gate", port: "act" }, { node: "verdict_gate", port: "passed" }],
+  "orchestrator-workers": [{ node: "join", port: "passed" }],
+  "budget-gate": [{ node: "budget_gate", port: "admit" }],
+  "trust-ledger": [{ node: "tier_gate", port: "ship" }],
+  "standing-goal-sentinel": [
+    { node: "goal_loop", port: "next_goal", minimum: 2 },
+    { node: "goal_loop", port: "done" },
+  ],
+  quorum: [{ node: "quorum", port: "act" }],
+  sparring: [{ node: "verdict_gate", port: "passed" }],
+  ratchet: [{ node: "target_gate", port: "improve" }, { node: "target_gate", port: "reached" }],
+  compost: [{ node: "proposal_gate", port: "review" }, { node: "human_review", port: "done" }],
+};
+
+function handoffNode(handoff) {
+  return handoff.fromNode ?? handoff.from_node;
+}
+
+function parseContent(content) {
+  if (typeof content !== "string") return content;
+  const trimmed = content.trim();
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return content;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return content;
+  }
+}
+
+function matchingHandoffs(handoffs, node, port) {
+  return handoffs.filter((handoff) => handoffNode(handoff) === node && handoff.port === port);
+}
+
+function semanticFailures(patternId, handoffs) {
+  const failures = [];
+  for (const requirement of semanticRequirements[patternId]) {
+    const actual = matchingHandoffs(handoffs, requirement.node, requirement.port).length;
+    const minimum = requirement.minimum ?? 1;
+    if (actual < minimum) {
+      failures.push(`expected ${requirement.node}:${requirement.port} at least ${minimum} time(s), observed ${actual}`);
+    }
+  }
+
+  if (patternId === "standing-goal-sentinel") {
+    const done = matchingHandoffs(handoffs, "goal_loop", "done").at(-1);
+    const results = parseContent(done?.content)?.results;
+    if (!Array.isArray(results) || results.length !== 2) {
+      failures.push(`standing goal result aggregation expected 2 results, observed ${Array.isArray(results) ? results.length : 0}`);
+    }
+  }
+  if (patternId === "quorum") {
+    const aggregate = parseContent(matchingHandoffs(handoffs, "quorum", "act").at(-1)?.content);
+    if (typeof aggregate !== "object" || aggregate === null || aggregate.successes < 2) {
+      failures.push("quorum aggregate did not contain at least two passing votes");
+    }
+  }
+  if (patternId === "ratchet") {
+    const reached = parseContent(matchingHandoffs(handoffs, "target_gate", "reached").at(-1)?.content);
+    const measurement = parseContent(reached?.input);
+    if (typeof measurement !== "object" || measurement === null || typeof measurement.metric !== "number" || measurement.metric > 0) {
+      failures.push("ratchet did not reach a top-level metric at or below target 0");
+    }
+  }
+  if (patternId === "compost") {
+    const review = parseContent(matchingHandoffs(handoffs, "human_review", "done").at(-1)?.content);
+    if (typeof review !== "object" || review === null || review.status !== "awaiting_human_review") {
+      failures.push("compost terminal did not preserve the awaiting_human_review boundary");
+    }
+  }
+  return failures;
+}
+
+function profileYaml(workflowId) {
+  return [
+    `profile_id: ${profileId}`,
+    `workflow_id: ${workflowId}`,
+    "description: Live model-backed DAG pattern validation.",
+    "default:",
+    `  llm_setting_id: ${settingId}`,
+    "  agent_type: claude-sdk",
+    "",
+  ].join("\n");
+}
+
+async function preparePattern(pattern) {
+  const parameters = patternParameters(pattern);
+  const instance = await request(`/api/dag/patterns/${encodeURIComponent(pattern.id)}/instantiate`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ parameters }),
+  });
+  await request("/api/dag/workflows/sync", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ yaml_text: instance.yaml_text, source_path: `builtin:${pattern.id}` }),
+  });
+  await request("/api/dag/profiles/sync", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ yaml_text: profileYaml(parameters.workflow_id), source_path: "validation:live-patterns" }),
+  });
+  return parameters.workflow_id;
+}
+
+async function waitForTerminal(runId, patternId) {
+  const deadline = Date.now() + timeoutMs;
+  let nextProgress = 0;
+  while (Date.now() < deadline) {
+    const status = await request(`/api/runs/${encodeURIComponent(runId)}/status`);
+    if (["completed", "failed", "cancelled"].includes(status.status)) return status;
+    if (Date.now() >= nextProgress) {
+      console.log(`${patternId}: ${status.status}`);
+      nextProgress = Date.now() + 10_000;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
+  }
+  await request(`/api/runs/${encodeURIComponent(runId)}/cancel`, { method: "POST" }).catch(() => undefined);
+  throw new Error(`Timed out after ${timeoutMs}ms`);
+}
+
+async function modelEvidence(runId) {
+  const dag = await request(`/api/dag-status/${encodeURIComponent(runId)}`);
+  const agentNodes = dag.graph.nodes.filter((node) => node.node_type === "agent");
+  const observed = [];
+  for (const node of agentNodes) {
+    const chat = await request(`/api/dag-status/${encodeURIComponent(runId)}/node/${encodeURIComponent(node.node_id)}/chat`);
+    const prompt = chat.messages.find((message) => message.role === "manager" && message.type === "prompt");
+    const config = prompt?.content?.agentConfig;
+    if (!config) continue;
+    observed.push({
+      node_id: node.node_id,
+      setting_id: config.llm_setting_id,
+      model: config.llm?.model,
+      provider: config.llm?.provider,
+      agent_type: config.agent_type,
+    });
+  }
+  return observed;
+}
+
+async function runPattern(pattern) {
+  const workflowId = await preparePattern(pattern);
+  const created = await request("/api/runs/create-and-run", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      workflow_id: workflowId,
+      profile: profileId,
+      prompt: prompts[pattern.id],
+    }),
+  });
+  const runId = created.run_id ?? created.runId;
+  if (!runId) throw new Error("Manager did not return run_id");
+  console.log(`${pattern.id}: run ${runId}`);
+  const status = await waitForTerminal(runId, pattern.id);
+  const handoffData = await request(`/api/runs/${encodeURIComponent(runId)}/handoffs`);
+  const handoffs = handoffData.handoffs ?? [];
+  const evidence = await modelEvidence(runId);
+  const wrongModels = evidence.filter((item) =>
+    item.setting_id !== settingId || (expectedModel && item.model !== expectedModel),
+  );
+  const failures = semanticFailures(pattern.id, handoffs);
+  if (status.status !== "completed") failures.push(`terminal status ${status.status}`);
+  if (handoffs.length === 0) failures.push("no handoffs");
+  if (evidence.length === 0) failures.push("no model dispatch evidence");
+  if (wrongModels.length > 0) failures.push(`wrong model evidence on: ${wrongModels.map((item) => item.node_id).join(", ")}`);
+  return {
+    pattern_id: pattern.id,
+    workflow_id: workflowId,
+    run_id: runId,
+    status: status.status,
+    handoff_count: handoffs.length,
+    semantic_handoffs: semanticRequirements[pattern.id].map((requirement) => ({
+      node: requirement.node,
+      port: requirement.port,
+      count: matchingHandoffs(handoffs, requirement.node, requirement.port).length,
+    })),
+    model_evidence: evidence,
+    passed: failures.length === 0,
+    failures,
+  };
+}
+
+const catalog = await request("/api/dag/patterns");
+const selected = catalog.patterns.filter((pattern) =>
+  requestedPatterns.length === 0 || requestedPatterns.includes(pattern.id),
+);
+if (selected.length === 0) {
+  console.error("No matching DAG patterns.");
+  process.exit(2);
+}
+
+const results = [];
+for (const pattern of selected) {
+  try {
+    const result = await runPattern(pattern);
+    results.push(result);
+    console.log(`${pattern.id}: ${result.passed ? "PASS" : "FAIL"}`);
+  } catch (error) {
+    results.push({
+      pattern_id: pattern.id,
+      passed: false,
+      failures: [error instanceof Error ? error.message : String(error)],
+    });
+    console.error(`${pattern.id}: FAIL ${results.at(-1).failures[0]}`);
+  }
+}
+
+const report = {
+  generated_at: new Date().toISOString(),
+  manager_url: baseUrl,
+  setting_id: settingId,
+  expected_model: expectedModel || null,
+  passed: results.every((result) => result.passed),
+  results,
+};
+if (outputPath) fs.writeFileSync(outputPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+console.log(JSON.stringify(report, null, 2));
+if (!report.passed) process.exitCode = 1;

--- a/scripts/validate-dag-patterns-live.mjs
+++ b/scripts/validate-dag-patterns-live.mjs
@@ -229,6 +229,7 @@ async function runPattern(pattern) {
   const handoffData = await request(`/api/runs/${encodeURIComponent(runId)}/handoffs`);
   const handoffs = handoffData.handoffs ?? [];
   const evidence = await modelEvidence(runId);
+  const evaluation = await request(`/api/runs/${encodeURIComponent(runId)}/eval-run`);
   const wrongModels = evidence.filter((item) =>
     item.setting_id !== settingId || (expectedModel && item.model !== expectedModel),
   );
@@ -237,6 +238,10 @@ async function runPattern(pattern) {
   if (handoffs.length === 0) failures.push("no handoffs");
   if (evidence.length === 0) failures.push("no model dispatch evidence");
   if (wrongModels.length > 0) failures.push(`wrong model evidence on: ${wrongModels.map((item) => item.node_id).join(", ")}`);
+  if (evaluation.verdict !== "pass") failures.push(`eval verdict ${evaluation.verdict ?? "missing"}`);
+  if ((evaluation.artifact_contracts?.empty_handoff_count ?? 0) > 0) failures.push("eval reported empty handoffs");
+  if ((evaluation.artifact_contracts?.auto_handoff_count ?? 0) > 0) failures.push("eval reported automatic handoffs");
+  if ((evaluation.dag_health?.failed_nodes ?? []).length > 0) failures.push("eval reported failed nodes");
   return {
     pattern_id: pattern.id,
     workflow_id: workflowId,
@@ -249,6 +254,12 @@ async function runPattern(pattern) {
       count: matchingHandoffs(handoffs, requirement.node, requirement.port).length,
     })),
     model_evidence: evidence,
+    evaluation: {
+      verdict: evaluation.verdict,
+      failed_nodes: evaluation.dag_health?.failed_nodes ?? [],
+      empty_handoff_count: evaluation.artifact_contracts?.empty_handoff_count ?? 0,
+      auto_handoff_count: evaluation.artifact_contracts?.auto_handoff_count ?? 0,
+    },
     passed: failures.length === 0,
     failures,
   };

--- a/scripts/validate-dag-patterns-live.mjs
+++ b/scripts/validate-dag-patterns-live.mjs
@@ -59,7 +59,7 @@ function patternParameters(pattern) {
 }
 
 const prompts = {
-  heartbeat: "Treat this as one actionable signal. Execute one bounded action and verify it. Use structured object handoffs and declared ports.",
+  heartbeat: "Use only this synthetic signal and do not inspect or modify the workspace: input value is 2. Classify it actionable and preserve the value in the handoff. The conductor must order exactly one action: multiply the value by 2, with done_when output.value equals 4. The worker returns top-level status success, value 4, and evidence 2 * 2 = 4. The verifier must return top-level verdict pass when value is exactly 4 with that evidence. Use structured object handoffs and declared ports.",
   "orchestrator-workers": "Use only this synthetic record and do not inspect or modify the workspace: {\"id\":\"sample-1\",\"count\":2,\"status\":\"ready\"}. Split it into exactly three independent, self-contained checks: id equals sample-1, count equals 2, and status equals ready. The indexed plan must tell every worker not to use builtin tools. Every worker returns top-level status success with evidence, then verify the aggregate.",
   "budget-gate": "Projected usage is 1 unit against a budget limit of 100. Return status within_budget, execute one bounded check, and audit it.",
   "trust-ledger": "The validation skill has 20 runs and 20 passes. Assign tier auto, execute one check, verify it, and preserve the measured evidence.",
@@ -67,7 +67,7 @@ const prompts = {
   quorum: "Preserve this concrete evidence: health_check=passed, regression_count=0, risk=low. Each independent voter should return top-level vote act with evidence. Continue only after the configured quorum.",
   sparring: "Use this self-contained synthetic case only and do not inspect or modify the workspace: input 1+1, broken output 3, expected output 2. Breaker returns the challenge, builder returns repaired output 2, and fresh verifier returns top-level verdict pass with evidence.",
   ratchet: "Use an in-memory synthetic metric only; do not inspect or modify the workspace. The baseline measurer must return current top-level metric 2 unchanged and stop; it must not simulate improvements. Each later improver returns metric reduced by exactly 1 until target 0.",
-  compost: "Use only these two synthetic repeated failures and do not inspect the workspace: missing top-level verdict twice; missing bounded retry twice. Propose no more than three grounded improvements with top-level status proposed. The terminal reviewer must return status awaiting_human_review and must not approve or apply them.",
+  compost: "Use only these two synthetic repeated failures and do not inspect the workspace: missing top-level verdict twice; missing bounded retry twice. Propose no more than three grounded improvements with top-level status proposed. The terminal reviewer must hand off exactly one object whose top-level key is status with literal value awaiting_human_review, plus proposals and no approval decision; do not use a synonym or nest the status.",
 };
 
 const semanticRequirements = {
@@ -252,6 +252,7 @@ async function runPattern(pattern) {
       node: requirement.node,
       port: requirement.port,
       count: matchingHandoffs(handoffs, requirement.node, requirement.port).length,
+      last_content: parseContent(matchingHandoffs(handoffs, requirement.node, requirement.port).at(-1)?.content),
     })),
     model_evidence: evidence,
     evaluation: {

--- a/scripts/validate-dag-patterns-live.mjs
+++ b/scripts/validate-dag-patterns-live.mjs
@@ -60,7 +60,7 @@ function patternParameters(pattern) {
 
 const prompts = {
   heartbeat: "Treat this as one actionable signal. Execute one bounded action and verify it. Use structured object handoffs and declared ports.",
-  "orchestrator-workers": "Split validation into three independent checks. Every worker must return status success with evidence, then verify the aggregate.",
+  "orchestrator-workers": "Use only this synthetic record and do not inspect or modify the workspace: {\"id\":\"sample-1\",\"count\":2,\"status\":\"ready\"}. Split it into exactly three independent, self-contained checks: id equals sample-1, count equals 2, and status equals ready. The indexed plan must tell every worker not to use builtin tools. Every worker returns top-level status success with evidence, then verify the aggregate.",
   "budget-gate": "Projected usage is 1 unit against a budget limit of 100. Return status within_budget, execute one bounded check, and audit it.",
   "trust-ledger": "The validation skill has 20 runs and 20 passes. Assign tier auto, execute one check, verify it, and preserve the measured evidence.",
   "standing-goal-sentinel": "Load exactly this JSON array and do not add descriptions: [{\"id\":\"goal-a\",\"predicate\":true},{\"id\":\"goal-b\",\"predicate\":true}]. Treat each predicate as an already evaluated literal boolean. Do not inspect the workspace or use tools.",

--- a/skills/README.md
+++ b/skills/README.md
@@ -90,3 +90,5 @@ Direct invocation examples:
 
 - Codex: `$homerail-install-ops`
 - Claude Code: `/homerail-install-ops`
+- DAG pattern selection in Codex: `$homerail-dag-patterns`
+- DAG pattern selection in Claude Code: `/homerail-dag-patterns`

--- a/skills/README.md
+++ b/skills/README.md
@@ -14,6 +14,13 @@ Supported target directories:
 
 - Codex: `${CODEX_HOME:-$HOME/.codex}/skills`
 - Claude Code: `$HOME/.claude/skills`
+- HomeRail Manager Agent: `${HOMERAIL_HOME:-$HOME/.homerail}/skills`
+
+Manager automatically creates the HomeRail Manager Agent skill directory and
+links missing built-in `homerail-*` skills from the active checkout. Existing
+entries are never replaced, so a user-owned skill with the same directory id
+overrides the built-in version. Every directory containing `SKILL.md` under
+this root is exposed to all Manager Agent harnesses on the next turn.
 
 ## macOS / Linux
 

--- a/skills/homerail-dag-ops/SKILL.md
+++ b/skills/homerail-dag-ops/SKILL.md
@@ -250,6 +250,7 @@ skills/
   homerail-install-ops/  # Local-source install, service startup, maintenance, smoke
   homerail-cli/          # CLI command reference
   homerail-dag-ops/      # DAG run, monitor, inspect, and author operations
+  homerail-dag-patterns/ # DAG pattern selection, composition, and instantiation
 
 assets/
   orchestrations/    # Public example DAG template YAML files

--- a/skills/homerail-dag-ops/SKILL.md
+++ b/skills/homerail-dag-ops/SKILL.md
@@ -13,6 +13,12 @@ description: |
 Before acting, apply `homerail-shared` rules. This skill assumes the local runtime
 is already ready. If not, run `hr start` or use `homerail-install-ops`.
 
+When this skill is loaded inside the HomeRail Manager Agent, do not invoke the
+CLI through shell. Use `list_orchestrations`, `create_and_run`, `invoke_run`, and
+`get_run_status`. For abstract pattern selection, load `homerail-dag-patterns`
+and use `list_dag_patterns`, `get_dag_pattern`, and
+`instantiate_dag_pattern` before `create_and_run`.
+
 ## Quick Path (runtime already ready)
 
 When the install is already done and you only need to run a DAG, follow this

--- a/skills/homerail-dag-patterns/SKILL.md
+++ b/skills/homerail-dag-patterns/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: homerail-dag-patterns
+description: |
+  Select, inspect, instantiate, adapt, and validate HomeRail's built-in DAG design patterns.
+  Use when an agent needs to design a reusable workflow for periodic triage, planner/worker fan-out,
+  budget admission, graduated trust, standing-goal verification, quorum decisions, adversarial
+  builder/breaker review, monotonic improvement, or evidence-driven process evolution. Also use
+  when deciding whether a workflow needs condition, loop, join, or while gateway semantics.
+---
+
+# HomeRail DAG Patterns
+
+Treat a pattern as an abstract control-flow invariant, not a finished task
+template. Read the live Manager catalog before choosing one; it is the source of
+truth for parameters and generated topology.
+
+## Select a Pattern
+
+```bash
+hr doctor
+hr --json patterns list
+hr --json patterns show <pattern-id>
+```
+
+Choose from constraints, not keyword similarity:
+
+- `heartbeat`: periodic work needs a cheap quiet exit, one selected action, and
+  an independent verdict.
+- `orchestrator-workers`: one planner can split independent work that must
+  aggregate before verification.
+- `budget-gate`: measured usage must admit or stop work before execution.
+- `trust-ledger`: autonomy varies per recurring skill based on measured history.
+- `standing-goal-sentinel`: previously satisfied goals must be re-verified as
+  standing invariants.
+- `quorum`: expensive or risky action requires independent n-of-m agreement.
+- `sparring`: a breaker, builder, and fresh verifier must remain separate.
+- `ratchet`: one metric should improve through bounded attempts until a target.
+- `compost`: repeated failures should produce a bounded set of proposals that
+  remain behind human review.
+
+Do not choose a pattern when the catalog's `avoid_when` conditions apply. A
+small linear DAG is better than a pattern whose invariant is unnecessary.
+
+## Instantiate and Adapt
+
+Generate YAML without syncing it first:
+
+```bash
+hr patterns instantiate quorum \
+  --set workflow_id=release-decision \
+  --set threshold=2 \
+  --output /tmp/release-decision.yaml
+```
+
+Adapt role names, prompts, evidence fields, and terminal actions to the task.
+Preserve the invariant that made the pattern useful:
+
+- Keep voters independent in `quorum`.
+- Keep planner, workers, and verifier distinct in `orchestrator-workers`.
+- Keep breaker, builder, and verifier distinct in `sparring`.
+- Keep `ratchet` bounded and metric-driven.
+- Keep policy changes behind review in `compost`.
+- Keep the quiet path cheaper than the action path in `heartbeat`.
+
+Do not put provider, model, API key, or base URL fields in generated workflow
+YAML. Bind models through HomeRail database settings and runtime profiles.
+
+## Compose Patterns
+
+Compose only at explicit boundaries. Common combinations:
+
+- Put `budget-gate` or `quorum` before an expensive `orchestrator-workers`
+  subgraph.
+- Put `trust-ledger` after independent verification, not before execution alone.
+- Run `standing-goal-sentinel` as a heartbeat action, but keep detection and
+  repair as separate runs.
+- Feed failed runs and violated goals into `compost`; never let Compost apply
+  its own policy proposals.
+
+When combining patterns, retain one structured handoff contract at each
+boundary. Avoid nested planners, duplicated verifiers, and loops without one
+clear stop predicate.
+
+## Use Gateway Semantics Correctly
+
+- `condition_gateway`: route one structured value by field and exact case.
+- `loop_gateway`: iterate a finite item list and emit `done` after the last item;
+  set `result_port` to include every ordered iteration result in the final payload.
+- `join_gateway`: aggregate all arrived inputs using `all`, `any`, or `n_of_m`;
+  configure `field`, `success_values`, and threshold explicitly.
+- `while_gateway`: compare the latest feedback value, emit `continue` while
+  unmatched, and emit `exhausted` after `max_iterations`.
+- `retry_policy.max_retries`: bound feedback-edge traversals independently of
+  the run-wide edge limit.
+
+Use `after` for completion dependencies and explicit output edges for data.
+Join nodes wait for all `after` dependencies before aggregating. While feedback
+edges must return directly to the while gateway.
+
+## Validate Before Running
+
+Inspect generated YAML, then sync and run it only when its task-specific prompts
+and runtime profile are complete:
+
+```bash
+hr dag sync /tmp/release-decision.yaml
+hr profile sync <profile.yaml> --workflow release-decision
+hr run --workflow release-decision --profile <profile-id> --prompt "<task>"
+hr dag watch <run-id> --timeout 600
+hr dag handoffs <run-id> --content-limit 0
+```
+
+Require all of the following before calling the adaptation useful:
+
+- `hr patterns instantiate` reports a valid graph.
+- The YAML contains pattern id, version, source, and resolved parameters.
+- Every branch reaches a terminal node or a bounded feedback edge.
+- A deterministic or fake-dispatch test exercises the topology.
+- A real model-backed run exercises task semantics before production use.
+- Terminal status and non-empty handoffs support the claimed result.

--- a/skills/homerail-dag-patterns/SKILL.md
+++ b/skills/homerail-dag-patterns/SKILL.md
@@ -14,6 +14,25 @@ Treat a pattern as an abstract control-flow invariant, not a finished task
 template. Read the live Manager catalog before choosing one; it is the source of
 truth for parameters and generated topology.
 
+## Manager Agent Native Path
+
+When running as the HomeRail Manager Agent, use Manager tools rather than shell,
+`curl`, or the `hr` binary:
+
+1. Call `list_dag_patterns` and compare `typical_uses`, `avoid_when`, required
+   primitives, and parameters.
+2. Call `get_dag_pattern` for the best candidate before changing Manager state.
+3. Call `instantiate_dag_pattern` with a stable `workflow_id`, task-specific
+   name, and typed parameters. Keep its default `sync=true` only after the
+   selection is justified.
+4. Call `create_and_run` with the returned `workflow_id`, an available runtime
+   profile when needed, and a prompt containing task inputs and boundaries.
+5. Use `get_run_status` for progress. Never claim the DAG started without the
+   real run id returned by `create_and_run`.
+
+For a simple one-step or linear task, do not force a pattern. Use an existing
+concrete orchestration or ask for the missing execution boundary.
+
 ## Select a Pattern
 
 ```bash

--- a/skills/homerail-dag-patterns/agents/openai.yaml
+++ b/skills/homerail-dag-patterns/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "HomeRail DAG Patterns"
+  short_description: "Choose and instantiate reusable DAG design patterns."
+  default_prompt: "Use $homerail-dag-patterns to select, adapt, and validate a HomeRail DAG design pattern."

--- a/skills/homerail-install-ops/SKILL.md
+++ b/skills/homerail-install-ops/SKILL.md
@@ -62,6 +62,8 @@ After restart, route user requests to the root skills this way:
   `$homerail-install-ops`; Claude Code invocation: `/homerail-install-ops`.
 - Use `homerail-dag-ops` for running DAGs, monitoring runs, checking handoffs,
   and writing DAG templates.
+- Use `homerail-dag-patterns` for selecting, composing, instantiating, and
+  validating built-in DAG design patterns.
 - Use `homerail-cli` for command syntax, flags, and evidence commands.
 - Use `homerail-shared` as background rules for all HomeRail operations.
 


### PR DESCRIPTION
## Summary

- add a four-layer DAG abstraction and a built-in catalog of nine reusable patterns
- expose pattern discovery and typed instantiation through Manager API and the `hr patterns` CLI
- add HomeRail Skill guidance and offline/live validation assets for AI agents
- make Manager Agent discover every `SKILL.md` under `HOMERAIL_HOME/skills`, install missing built-in HomeRail skills, and load relevant skill bodies on demand
- let host Codex, host-shell, and container Manager Agent runtimes select, instantiate, sync, and run DAG patterns without shell commands

## Why

HomeRail had concrete orchestration templates but lacked a reusable vocabulary for control-flow invariants such as heartbeat, quorum, budget gates, trust ledgers, standing-goal sentinels, sparring, ratchets, and compost loops. Manager Agent also could not natively consume HomeRail-owned skills from `HOMERAIL_HOME/skills`.

The pattern design was inspired by the agentic workflow article shared in this discussion:

- https://x.com/i/status/2074169173178212621

The implementation treats those ideas as abstract DAG patterns rather than copying the article's shell-based implementation.

## Impact

AI agents can inspect pattern intent, roles, suitable and unsuitable scenarios, required primitives, and typed parameters before generating a validated workflow. Manager Agent now follows a native tool path:

`read_skill -> list_dag_patterns -> get_dag_pattern -> instantiate_dag_pattern -> create_and_run`

Existing user-owned skills take precedence over built-in skills with the same id.

## Validation

- full isolated build and test matrix: 972 passed, 2 skipped
- GitHub Actions core matrix: Linux Node 20/24 and Windows Node 24 passed with isolated HOMERAIL_HOME
- all built-in patterns instantiate as valid provider-independent YAML
- offline gateway fixtures cover quorum and ratchet exhaustion
- live pattern validation completed against the configured local Qwen runtime
- real Codex Manager Agent selected `heartbeat` through Skill tools, synchronized it, and started run `40061f9d47d935212cb09728`
- the run completed through actionable triage, conductor, worker, independent verifier, `passed` gateway, and terminal reporter
- run evaluation verdict: pass; no empty or automatic handoffs

## WIP

This PR remains a draft pending broader review of the abstraction/API shape, additional real-world pattern selection trials, and packaged Windows validation of the `HOMERAIL_HOME/skills` junction behavior.