### PR TITLE
WIP: implement WorkflowSpec v1 and immutable DAG revisions

### DIFF
--- a/assets/orchestrations/README.md
+++ b/assets/orchestrations/README.md
@@ -2,9 +2,10 @@
 
 This directory contains public DAG templates. They are not implicit runtime
 defaults; pass a template path explicitly or copy a template before editing it.
-The YAML `workflow_id` is the stable database identity. AI edits may change the
-workflow body, prompts, nodes, and edges, but should keep `workflow_id` unchanged
-unless intentionally creating a new workflow/version.
+Legacy YAML uses `workflow_id` as the stable database identity. WorkflowSpec v1
+uses `metadata.id`. AI edits may change the workflow body, prompts, nodes, and
+edges, but should keep that identity unchanged unless intentionally creating a
+different workflow.
 
 Sync a template into the Manager database before treating it as the effective
 runtime instance:
@@ -12,6 +13,18 @@ runtime instance:
 ```bash
 node homerail_cli/dist/cli.js dag sync assets/orchestrations/public-dev-5node.yaml.template
 ```
+
+Use `workflow-spec-v1-minimal.yaml.template` for the smallest strict v1 example:
+
+```bash
+node homerail_cli/dist/cli.js --json dag validate \
+  assets/orchestrations/workflow-spec-v1-minimal.yaml.template
+node homerail_cli/dist/cli.js dag sync \
+  assets/orchestrations/workflow-spec-v1-minimal.yaml.template
+```
+
+WorkflowSpec v1 uses named contracts, top-level edges, and explicit terminal
+outcomes. Bind its logical agents through a separate database runtime profile.
 
 Start with `public-dev-5node.yaml.template` for the release smoke path:
 

--- a/assets/orchestrations/README.md
+++ b/assets/orchestrations/README.md
@@ -25,6 +25,17 @@ node homerail_cli/dist/cli.js dag sync \
 
 WorkflowSpec v1 uses named contracts, top-level edges, and explicit terminal
 outcomes. Bind its logical agents through a separate database runtime profile.
+Additional strict v1 examples cover reusable graph primitives:
+
+- `workflow-spec-v1-fanout.yaml.template`: fan-out plus explicit join;
+- `workflow-spec-v1-condition.yaml.template`: field-based routing;
+- `workflow-spec-v1-foreach.yaml.template`: bounded collection iteration;
+- `workflow-spec-v1-bounded-while.yaml.template`: bounded feedback and explicit
+  exhaustion.
+
+Validate any of them with `hr dag validate <path>`. The foreach example expects
+the run prompt to be a JSON-encoded string array; the bounded-while example
+expects a JSON object containing a numeric `score`.
 
 Start with `public-dev-5node.yaml.template` for the release smoke path:
 

--- a/assets/orchestrations/workflow-spec-v1-bounded-while.yaml.template
+++ b/assets/orchestrations/workflow-spec-v1-bounded-while.yaml.template
@@ -1,0 +1,77 @@
+api_version: homerail.ai/v1
+kind: Workflow
+
+metadata:
+  id: workflow-spec-v1-bounded-while
+  name: WorkflowSpec v1 Bounded While
+
+spec:
+  description: Improve a metric until it reaches its target or a hard iteration bound.
+
+  contracts:
+    Metric:
+      type: object
+      additionalProperties: false
+      required: [score]
+      properties:
+        score: { type: number, minimum: 0, maximum: 100 }
+    GateResult:
+      type: object
+      required: [input, iteration, max_iterations, matched]
+      properties:
+        input: { type: object }
+        iteration: { type: integer, minimum: 0 }
+        max_iterations: { type: integer, minimum: 1 }
+        matched: { type: boolean }
+
+  agents:
+    improver:
+      system: Improve the supplied metric and hand off a Metric object on measured.
+
+  nodes:
+    target:
+      kind: while
+      inputs:
+        state: { contract: Metric }
+      outputs:
+        improve: { contract: GateResult }
+        reached: { contract: GateResult }
+        exhausted: { contract: GateResult }
+      config:
+        field: score
+        operator: gte
+        value: 80
+        continue_port: improve
+        done_port: reached
+        exhausted_port: exhausted
+        max_iterations: 3
+
+    improve:
+      kind: agent
+      agent: improver
+      inputs:
+        state: { contract: GateResult }
+      outputs:
+        measured: { contract: Metric }
+
+    done:
+      kind: terminal
+      outcome: success
+      inputs:
+        result: { contract: GateResult }
+
+    stopped:
+      kind: terminal
+      outcome: failure
+      inputs:
+        result: { contract: GateResult }
+
+  edges:
+    - { from: $run.input, to: target.state }
+    - { from: target.improve, to: improve.state }
+    - kind: feedback
+      from: improve.measured
+      to: target.state
+      max_traversals: 3
+    - { from: target.reached, to: done.result }
+    - { from: target.exhausted, to: stopped.result }

--- a/assets/orchestrations/workflow-spec-v1-condition.yaml.template
+++ b/assets/orchestrations/workflow-spec-v1-condition.yaml.template
@@ -1,0 +1,66 @@
+api_version: homerail.ai/v1
+kind: Workflow
+
+metadata:
+  id: workflow-spec-v1-condition
+  name: WorkflowSpec v1 Condition
+
+spec:
+  description: Classify a task and route it through explicit success or failure terminals.
+
+  contracts:
+    Text:
+      type: string
+      maxLength: 20000
+    Decision:
+      type: object
+      additionalProperties: false
+      required: [route, reason]
+      properties:
+        route: { type: string, enum: [approve, reject] }
+        reason: { type: string, maxLength: 4000 }
+
+  agents:
+    classifier:
+      system: Classify the task and hand off a Decision object on decision.
+
+  nodes:
+    classify:
+      kind: agent
+      agent: classifier
+      inputs:
+        task: { contract: Text }
+      outputs:
+        decision: { contract: Decision }
+
+    route:
+      kind: condition
+      inputs:
+        decision: { contract: Decision }
+      outputs:
+        approved: { contract: Decision }
+        rejected: { contract: Decision }
+      config:
+        field: route
+        routes:
+          approve: approved
+          reject: rejected
+        default: rejected
+
+    approved:
+      kind: terminal
+      outcome: success
+      inputs:
+        decision: { contract: Decision }
+
+    rejected:
+      kind: terminal
+      outcome: failure
+      inputs:
+        decision: { contract: Decision }
+
+  edges:
+    - { from: $run.input, to: classify.task }
+    - { from: classify.decision, to: route.decision }
+    - { from: route.approved, to: approved.decision }
+    - { from: route.rejected, to: rejected.decision }

--- a/assets/orchestrations/workflow-spec-v1-fanout.yaml.template
+++ b/assets/orchestrations/workflow-spec-v1-fanout.yaml.template
@@ -12,12 +12,24 @@ spec:
     Text:
       type: string
       maxLength: 20000
+    WorkOrder:
+      type: object
+      required: [objective]
+      properties:
+        objective: { type: string, maxLength: 4000 }
+        steps:
+          type: array
+          maxItems: 20
+          items:
+            oneOf:
+              - { type: string, maxLength: 4000 }
+              - { type: object }
     Verdict:
       type: object
       additionalProperties: false
       required: [status, evidence]
       properties:
-        status: { type: string, enum: [done, blocked] }
+        status: { type: string, enum: [done, success, blocked] }
         evidence: { type: string, maxLength: 20000 }
     JoinResult:
       type: object
@@ -27,9 +39,19 @@ spec:
 
   agents:
     planner:
-      system: Turn the task into one concise work order and hand it off on plan.
+      system: |
+        Turn the task into a WorkOrder object, then hand it off on plan.
+        The handoff content must have top-level objective and steps fields.
+        Never wrap those fields inside work_order, plan, data, or another object.
+        Use at most three concise steps. Do not require filesystem, shell,
+        network, deployment, or artifact work unless the user explicitly asks.
     worker:
-      system: Execute the work order and hand off a Verdict object on result.
+      system: |
+        Execute the work order and hand off a Verdict object on result.
+        The handoff content must have top-level status and evidence fields.
+        Never wrap those fields inside verdict, result, data, or another object.
+        Do not inspect or modify the workspace and do not call external tools
+        unless the user task explicitly requires that work.
 
   nodes:
     plan:
@@ -38,13 +60,13 @@ spec:
       inputs:
         task: { contract: Text }
       outputs:
-        plan: { contract: Text }
+        plan: { contract: WorkOrder }
 
     worker_one:
       kind: agent
       agent: worker
       inputs:
-        task: { contract: Text }
+        task: { contract: WorkOrder }
       outputs:
         result: { contract: Verdict }
 
@@ -52,7 +74,7 @@ spec:
       kind: agent
       agent: worker
       inputs:
-        task: { contract: Text }
+        task: { contract: WorkOrder }
       outputs:
         result: { contract: Verdict }
 
@@ -67,7 +89,7 @@ spec:
       config:
         mode: all
         field: status
-        success_values: [done]
+        success_values: [done, success]
         passed_port: passed
         failed_port: failed
 

--- a/assets/orchestrations/workflow-spec-v1-fanout.yaml.template
+++ b/assets/orchestrations/workflow-spec-v1-fanout.yaml.template
@@ -1,0 +1,93 @@
+api_version: homerail.ai/v1
+kind: Workflow
+
+metadata:
+  id: workflow-spec-v1-fanout
+  name: WorkflowSpec v1 Fan-out and Join
+
+spec:
+  description: Fan one plan out to two workers and join their structured verdicts.
+
+  contracts:
+    Text:
+      type: string
+      maxLength: 20000
+    Verdict:
+      type: object
+      additionalProperties: false
+      required: [status, evidence]
+      properties:
+        status: { type: string, enum: [done, blocked] }
+        evidence: { type: string, maxLength: 20000 }
+    JoinResult:
+      type: object
+      required: [passed]
+      properties:
+        passed: { type: boolean }
+
+  agents:
+    planner:
+      system: Turn the task into one concise work order and hand it off on plan.
+    worker:
+      system: Execute the work order and hand off a Verdict object on result.
+
+  nodes:
+    plan:
+      kind: agent
+      agent: planner
+      inputs:
+        task: { contract: Text }
+      outputs:
+        plan: { contract: Text }
+
+    worker_one:
+      kind: agent
+      agent: worker
+      inputs:
+        task: { contract: Text }
+      outputs:
+        result: { contract: Verdict }
+
+    worker_two:
+      kind: agent
+      agent: worker
+      inputs:
+        task: { contract: Text }
+      outputs:
+        result: { contract: Verdict }
+
+    join:
+      kind: join
+      inputs:
+        one: { contract: Verdict }
+        two: { contract: Verdict }
+      outputs:
+        passed: { contract: JoinResult }
+        failed: { contract: JoinResult }
+      config:
+        mode: all
+        field: status
+        success_values: [done]
+        passed_port: passed
+        failed_port: failed
+
+    done:
+      kind: terminal
+      outcome: success
+      inputs:
+        result: { contract: JoinResult }
+
+    blocked:
+      kind: terminal
+      outcome: failure
+      inputs:
+        result: { contract: JoinResult }
+
+  edges:
+    - { from: $run.input, to: plan.task }
+    - { from: plan.plan, to: worker_one.task }
+    - { from: plan.plan, to: worker_two.task }
+    - { from: worker_one.result, to: join.one }
+    - { from: worker_two.result, to: join.two }
+    - { from: join.passed, to: done.result }
+    - { from: join.failed, to: blocked.result }

--- a/assets/orchestrations/workflow-spec-v1-foreach.yaml.template
+++ b/assets/orchestrations/workflow-spec-v1-foreach.yaml.template
@@ -1,0 +1,84 @@
+api_version: homerail.ai/v1
+kind: Workflow
+
+metadata:
+  id: workflow-spec-v1-foreach
+  name: WorkflowSpec v1 Foreach
+
+spec:
+  description: Process a bounded JSON array one item at a time and collect results.
+
+  contracts:
+    Items:
+      type: array
+      minItems: 1
+      maxItems: 100
+      items: { type: string, maxLength: 4000 }
+    Iteration:
+      type: object
+      required: [item, index, total]
+      properties:
+        item: { type: string, maxLength: 4000 }
+        index: { type: integer, minimum: 0 }
+        total: { type: integer, minimum: 1 }
+    ItemResult:
+      type: object
+      additionalProperties: false
+      required: [item, result]
+      properties:
+        item: { type: string, maxLength: 4000 }
+        result: { type: string, maxLength: 20000 }
+    Summary:
+      type: object
+      required: [total, completed, results]
+      properties:
+        total: { type: integer, minimum: 0 }
+        completed: { type: boolean }
+        results:
+          type: array
+          maxItems: 100
+          items:
+            type: object
+
+  agents:
+    worker:
+      system: Process the current iteration and hand off an ItemResult object on result.
+
+  nodes:
+    each:
+      kind: foreach
+      inputs:
+        items: { contract: Items }
+        result: { contract: ItemResult }
+      outputs:
+        next: { contract: Iteration }
+        done: { contract: Summary }
+      config:
+        input: items
+        item_port: next
+        result_port: result
+        done_port: done
+        max_items: 100
+
+    worker:
+      kind: agent
+      agent: worker
+      inputs:
+        task: { contract: Iteration }
+      outputs:
+        result: { contract: ItemResult }
+
+    done:
+      kind: terminal
+      outcome: success
+      inputs:
+        summary: { contract: Summary }
+
+  edges:
+    - { from: $run.input, to: each.items }
+    - { from: each.next, to: worker.task }
+    - kind: feedback
+      from: worker.result
+      to: each.result
+      max_traversals: 100
+    - { from: each.done, to: done.summary }

--- a/assets/orchestrations/workflow-spec-v1-minimal.yaml.template
+++ b/assets/orchestrations/workflow-spec-v1-minimal.yaml.template
@@ -1,0 +1,37 @@
+api_version: homerail.ai/v1
+kind: Workflow
+
+metadata:
+  id: workflow-spec-v1-minimal
+  name: WorkflowSpec v1 Minimal
+
+spec:
+  description: Run one provider-neutral agent and finish through an explicit terminal.
+
+  contracts:
+    Text:
+      type: string
+      maxLength: 20000
+
+  agents:
+    worker:
+      system: Complete the supplied task and return a concise result.
+
+  nodes:
+    execute:
+      kind: agent
+      agent: worker
+      inputs:
+        task: { contract: Text }
+      outputs:
+        result: { contract: Text }
+
+    done:
+      kind: terminal
+      outcome: success
+      inputs:
+        result: { contract: Text }
+
+  edges:
+    - { from: $run.input, to: execute.task }
+    - { from: execute.result, to: done.result }

--- a/docs/dag-workflow-spec-v1-design.md
+++ b/docs/dag-workflow-spec-v1-design.md
@@ -3,6 +3,10 @@
 Status: Draft for design review. No runtime behavior is implemented by this
 document.
 
+For a complete Chinese overview of the proposed DSL, its rationale, execution
+model, compatibility strategy, and future extension boundary, see
+[`dag-workflow-spec-v1-overview.zh-CN.md`](dag-workflow-spec-v1-overview.zh-CN.md).
+
 ## Context
 
 HomeRail currently uses YAML as both the authoring format and the persisted

--- a/docs/dag-workflow-spec-v1-design.md
+++ b/docs/dag-workflow-spec-v1-design.md
@@ -1,7 +1,8 @@
 # WorkflowSpec v1 Design
 
-Status: Draft for design review. No runtime behavior is implemented by this
-document.
+Status: Accepted for incremental implementation on 2026-07-11. WorkflowSpec
+validation and canonical compilation may land before runtime adoption; legacy
+runtime behavior remains authoritative until the runtime migration phase.
 
 For a complete Chinese overview of the proposed DSL, its rationale, execution
 model, compatibility strategy, and future extension boundary, see
@@ -77,7 +78,7 @@ format.
 
 ## Proposed Authoring Envelope
 
-The envelope below is a candidate, not a frozen decision:
+The v1 envelope is:
 
 ```yaml
 api_version: homerail.ai/v1
@@ -92,6 +93,10 @@ spec:
   workspace:
     mode: isolated
 
+  contracts:
+    Task: { type: object }
+    Evidence: { type: object }
+
   agents:
     reviewer:
       system: Review the supplied release evidence.
@@ -100,23 +105,34 @@ spec:
     review:
       kind: agent
       agent: reviewer
+      inputs:
+        task: { contract: Task }
       outputs:
-        reviewed:
-          to: report.in:evidence
+        reviewed: { contract: Evidence }
 
     report:
       kind: agent
       agent: reviewer
-      after: [review]
+      inputs:
+        evidence: { contract: Evidence }
       outputs:
-        done:
-          to: ""
+        done: { contract: Evidence }
+
+    success:
+      kind: terminal
+      outcome: success
+      inputs:
+        result: { contract: Evidence }
+
+  edges:
+    - { from: $run.input, to: review.task }
+    - { from: review.reviewed, to: report.evidence }
+    - { from: report.done, to: success.result }
 ```
 
-The first version should favor a small migration surface. Existing inline
-`outputs.<port>.to` routing can remain authoring syntax while the compiler lowers
-it to explicit canonical edges. The empty-string terminal target is retained in
-this draft only for compatibility and remains an open design decision.
+V1 uses top-level edges and explicit terminal nodes only. Existing inline
+`outputs.<port>.to` routing and empty-string terminal targets remain supported
+only by the isolated legacy/v0 adapter.
 
 ## Strict Schema
 
@@ -283,6 +299,9 @@ Manager should expose:
 
 ```text
 GET /api/dag/schema
+POST /api/dag/validate
+GET /api/dag/workflows/:workflow_id/revisions
+GET /api/dag/workflows/:workflow_id/revisions/:revision
 ```
 
 Proposed response data:
@@ -297,10 +316,14 @@ Proposed response data:
 }
 ```
 
-The endpoint should support ETag or a stable schema hash. It must return the
+The schema endpoint supports ETag and a stable schema hash. It returns the
 same schema used by Manager validation, not a separately maintained copy. CLI
-and Manager Agent tools can use this endpoint to explain validation failures or
-author a compatible document.
+and Manager Agent tools use these endpoints to fetch the live contract, receive
+structured diagnostics, and inspect immutable source/canonical provenance.
+
+CLI entry points are `hr dag schema` and `hr dag validate <file>`. Manager Agent
+uses `get_dag_schema`, `validate_dag_workflow`, and `sync_dag_workflow`; custom
+source is not synced until validation succeeds.
 
 ## Diagnostics
 
@@ -349,20 +372,23 @@ a clean boundary for it:
 - runtime graph snapshots are serializable;
 - completed or traversed graph regions can later be protected by patch policy.
 
-## Open Design Decisions
+## Accepted Decisions
 
-1. Use the proposed `api_version`/`kind`/`metadata`/`spec` envelope, or retain
-   the current flat root with only `schema_version`?
-2. Keep inline output routes in v1, or require a top-level explicit edge list?
-3. Should a data route imply a completion dependency?
-4. How should terminal success, terminal failure, and cancellation be expressed
-   without an empty-string target?
-5. Should input ports declare schemas independently or reference output schemas?
-6. Is JSON Schema the hand-authored source of truth, or generated from a typed
-   schema definition used by TypeScript?
-7. Is strict RuntimeProfile v1 included in the same implementation, or left as
-   a compatible but separately versioned follow-up?
-8. Should formatting-only source changes be retained as non-semantic source
-   versions even when canonical revision does not change?
+1. Use the `api_version`/`kind`/`metadata`/`spec` envelope.
+2. Require top-level explicit `spec.edges`; inline routes are legacy-only.
+3. A data edge implies completion dependency; `depends_on` is control-only.
+4. Express completion with explicit terminal nodes whose outcome is `success`,
+   `failure`, or `cancelled`.
+5. Input and output ports reference the same named, bounded JSON Schema contract.
+6. A typed TypeBox definition generates both TypeScript types and the exact JSON
+   Schema returned by Manager.
+7. RuntimeProfile v1 remains a separately versioned follow-up.
+8. Formatting-only source changes update sync audit metadata but do not create a
+   semantic revision.
+9. Run input is the reserved source `$run.input`.
+10. V1 node kinds are `agent`, `condition`, `join`, `foreach`, `while`, and
+    `terminal`.
 
-Implementation should not begin until these decisions are reviewed.
+These decisions freeze WorkflowSpec v1 authoring semantics. Later additions
+require a compatible schema extension or a new API version; legacy aliases must
+not leak into v1.

--- a/docs/dag-workflow-spec-v1-design.md
+++ b/docs/dag-workflow-spec-v1-design.md
@@ -7,6 +7,8 @@ runtime behavior remains authoritative until the runtime migration phase.
 For a complete Chinese overview of the proposed DSL, its rationale, execution
 model, compatibility strategy, and future extension boundary, see
 [`dag-workflow-spec-v1-overview.zh-CN.md`](dag-workflow-spec-v1-overview.zh-CN.md).
+For the runnable authoring flow and minimal v1 source, see
+[`workflow-spec-v1-authoring.md`](workflow-spec-v1-authoring.md).
 
 ## Context
 

--- a/docs/dag-workflow-spec-v1-design.md
+++ b/docs/dag-workflow-spec-v1-design.md
@@ -1,0 +1,364 @@
+# WorkflowSpec v1 Design
+
+Status: Draft for design review. No runtime behavior is implemented by this
+document.
+
+## Context
+
+HomeRail currently uses YAML as both the authoring format and the persisted
+source for DAG workflows. `parseDAGYaml()` normalizes that YAML directly into
+`ParsedDAG`, and stored workflows are parsed again when a run is created. This
+has worked for the initial static DAG runtime and the built-in pattern library,
+but the contract is implicit:
+
+- there is no workflow schema or language version;
+- unknown fields can be ignored instead of rejected;
+- gateway configuration is represented by one permissive structure;
+- handoff ports describe routing but not payload schemas;
+- aliases such as `type`, `node_type`, `gateway.kind`, and `gateway.type` are
+  normalized by code rather than defined by a public contract;
+- a workflow row is mutable and has no immutable revision history;
+- the authoring representation and runtime graph types are coupled.
+
+YAML is a serialization format, not the domain model. HomeRail already has an
+implicit DSL; WorkflowSpec v1 makes that DSL explicit while retaining YAML and
+JSON as interchangeable serializations.
+
+## Goals
+
+1. Define one strict, versioned public contract for static DAG workflows.
+2. Compile authoring documents into a canonical, provider-independent IR.
+3. Preserve every existing legacy workflow without changing its behavior.
+4. Persist immutable workflow revisions and bind each run to an exact revision.
+5. Expose the public JSON Schema through Manager for CLI and AI clients.
+6. Produce path-aware diagnostics suitable for humans and autonomous agents.
+7. Keep runtime model selection in database-backed runtime profiles.
+
+## Non-goals
+
+- Dynamic graph mutation or a Graph Patch protocol.
+- Executor-Advisor, sub-DAG calls, or new orchestration patterns.
+- New gateway behavior.
+- A general-purpose expression or scripting language.
+- Replacing YAML with a custom textual syntax.
+- Embedding provider names, models, endpoints, or secrets in workflow source.
+- Automatically rewriting stored legacy YAML.
+
+Dynamic graph mutation will be designed separately after the static language,
+canonical IR, revision model, and run snapshot contract are stable.
+
+## Proposed Architecture
+
+```text
+YAML or JSON
+    |
+    v
+WorkflowSpec v1                 public authoring DSL
+    |
+    | parse, validate, normalize, compile
+    v
+CanonicalWorkflowIR v1          provider-independent canonical graph
+    |
+    | bind workflow revision and runtime profile
+    v
+RunPlan revision 0              immutable run-start snapshot
+    |
+    v
+Runtime graph state             execution state, mailboxes, counters
+```
+
+Legacy YAML uses a separate legacy adapter and compiles into the same canonical
+IR. Runtime code should consume canonical IR rather than branch on source
+format.
+
+## Proposed Authoring Envelope
+
+The envelope below is a candidate, not a frozen decision:
+
+```yaml
+api_version: homerail.ai/v1
+kind: Workflow
+
+metadata:
+  id: release-review
+  name: Release Review
+
+spec:
+  description: Review one release candidate and report a verified verdict.
+  workspace:
+    mode: isolated
+
+  agents:
+    reviewer:
+      system: Review the supplied release evidence.
+
+  nodes:
+    review:
+      kind: agent
+      agent: reviewer
+      outputs:
+        reviewed:
+          to: report.in:evidence
+
+    report:
+      kind: agent
+      agent: reviewer
+      after: [review]
+      outputs:
+        done:
+          to: ""
+```
+
+The first version should favor a small migration surface. Existing inline
+`outputs.<port>.to` routing can remain authoring syntax while the compiler lowers
+it to explicit canonical edges. The empty-string terminal target is retained in
+this draft only for compatibility and remains an open design decision.
+
+## Strict Schema
+
+WorkflowSpec v1 should publish a JSON Schema with these properties:
+
+- unknown fields are rejected at every defined object boundary;
+- `api_version` and `kind` are required and constant for v1;
+- node definitions are a discriminated union by `kind`;
+- gateway configuration is a discriminated union by gateway kind;
+- node and port identifiers use one documented identifier grammar;
+- output targets use one documented grammar and are validated before compile;
+- limits, retry bounds, thresholds, and iteration counts are range checked;
+- provider, model, API key, and endpoint fields are prohibited;
+- defaults are documented and materialized in canonical IR.
+
+Schema validation is necessary but not sufficient. Semantic validation still
+checks graph connectivity, references, cycles, feedback bounds, gateway
+dependencies, terminal paths, and provider policy.
+
+### Handoff Contracts
+
+V1 should allow ports to declare optional JSON Schema payload contracts. A
+minimal shape could be:
+
+```yaml
+outputs:
+  verdict:
+    payload_schema:
+      type: object
+      required: [verdict, evidence]
+      additionalProperties: false
+      properties:
+        verdict:
+          enum: [pass, fail]
+        evidence:
+          type: array
+    to: gate.in:verdict
+```
+
+The design must decide whether input ports repeat their expected schema or
+reference an output contract. Compile-time compatibility checks should be
+limited to deterministic JSON Schema relationships that HomeRail can explain;
+runtime payload validation remains authoritative.
+
+## Canonical IR
+
+Canonical IR is JSON-compatible, contains no YAML aliases or shorthand, and is
+stable for hashing and persistence. It should contain:
+
+- normalized workflow metadata;
+- resolved workspace and policy defaults;
+- canonical agent references without runtime model credentials;
+- a discriminated node union;
+- explicit node input and output ports;
+- explicit edges with structured source and target references;
+- normalized retry and gateway configuration;
+- derived entry, terminal, and bounded-feedback metadata;
+- the source API version and compiler version.
+
+Illustrative TypeScript only:
+
+```ts
+interface CanonicalWorkflowIR {
+  ir_version: "1";
+  workflow_id: string;
+  name: string;
+  description?: string;
+  agents: Record<string, CanonicalAgentSpec>;
+  nodes: CanonicalNode[];
+  edges: CanonicalEdge[];
+  entry_nodes: string[];
+  terminal_nodes: string[];
+  feedback_sources: string[];
+  source_api_version: string;
+  compiler_version: string;
+}
+```
+
+Canonical serialization must sort map-derived collections and materialize
+defaults so semantically equivalent source documents produce the same
+canonical hash.
+
+`ParsedDAG` can be evolved into this IR or become a runtime projection of it.
+The public DSL must not expose runtime-only mutable state such as node status,
+mailboxes, traversal counters, dispatch credentials, or worker identities.
+
+## Dependency and Edge Semantics
+
+Current YAML uses both `after` and routed outputs:
+
+- `after` is a completion barrier;
+- an output route carries data into a named input mailbox.
+
+This distinction is useful, but requiring both for the common data dependency
+is error prone. Two options need design review:
+
+1. Preserve current semantics exactly in v1. Authors declare both control and
+   data dependencies when both are needed.
+2. Make a data route imply a completion dependency in v1, with `after` reserved
+   for control-only barriers. The compiler emits both canonical edge forms.
+
+Option 2 is the current recommendation because it removes redundant authoring
+state, but it requires explicit rules for fan-in and bounded feedback edges.
+
+## Workflow Identity and Revisions
+
+`metadata.id` is the stable workflow identity. Revision is assigned by Manager,
+not trusted from authoring input.
+
+Proposed persistence model:
+
+```text
+dag_workflows
+  workflow_id
+  head_revision
+  created_at
+  updated_at
+
+dag_workflow_revisions
+  workflow_id
+  revision
+  api_version
+  source_format
+  source_text
+  source_hash
+  canonical_json
+  canonical_hash
+  compiler_version
+  created_at
+```
+
+Sync behavior:
+
+- first sync creates revision 1;
+- a new canonical hash creates the next immutable revision;
+- the same canonical hash is idempotent and does not create a revision;
+- source-only formatting changes may update source metadata without changing
+  semantic revision, subject to an explicit retention policy;
+- every run stores workflow id, workflow revision, canonical hash, and compiler
+  version in its immutable start metadata.
+
+This model prevents a parser upgrade or later workflow sync from changing the
+meaning of an already-created run.
+
+## Legacy Compatibility
+
+Existing unversioned YAML is `legacy/v0` and remains accepted through a legacy
+adapter. Compatibility rules:
+
+- legacy parsing keeps current aliases and defaults;
+- legacy semantic behavior is covered by characterization tests before refactor;
+- legacy source compiles into CanonicalWorkflowIR v1;
+- legacy rows are not rewritten automatically;
+- new built-in pattern instances and newly generated examples use v1;
+- a future `hr dag migrate` command may produce reviewed v1 source, but it is
+  not required for the first implementation.
+
+The compatibility layer should be isolated. New v1 features must not be added
+to the legacy parser through more aliases.
+
+## Manager Schema API
+
+Manager should expose:
+
+```text
+GET /api/dag/schema
+```
+
+Proposed response data:
+
+```json
+{
+  "api_version": "homerail.ai/v1",
+  "kind": "Workflow",
+  "schema": {},
+  "compiler_version": "1",
+  "examples": ["minimal", "fan-out", "bounded-loop"]
+}
+```
+
+The endpoint should support ETag or a stable schema hash. It must return the
+same schema used by Manager validation, not a separately maintained copy. CLI
+and Manager Agent tools can use this endpoint to explain validation failures or
+author a compatible document.
+
+## Diagnostics
+
+Errors should include:
+
+- stable error code;
+- source path when available;
+- YAML/JSON path;
+- line and column when available;
+- concise message;
+- optional expected values or remediation hint.
+
+Example:
+
+```text
+DAG_SCHEMA_UNKNOWN_FIELD at spec.nodes.review.gatway_config (line 24, col 7):
+unknown field 'gatway_config'; expected 'gateway_config'
+```
+
+The compiler should collect independent schema errors where safe instead of
+stopping at the first typo.
+
+## Security and Policy Boundaries
+
+- Workflow source cannot contain secrets or direct runtime credentials.
+- Runtime profiles continue to reference encrypted database settings by id or
+  alias.
+- Schema retrieval is read-only and contains no configured provider data.
+- Payload schemas need size and nesting limits to avoid validation abuse.
+- Canonical hashes must be computed from deterministic serialization.
+- Compiler and migration code must not execute YAML tags, expressions, or
+  embedded scripts.
+
+## Dynamic Graph Boundary
+
+Future dynamic graphs should not edit persisted WorkflowSpec source. A run will
+start from an immutable RunPlan and accept audited Graph Patch commands against
+the current graph revision. Expected patch fields include operation,
+base_revision, idempotency_key, actor, reason, and a typed node or edge payload.
+
+Graph Patch is deliberately not specified here. WorkflowSpec v1 must only leave
+a clean boundary for it:
+
+- canonical node and edge types are reusable by patches;
+- each run has a graph revision;
+- runtime graph snapshots are serializable;
+- completed or traversed graph regions can later be protected by patch policy.
+
+## Open Design Decisions
+
+1. Use the proposed `api_version`/`kind`/`metadata`/`spec` envelope, or retain
+   the current flat root with only `schema_version`?
+2. Keep inline output routes in v1, or require a top-level explicit edge list?
+3. Should a data route imply a completion dependency?
+4. How should terminal success, terminal failure, and cancellation be expressed
+   without an empty-string target?
+5. Should input ports declare schemas independently or reference output schemas?
+6. Is JSON Schema the hand-authored source of truth, or generated from a typed
+   schema definition used by TypeScript?
+7. Is strict RuntimeProfile v1 included in the same implementation, or left as
+   a compatible but separately versioned follow-up?
+8. Should formatting-only source changes be retained as non-semantic source
+   versions even when canonical revision does not change?
+
+Implementation should not begin until these decisions are reviewed.

--- a/docs/dag-workflow-spec-v1-implementation-plan.md
+++ b/docs/dag-workflow-spec-v1-implementation-plan.md
@@ -3,6 +3,10 @@
 Status: Draft task design. This plan depends on approval of
 `dag-workflow-spec-v1-design.md` and does not authorize implementation yet.
 
+Review the overall DSL model and the Why/How rationale in
+[`dag-workflow-spec-v1-overview.zh-CN.md`](dag-workflow-spec-v1-overview.zh-CN.md)
+before resolving implementation tasks.
+
 ## Delivery Boundary
 
 The first delivery includes strict WorkflowSpec v1 validation, canonical IR,

--- a/docs/dag-workflow-spec-v1-implementation-plan.md
+++ b/docs/dag-workflow-spec-v1-implementation-plan.md
@@ -31,15 +31,20 @@ Implemented on the Draft PR branch:
   feedback metadata, and explicit success/failure/cancelled terminals;
 - schema, validation, revision, CLI, and Manager Agent access surfaces.
 - all built-in pattern catalog details and generated instances emit strict v1,
-  with runtime graph parity checked against their legacy templates.
+  with runtime graph parity checked against their legacy templates;
+- a tracked provider-neutral v1 example runs through the same path used for
+  normal DAG creation;
+- every public legacy orchestration asset is covered by legacy-to-v1 runtime
+  graph parity, with executable quorum, condition, and bounded-ratchet
+  transition tests.
 
 Still pending before the Draft can be considered ready:
 
-- add tracked standalone v1 examples and migrate selected public assets;
-- broaden legacy/v1 transition parity beyond built-in patterns to every public
-  gateway asset;
-- complete full repository, Docker, Windows, and model-backed validation;
-- finalize public migration/authoring documentation.
+- decide which remaining public legacy assets should stay as compatibility
+  fixtures until runtime profiles and scorecards have independent v1 documents;
+- add fan-out, conditional, foreach, and bounded-while standalone v1 examples;
+- complete Windows and model-backed validation;
+- finalize migration policy and authoring documentation.
 
 ## Phase 0: Freeze Existing Behavior
 

--- a/docs/dag-workflow-spec-v1-implementation-plan.md
+++ b/docs/dag-workflow-spec-v1-implementation-plan.md
@@ -37,13 +37,17 @@ Implemented on the Draft PR branch:
   same runtime projection used for normal DAG creation;
 - every public legacy orchestration asset is covered by legacy-to-v1 runtime
   graph parity, with executable quorum, condition, and bounded-ratchet
-  transition tests.
+  transition tests;
+- local Claude SDK plus Kimi model-backed runs complete the minimal, condition,
+  and fan-out/join v1 examples with persisted handoffs and passing scorecards;
+- contract-invalid correction exhaustion fails only its run instead of
+  terminating Manager.
 
 Still pending before the Draft can be considered ready:
 
 - decide which remaining public legacy assets should stay as compatibility
   fixtures until runtime profiles and scorecards have independent v1 documents;
-- complete Windows and model-backed validation;
+- complete Windows validation and the isolated remote-runner model matrix;
 - finalize migration policy and authoring documentation.
 
 ## Phase 0: Freeze Existing Behavior

--- a/docs/dag-workflow-spec-v1-implementation-plan.md
+++ b/docs/dag-workflow-spec-v1-implementation-plan.md
@@ -1,7 +1,8 @@
 # WorkflowSpec v1 Implementation Plan
 
-Status: Draft task design. This plan depends on approval of
-`dag-workflow-spec-v1-design.md` and does not authorize implementation yet.
+Status: Active. The WorkflowSpec v1 design decisions were accepted on
+2026-07-11. Delivery remains incremental and legacy runtime behavior must stay
+compatible throughout the migration.
 
 Review the overall DSL model and the Why/How rationale in
 [`dag-workflow-spec-v1-overview.zh-CN.md`](dag-workflow-spec-v1-overview.zh-CN.md)
@@ -15,6 +16,27 @@ immutable workflow revisions, legacy YAML compatibility, and
 
 It does not include dynamic graph mutation, Graph Patch, new gateway behavior,
 new DAG patterns, or a custom textual language.
+
+## Current Implementation State
+
+Implemented on the Draft PR branch:
+
+- accepted v1 decisions and a typed TypeBox schema source of truth;
+- safe YAML/JSON parsing, path/line diagnostics, semantic validation, canonical
+  JSON and SHA-256 hashing;
+- isolated legacy/v0 compilation and unchanged legacy runtime parsing;
+- immutable workflow revisions with formatting-only sync idempotency;
+- run revision/hash/compiler provenance, including cold recovery;
+- runtime projection for v1, named contract validation, `$run.input`, bounded
+  feedback metadata, and explicit success/failure/cancelled terminals;
+- schema, validation, revision, CLI, and Manager Agent access surfaces.
+
+Still pending before the Draft can be considered ready:
+
+- migrate built-in generated pattern instances and tracked v1 examples;
+- broaden legacy/v1 transition parity across every gateway asset;
+- complete full repository, Docker, Windows, and model-backed validation;
+- finalize public migration/authoring documentation.
 
 ## Phase 0: Freeze Existing Behavior
 
@@ -291,14 +313,10 @@ Each PR must keep legacy workflows runnable and include migration or parity
 evidence appropriate to its blast radius. Graph Patch starts only after all four
 are merged and WorkflowSpec v1 is stable.
 
-## Discussion Gate
+## Decision Gate
 
-Implementation remains paused until the design review resolves:
-
-- public envelope shape;
-- edge and `after` semantics;
-- terminal representation;
-- handoff payload schema ownership;
-- schema source-of-truth strategy;
-- RuntimeProfile v1 scope;
-- formatting-only revision retention.
+The design gate is resolved in `dag-workflow-spec-v1-design.md`. Implementation
+must preserve those accepted decisions. Any proposal to change the envelope,
+edge semantics, terminal representation, contract ownership, schema source of
+truth, RuntimeProfile scope, or revision retention returns to design review
+before code changes.

--- a/docs/dag-workflow-spec-v1-implementation-plan.md
+++ b/docs/dag-workflow-spec-v1-implementation-plan.md
@@ -1,0 +1,300 @@
+# WorkflowSpec v1 Implementation Plan
+
+Status: Draft task design. This plan depends on approval of
+`dag-workflow-spec-v1-design.md` and does not authorize implementation yet.
+
+## Delivery Boundary
+
+The first delivery includes strict WorkflowSpec v1 validation, canonical IR,
+immutable workflow revisions, legacy YAML compatibility, and
+`GET /api/dag/schema`.
+
+It does not include dynamic graph mutation, Graph Patch, new gateway behavior,
+new DAG patterns, or a custom textual language.
+
+## Phase 0: Freeze Existing Behavior
+
+### DSV1-001: Legacy characterization fixtures
+
+- Capture canonical test fixtures for every current public orchestration asset.
+- Cover aliases currently accepted by `parseDAGYaml()`.
+- Cover condition, loop, join, and while gateways.
+- Cover terminal edges, failure routes, retry policies, requirements, scorecard,
+  workspace, limits, pattern metadata, and runtime profile application.
+- Record current valid/invalid outcomes before parser refactoring.
+
+Done when:
+
+- every tracked orchestration asset parses in a focused compatibility suite;
+- representative legacy aliases have explicit tests;
+- no production parser code has changed.
+
+### DSV1-002: Persistence and run provenance baseline
+
+- Characterize current workflow upsert, YAML hash, runtime profile resolution,
+  run creation, cold recovery, and replay metadata.
+- Add assertions showing exactly which workflow identity and source evidence a
+  run currently retains.
+
+Done when:
+
+- tests would detect loss of an existing workflow or runtime profile;
+- current recovery and replay behavior is documented by assertions.
+
+## Phase 1: Public Schema and Typed Source Model
+
+### DSV1-101: Resolve design decisions
+
+- Record decisions for the eight open questions in the design document.
+- Add examples for the selected terminal, edge, and port contract syntax.
+- Mark rejected alternatives and compatibility consequences.
+
+Done when:
+
+- the design document contains no unresolved syntax or ownership decision that
+  blocks schema implementation.
+
+### DSV1-102: Define WorkflowSpec v1 schema
+
+- Create one public schema source for `homerail.ai/v1` Workflow documents.
+- Define strict root, metadata, workspace, agent, node, gateway, output, retry,
+  policy, and pattern metadata objects.
+- Use discriminated unions for node and gateway kinds.
+- Prohibit provider and secret fields.
+- Bound identifiers, collection sizes, retries, thresholds, and iterations.
+
+Done when:
+
+- valid v1 fixtures pass;
+- unknown and misspelled fields fail with a JSON path;
+- invalid gateway-specific fields fail before graph compilation;
+- schema artifacts cannot drift from Manager validation unnoticed.
+
+### DSV1-103: Source-aware diagnostics
+
+- Parse YAML with source ranges.
+- Map schema and semantic diagnostics to line/column locations.
+- Define stable diagnostic codes and JSON output.
+- Preserve concise CLI text output.
+
+Done when:
+
+- malformed fixtures assert code, path, line, and message;
+- multiple independent field errors can be returned together.
+
+## Phase 2: Canonical Compiler and IR
+
+### DSV1-201: Define CanonicalWorkflowIR v1
+
+- Replace permissive graph configuration shapes with discriminated canonical
+  node and gateway unions.
+- Define structured port and edge references.
+- Keep runtime-only mutable fields out of IR.
+- Define deterministic ordering and serialization.
+
+Done when:
+
+- canonical IR has no YAML shorthand or aliases;
+- equivalent v1 documents produce byte-identical canonical JSON and hash;
+- TypeScript exhaustiveness checks cover every node and gateway kind.
+
+### DSV1-202: Compile WorkflowSpec v1
+
+- Validate source schema.
+- Normalize defaults and routing shorthand.
+- Build explicit canonical edges and derived graph metadata.
+- Run semantic graph validation against canonical IR.
+
+Done when:
+
+- v1 fixtures compile to approved IR snapshots;
+- invalid references, cycles, unbounded feedback, and terminal gaps fail with
+  actionable diagnostics.
+
+### DSV1-203: Isolate legacy/v0 adapter
+
+- Move current compatibility normalization behind a legacy adapter.
+- Compile legacy source into the same canonical IR.
+- Prevent new v1-only aliases from entering the legacy path.
+
+Done when:
+
+- all Phase 0 fixtures retain behavior;
+- runtime execution cannot distinguish v1 IR from equivalent legacy IR;
+- legacy warnings identify the source as unversioned without blocking it.
+
+### DSV1-204: Move runtime consumers to canonical IR
+
+- Update graph executor, active run creation, validation, scorecard, recovery,
+  and inspection paths to consume canonical IR or a single projection of it.
+- Remove source-format conditionals from runtime code.
+
+Done when:
+
+- existing package tests pass for both source formats;
+- one parity test runs equivalent legacy and v1 workflows and compares graph
+  transitions and terminal output.
+
+## Phase 3: Immutable Workflow Revisions
+
+### DSV1-301: Add revision persistence
+
+- Add immutable workflow revision storage and a mutable workflow head pointer.
+- Store source text/hash, canonical JSON/hash, API version, and compiler version.
+- Migrate existing workflow rows transactionally as legacy revision 1.
+
+Done when:
+
+- existing databases migrate without data loss;
+- changed canonical content creates revision N+1;
+- idempotent sync does not create a duplicate revision;
+- rollback to the pre-migration binary remains covered by the repository's
+  migration compatibility policy.
+
+### DSV1-302: Bind runs to exact workflow revisions
+
+- Include workflow revision, canonical hash, and compiler version in run-start
+  metadata.
+- Recover and inspect runs from their immutable snapshot.
+- Keep later workflow syncs from changing active or historical runs.
+
+Done when:
+
+- a workflow can be updated while an older run continues with its original IR;
+- cold recovery and replay preserve the same revision and graph hash;
+- API and CLI inspection expose provenance.
+
+## Phase 4: Manager API and CLI
+
+### DSV1-401: Implement `GET /api/dag/schema`
+
+- Return the exact WorkflowSpec v1 JSON Schema used by Manager.
+- Include API version, kind, compiler version, and stable schema hash/ETag.
+- Do not expose provider configuration or secrets.
+
+Done when:
+
+- endpoint schema validates all approved v1 fixtures;
+- endpoint supports cache validation;
+- API tests prove the response and internal validator use the same schema.
+
+### DSV1-402: Add CLI validation and inspection
+
+- Add or extend a command to validate YAML/JSON without syncing it.
+- Support human-readable and JSON diagnostics.
+- Show source version, canonical hash, and derived graph summary.
+- Add an opt-in command to print or fetch the public schema.
+
+Done when:
+
+- CI can validate all tracked workflow assets without starting Manager runtime;
+- AI clients can consume structured diagnostics.
+
+### DSV1-403: Manager Agent schema access
+
+- Expose schema retrieval and validation through bounded Manager Agent tools.
+- Update DAG authoring skill guidance to request the live schema before emitting
+  v1 source.
+
+Done when:
+
+- Manager Agent can produce a valid v1 workflow through public tools;
+- invalid generated source returns diagnostics rather than partial sync.
+
+## Phase 5: Built-in Assets and Documentation
+
+### DSV1-501: Migrate generated patterns and examples
+
+- Make built-in pattern instantiation emit WorkflowSpec v1.
+- Convert tracked examples after parity tests pass.
+- Retain legacy fixtures specifically for compatibility testing.
+
+Done when:
+
+- every built-in pattern emits strict v1 source;
+- static, fake-dispatch, and real model-backed pattern validation remain green;
+- no runtime profile embeds provider or secret data.
+
+### DSV1-502: Publish authoring and migration documentation
+
+- Document the v1 language, defaults, node/gateway contracts, handoff schemas,
+  diagnostics, revisions, and compatibility policy.
+- Document that Graph Patch is a separate future protocol.
+- Provide minimal, fan-out, conditional, finite-loop, and bounded-while examples.
+
+Done when:
+
+- a new user or AI can author, validate, sync, and run v1 without reading
+  Manager source code.
+
+## Required Test Matrix
+
+### Schema tests
+
+- Valid minimal and full WorkflowSpec v1 documents.
+- Unknown fields at every object layer.
+- Every node and gateway discriminant.
+- Invalid identifiers, references, bounds, output targets, and payload schemas.
+- Explicit rejection of provider, model, endpoint, and secret fields.
+
+### Compiler tests
+
+- Stable canonical snapshots and hashes.
+- Equivalent YAML and JSON produce identical IR.
+- Default materialization and deterministic ordering.
+- Data/control dependency semantics selected in design review.
+- Terminal and feedback edge normalization.
+
+### Compatibility tests
+
+- Every existing orchestration asset.
+- Existing database rows and runtime profiles.
+- Legacy aliases and current error behavior where compatibility requires it.
+- Legacy and v1 execution parity.
+
+### Persistence tests
+
+- Initial migration, idempotent sync, semantic revision, concurrent sync, and
+  transaction rollback.
+- Run provenance, cold recovery, replay, and historical inspection.
+- Source hash versus canonical hash behavior.
+
+### API and CLI tests
+
+- Schema endpoint, ETag/hash, and no secret leakage.
+- Validation diagnostics in text and JSON modes.
+- Pattern instantiation and workflow sync through CLI and Manager Agent tools.
+
+### End-to-end gates
+
+- Root typecheck, build, and package tests on supported Node versions.
+- Windows CI and Docker lifecycle test.
+- Legacy public smoke DAG.
+- WorkflowSpec v1 public smoke DAG.
+- Full model-backed DAG pattern validation on the isolated live runner.
+
+## Pull Request Strategy
+
+Do not implement all phases in one review unit after the design is approved.
+Recommended implementation PR sequence:
+
+1. Schema, diagnostics, canonical IR, and legacy compiler parity.
+2. Runtime adoption of canonical IR.
+3. Workflow revision persistence and run provenance.
+4. Manager schema API, CLI, Manager Agent tools, assets, and documentation.
+
+Each PR must keep legacy workflows runnable and include migration or parity
+evidence appropriate to its blast radius. Graph Patch starts only after all four
+are merged and WorkflowSpec v1 is stable.
+
+## Discussion Gate
+
+Implementation remains paused until the design review resolves:
+
+- public envelope shape;
+- edge and `after` semantics;
+- terminal representation;
+- handoff payload schema ownership;
+- schema source-of-truth strategy;
+- RuntimeProfile v1 scope;
+- formatting-only revision retention.

--- a/docs/dag-workflow-spec-v1-implementation-plan.md
+++ b/docs/dag-workflow-spec-v1-implementation-plan.md
@@ -32,8 +32,9 @@ Implemented on the Draft PR branch:
 - schema, validation, revision, CLI, and Manager Agent access surfaces.
 - all built-in pattern catalog details and generated instances emit strict v1,
   with runtime graph parity checked against their legacy templates;
-- a tracked provider-neutral v1 example runs through the same path used for
-  normal DAG creation;
+- tracked provider-neutral minimal, fan-out/join, condition, foreach, and
+  bounded-while v1 examples compile through the public CLI and run through the
+  same runtime projection used for normal DAG creation;
 - every public legacy orchestration asset is covered by legacy-to-v1 runtime
   graph parity, with executable quorum, condition, and bounded-ratchet
   transition tests.
@@ -42,7 +43,6 @@ Still pending before the Draft can be considered ready:
 
 - decide which remaining public legacy assets should stay as compatibility
   fixtures until runtime profiles and scorecards have independent v1 documents;
-- add fan-out, conditional, foreach, and bounded-while standalone v1 examples;
 - complete Windows and model-backed validation;
 - finalize migration policy and authoring documentation.
 

--- a/docs/dag-workflow-spec-v1-implementation-plan.md
+++ b/docs/dag-workflow-spec-v1-implementation-plan.md
@@ -30,11 +30,14 @@ Implemented on the Draft PR branch:
 - runtime projection for v1, named contract validation, `$run.input`, bounded
   feedback metadata, and explicit success/failure/cancelled terminals;
 - schema, validation, revision, CLI, and Manager Agent access surfaces.
+- all built-in pattern catalog details and generated instances emit strict v1,
+  with runtime graph parity checked against their legacy templates.
 
 Still pending before the Draft can be considered ready:
 
-- migrate built-in generated pattern instances and tracked v1 examples;
-- broaden legacy/v1 transition parity across every gateway asset;
+- add tracked standalone v1 examples and migrate selected public assets;
+- broaden legacy/v1 transition parity beyond built-in patterns to every public
+  gateway asset;
 - complete full repository, Docker, Windows, and model-backed validation;
 - finalize public migration/authoring documentation.
 

--- a/docs/dag-workflow-spec-v1-overview.zh-CN.md
+++ b/docs/dag-workflow-spec-v1-overview.zh-CN.md
@@ -1,0 +1,911 @@
+# WorkflowSpec v1 DSL 总体设计概要
+
+状态：`Proposed / WIP`
+
+本文是 WorkflowSpec v1 的总体架构说明，用于设计评审，不代表协议已经冻结，
+也不授权开始实现。当前 Draft PR 只包含文档和任务设计。
+
+## 1. 一句话结论
+
+HomeRail 不需要发明新的文本语言，但需要把当前隐式存在的 DAG 语言正式化：
+
+- YAML 和 JSON 是供人类与 AI 编辑的序列化格式；
+- WorkflowSpec v1 是公开、严格、版本化的 DSL；
+- CanonicalWorkflowIR v1 是 Manager 内部唯一执行语义；
+- RunPlan 是每次运行绑定到具体 workflow revision 的不可变快照；
+- Graph Patch 是未来动态改图协议，不属于 WorkflowSpec v1。
+
+```text
+YAML / JSON
+    |
+    v
+WorkflowSpec v1                 公开 DSL
+    |
+    | parse + schema validate + semantic validate + compile
+    v
+CanonicalWorkflowIR v1          唯一规范语义
+    |
+    | bind workflow revision + runtime profile
+    v
+RunPlan revision 0              单次运行的不可变起点
+    |
+    v
+Runtime Graph State             node state / mailbox / counters
+```
+
+核心原则是：**源码、语义、运行状态必须是三个不同层次。**
+
+## 2. 为什么现在需要 DSL
+
+当前 HomeRail 已经有一套可工作的 YAML 语言，但它是由代码行为隐式定义的：
+
+- [`parseDAGYaml()`](../homerail_manager/src/orchestration/yaml-loader.ts) 直接把
+  YAML 转成 `ParsedDAG`；
+- [`graph.ts`](../homerail_manager/src/orchestration/graph.ts) 同时承担源码结构、
+  规范图和部分运行时接口的类型职责；
+- 数据库保存原始 YAML 和 source hash，创建运行时再用当前 parser 重新解析；
+- `type`、`node_type`、`gateway.kind`、`gateway.type` 等多种写法由兼容代码归一化；
+- 未知字段、拼写错误和不适用于当前 node kind 的字段缺少统一严格校验；
+- `outputs.to`、`after` 和 `to: ""` 分别隐式表达数据流、完成依赖和终止；
+- handoff port 有名字，但没有机器可验证的 payload contract；
+- 同一个 `workflow_id` 更新时覆盖旧源码，没有不可变 revision 历史。
+
+这些问题在简单静态 DAG 中可以由测试和 prompt 约束兜底，但当 AI 自动生成 DAG、
+模式开始组合、工作流长期复用、数据库保存多个版本，或者未来支持运行中改图时，
+隐式语义会产生四类风险：
+
+1. **静默错误**：字段拼错但 YAML 仍能解析，运行结果与作者意图不同。
+2. **语义漂移**：Manager 升级 parser 后，数据库中同一份 YAML 产生不同图。
+3. **不可复现**：只知道 `workflow_id`，无法证明某次运行使用的是哪个 revision。
+4. **无法安全扩展**：动态图若直接操作当前松散结构，很难校验并发、审计和回放。
+
+因此需要定义 DSL。这里的“DSL”不是新语法，而是 **字段、类型、约束、编译、
+版本与执行语义的完整契约**。
+
+## 3. 设计目标
+
+### 3.1 必须实现
+
+1. v1 文档在系统边界严格校验，未知字段直接报错。
+2. YAML 和 JSON 表达同一份 WorkflowSpec，编译后得到相同 canonical hash。
+3. 所有 node、gateway、port 和 edge 都有单一、明确的语义。
+4. 运行时只消费 CanonicalWorkflowIR，不直接理解 YAML 兼容写法。
+5. 现有未版本化 YAML 继续运行，行为不回归。
+6. 每次语义修改生成不可变 workflow revision。
+7. 每个 run 绑定确切 revision、canonical hash 和 compiler version。
+8. Manager 通过 `GET /api/dag/schema` 向 CLI 和 AI 提供真实 Schema。
+9. 错误包含 code、路径、行列和可执行修复信息。
+
+### 3.2 明确不做
+
+- 不发明类似编程语言的新文本语法；
+- 不允许在 DSL 中嵌入任意脚本或表达式；
+- 不在 workflow 中保存 provider、model、endpoint 或 secret；
+- 不在首版实现动态 Graph Patch；
+- 不借本次改造新增 Executor-Advisor、Human Approval 等运行时 node kind；
+- 不自动重写用户已经保存的 legacy YAML；
+- 不把 RuntimeProfile v1 强行纳入首个 WorkflowSpec 实现 PR。
+
+## 4. 设计原则
+
+### 4.1 声明式，而不是可编程
+
+**Why**：任意表达式、脚本和模板求值会扩大安全面，使 Schema 无法完整描述行为，
+也让 AI 难以预测运行结果。
+
+**How**：condition 只支持有限字段选择和枚举路由；while 只支持有限比较运算；
+所有循环必须有静态上限；真正的 shell/API 检查由未来受控 node kind 实现，而不是
+塞进条件表达式。
+
+### 4.2 Provider-independent
+
+**Why**：DAG 描述工作分工和证据流，不应绑定某个账号、模型或部署地址。同一 DAG
+应能在 Codex、Claude-compatible harness 或本地模型之间切换。
+
+**How**：WorkflowSpec 只引用逻辑 agent role；运行前由数据库中的 RuntimeProfile
+绑定 `llm_setting_id` 和 `agent_type`。Schema 明确禁止 credentials 和 provider URL。
+
+### 4.3 严格边界，宽容迁移
+
+**Why**：新文档必须尽早拒绝错误，但现有用户资产不能因升级突然失效。
+
+**How**：有 `api_version` 的 v1 走严格 compiler；无版本文档走 legacy/v0 adapter。
+两条输入路径最终编译到同一个 canonical IR，运行时不区分来源。
+
+### 4.4 一种语义，一种规范表示
+
+**Why**：如果同一条边既能写在 node 内，也能写在顶层，或者终点既能用空字符串又能
+用 terminal node，Schema、AI 生成和未来 patch 都会出现分支组合。
+
+**How**：v1 选择一个推荐写法；所有 legacy shorthand 只存在于 adapter，canonical IR
+永远只有显式 node、port 和 edge。
+
+### 4.5 Revision 表示语义，而不是文本
+
+**Why**：缩进、注释和 key 顺序变化不应制造新的可执行版本；行为变化必须留下不可变
+revision。
+
+**How**：同时计算 source hash 和 canonical hash。只有 canonical hash 变化才增加
+semantic revision；每次 sync 仍写 audit event，保留谁在何时提交了什么 source。
+
+## 5. WorkflowSpec v1 文档结构
+
+推荐的公开 envelope：
+
+```yaml
+api_version: homerail.ai/v1
+kind: Workflow
+
+metadata:
+  id: release-review
+  name: Release Review
+  labels:
+    domain: engineering
+
+spec:
+  description: Verify one release candidate and report a final verdict.
+  workspace:
+    mode: isolated
+
+  contracts: {}
+  agents: {}
+  nodes: {}
+  edges: []
+  policies: {}
+```
+
+### 5.1 为什么使用 envelope
+
+**Why**：当前 flat root 把身份、说明、执行定义和策略混在一起。未来若增加
+`RuntimeProfile`、`Pattern` 或其他资源类型，只加 `schema_version` 无法可靠分派。
+
+**How**：
+
+- `api_version` 决定 parser/compiler 与兼容策略；
+- `kind` 决定资源 Schema；
+- `metadata` 只保存身份、名称、标签等控制面信息；
+- `spec` 保存声明式期望状态；
+- 运行状态、revision、hash、数据库 id 不由用户在 `spec` 中伪造。
+
+代价是多两层缩进，但换来稳定资源模型、清晰升级路径和统一 API。
+
+### 5.2 Metadata
+
+建议 v1 首版只包含：
+
+- `id`：稳定 `workflow_id`，必填；
+- `name`：展示名称，必填或由 id 生成；
+- `labels`：受限字符串 map，可选；
+- `annotations`：受大小限制的非执行元数据，可选。
+
+Revision 不由源码指定。Manager 接受 sync 后分配 revision，避免客户端覆盖或伪造历史。
+
+### 5.3 Spec
+
+`spec` 是可执行意图，包含：
+
+- `description`；
+- `workspace`；
+- `contracts`；
+- `agents`；
+- `nodes`；
+- `edges`；
+- `policies`。
+
+所有对象 `additionalProperties: false`，除非字段本身明确是用户命名 map。
+
+## 6. Agent、Node 与 Port
+
+### 6.1 Agent 是能力配置，不是图节点
+
+```yaml
+agents:
+  verifier:
+    system: |
+      Verify the supplied evidence against the acceptance contract.
+    skills:
+      - homerail-dag-ops
+```
+
+**Why**：同一种角色可能被多个 node 使用，模型绑定也应独立于拓扑。
+
+**How**：node 通过 `agent` 引用逻辑 role；RuntimeProfile 按 role 绑定模型。Agent 定义
+不能包含 provider、model 或 secret。
+
+### 6.2 Node 是一次可调度行为或确定性控制点
+
+建议首版 node kind 使用判别联合，而不是一个包含全部可选字段的大对象：
+
+```text
+agent
+condition
+join
+foreach
+while
+terminal
+```
+
+每种 kind 有独立 Schema。例如 agent node：
+
+```yaml
+nodes:
+  verify:
+    kind: agent
+    agent: verifier
+    inputs:
+      evidence:
+        contract: VerificationInput
+    outputs:
+      verdict:
+        contract: VerificationVerdict
+```
+
+**Why**：`condition` 不应该接受 agent 字段，`agent` 也不应该携带 join threshold。
+判别联合能在同步前发现错误，并让 TypeScript 对 node kind 做穷尽检查。
+
+**How**：Schema 先按 `kind` 选择分支，compiler 再生成 canonical node。未知 kind 在 v1
+中报错；未来新增 node kind 必须通过版本化 Schema 发布，不能落入任意 `extra`。
+
+### 6.3 Port 是节点的公开接口
+
+Input port 定义节点愿意接收什么，output port 定义节点可能产生什么。拓扑不写在 port
+内部，而由顶层 edge 连接。
+
+```yaml
+inputs:
+  evidence:
+    contract: VerificationInput
+outputs:
+  verdict:
+    contract: VerificationVerdict
+```
+
+这样一个 node 可以在不同 workflow 中复用，port contract 不随连接目标改变。
+
+## 7. Handoff Contract
+
+推荐使用命名 contract，内容采用受限 JSON Schema：
+
+```yaml
+contracts:
+  VerificationVerdict:
+    type: object
+    additionalProperties: false
+    required: [verdict, evidence]
+    properties:
+      verdict:
+        type: string
+        enum: [pass, fail]
+      evidence:
+        type: array
+        maxItems: 100
+        items:
+          type: string
+```
+
+### 7.1 Why
+
+当前 gateway 依赖 prompt 约定 `status`、`vote`、`metric` 等字段。模型若返回空内容、
+嵌套字段或拼写变化，通常只能在路由后或 scorecard 中发现。输入输出分别复制 Schema
+又会产生漂移。
+
+### 7.2 How
+
+- contract 在 workflow 内命名一次；
+- input/output port 通过名字引用同一 contract；
+- compiler 校验 contract 存在，并检查 edge 两端是否引用兼容 contract；
+- handoff 进入 mailbox 前执行运行时验证；
+- contract violation 生成结构化 node failure，不能走 success edge；
+- 错误证据记录 node、port、contract、JSON path 和实际值摘要；
+- Schema 深度、属性数量、字符串长度和数组长度都受限。
+
+首版不尝试证明任意两个 JSON Schema 的数学包含关系。最可靠规则是 edge 两端引用同一
+命名 contract；显式兼容映射留给后续版本。
+
+## 8. Edge 与依赖语义
+
+推荐 v1 使用顶层显式 edge：
+
+```yaml
+edges:
+  - from: triage.classified
+    to: signal_gate.signal
+
+  - from: signal_gate.actionable
+    to: execute.task
+
+  - from: verify.verdict
+    to: verdict_gate.verdict
+```
+
+### 8.1 为什么不继续使用 `outputs.<port>.to`
+
+**Why**：内联 route 把“节点接口”和“当前工作流拓扑”耦合在一起：
+
+- 想查看所有边必须遍历每个 node；
+- 一条 output 连多个目标时格式会变化；
+- port contract 和 route 配置混在同一对象；
+- reverse edge、diff、可视化和未来 Graph Patch 都更复杂；
+- 同时支持 inline 与 top-level edge 会形成两个真相来源。
+
+**How**：v1 node 只声明 port；所有连接在 `spec.edges`。Legacy adapter 把现有
+`outputs.to` 降低为 canonical edge，用户旧 YAML 不需要立刻迁移。
+
+### 8.2 数据边隐含完成依赖
+
+普通数据 edge 表示：目标 node 必须等来源 node 完成并成功把 payload 送达后才能 ready。
+
+**Why**：当前作者通常需要同时写：
+
+```yaml
+after: [plan]
+outputs:
+  planned:
+    to: implement.in:plan
+```
+
+两处信息表达同一个常见依赖，容易漏写或写出矛盾。
+
+**How**：compiler 从普通数据 edge 自动生成 runtime completion dependency。只有
+“等待某节点完成但不接收数据”的情况才使用：
+
+```yaml
+depends_on: [audit]
+```
+
+### 8.3 Fan-out、Fan-in 与 Loop
+
+- 一个 output port 可通过多条 edge fan-out；
+- fan-in 必须进入显式 `join` node，不能靠 mailbox 数量猜测；
+- 普通 edge 必须保持无环；
+- 反馈 edge 只允许连接到 `foreach` 或 `while`，并声明静态 traversal 上限；
+- compiler 把反馈 edge 与普通 edge 分开验证。
+
+未来动态图仍复用同一种 canonical edge，不修改 WorkflowSpec 源文件。
+
+## 9. Terminal Node
+
+推荐用显式 terminal node 替代 `to: ""`：
+
+```yaml
+nodes:
+  success:
+    kind: terminal
+    outcome: success
+    inputs:
+      result:
+        contract: VerificationVerdict
+
+  review_required:
+    kind: terminal
+    outcome: failure
+    reason: review_required
+```
+
+### 9.1 Why
+
+空字符串只能表示“没有目标”，无法表达：
+
+- 这是成功、业务失败、取消还是等待人工；
+- 哪个 payload 是最终证据；
+- 多个终点中哪个决定 run outcome；
+- 可视化和 API 应显示什么终态；
+- 动态 patch 是否允许在该终点后追加节点。
+
+### 9.2 How
+
+- terminal 是不可调度、不调用模型的确定性 node；
+- 它只能有 inputs，不能有 outputs；
+- `outcome` 首版限定为 `success | failure | cancelled`；
+- run outcome 由实际到达的 terminal 决定；
+- 多 terminal 到达规则必须由 compiler 证明互斥，或定义明确的 outcome precedence；
+- `waiting_for_approval` 不伪装成 terminal，它属于未来可暂停 node kind。
+
+Legacy adapter 将 `to: ""` 映射为合成 terminal node，并根据来源 port 与 failure condition
+推导 outcome；无法可靠推导时产生迁移 warning，但保持当前运行行为。
+
+## 10. Gateway 语义
+
+Gateway 是确定性控制节点，不调用模型。
+
+### 10.1 Condition
+
+```yaml
+signal_gate:
+  kind: condition
+  input: signal
+  config:
+    field: status
+    routes:
+      actionable: actionable
+      quiet: quiet
+    default: quiet
+```
+
+不引入任意表达式，只读取已验证 payload 的受限 dotted field，并按精确值路由。
+
+### 10.2 Join
+
+```yaml
+quorum:
+  kind: join
+  config:
+    mode: n_of_m
+    field: vote
+    success_values: [act]
+    threshold: 2
+```
+
+Join 明确声明等待集合、成功规则和输出 contract。首版保持当前“等待全部声明上游”的
+行为；early completion/cancellation 属于后续 Pattern Runtime 能力。
+
+### 10.3 Foreach
+
+Foreach 对一个有限数组逐项执行，并聚合有序结果。输入数组和单项结果都必须有
+contract；最大 item 数量受 workflow policy 限制。
+
+### 10.4 While
+
+While 只比较当前受控字段，必须声明 `max_iterations`。每次反馈 edge 也有独立 traversal
+limit，避免 run-wide limit 成为唯一保险。
+
+## 11. 完整示例
+
+下面展示推荐语义，不代表字段名已经最终冻结：
+
+```yaml
+api_version: homerail.ai/v1
+kind: Workflow
+
+metadata:
+  id: bounded-review
+  name: Bounded Review
+
+spec:
+  description: Execute one task and independently verify it.
+  workspace:
+    mode: isolated
+
+  contracts:
+    Task:
+      type: object
+      additionalProperties: false
+      required: [objective]
+      properties:
+        objective:
+          type: string
+
+    Result:
+      type: object
+      additionalProperties: false
+      required: [status, evidence]
+      properties:
+        status:
+          enum: [success, failure]
+        evidence:
+          type: array
+          items:
+            type: string
+
+    Verdict:
+      type: object
+      additionalProperties: false
+      required: [verdict, evidence]
+      properties:
+        verdict:
+          enum: [pass, fail]
+        evidence:
+          type: array
+          items:
+            type: string
+
+  agents:
+    worker:
+      system: Execute only the supplied objective and return evidence.
+    verifier:
+      system: Independently verify the result against the objective.
+
+  nodes:
+    execute:
+      kind: agent
+      agent: worker
+      inputs:
+        task: { contract: Task }
+      outputs:
+        result: { contract: Result }
+
+    verify:
+      kind: agent
+      agent: verifier
+      inputs:
+        result: { contract: Result }
+      outputs:
+        verdict: { contract: Verdict }
+
+    verdict_gate:
+      kind: condition
+      inputs:
+        verdict: { contract: Verdict }
+      outputs:
+        passed: { contract: Verdict }
+        failed: { contract: Verdict }
+      config:
+        field: verdict
+        routes:
+          pass: passed
+          fail: failed
+        default: failed
+
+    done:
+      kind: terminal
+      outcome: success
+      inputs:
+        result: { contract: Verdict }
+
+    review_required:
+      kind: terminal
+      outcome: failure
+      reason: independent_verification_failed
+      inputs:
+        result: { contract: Verdict }
+
+  edges:
+    - from: execute.result
+      to: verify.result
+    - from: verify.verdict
+      to: verdict_gate.verdict
+    - from: verdict_gate.passed
+      to: done.result
+    - from: verdict_gate.failed
+      to: review_required.result
+```
+
+运行时 task 如何进入 entry node 仍需最终设计：推荐把 run input 作为保留 source
+`$run.input`，而不是创建虚假的 agent node。例如：
+
+```yaml
+edges:
+  - from: $run.input
+    to: execute.task
+```
+
+这项需要在 Schema 冻结前确认。
+
+## 12. 编译器
+
+WorkflowSpec compiler 是 DSL 的真正语义边界。
+
+### 12.1 编译阶段
+
+```text
+1. Safe parse
+2. Detect api_version and kind
+3. Structural schema validation
+4. Source normalization
+5. Port and contract resolution
+6. Edge lowering and dependency derivation
+7. Semantic graph validation
+8. Policy validation
+9. Canonical ordering and serialization
+10. canonical hash
+```
+
+### 12.2 Why
+
+如果 parser、validator、runtime 各自理解一部分 YAML 语义，任何新增字段都需要在多个
+地方同步修改，legacy alias 也会泄漏到运行时。
+
+### 12.3 How
+
+- v1 compiler 只接受严格 WorkflowSpec；
+- legacy adapter 先把 v0 转成内部 source model，再复用后半段 compiler；
+- runtime 只接收 CanonicalWorkflowIR；
+- compiler output 是纯数据，可 snapshot、hash、diff 和缓存；
+- compiler version 写入 revision 和 run metadata；
+- CI 用 approved fixtures 证明相同输入始终得到相同 IR。
+
+## 13. CanonicalWorkflowIR
+
+Canonical IR 不是用户编辑格式。它必须：
+
+- 不包含 YAML shorthand、anchor、注释和 key-order 差异；
+- materialize 所有默认值；
+- node 和 edge 使用结构化引用；
+- map-derived collection 按稳定规则排序；
+- 包含 derived entry、terminal、dependency 和 feedback metadata；
+- 不包含 node status、mailbox、counter、worker id 或 secret；
+- 能通过确定性 JSON serialization 计算 canonical hash。
+
+```ts
+interface CanonicalWorkflowIR {
+  ir_version: "1";
+  workflow_id: string;
+  name: string;
+  agents: Record<string, CanonicalAgentSpec>;
+  contracts: Record<string, CanonicalContract>;
+  nodes: CanonicalNode[];
+  edges: CanonicalEdge[];
+  entry_nodes: string[];
+  terminal_nodes: string[];
+  feedback_edges: string[];
+  source_api_version: "homerail.ai/v1" | "legacy/v0";
+  compiler_version: string;
+}
+```
+
+现有 `ParsedDAG` 可以演化为 canonical IR，也可以成为它的 runtime projection；最终只应
+保留一个 authoritative graph representation。
+
+## 14. Workflow Revision 与数据库
+
+### 14.1 数据模型
+
+```text
+dag_workflows
+  workflow_id
+  head_revision
+  created_at
+  updated_at
+
+dag_workflow_revisions
+  workflow_id
+  revision
+  api_version
+  source_format
+  source_text
+  source_hash
+  canonical_json
+  canonical_hash
+  compiler_version
+  created_at
+
+dag_workflow_sync_events
+  workflow_id
+  submitted_source_hash
+  resulting_revision
+  actor
+  created_at
+```
+
+### 14.2 Why
+
+当前 upsert 会替换同一 `workflow_id` 的 YAML。虽然运行元数据保存图状态，但无法从
+workflow catalog 明确回答“当时同步的是第几版、后来为什么变化”。
+
+### 14.3 How
+
+- 首次 sync 创建 revision 1；
+- canonical hash 改变时原子创建 N+1，并更新 head；
+- canonical hash 相同的格式变化不创建 semantic revision；
+- 每次提交都写 sync event；
+- run creation 固定读取某个 revision，生成 immutable RunPlan；
+- run metadata 写入 workflow id、revision、canonical hash、compiler version；
+- 后续 sync 不改变 active 或 historical run。
+
+## 15. RuntimeProfile
+
+RuntimeProfile 继续与 WorkflowSpec 分离。
+
+```text
+WorkflowSpec: verifier 是什么角色、有哪些 port、位于图中哪里
+RuntimeProfile: verifier 使用哪个 llm_setting_id 和 agent_type
+```
+
+### Why
+
+- 模型可用性和账号配置比 workflow 生命周期短；
+- workflow 需要可移植、可分享；
+- secret 必须留在 Manager encrypted store；
+- 同一 revision 应能在不同 profile 下运行。
+
+### How
+
+- compiler 检查所有逻辑 agent role 都存在；
+- run creation 绑定 profile 并生成 RunPlan；
+- profile 只引用数据库 setting id 或 alias；
+- WorkflowSpec Schema 拒绝 provider/model/key/url；
+- strict RuntimeProfile v1 另开后续范围，不阻塞 WorkflowSpec v1。
+
+## 16. Legacy YAML 兼容
+
+### 16.1 兼容目标
+
+所有当前可运行 YAML 必须继续运行，包括：
+
+- flat root；
+- `outputs.<port>.to`；
+- `after`；
+- `to: ""`；
+- `type` / `node_type` alias；
+- `gateway` / `gateway_config` alias；
+- condition、loop、join、while 当前行为；
+- runtime profile、pattern metadata 和 scorecard。
+
+### 16.2 实现方式
+
+```text
+legacy YAML
+    |
+    v
+LegacyParser v0
+    |
+    v
+LegacyLoweringAdapter
+    |
+    v
+CanonicalWorkflowIR v1
+```
+
+- 旧 source 不自动改写；
+- legacy compiler 有 characterization tests；
+- 新功能不继续加入 legacy alias；
+- 新建 pattern/example 最终改为输出 v1；
+- 未来可提供 `hr dag migrate` 生成供人工 review 的 v1 YAML；
+- legacy 与等价 v1 必须有 transition parity test。
+
+## 17. Schema 与 API
+
+Manager 提供：
+
+```text
+GET /api/dag/schema
+```
+
+响应至少包含：
+
+```json
+{
+  "api_version": "homerail.ai/v1",
+  "kind": "Workflow",
+  "schema": {},
+  "schema_hash": "sha256:...",
+  "compiler_version": "1"
+}
+```
+
+### Why
+
+CLI、Manager Agent 和其他 AI 不能依赖过时文档猜字段。Schema endpoint 必须返回
+Manager 当前真正用于验证的同一份 Schema。
+
+### How
+
+- 一个 typed schema definition 同时产生运行时 validator、TypeScript type 和 JSON Schema；
+- CI 比较导出 artifact，防止漂移；
+- endpoint 支持 ETag/schema hash；
+- schema 内容不包含已配置 provider 或 secret；
+- CLI 可通过本地 bundled schema 离线验证，并显示 Manager schema version 是否兼容。
+
+具体使用哪个 schema library 在实现前根据现有依赖和输出质量评估，不在概要中提前锁死。
+
+## 18. 诊断模型
+
+每个错误包含：
+
+```json
+{
+  "code": "DAG_SCHEMA_UNKNOWN_FIELD",
+  "path": "spec.nodes.review.gatway_config",
+  "line": 24,
+  "column": 7,
+  "message": "unknown field 'gatway_config'",
+  "hint": "did you mean 'gateway_config'?"
+}
+```
+
+错误分层：
+
+1. parse error；
+2. schema error；
+3. reference/contract error；
+4. graph semantic error；
+5. policy error；
+6. runtime contract violation。
+
+CLI 文本输出和 API JSON 输出使用同一 diagnostic model。Compiler 在安全情况下聚合
+多个独立错误，避免 AI 每次只修一个 typo 后反复 sync。
+
+## 19. 安全边界
+
+- 禁止自定义 YAML tag 和不安全对象构造；
+- 不执行 DSL 中的任意表达式或脚本；
+- 对文档大小、node 数、edge 数、contract 深度和字符串长度设限；
+- 所有 loop/retry/feedback 有静态上限；
+- workflow 不含 provider credential；
+- source hash 与 canonical hash 使用明确编码和确定性序列化；
+- compiler 不访问网络、不启动 worker、不执行用户命令；
+- sync 先完整 validate/compile，再在数据库事务中提交 revision。
+
+## 20. 与六项 Pattern Runtime 缺口的关系
+
+WorkflowSpec v1 不实现六项能力，但必须证明架构不会阻止它们：
+
+| 后续能力 | v1 需要预留的基础 |
+| --- | --- |
+| Executor-Advisor | 严格 node kind、命名 port contract、独立 runtime profile binding |
+| Deterministic check/rollback | 可扩展判别 node union、显式 failure edge、明确 terminal outcome |
+| Human Approval | 可持久化 RunPlan、非 terminal pause state、审计身份边界 |
+| Artifact ownership | workflow policy namespace、node capability/permission contract |
+| Durable state/triggers | workflow identity/revision、外部 binding 与运行输入边界 |
+| Dynamic fan-out/heterogeneous roles | canonical node/edge、显式 agent role、未来 graph revision |
+
+这些能力不能通过 `extra` 或 prompt 偷渡到 v1。每个新 node kind 都需要 Schema、compiler、
+IR、persistence、runtime 和测试共同支持。
+
+## 21. 未来 Dynamic Graph Patch
+
+动态图不修改已入库 WorkflowSpec。一次 run 从 immutable RunPlan revision 0 开始，未来
+通过独立协议追加受审计 patch：
+
+```json
+{
+  "operation": "add_node",
+  "base_revision": 4,
+  "idempotency_key": "plan-item-3",
+  "actor": "orchestrator",
+  "reason": "planner produced a third independent task",
+  "node": {}
+}
+```
+
+Graph Patch 的核心规则将在独立设计中确定：
+
+- optimistic concurrency；
+- idempotency；
+- completed/traversed region 保护；
+- patch 后完整图校验；
+- graph revision、snapshot 和 replay；
+- actor capability 与预算限制；
+- add/remove/replace 操作边界。
+
+WorkflowSpec v1 现在只需保证 canonical node/edge 可复用、RunPlan 有 revision、运行图可
+序列化。不能为了“以后可能动态”把 patch 语义提前混进静态 DSL。
+
+## 22. 实施顺序
+
+推荐按以下顺序实现，而不是一次大改：
+
+1. **冻结 legacy 行为**：为全部现有资产建立 characterization tests。
+2. **Schema 与 diagnostics**：先能严格解释 v1，暂不接 runtime。
+3. **Canonical IR/compiler**：v1 与 legacy 都编译到同一 IR。
+4. **Runtime 迁移**：executor、recovery、scorecard 消费 canonical IR。
+5. **Revision persistence**：迁移数据库并绑定 run provenance。
+6. **Schema API/CLI/Manager Agent**：公开真实契约。
+7. **迁移 built-in patterns/examples**：用等价与 live tests 证明无回归。
+
+每一步都必须保持 legacy DAG 可运行。Dynamic Graph Patch 只有在以上全部稳定后才开始。
+
+## 23. 验收标准
+
+WorkflowSpec v1 只有同时满足以下条件才算完成：
+
+- strict v1 unknown field test 通过；
+- YAML/JSON 等价 source 产生相同 IR/hash；
+- 所有 node/gateway kind 有 Schema 和 exhaustiveness test；
+- handoff contract 在编译期解析、运行时执行；
+- legacy 全资产与等价 v1 transition parity 通过；
+- 数据库 migration 不丢 workflow/profile；
+- semantic update 创建 revision，格式变化不创建 semantic revision；
+- run cold recovery/replay 保留 revision/hash/compiler；
+- `/api/dag/schema` 与内部 validator 是同一 Schema；
+- CLI 和 Manager Agent 能获得结构化 diagnostics；
+- Linux、Windows、Docker、public smoke 和 live pattern CI 全绿；
+- 没有 Graph Patch 或新增 pattern runtime 能力混入首版。
+
+## 24. 需要评审确认的决策
+
+本文当前推荐，但尚未由项目 owner 确认：
+
+1. 使用 `api_version / kind / metadata / spec` envelope；
+2. v1 只使用顶层显式 `edges`；
+3. 普通数据 edge 隐含完成依赖，`depends_on` 只做控制屏障；
+4. 使用显式 terminal node，淘汰空字符串终点；
+5. handoff 两端引用同一命名 JSON Schema contract；
+6. typed schema definition 是 validator、TypeScript type、JSON Schema 的单一来源；
+7. RuntimeProfile v1 独立后续实现；
+8. 格式变化只写 sync audit，不增加 semantic revision；
+9. run input 使用保留 source `$run.input`；
+10. v1 node kind 名称采用 `agent / condition / join / foreach / while / terminal`。
+
+确认后，应把这些条目改为正式 decision，并在主设计文档中删除相应 open question；
+确认前不开始实现。

--- a/docs/dag-workflow-spec-v1-overview.zh-CN.md
+++ b/docs/dag-workflow-spec-v1-overview.zh-CN.md
@@ -892,9 +892,9 @@ WorkflowSpec v1 只有同时满足以下条件才算完成：
 - Linux、Windows、Docker、public smoke 和 live pattern CI 全绿；
 - 没有 Graph Patch 或新增 pattern runtime 能力混入首版。
 
-## 24. 需要评审确认的决策
+## 24. 已确认的 v1 决策
 
-本文当前推荐，但尚未由项目 owner 确认：
+以下决策已于 2026-07-11 确认并进入增量实现：
 
 1. 使用 `api_version / kind / metadata / spec` envelope；
 2. v1 只使用顶层显式 `edges`；
@@ -907,5 +907,5 @@ WorkflowSpec v1 只有同时满足以下条件才算完成：
 9. run input 使用保留 source `$run.input`；
 10. v1 node kind 名称采用 `agent / condition / join / foreach / while / terminal`。
 
-确认后，应把这些条目改为正式 decision，并在主设计文档中删除相应 open question；
-确认前不开始实现。
+这些条目是 WorkflowSpec v1 的实现边界。若后续要改变 envelope、edge、terminal、contract
+或 revision 语义，应重新进入设计评审，而不是在 parser 中增加隐式 alias。

--- a/docs/workflow-spec-v1-authoring.md
+++ b/docs/workflow-spec-v1-authoring.md
@@ -73,6 +73,9 @@ the entry contract.
 - Unknown fields fail validation instead of being ignored.
 - Node kinds are `agent`, `condition`, `join`, `foreach`, `while`, and
   `terminal`.
+- `condition.config.field` and `while.config.field` are optional. Omit `field`
+  to route or compare the complete handoff payload; set it to a dotted path to
+  inspect one nested value.
 - Ports declare interfaces. Connections exist only in `spec.edges`.
 - A data edge carries a payload and implies a completion dependency.
 - `depends_on` is only for a completion barrier that carries no payload.

--- a/docs/workflow-spec-v1-authoring.md
+++ b/docs/workflow-spec-v1-authoring.md
@@ -124,6 +124,8 @@ contracts:
 V1 requires the source and target ports of an edge to reference the same named
 contract. Manager validates run input and model handoffs at runtime. A contract
 violation fails the node and cannot continue through a success edge.
+The bounded contract subset supports `oneOf` with two to eight branches when a
+payload field legitimately has a small set of disjoint JSON shapes.
 
 ## Sync and Revisions
 

--- a/docs/workflow-spec-v1-authoring.md
+++ b/docs/workflow-spec-v1-authoring.md
@@ -67,6 +67,21 @@ Run input is the prompt supplied when the run starts. A JSON object or array
 may be supplied as a JSON-encoded prompt; Manager parses it before validating
 the entry contract.
 
+## Example Library
+
+Tracked provider-neutral examples live in `assets/orchestrations/`:
+
+- `workflow-spec-v1-minimal.yaml.template` for one agent and one terminal;
+- `workflow-spec-v1-fanout.yaml.template` for fan-out and explicit join;
+- `workflow-spec-v1-condition.yaml.template` for field-based routing;
+- `workflow-spec-v1-foreach.yaml.template` for bounded collection iteration;
+- `workflow-spec-v1-bounded-while.yaml.template` for bounded feedback and an
+  explicit exhaustion outcome.
+
+These documents intentionally contain no provider or model binding. Sync a
+database runtime profile for real runs; the test suite binds a deterministic
+dispatcher separately when checking graph behavior.
+
 ## Language Rules
 
 - Root fields are `api_version`, `kind`, `metadata`, and `spec` only.

--- a/docs/workflow-spec-v1-authoring.md
+++ b/docs/workflow-spec-v1-authoring.md
@@ -1,0 +1,149 @@
+# WorkflowSpec v1 Authoring
+
+WorkflowSpec is HomeRail's versioned DAG language. YAML and JSON are equivalent
+serializations; Manager compiles either form into the same canonical graph and
+hash.
+
+## Discover the Live Contract
+
+Do not copy a stale schema from documentation when Manager is available:
+
+```bash
+hr dag schema > /tmp/homerail-workflow-schema.json
+hr --json dag validate ./workflow.yaml
+```
+
+The corresponding Manager endpoints are:
+
+```text
+GET  /api/dag/schema
+POST /api/dag/validate
+```
+
+Manager Agent uses `get_dag_schema`, `validate_dag_workflow`, and
+`sync_dag_workflow` for the same flow.
+
+## Minimal Runnable Workflow
+
+```yaml
+api_version: homerail.ai/v1
+kind: Workflow
+
+metadata:
+  id: verified-task
+  name: Verified Task
+
+spec:
+  contracts:
+    Text:
+      type: string
+      maxLength: 20000
+
+  agents:
+    worker:
+      system: Execute the supplied task and return concise evidence.
+
+  nodes:
+    execute:
+      kind: agent
+      agent: worker
+      inputs:
+        task: { contract: Text }
+      outputs:
+        result: { contract: Text }
+
+    done:
+      kind: terminal
+      outcome: success
+      inputs:
+        result: { contract: Text }
+
+  edges:
+    - { from: $run.input, to: execute.task }
+    - { from: execute.result, to: done.result }
+```
+
+Run input is the prompt supplied when the run starts. A JSON object or array
+may be supplied as a JSON-encoded prompt; Manager parses it before validating
+the entry contract.
+
+## Language Rules
+
+- Root fields are `api_version`, `kind`, `metadata`, and `spec` only.
+- Unknown fields fail validation instead of being ignored.
+- Node kinds are `agent`, `condition`, `join`, `foreach`, `while`, and
+  `terminal`.
+- Ports declare interfaces. Connections exist only in `spec.edges`.
+- A data edge carries a payload and implies a completion dependency.
+- `depends_on` is only for a completion barrier that carries no payload.
+- Multiple producers must converge through an explicit `join`.
+- Feedback may target only `foreach` or `while` and requires
+  `max_traversals`.
+- Every output port must be routed. Every non-terminal node must have a path to
+  a terminal.
+- Terminal outcome is `success`, `failure`, or `cancelled`.
+- Provider, model, endpoint, API key, and other runtime credentials are not
+  workflow fields. Bind them through a database runtime profile.
+
+## Contracts
+
+Contracts are named once and referenced by both sides of an edge:
+
+```yaml
+contracts:
+  Verdict:
+    type: object
+    additionalProperties: false
+    required: [verdict, evidence]
+    properties:
+      verdict: { type: string, enum: [pass, fail] }
+      evidence:
+        type: array
+        maxItems: 100
+        items: { type: string, maxLength: 4000 }
+```
+
+V1 requires the source and target ports of an edge to reference the same named
+contract. Manager validates run input and model handoffs at runtime. A contract
+violation fails the node and cannot continue through a success edge.
+
+## Sync and Revisions
+
+```bash
+hr --json dag validate ./workflow.yaml
+hr dag sync ./workflow.yaml
+hr profile sync ./runtime.profile.yaml --workflow verified-task
+hr run --workflow verified-task --profile local-main --prompt "Inspect the release"
+```
+
+The first sync creates revision 1. A changed canonical hash creates revision
+N+1. Whitespace, comments, and formatting changes update source audit metadata
+without creating a semantic revision. Every run stores its exact workflow
+revision, canonical hash, compiler version, contracts, and runtime graph so a
+later workflow sync cannot change an active or historical run.
+
+Revision inspection endpoints are:
+
+```text
+GET /api/dag/workflows/:workflow_id/revisions
+GET /api/dag/workflows/:workflow_id/revisions/:revision
+```
+
+## Legacy Compatibility
+
+Unversioned HomeRail YAML remains accepted as `legacy/v0`. Its aliases, inline
+`outputs.<port>.to` routes, `after`, gateway names, and empty-string terminals
+continue through an isolated adapter. New workflows and generated built-in
+pattern instances use strict v1.
+
+Legacy source is not rewritten automatically. Validate and review a migrated
+v1 document before syncing it because v1 intentionally makes data dependencies,
+terminal outcomes, contracts, and feedback bounds explicit.
+
+## Not Part of v1
+
+WorkflowSpec describes a static workflow revision. Dynamic graph changes will
+use a separate audited Graph Patch protocol against a run graph revision. Human
+approval nodes, executable deterministic predicates, rollback compensation,
+durable schedules, and dynamic fan-out remain separate runtime capabilities;
+they must not be emulated through unvalidated YAML fields.

--- a/homerail_cli/src/commands/dag.ts
+++ b/homerail_cli/src/commands/dag.ts
@@ -19,6 +19,31 @@ interface GlobalOpts {
   requestTimeout?: number;
 }
 
+interface WorkflowDiagnostic {
+  severity: "error" | "warning";
+  code: string;
+  path: string;
+  message: string;
+  line?: number;
+  column?: number;
+  hint?: string;
+}
+
+interface WorkflowValidationResult {
+  valid: boolean;
+  source_format: "yaml" | "json";
+  source_api_version?: string;
+  canonical_hash?: string;
+  diagnostics: WorkflowDiagnostic[];
+  summary?: {
+    workflow_id: string;
+    node_count: number;
+    edge_count: number;
+    entry_nodes: string[];
+    terminal_nodes: string[];
+  };
+}
+
 export function registerDagCommands(program: Command): void {
   const dagCmd = program.command("dag").description("DAG status and supervision commands");
   const registerResumeCommand = (command: Command) => {
@@ -60,6 +85,66 @@ export function registerDagCommands(program: Command): void {
         const workflow = resp.data?.workflow;
         console.log(`DAG synced: ${workflow?.workflow_id ?? "unknown"} (${workflow?.name ?? "unnamed"})`);
         console.log("workflow_id is the stable identity. Keep it unchanged when editing YAML; change it only for a new workflow/version.");
+      } catch (err: unknown) {
+        console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+        process.exitCode = 1;
+      }
+    });
+
+  dagCmd
+    .command("validate <template>")
+    .description("Validate a DAG YAML or JSON document without syncing it")
+    .action(async (template: string) => {
+      const globalOpts = program.opts<GlobalOpts>();
+      const filePath = resolveTemplatePath(orchestrationsDir(), template);
+      if (!fs.existsSync(filePath)) {
+        console.error(`Error: DAG document not found: ${template}`);
+        process.exitCode = 1;
+        return;
+      }
+      try {
+        const client = getClient(globalOpts);
+        const response = await client.post("/api/dag/validate", {
+          source: fs.readFileSync(filePath, "utf8"),
+        }) as { data?: WorkflowValidationResult };
+        const result = response.data;
+        if (!result) throw new Error("Manager returned no validation result");
+        if (globalOpts.json) {
+          console.log(JSON.stringify(result));
+        } else if (result.valid) {
+          const summary = result.summary;
+          console.log(`Valid ${result.source_api_version ?? "workflow"}: ${summary?.workflow_id ?? template}`);
+          console.log(`Nodes: ${summary?.node_count ?? 0}  Edges: ${summary?.edge_count ?? 0}`);
+          if (result.canonical_hash) console.log(`Canonical hash: ${result.canonical_hash}`);
+          for (const entry of result.diagnostics.filter((item) => item.severity === "warning")) {
+            console.log(formatWorkflowDiagnostic(entry));
+          }
+        } else {
+          for (const entry of result.diagnostics) console.error(formatWorkflowDiagnostic(entry));
+          process.exitCode = 1;
+        }
+      } catch (err: unknown) {
+        console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+        process.exitCode = 1;
+      }
+    });
+
+  dagCmd
+    .command("schema")
+    .description("Fetch the live WorkflowSpec JSON Schema from Manager")
+    .action(async () => {
+      const globalOpts = program.opts<GlobalOpts>();
+      try {
+        const client = getClient(globalOpts);
+        const response = await client.get("/api/dag/schema") as {
+          data?: { schema?: unknown; api_version?: string; compiler_version?: string; schema_hash?: string };
+        };
+        if (!response.data?.schema) throw new Error("Manager returned no WorkflowSpec schema");
+        if (globalOpts.json) {
+          console.log(JSON.stringify(response.data));
+        } else {
+          console.log(JSON.stringify(response.data.schema, null, 2));
+        }
       } catch (err: unknown) {
         console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
         process.exitCode = 1;
@@ -198,4 +283,12 @@ export function registerDagCommands(program: Command): void {
     });
 
   registerResumeCommand(program);
+}
+
+function formatWorkflowDiagnostic(entry: WorkflowDiagnostic): string {
+  const location = entry.line !== undefined
+    ? ` line ${entry.line}${entry.column !== undefined ? `:${entry.column}` : ""}`
+    : "";
+  const hint = entry.hint ? ` Hint: ${entry.hint}` : "";
+  return `${entry.code} ${entry.path}${location}: ${entry.message}.${hint}`;
 }

--- a/homerail_cli/tests/commands.test.ts
+++ b/homerail_cli/tests/commands.test.ts
@@ -557,6 +557,101 @@ nodes:
   });
 });
 
+describe("dag WorkflowSpec commands", () => {
+  it("prints structured validation output for AI clients", async () => {
+    const sourcePath = join(tempHome, "workflow.yaml");
+    writeFileSync(sourcePath, "api_version: homerail.ai/v1\nkind: Workflow\n");
+    mockFetch({
+      success: true,
+      message: "DAG workflow is valid",
+      data: {
+        valid: true,
+        source_format: "yaml",
+        source_api_version: "homerail.ai/v1",
+        canonical_hash: "a".repeat(64),
+        diagnostics: [],
+        summary: {
+          workflow_id: "cli-workflow",
+          node_count: 2,
+          edge_count: 2,
+          entry_nodes: ["execute"],
+          terminal_nodes: ["done"],
+        },
+      },
+    });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const program = createProgram();
+    await program.parseAsync(["node", "homerail", "--json", "dag", "validate", sourcePath]);
+
+    expect(JSON.parse(String(logSpy.mock.calls[0][0]))).toMatchObject({
+      valid: true,
+      source_api_version: "homerail.ai/v1",
+      summary: { workflow_id: "cli-workflow" },
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      "http://localhost:19191/api/dag/validate",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ source: "api_version: homerail.ai/v1\nkind: Workflow\n" }),
+      }),
+    );
+  });
+
+  it("prints source diagnostics and exits non-zero for an invalid workflow", async () => {
+    const sourcePath = join(tempHome, "invalid.yaml");
+    writeFileSync(sourcePath, "api_version: homerail.ai/v1\nkind: Workflow\n");
+    mockFetch({
+      success: false,
+      message: "DAG workflow validation failed",
+      data: {
+        valid: false,
+        source_format: "yaml",
+        source_api_version: "homerail.ai/v1",
+        diagnostics: [{
+          severity: "error",
+          code: "DAG_SCHEMA_REQUIRED_FIELD",
+          path: "/metadata",
+          message: "Expected required property",
+          line: 1,
+          column: 1,
+        }],
+      },
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const program = createProgram();
+    await program.parseAsync(["node", "homerail", "dag", "validate", sourcePath]);
+
+    expect(process.exitCode).toBe(1);
+    expect(errorSpy.mock.calls.flat().join("\n")).toContain(
+      "DAG_SCHEMA_REQUIRED_FIELD /metadata line 1:1",
+    );
+  });
+
+  it("fetches the live schema from Manager", async () => {
+    mockFetch({
+      success: true,
+      message: "WorkflowSpec v1 schema retrieved",
+      data: {
+        api_version: "homerail.ai/v1",
+        compiler_version: "1",
+        schema_hash: "b".repeat(64),
+        schema: { type: "object" },
+      },
+    });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const program = createProgram();
+    await program.parseAsync(["node", "homerail", "--json", "dag", "schema"]);
+
+    expect(JSON.parse(String(logSpy.mock.calls[0][0]))).toMatchObject({
+      api_version: "homerail.ai/v1",
+      schema: { type: "object" },
+    });
+  });
+});
+
 describe("provider command", () => {
   it("provider list prints provider table in human-readable mode", async () => {
     mockFetch({

--- a/homerail_cli/tests/commands.test.ts
+++ b/homerail_cli/tests/commands.test.ts
@@ -543,7 +543,7 @@ nodes:
     expect(combined).not.toContain("token-plan-cn.xiaomimimo.com");
   });
 
-  it("requires public orchestration templates to define workflow_id", () => {
+  it("requires public orchestration templates to define a stable workflow identity", () => {
     const orchestrationsDir = new URL("../../assets/orchestrations/", import.meta.url);
     const templatePaths = readdirSync(orchestrationsDir)
       .filter((name) => name.endsWith(".yaml.template"))
@@ -552,7 +552,7 @@ nodes:
     expect(templatePaths.length).toBeGreaterThan(0);
     for (const templatePath of templatePaths) {
       const yaml = readFileSync(templatePath, "utf8");
-      expect(yaml, templatePath.pathname).toMatch(/^workflow_id:\s*\S+/m);
+      expect(yaml, templatePath.pathname).toMatch(/^(?:workflow_id:\s*\S+|\s+id:\s*\S+)/m);
     }
   });
 });

--- a/homerail_manager/package-lock.json
+++ b/homerail_manager/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@sinclair/typebox": "^0.34.51",
+        "ajv": "^8.20.0",
         "better-sqlite3": "^12.11.1",
         "homerail-protocol": "file:../homerail_protocol",
         "ws": "^8.18.0",
@@ -857,6 +859,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.51",
+      "resolved": "https://registry.npmmirror.com/@sinclair/typebox/-/typebox-0.34.51.tgz",
+      "integrity": "sha512-Nu4sNPT4G3QgAvxmdUCR/NBmsi23F2tEIcbMOZJVHS+qEgk+rmXxQikEeoKFyaX+UEggAoTvHUvIlj8MfYPzXQ==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -1041,6 +1049,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmmirror.com/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/assertion-error": {
@@ -1274,6 +1298,28 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmmirror.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmmirror.com/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1360,6 +1406,12 @@
       "resolved": "https://registry.npmmirror.com/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -1838,6 +1890,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rolldown": {

--- a/homerail_manager/package.json
+++ b/homerail_manager/package.json
@@ -21,6 +21,8 @@
     "npm": ">=10"
   },
   "dependencies": {
+    "@sinclair/typebox": "^0.34.51",
+    "ajv": "^8.20.0",
     "better-sqlite3": "^12.11.1",
     "homerail-protocol": "file:../homerail_protocol",
     "ws": "^8.18.0",

--- a/homerail_manager/src/orchestration/change-orchestrator.ts
+++ b/homerail_manager/src/orchestration/change-orchestrator.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import { fileURLToPath } from "node:url";
 import type { GraphExecutor } from "./graph-executor.js";
 import type { DAGAgentConfig, DAGGraphNode, DAGOutputRoute, ParsedDAG } from "./graph.js";
-import { parseDAGYamlFile } from "./yaml-loader.js";
+import { parseWorkflowSourceFile } from "./workflow-spec-v1.js";
 import { assertProviderPolicy } from "./provider-policy.js";
 import { assertNoYamlProviderRuntime } from "./runtime-selection.js";
 import {
@@ -230,7 +230,7 @@ function _loadDagForRequest(request: CreateRunRequest): ParsedDAG {
     throw new Error("Missing required field: yamlPath or workflow_id");
   }
   const resolvedPath = _resolveYamlPath(request.yamlPath);
-  return parseDAGYamlFile(resolvedPath);
+  return parseWorkflowSourceFile(resolvedPath);
 }
 
 function _applyRuntimeProfile(parsed: ParsedDAG, request: CreateRunRequest): ParsedDAG {

--- a/homerail_manager/src/orchestration/change-orchestrator.ts
+++ b/homerail_manager/src/orchestration/change-orchestrator.ts
@@ -35,6 +35,10 @@ export interface CreateRunResponse {
   runId: string;
   workflowId?: string;
   workflowName?: string;
+  workflowRevision?: number;
+  canonicalHash?: string;
+  compilerVersion?: string;
+  sourceApiVersion?: string;
   nodeCount: number;
   status: string;
   createdAt: number;
@@ -119,6 +123,10 @@ export interface CreateAndRunResponse {
   runId: string;
   workflowId?: string;
   workflowName?: string;
+  workflowRevision?: number;
+  canonicalHash?: string;
+  compilerVersion?: string;
+  sourceApiVersion?: string;
   nodeCount: number;
   status: string;
   createdAt: number;
@@ -258,6 +266,10 @@ export class ChangeOrchestrator {
       runId: run.runId,
       workflowId: run.workflowId,
       workflowName: run.workflowName,
+      workflowRevision: run.workflowRevision,
+      canonicalHash: run.canonicalHash,
+      compilerVersion: run.compilerVersion,
+      sourceApiVersion: run.sourceApiVersion,
       nodeCount: run.nodeCount ?? dagWithRuntime.graph.nodes.length,
       status: run.status,
       createdAt: run.createdAt,
@@ -281,6 +293,10 @@ export class ChangeOrchestrator {
       runId: createResult.runId,
       workflowId: createResult.workflowId,
       workflowName: createResult.workflowName,
+      workflowRevision: createResult.workflowRevision,
+      canonicalHash: createResult.canonicalHash,
+      compilerVersion: createResult.compilerVersion,
+      sourceApiVersion: createResult.sourceApiVersion,
       nodeCount: createResult.nodeCount,
       status: createResult.status,
       createdAt: createResult.createdAt,

--- a/homerail_manager/src/orchestration/dag-engine.ts
+++ b/homerail_manager/src/orchestration/dag-engine.ts
@@ -26,6 +26,7 @@ export interface DAGTransitionResult {
   affectedNodes: string[];
   routedNodes: string[];
   terminalFailure?: boolean;
+  terminalOutcome?: "success" | "failure" | "cancelled";
 }
 
 export function isFailurePort(port: string): boolean {
@@ -250,12 +251,20 @@ export function handoff(
       edge.to_node !== "" &&
       edgeMatchesHandoff(edge, port),
   );
-  const terminalFailure = isFailurePort(port) && matchingDownstream.length === 0;
+  const matchingTerminal = run.graph.edges.find(
+    (edge) => edge.from_node === fromNode && edge.to_node === "" && edgeMatchesHandoff(edge, port),
+  );
+  const terminalOutcome = matchingTerminal?.terminal_outcome;
+  const terminalFailure = terminalOutcome === "failure" ||
+    (terminalOutcome === undefined && isFailurePort(port) && matchingDownstream.length === 0);
+  const terminalCancelled = terminalOutcome === "cancelled";
   run.handoffedNodes.add(fromNode);
   run.nodeStates.set(
     fromNode,
     terminalFailure
       ? "FAILED"
+      : terminalCancelled
+        ? "CANCELLED"
       : run.loopSources.has(fromNode)
         ? "RUNNING"
         : "COMPLETED",
@@ -285,6 +294,7 @@ export function handoff(
     affectedNodes: Array.from(affected).sort(),
     routedNodes: Array.from(mailboxReceivers).sort(),
     terminalFailure,
+    terminalOutcome,
   };
 }
 
@@ -326,7 +336,7 @@ export function isRunTerminal(run: DAGRun): boolean {
   for (const [id, state] of run.nodeStates) {
     if (state === "READY") return false;
     if (state === "FAILED") continue;
-    if (state === "SKIPPED") continue;
+    if (state === "SKIPPED" || state === "CANCELLED") continue;
     if (run.loopSources.has(id) && state === "RUNNING") continue;
     if (state === "RUNNING" || state === "PENDING") return false;
     if (state !== "COMPLETED") return false;

--- a/homerail_manager/src/orchestration/dag-patterns.ts
+++ b/homerail_manager/src/orchestration/dag-patterns.ts
@@ -2,6 +2,7 @@ import YAML from "yaml";
 
 import { assertGraphValid, validateGraph, type GraphValidationResult } from "./graph-validator.js";
 import type { ParsedDAG } from "./graph.js";
+import { assertRuntimeGraphParity } from "./runtime-graph-parity.js";
 import {
   canonicalWorkflowToV1Document,
   compileWorkflowSource,
@@ -753,7 +754,7 @@ function buildPatternWorkflow(
     throw new Error(`Built-in DAG pattern '${definition.id}' failed WorkflowSpec v1 compilation: ${compilation.diagnostics.map((entry) => `${entry.code} ${entry.path}: ${entry.message}`).join("; ")}`);
   }
   const parsed = projectCanonicalWorkflowToParsedDAG(compilation.canonical);
-  assertPatternRuntimeParity(definition.id, legacyParsed, parsed);
+  assertRuntimeGraphParity(`Built-in DAG pattern '${definition.id}'`, legacyParsed, parsed);
   const validation = validateGraph(parsed.graph);
   assertGraphValid(parsed.graph);
   return {
@@ -762,59 +763,4 @@ function buildPatternWorkflow(
     parsed,
     validation,
   };
-}
-
-function assertPatternRuntimeParity(id: string, legacy: ParsedDAG, v1: ParsedDAG): void {
-  const sortObject = (value: unknown): unknown => {
-    if (Array.isArray(value)) return value.map(sortObject);
-    if (!value || typeof value !== "object") return value;
-    return Object.fromEntries(Object.entries(value as Record<string, unknown>)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([key, entry]) => [key, sortObject(entry)]));
-  };
-  const normalizeGateway = (value: Record<string, unknown> | undefined, nodeType: string) => {
-    if (!value) return {};
-    const { type: _type, kind: _kind, ...rest } = value;
-    return sortObject(nodeType === "loop_gateway"
-      ? { input: "items", max_items: 10_000, ...rest }
-      : rest);
-  };
-  const nodes = (parsed: ParsedDAG) => parsed.graph.nodes
-    .map((node) => ({
-      id: node.node_id,
-      type: node.node_type,
-      agent: node.agent,
-      after: [...node.after].sort(),
-      gateway: normalizeGateway(node.gateway_config as Record<string, unknown> | undefined, node.node_type),
-    }))
-    .sort((left, right) => left.id.localeCompare(right.id));
-  const edges = (parsed: ParsedDAG) => parsed.graph.edges
-    .map((edge) => ({
-      from_node: edge.from_node,
-      from_port: edge.from_port,
-      to_node: edge.to_node,
-      to_port: edge.to_port,
-      condition: edge.condition,
-      label: edge.label,
-      max_retries: edge.retry_policy?.max_retries ?? (
-        parsed.loop_sources.includes(edge.to_node) &&
-        parsed.graph.nodes.find((node) => node.node_id === edge.from_node)?.after.includes(edge.to_node)
-          ? 3
-          : undefined
-      ),
-    }))
-    .sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
-  const legacyNodes = nodes(legacy);
-  const v1Nodes = nodes(v1);
-  const legacyEdges = edges(legacy);
-  const v1Edges = edges(v1);
-  if (JSON.stringify(legacyNodes) !== JSON.stringify(v1Nodes) || JSON.stringify(legacyEdges) !== JSON.stringify(v1Edges)) {
-    const nodeIndex = legacyNodes.findIndex((node, index) => JSON.stringify(node) !== JSON.stringify(v1Nodes[index]));
-    const edgeIndex = legacyEdges.findIndex((edge, index) => JSON.stringify(edge) !== JSON.stringify(v1Edges[index]));
-    throw new Error(
-      `Built-in DAG pattern '${id}' changed runtime graph while migrating to WorkflowSpec v1; ` +
-      `node_diff=${JSON.stringify([legacyNodes[nodeIndex], v1Nodes[nodeIndex]])}; ` +
-      `edge_diff=${JSON.stringify([legacyEdges[edgeIndex], v1Edges[edgeIndex]])}`,
-    );
-  }
 }

--- a/homerail_manager/src/orchestration/dag-patterns.ts
+++ b/homerail_manager/src/orchestration/dag-patterns.ts
@@ -2,6 +2,11 @@ import YAML from "yaml";
 
 import { assertGraphValid, validateGraph, type GraphValidationResult } from "./graph-validator.js";
 import type { ParsedDAG } from "./graph.js";
+import {
+  canonicalWorkflowToV1Document,
+  compileWorkflowSource,
+  projectCanonicalWorkflowToParsedDAG,
+} from "./workflow-spec-v1.js";
 import { parseDAGYaml } from "./yaml-loader.js";
 
 export const DAG_PATTERN_SOURCE = {
@@ -616,7 +621,11 @@ function clone<T>(value: T): T {
 }
 
 function publicDefinition(definition: DAGPatternDefinition): DAGPatternDefinition {
-  return clone(definition);
+  const parameters = resolveParameters(definition, {});
+  return {
+    ...clone(definition),
+    workflow_template: buildPatternWorkflow(definition, parameters).workflow,
+  };
 }
 
 export function listDAGPatterns(): DAGPatternSummary[] {
@@ -712,6 +721,18 @@ export function instantiateDAGPattern(
   const definition = definitionById.get(id);
   if (!definition) throw new Error(`DAG pattern not found: ${id}`);
   const parameters = resolveParameters(definition, supplied);
+  const built = buildPatternWorkflow(definition, parameters);
+  return {
+    pattern: publicDefinition(definition),
+    parameters,
+    ...built,
+  };
+}
+
+function buildPatternWorkflow(
+  definition: DAGPatternDefinition,
+  parameters: Record<string, string | number | boolean>,
+): Omit<InstantiatedDAGPattern, "pattern" | "parameters"> {
   const workflow = interpolate(definition.workflow_template, parameters) as Record<string, unknown>;
   workflow.pattern = {
     id: definition.id,
@@ -719,16 +740,81 @@ export function instantiateDAGPattern(
     source: definition.source.url,
     parameters,
   };
-  const yamlText = YAML.stringify(workflow, { lineWidth: 0 });
-  const parsed = parseDAGYaml(yamlText);
+  const legacyYaml = YAML.stringify(workflow, { lineWidth: 0 });
+  const legacyParsed = parseDAGYaml(legacyYaml);
+  const legacyCompilation = compileWorkflowSource(legacyYaml);
+  if (!legacyCompilation.valid || !legacyCompilation.canonical) {
+    throw new Error(`Built-in DAG pattern '${definition.id}' failed legacy compilation: ${legacyCompilation.diagnostics.map((entry) => entry.message).join("; ")}`);
+  }
+  const v1Workflow = canonicalWorkflowToV1Document(legacyCompilation.canonical);
+  const yamlText = YAML.stringify(v1Workflow, { lineWidth: 0 });
+  const compilation = compileWorkflowSource(yamlText);
+  if (!compilation.valid || !compilation.canonical) {
+    throw new Error(`Built-in DAG pattern '${definition.id}' failed WorkflowSpec v1 compilation: ${compilation.diagnostics.map((entry) => `${entry.code} ${entry.path}: ${entry.message}`).join("; ")}`);
+  }
+  const parsed = projectCanonicalWorkflowToParsedDAG(compilation.canonical);
+  assertPatternRuntimeParity(definition.id, legacyParsed, parsed);
   const validation = validateGraph(parsed.graph);
   assertGraphValid(parsed.graph);
   return {
-    pattern: publicDefinition(definition),
-    parameters,
-    workflow,
+    workflow: v1Workflow,
     yaml_text: yamlText,
     parsed,
     validation,
   };
+}
+
+function assertPatternRuntimeParity(id: string, legacy: ParsedDAG, v1: ParsedDAG): void {
+  const sortObject = (value: unknown): unknown => {
+    if (Array.isArray(value)) return value.map(sortObject);
+    if (!value || typeof value !== "object") return value;
+    return Object.fromEntries(Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => [key, sortObject(entry)]));
+  };
+  const normalizeGateway = (value: Record<string, unknown> | undefined, nodeType: string) => {
+    if (!value) return {};
+    const { type: _type, kind: _kind, ...rest } = value;
+    return sortObject(nodeType === "loop_gateway"
+      ? { input: "items", max_items: 10_000, ...rest }
+      : rest);
+  };
+  const nodes = (parsed: ParsedDAG) => parsed.graph.nodes
+    .map((node) => ({
+      id: node.node_id,
+      type: node.node_type,
+      agent: node.agent,
+      after: [...node.after].sort(),
+      gateway: normalizeGateway(node.gateway_config as Record<string, unknown> | undefined, node.node_type),
+    }))
+    .sort((left, right) => left.id.localeCompare(right.id));
+  const edges = (parsed: ParsedDAG) => parsed.graph.edges
+    .map((edge) => ({
+      from_node: edge.from_node,
+      from_port: edge.from_port,
+      to_node: edge.to_node,
+      to_port: edge.to_port,
+      condition: edge.condition,
+      label: edge.label,
+      max_retries: edge.retry_policy?.max_retries ?? (
+        parsed.loop_sources.includes(edge.to_node) &&
+        parsed.graph.nodes.find((node) => node.node_id === edge.from_node)?.after.includes(edge.to_node)
+          ? 3
+          : undefined
+      ),
+    }))
+    .sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
+  const legacyNodes = nodes(legacy);
+  const v1Nodes = nodes(v1);
+  const legacyEdges = edges(legacy);
+  const v1Edges = edges(v1);
+  if (JSON.stringify(legacyNodes) !== JSON.stringify(v1Nodes) || JSON.stringify(legacyEdges) !== JSON.stringify(v1Edges)) {
+    const nodeIndex = legacyNodes.findIndex((node, index) => JSON.stringify(node) !== JSON.stringify(v1Nodes[index]));
+    const edgeIndex = legacyEdges.findIndex((edge, index) => JSON.stringify(edge) !== JSON.stringify(v1Edges[index]));
+    throw new Error(
+      `Built-in DAG pattern '${id}' changed runtime graph while migrating to WorkflowSpec v1; ` +
+      `node_diff=${JSON.stringify([legacyNodes[nodeIndex], v1Nodes[nodeIndex]])}; ` +
+      `edge_diff=${JSON.stringify([legacyEdges[edgeIndex], v1Edges[edgeIndex]])}`,
+    );
+  }
 }

--- a/homerail_manager/src/orchestration/graph.ts
+++ b/homerail_manager/src/orchestration/graph.ts
@@ -32,6 +32,7 @@ export interface DAGGatewayConfig {
   cases?: Record<string, string>;
   default_port?: string;
   items?: unknown[];
+  input?: string;
   item_port?: string;
   result_port?: string;
   done_port?: string;
@@ -44,6 +45,7 @@ export interface DAGGatewayConfig {
   operator?: "eq" | "ne" | "gt" | "gte" | "lt" | "lte" | "truthy" | "falsy" | string;
   value?: unknown;
   max_iterations?: number;
+  max_items?: number;
 }
 
 export interface DAGPatternInstanceMeta {
@@ -78,6 +80,7 @@ export interface DAGEdge {
   condition: string;
   label?: string;
   retry_policy?: DAGEdgeRetryPolicy;
+  terminal_outcome?: "success" | "failure" | "cancelled";
 }
 
 export interface RuntimeProfileAgentMapping {
@@ -139,6 +142,12 @@ export interface ScorecardPolicyConfig {
 export interface ResolvedWorkflowMeta {
   name: string;
   workflow_id?: string;
+  workflow_revision?: number;
+  canonical_hash?: string;
+  compiler_version?: string;
+  source_api_version?: string;
+  contracts?: Record<string, unknown>;
+  run_input_targets?: Array<{ node: string; port: string; contract?: string }>;
   description?: string;
   llm?: { provider?: string; model?: string };
   runtime_profiles?: Record<string, RuntimeProfile>;

--- a/homerail_manager/src/orchestration/json-contract.ts
+++ b/homerail_manager/src/orchestration/json-contract.ts
@@ -1,0 +1,43 @@
+import AjvModule, { type ErrorObject, type ValidateFunction } from "ajv";
+
+const AjvConstructor = AjvModule as unknown as new (
+  options?: Record<string, unknown>,
+) => {
+  compile(schema: object): ValidateFunction;
+  validateSchema(schema: object): boolean;
+  errors?: ErrorObject[] | null;
+};
+
+const ajv = new AjvConstructor({ allErrors: true, strict: true });
+const validators = new WeakMap<object, ValidateFunction>();
+
+function errorDetails(errors: ErrorObject[] | null | undefined): string {
+  return (errors ?? [])
+    .slice(0, 5)
+    .map((error) => `${error.instancePath || error.schemaPath || "/"}: ${error.message ?? error.keyword}`)
+    .join("; ");
+}
+
+export function validateJsonContractSchema(schema: unknown): { valid: boolean; details: string } {
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
+    return { valid: false, details: "contract schema must be an object" };
+  }
+  if (validators.has(schema)) return { valid: true, details: "" };
+  try {
+    const valid = ajv.validateSchema(schema);
+    if (!valid) return { valid: false, details: errorDetails(ajv.errors) };
+    const validate = ajv.compile(schema);
+    validators.set(schema, validate);
+    return { valid: true, details: "" };
+  } catch (error) {
+    return { valid: false, details: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+export function validateJsonContract(schema: unknown, value: unknown): { valid: boolean; details: string } {
+  const schemaResult = validateJsonContractSchema(schema);
+  if (!schemaResult.valid || !schema || typeof schema !== "object" || Array.isArray(schema)) return schemaResult;
+  const validate = validators.get(schema)!;
+  const valid = validate(value);
+  return { valid, details: errorDetails(validate.errors) };
+}

--- a/homerail_manager/src/orchestration/runtime-graph-parity.ts
+++ b/homerail_manager/src/orchestration/runtime-graph-parity.ts
@@ -1,0 +1,67 @@
+import type { ParsedDAG } from "./graph.js";
+
+function sortObject(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortObject);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(Object.entries(value as Record<string, unknown>)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, entry]) => [key, sortObject(entry)]));
+}
+
+function normalizeGateway(value: Record<string, unknown> | undefined, nodeType: string): unknown {
+  if (!value) return {};
+  const { type: _type, kind: _kind, ...rest } = value;
+  return sortObject(nodeType === "loop_gateway"
+    ? { input: "items", max_items: 10_000, ...rest }
+    : rest);
+}
+
+export function runtimeGraphSignature(parsed: ParsedDAG): { nodes: unknown[]; edges: unknown[] } {
+  const nodes = parsed.graph.nodes
+    .map((node) => ({
+      id: node.node_id,
+      type: node.node_type,
+      agent: node.agent,
+      after: [...node.after].sort(),
+      gateway: normalizeGateway(
+        node.gateway_config as Record<string, unknown> | undefined,
+        node.node_type,
+      ),
+    }))
+    .sort((left, right) => left.id.localeCompare(right.id));
+  const edges = parsed.graph.edges
+    .map((edge) => ({
+      from_node: edge.from_node,
+      from_port: edge.from_port,
+      to_node: edge.to_node,
+      to_port: edge.to_port,
+      condition: edge.condition,
+      label: edge.label,
+      max_retries: edge.retry_policy?.max_retries ?? (
+        parsed.loop_sources.includes(edge.to_node) &&
+        parsed.graph.nodes.find((node) => node.node_id === edge.from_node)?.after.includes(edge.to_node)
+          ? 3
+          : undefined
+      ),
+    }))
+    .sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
+  return { nodes, edges };
+}
+
+export function assertRuntimeGraphParity(label: string, expected: ParsedDAG, actual: ParsedDAG): void {
+  const expectedSignature = runtimeGraphSignature(expected);
+  const actualSignature = runtimeGraphSignature(actual);
+  if (JSON.stringify(expectedSignature) === JSON.stringify(actualSignature)) return;
+
+  const nodeIndex = expectedSignature.nodes.findIndex(
+    (node, index) => JSON.stringify(node) !== JSON.stringify(actualSignature.nodes[index]),
+  );
+  const edgeIndex = expectedSignature.edges.findIndex(
+    (edge, index) => JSON.stringify(edge) !== JSON.stringify(actualSignature.edges[index]),
+  );
+  throw new Error(
+    `${label} changed its runtime graph while migrating to WorkflowSpec v1; ` +
+    `node_diff=${JSON.stringify([expectedSignature.nodes[nodeIndex], actualSignature.nodes[nodeIndex]])}; ` +
+    `edge_diff=${JSON.stringify([expectedSignature.edges[edgeIndex], actualSignature.edges[edgeIndex]])}`,
+  );
+}

--- a/homerail_manager/src/orchestration/workflow-spec-v1-schema.ts
+++ b/homerail_manager/src/orchestration/workflow-spec-v1-schema.ts
@@ -96,7 +96,7 @@ const ConditionNode = Type.Object({
   kind: Type.Literal("condition"),
   ...NodeBase,
   config: Type.Object({
-    field: Type.String({ minLength: 1, maxLength: 256 }),
+    field: Type.Optional(Type.String({ minLength: 1, maxLength: 256 })),
     routes: Type.Record(Type.String({ minLength: 1, maxLength: 128 }), Identifier, {
       minProperties: 1,
       maxProperties: 128,
@@ -134,7 +134,7 @@ const WhileNode = Type.Object({
   kind: Type.Literal("while"),
   ...NodeBase,
   config: Type.Object({
-    field: Type.String({ minLength: 1, maxLength: 256 }),
+    field: Type.Optional(Type.String({ minLength: 1, maxLength: 256 })),
     operator: Type.Union([
       Type.Literal("eq"),
       Type.Literal("ne"),

--- a/homerail_manager/src/orchestration/workflow-spec-v1-schema.ts
+++ b/homerail_manager/src/orchestration/workflow-spec-v1-schema.ts
@@ -60,6 +60,7 @@ const ContractSchema = Type.Recursive((This) => Type.Object({
   additionalProperties: Type.Optional(Type.Boolean()),
   properties: Type.Optional(Type.Record(JsonPropertyName, This, { maxProperties: 128 })),
   items: Type.Optional(This),
+  oneOf: Type.Optional(Type.Array(This, { minItems: 2, maxItems: 8 })),
   minItems: Type.Optional(Type.Integer({ minimum: 0, maximum: 10_000 })),
   maxItems: Type.Optional(Type.Integer({ minimum: 0, maximum: 10_000 })),
   minLength: Type.Optional(Type.Integer({ minimum: 0, maximum: 1_000_000 })),

--- a/homerail_manager/src/orchestration/workflow-spec-v1-schema.ts
+++ b/homerail_manager/src/orchestration/workflow-spec-v1-schema.ts
@@ -1,0 +1,254 @@
+import { Type, type Static, type TSchema } from "@sinclair/typebox";
+
+export const WORKFLOW_API_VERSION = "homerail.ai/v1" as const;
+export const WORKFLOW_KIND = "Workflow" as const;
+export const WORKFLOW_COMPILER_VERSION = "1" as const;
+
+const IDENTIFIER_PATTERN = "^[a-z][a-z0-9]*(?:[-_][a-z0-9]+)*$";
+const PORT_REFERENCE_PATTERN = "^(?:\\$run\\.input|[a-z][a-z0-9]*(?:[-_][a-z0-9]+)*\\.[a-z][a-z0-9]*(?:[-_][a-z0-9]+)*)$";
+
+const Identifier = Type.String({
+  minLength: 1,
+  maxLength: 64,
+  pattern: IDENTIFIER_PATTERN,
+});
+
+const ContractIdentifier = Type.String({
+  minLength: 1,
+  maxLength: 64,
+  pattern: "^[A-Za-z][A-Za-z0-9]*(?:[-_][A-Za-z0-9]+)*$",
+});
+
+const JsonPropertyName = Type.String({
+  minLength: 1,
+  maxLength: 128,
+  pattern: "^[A-Za-z_][A-Za-z0-9_-]*$",
+});
+
+const ShortText = Type.String({ maxLength: 512 });
+const LongText = Type.String({ maxLength: 32_768 });
+
+const StringMap = Type.Record(Identifier, Type.String({ maxLength: 1024 }), {
+  maxProperties: 64,
+});
+
+const JsonValue = Type.Recursive((This) => Type.Union([
+  Type.Null(),
+  Type.Boolean(),
+  Type.Number(),
+  Type.String({ maxLength: 16_384 }),
+  Type.Array(This, { maxItems: 256 }),
+  Type.Record(Type.String({ minLength: 1, maxLength: 128 }), This, { maxProperties: 256 }),
+]));
+
+// Workflow contracts intentionally expose a bounded JSON Schema subset. This
+// keeps contracts portable and makes runtime payload validation predictable.
+const ContractSchema = Type.Recursive((This) => Type.Object({
+  type: Type.Optional(Type.Union([
+    Type.Literal("null"),
+    Type.Literal("boolean"),
+    Type.Literal("number"),
+    Type.Literal("integer"),
+    Type.Literal("string"),
+    Type.Literal("array"),
+    Type.Literal("object"),
+  ])),
+  description: Type.Optional(ShortText),
+  enum: Type.Optional(Type.Array(JsonValue, { minItems: 1, maxItems: 64 })),
+  const: Type.Optional(JsonValue),
+  required: Type.Optional(Type.Array(JsonPropertyName, { uniqueItems: true, maxItems: 128 })),
+  additionalProperties: Type.Optional(Type.Boolean()),
+  properties: Type.Optional(Type.Record(JsonPropertyName, This, { maxProperties: 128 })),
+  items: Type.Optional(This),
+  minItems: Type.Optional(Type.Integer({ minimum: 0, maximum: 10_000 })),
+  maxItems: Type.Optional(Type.Integer({ minimum: 0, maximum: 10_000 })),
+  minLength: Type.Optional(Type.Integer({ minimum: 0, maximum: 1_000_000 })),
+  maxLength: Type.Optional(Type.Integer({ minimum: 0, maximum: 1_000_000 })),
+  minimum: Type.Optional(Type.Number()),
+  maximum: Type.Optional(Type.Number()),
+  pattern: Type.Optional(Type.String({ maxLength: 512 })),
+}, { additionalProperties: false }));
+
+const Port = Type.Object({
+  contract: Type.Optional(ContractIdentifier),
+  description: Type.Optional(ShortText),
+}, { additionalProperties: false });
+
+const PortMap = Type.Record(Identifier, Port, { maxProperties: 128 });
+
+const NodeBase = {
+  description: Type.Optional(ShortText),
+  depends_on: Type.Optional(Type.Array(Identifier, {
+    uniqueItems: true,
+    maxItems: 256,
+  })),
+  inputs: Type.Optional(PortMap),
+  outputs: Type.Optional(PortMap),
+};
+
+const AgentNode = Type.Object({
+  kind: Type.Literal("agent"),
+  agent: Identifier,
+  ...NodeBase,
+}, { additionalProperties: false });
+
+const ConditionNode = Type.Object({
+  kind: Type.Literal("condition"),
+  ...NodeBase,
+  config: Type.Object({
+    field: Type.String({ minLength: 1, maxLength: 256 }),
+    routes: Type.Record(Type.String({ minLength: 1, maxLength: 128 }), Identifier, {
+      minProperties: 1,
+      maxProperties: 128,
+    }),
+    default: Type.Optional(Identifier),
+  }, { additionalProperties: false }),
+}, { additionalProperties: false });
+
+const JoinNode = Type.Object({
+  kind: Type.Literal("join"),
+  ...NodeBase,
+  config: Type.Object({
+    mode: Type.Union([Type.Literal("all"), Type.Literal("any"), Type.Literal("n_of_m")]),
+    field: Type.Optional(Type.String({ minLength: 1, maxLength: 256 })),
+    success_values: Type.Optional(Type.Array(JsonValue, { minItems: 1, maxItems: 128 })),
+    threshold: Type.Optional(Type.Integer({ minimum: 1, maximum: 256 })),
+    passed_port: Type.Optional(Identifier),
+    failed_port: Type.Optional(Identifier),
+  }, { additionalProperties: false }),
+}, { additionalProperties: false });
+
+const ForeachNode = Type.Object({
+  kind: Type.Literal("foreach"),
+  ...NodeBase,
+  config: Type.Object({
+    input: Identifier,
+    item_port: Identifier,
+    result_port: Identifier,
+    done_port: Identifier,
+    max_items: Type.Integer({ minimum: 1, maximum: 10_000 }),
+  }, { additionalProperties: false }),
+}, { additionalProperties: false });
+
+const WhileNode = Type.Object({
+  kind: Type.Literal("while"),
+  ...NodeBase,
+  config: Type.Object({
+    field: Type.String({ minLength: 1, maxLength: 256 }),
+    operator: Type.Union([
+      Type.Literal("eq"),
+      Type.Literal("ne"),
+      Type.Literal("gt"),
+      Type.Literal("gte"),
+      Type.Literal("lt"),
+      Type.Literal("lte"),
+      Type.Literal("truthy"),
+      Type.Literal("falsy"),
+    ]),
+    value: Type.Optional(JsonValue),
+    continue_port: Identifier,
+    done_port: Identifier,
+    exhausted_port: Type.Optional(Identifier),
+    max_iterations: Type.Integer({ minimum: 1, maximum: 10_000 }),
+  }, { additionalProperties: false }),
+}, { additionalProperties: false });
+
+const TerminalNode = Type.Object({
+  kind: Type.Literal("terminal"),
+  description: Type.Optional(ShortText),
+  depends_on: Type.Optional(Type.Array(Identifier, {
+    uniqueItems: true,
+    maxItems: 256,
+  })),
+  inputs: Type.Optional(PortMap),
+  outcome: Type.Union([
+    Type.Literal("success"),
+    Type.Literal("failure"),
+    Type.Literal("cancelled"),
+  ]),
+  reason: Type.Optional(Type.String({ minLength: 1, maxLength: 256 })),
+}, { additionalProperties: false });
+
+const WorkflowNode = Type.Union([
+  AgentNode,
+  ConditionNode,
+  JoinNode,
+  ForeachNode,
+  WhileNode,
+  TerminalNode,
+]);
+
+const DataEdge = Type.Object({
+  from: Type.String({ pattern: PORT_REFERENCE_PATTERN, maxLength: 130 }),
+  to: Type.String({ pattern: PORT_REFERENCE_PATTERN, maxLength: 130 }),
+  condition: Type.Optional(Type.Union([
+    Type.Literal("on_success"),
+    Type.Literal("on_failure"),
+    Type.Literal("always"),
+  ])),
+  retry: Type.Optional(Type.Object({
+    max_retries: Type.Integer({ minimum: 0, maximum: 20 }),
+  }, { additionalProperties: false })),
+}, { additionalProperties: false });
+
+const FeedbackEdge = Type.Object({
+  kind: Type.Literal("feedback"),
+  from: Type.String({ pattern: PORT_REFERENCE_PATTERN, maxLength: 130 }),
+  to: Type.String({ pattern: PORT_REFERENCE_PATTERN, maxLength: 130 }),
+  max_traversals: Type.Integer({ minimum: 1, maximum: 10_000 }),
+}, { additionalProperties: false });
+
+const WorkflowEdge = Type.Union([DataEdge, FeedbackEdge]);
+
+export const WorkflowSpecV1Schema = Type.Object({
+  api_version: Type.Literal(WORKFLOW_API_VERSION),
+  kind: Type.Literal(WORKFLOW_KIND),
+  metadata: Type.Object({
+    id: Identifier,
+    name: Type.String({ minLength: 1, maxLength: 256 }),
+    labels: Type.Optional(StringMap),
+    annotations: Type.Optional(StringMap),
+  }, { additionalProperties: false }),
+  spec: Type.Object({
+    description: Type.Optional(LongText),
+    workspace: Type.Optional(Type.Object({
+      mode: Type.Union([Type.Literal("isolated"), Type.Literal("shared")]),
+    }, { additionalProperties: false })),
+    contracts: Type.Optional(Type.Record(ContractIdentifier, ContractSchema, { maxProperties: 128 })),
+    agents: Type.Record(Identifier, Type.Object({
+      description: Type.Optional(ShortText),
+      system: Type.Optional(LongText),
+      skills: Type.Optional(Type.Array(Type.String({ minLength: 1, maxLength: 256 }), {
+        uniqueItems: true,
+        maxItems: 128,
+      })),
+    }, { additionalProperties: false }), { maxProperties: 256 }),
+    nodes: Type.Record(Identifier, WorkflowNode, {
+      minProperties: 1,
+      maxProperties: 1000,
+    }),
+    edges: Type.Array(WorkflowEdge, { maxItems: 10_000 }),
+    policies: Type.Optional(Type.Object({
+      max_nodes: Type.Optional(Type.Integer({ minimum: 1, maximum: 1000 })),
+      max_edges: Type.Optional(Type.Integer({ minimum: 0, maximum: 10_000 })),
+      max_parallelism: Type.Optional(Type.Integer({ minimum: 1, maximum: 256 })),
+      max_dispatches: Type.Optional(Type.Integer({ minimum: 1, maximum: 100_000 })),
+      max_handoffs: Type.Optional(Type.Integer({ minimum: 1, maximum: 100_000 })),
+      max_corrections_per_node: Type.Optional(Type.Integer({ minimum: 0, maximum: 100 })),
+      max_edge_traversals: Type.Optional(Type.Integer({ minimum: 1, maximum: 10_000 })),
+      max_tool_calls_per_node: Type.Optional(Type.Integer({ minimum: 0, maximum: 100_000 })),
+    }, { additionalProperties: false })),
+  }, { additionalProperties: false }),
+}, {
+  $id: "https://homerail.ai/schemas/workflow/homerail.ai-v1.json",
+  additionalProperties: false,
+});
+
+export type WorkflowSpecV1 = Static<typeof WorkflowSpecV1Schema>;
+export type WorkflowSpecV1Node = Static<typeof WorkflowNode>;
+export type WorkflowSpecV1Edge = Static<typeof WorkflowEdge>;
+export type WorkflowContractSchema = Static<typeof ContractSchema>;
+
+export function publicWorkflowSpecV1Schema(): TSchema {
+  return WorkflowSpecV1Schema;
+}

--- a/homerail_manager/src/orchestration/workflow-spec-v1-schema.ts
+++ b/homerail_manager/src/orchestration/workflow-spec-v1-schema.ts
@@ -228,6 +228,12 @@ export const WorkflowSpecV1Schema = Type.Object({
       maxProperties: 1000,
     }),
     edges: Type.Array(WorkflowEdge, { maxItems: 10_000 }),
+    pattern: Type.Optional(Type.Object({
+      id: Identifier,
+      version: Type.String({ minLength: 1, maxLength: 64 }),
+      source: Type.Optional(Type.String({ minLength: 1, maxLength: 2048 })),
+      parameters: Type.Optional(Type.Record(Identifier, JsonValue, { maxProperties: 128 })),
+    }, { additionalProperties: false })),
     policies: Type.Optional(Type.Object({
       max_nodes: Type.Optional(Type.Integer({ minimum: 1, maximum: 1000 })),
       max_edges: Type.Optional(Type.Integer({ minimum: 0, maximum: 10_000 })),

--- a/homerail_manager/src/orchestration/workflow-spec-v1.ts
+++ b/homerail_manager/src/orchestration/workflow-spec-v1.ts
@@ -1094,7 +1094,7 @@ function authoringNode(node: CanonicalNode, canonical: CanonicalWorkflowIR): Rec
     return {
       ...base,
       config: {
-        field: configString(config, "field", "status"),
+        ...(config.field ? { field: config.field } : {}),
         routes: config.routes ?? config.cases ?? {},
         ...(config.default_port || config.default ? { default: config.default_port ?? config.default } : {}),
       },
@@ -1148,7 +1148,7 @@ function authoringNode(node: CanonicalNode, canonical: CanonicalWorkflowIR): Rec
     ...base,
     outputs,
     config: {
-      field: configString(config, "field", "status"),
+      ...(config.field ? { field: config.field } : {}),
       operator: configString(config, "operator", "eq"),
       ...(config.value !== undefined ? { value: config.value } : {}),
       continue_port: continuePort,

--- a/homerail_manager/src/orchestration/workflow-spec-v1.ts
+++ b/homerail_manager/src/orchestration/workflow-spec-v1.ts
@@ -79,6 +79,12 @@ export interface CanonicalWorkflowIR {
     system?: string;
     skills: string[];
   }>;
+  pattern?: {
+    id: string;
+    version: string;
+    source?: string;
+    parameters: Record<string, unknown>;
+  };
   policies: {
     max_nodes: number;
     max_edges: number;
@@ -592,6 +598,14 @@ function compileV1(workflow: WorkflowSpecV1): CanonicalWorkflowIR {
         ...(agent.system ? { system: agent.system } : {}),
         skills: [...(agent.skills ?? [])].sort(),
       }])),
+    ...(workflow.spec.pattern ? {
+      pattern: {
+        id: workflow.spec.pattern.id,
+        version: workflow.spec.pattern.version,
+        ...(workflow.spec.pattern.source ? { source: workflow.spec.pattern.source } : {}),
+        parameters: deepSort(workflow.spec.pattern.parameters ?? {}) as Record<string, unknown>,
+      },
+    } : {}),
     policies: {
       max_nodes: workflow.spec.policies?.max_nodes ?? 1000,
       max_edges: workflow.spec.policies?.max_edges ?? 10_000,
@@ -630,7 +644,7 @@ function legacyTerminalId(edge: DAGEdge, index: number): string {
 function compileLegacy(parsed: ParsedDAG): CanonicalWorkflowIR {
   const inputPorts = new Map<string, Set<string>>();
   for (const edge of parsed.graph.edges) {
-    if (edge.to_node) {
+    if (edge.to_node && edge.label !== "after_dep") {
       if (!inputPorts.has(edge.to_node)) inputPorts.set(edge.to_node, new Set());
       inputPorts.get(edge.to_node)?.add(edge.to_port);
     }
@@ -645,6 +659,7 @@ function compileLegacy(parsed: ParsedDAG): CanonicalWorkflowIR {
     outputs: Object.keys(node.outputs).sort().map((name) => ({ name })),
     ...(legacyKind(node) !== "agent" ? { config: deepSort(node.gateway_config ?? {}) as Record<string, unknown> } : {}),
   }));
+  const sourceNodes = new Map(parsed.graph.nodes.map((node) => [node.node_id, node]));
   const edges: CanonicalEdge[] = [];
   parsed.graph.edges.forEach((edge, index) => {
     if (!edge.to_node) {
@@ -667,13 +682,16 @@ function compileLegacy(parsed: ParsedDAG): CanonicalWorkflowIR {
       });
       return;
     }
+    const feedback = parsed.loop_sources.includes(edge.to_node) &&
+      sourceNodes.get(edge.from_node)?.after.includes(edge.to_node);
     edges.push({
       id: "",
-      kind: edge.label === "after_dep" ? "control" : "data",
+      kind: edge.label === "after_dep" ? "control" : feedback ? "feedback" : "data",
       from: { node: edge.from_node, port: edge.from_port },
       to: { node: edge.to_node, port: edge.to_port },
       condition: edge.condition as CanonicalEdge["condition"],
       retry: { max_retries: edge.retry_policy?.max_retries ?? 0 },
+      ...(feedback ? { max_traversals: edge.retry_policy?.max_retries ?? 3 } : {}),
     });
   });
   edges.sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
@@ -699,6 +717,14 @@ function compileLegacy(parsed: ParsedDAG): CanonicalWorkflowIR {
         ...(agent.system ? { system: agent.system } : {}),
         skills: [...(agent.skills ?? [])].sort(),
       }])),
+    ...(parsed.meta.pattern ? {
+      pattern: {
+        id: parsed.meta.pattern.id,
+        version: parsed.meta.pattern.version,
+        ...(parsed.meta.pattern.source ? { source: parsed.meta.pattern.source } : {}),
+        parameters: deepSort(parsed.meta.pattern.parameters ?? {}) as Record<string, unknown>,
+      },
+    } : {}),
     policies: {
       max_nodes: 1000,
       max_edges: 10_000,
@@ -713,7 +739,7 @@ function compileLegacy(parsed: ParsedDAG): CanonicalWorkflowIR {
     edges,
     entry_nodes: nodes.filter((node) => !incoming.has(node.id)).map((node) => node.id).sort(),
     terminal_nodes: nodes.filter((node) => node.kind === "terminal").map((node) => node.id).sort(),
-    feedback_edges: [],
+    feedback_edges: edges.filter((edge) => edge.kind === "feedback").map((edge) => edge.id),
     legacy_compat: deepSort({
       meta: parsed.meta,
       graph: parsed.graph,
@@ -1003,6 +1029,7 @@ export function projectCanonicalWorkflowToParsedDAG(canonical: CanonicalWorkflow
         max_tool_calls_per_node: canonical.policies.max_tool_calls_per_node,
       },
       agents,
+      pattern: canonical.pattern,
       contracts: canonical.contracts,
       run_input_targets: runInputTargets,
       source_api_version: canonical.source_api_version,
@@ -1015,4 +1042,161 @@ export function projectCanonicalWorkflowToParsedDAG(canonical: CanonicalWorkflow
       .map((node) => node.id)
       .sort(),
   };
+}
+
+function authoringPorts(ports: CanonicalPort[]): Record<string, { contract?: string; description?: string }> | undefined {
+  if (ports.length === 0) return undefined;
+  return Object.fromEntries(ports.map((port) => [port.name, {
+    ...(port.contract ? { contract: port.contract } : {}),
+    ...(port.description ? { description: port.description } : {}),
+  }]));
+}
+
+function configString(config: Record<string, unknown>, key: string, fallback: string): string {
+  return typeof config[key] === "string" && config[key] ? String(config[key]) : fallback;
+}
+
+function authoringNode(node: CanonicalNode, canonical: CanonicalWorkflowIR): Record<string, unknown> {
+  const incomingDataDependencies = new Set(
+    canonical.edges
+      .filter((edge) => edge.kind === "data" && edge.to.node === node.id && edge.from.node !== "$run")
+      .map((edge) => edge.from.node),
+  );
+  const dependsOn = node.depends_on.filter((dependency) => !incomingDataDependencies.has(dependency));
+  const base: Record<string, unknown> = {
+    kind: node.kind,
+    ...(node.description ? { description: node.description } : {}),
+    ...(dependsOn.length > 0 ? { depends_on: dependsOn } : {}),
+    ...(authoringPorts(node.inputs) ? { inputs: authoringPorts(node.inputs) } : {}),
+    ...(node.kind !== "terminal" && authoringPorts(node.outputs) ? { outputs: authoringPorts(node.outputs) } : {}),
+  };
+  if (node.kind === "agent") return { ...base, agent: node.agent };
+  if (node.kind === "terminal") {
+    return { ...base, outcome: node.outcome ?? "success", ...(node.reason ? { reason: node.reason } : {}) };
+  }
+  const config = node.config ?? {};
+  if (node.kind === "condition") {
+    return {
+      ...base,
+      config: {
+        field: configString(config, "field", "status"),
+        routes: config.routes ?? config.cases ?? {},
+        ...(config.default_port || config.default ? { default: config.default_port ?? config.default } : {}),
+      },
+    };
+  }
+  if (node.kind === "join") {
+    return {
+      ...base,
+      config: {
+        mode: config.mode === "any" || config.mode === "n_of_m" ? config.mode : "all",
+        ...(config.field ? { field: config.field } : {}),
+        ...(config.success_values ? { success_values: config.success_values } : {}),
+        ...(config.threshold ? { threshold: config.threshold } : {}),
+        ...(config.passed_port ? { passed_port: config.passed_port } : {}),
+        ...(config.failed_port ? { failed_port: config.failed_port } : {}),
+      },
+    };
+  }
+  if (node.kind === "foreach") {
+    const inputs = { ...(base.inputs as Record<string, unknown> | undefined ?? {}) };
+    const outputs = { ...(base.outputs as Record<string, unknown> | undefined ?? {}) };
+    const input = configString(config, "input", inputs.items ? "items" : Object.keys(inputs)[0] ?? "items");
+    const resultPort = configString(config, "result_port", "result");
+    const itemPort = configString(config, "item_port", "next_item");
+    const donePort = configString(config, "done_port", "done");
+    inputs[input] ??= {};
+    inputs[resultPort] ??= {};
+    outputs[itemPort] ??= {};
+    outputs[donePort] ??= {};
+    return {
+      ...base,
+      inputs,
+      outputs,
+      config: {
+        input,
+        item_port: itemPort,
+        result_port: resultPort,
+        done_port: donePort,
+        max_items: typeof config.max_items === "number" ? config.max_items : 10_000,
+      },
+    };
+  }
+  const outputs = { ...(base.outputs as Record<string, unknown> | undefined ?? {}) };
+  const continuePort = configString(config, "continue_port", "continue");
+  const donePort = configString(config, "done_port", "done");
+  const exhaustedPort = configString(config, "exhausted_port", "exhausted");
+  outputs[continuePort] ??= {};
+  outputs[donePort] ??= {};
+  outputs[exhaustedPort] ??= {};
+  return {
+    ...base,
+    outputs,
+    config: {
+      field: configString(config, "field", "status"),
+      operator: configString(config, "operator", "eq"),
+      ...(config.value !== undefined ? { value: config.value } : {}),
+      continue_port: continuePort,
+      done_port: donePort,
+      exhausted_port: exhaustedPort,
+      max_iterations: typeof config.max_iterations === "number" ? config.max_iterations : 3,
+    },
+  };
+}
+
+export function canonicalWorkflowToV1Document(canonical: CanonicalWorkflowIR): Record<string, unknown> {
+  const edges = canonical.edges
+    .filter((edge) => edge.kind !== "control")
+    .map((edge) => {
+      const defaultCondition = FAILURE_PORT_NAMES.has(edge.from.port.toLowerCase()) ? "on_failure" : "on_success";
+      if (edge.kind === "feedback") {
+        return {
+          kind: "feedback",
+          from: `${edge.from.node}.${edge.from.port}`,
+          to: `${edge.to.node}.${edge.to.port}`,
+          max_traversals: edge.max_traversals ?? (edge.retry.max_retries || 3),
+        };
+      }
+      return {
+        from: edge.from.node === "$run" ? "$run.input" : `${edge.from.node}.${edge.from.port}`,
+        to: `${edge.to.node}.${edge.to.port}`,
+        ...(edge.condition !== defaultCondition ? { condition: edge.condition } : {}),
+        ...(edge.retry.max_retries > 0 ? { retry: { max_retries: edge.retry.max_retries } } : {}),
+      };
+    });
+  return {
+    api_version: WORKFLOW_API_VERSION,
+    kind: WORKFLOW_KIND,
+    metadata: {
+      id: canonical.workflow_id,
+      name: canonical.name,
+      ...(Object.keys(canonical.labels).length > 0 ? { labels: canonical.labels } : {}),
+      ...(Object.keys(canonical.annotations).length > 0 ? { annotations: canonical.annotations } : {}),
+    },
+    spec: {
+      ...(canonical.description ? { description: canonical.description } : {}),
+      workspace: canonical.workspace,
+      ...(Object.keys(canonical.contracts).length > 0 ? { contracts: canonical.contracts } : {}),
+      agents: Object.fromEntries(Object.entries(canonical.agents).map(([id, agent]) => [id, {
+        ...(agent.description ? { description: agent.description } : {}),
+        ...(agent.system ? { system: agent.system } : {}),
+        ...(agent.skills.length > 0 ? { skills: agent.skills } : {}),
+      }])),
+      nodes: Object.fromEntries(canonical.nodes.map((node) => [node.id, authoringNode(node, canonical)])),
+      edges,
+      ...(canonical.pattern ? { pattern: canonical.pattern } : {}),
+      ...(_isDefaultPolicies(canonical.policies) ? {} : { policies: canonical.policies }),
+    },
+  };
+}
+
+function _isDefaultPolicies(policies: CanonicalWorkflowIR["policies"]): boolean {
+  return policies.max_nodes === 1000 &&
+    policies.max_edges === 10_000 &&
+    policies.max_parallelism === 32 &&
+    policies.max_dispatches === 30 &&
+    policies.max_handoffs === 50 &&
+    policies.max_corrections_per_node === 2 &&
+    policies.max_edge_traversals === 3 &&
+    policies.max_tool_calls_per_node === 0;
 }

--- a/homerail_manager/src/orchestration/workflow-spec-v1.ts
+++ b/homerail_manager/src/orchestration/workflow-spec-v1.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
 import { LineCounter, isNode, parseDocument, type Document } from "yaml";
 import { Value } from "@sinclair/typebox/value";
 import type {
@@ -847,6 +848,20 @@ export function compileWorkflowSource(source: string): WorkflowCompilationResult
     };
   }
   return resultForCanonical(format, [], compileV1(workflow));
+}
+
+export function parseWorkflowSource(source: string): ParsedDAG {
+  const compilation = compileWorkflowSource(source);
+  if (!compilation.valid || !compilation.canonical) {
+    throw new Error(compilation.diagnostics.map((entry) => `${entry.code} ${entry.path}: ${entry.message}`).join("; "));
+  }
+  return compilation.source_api_version === "legacy/v0"
+    ? parseDAGYaml(source)
+    : projectCanonicalWorkflowToParsedDAG(compilation.canonical);
+}
+
+export function parseWorkflowSourceFile(filePath: string): ParsedDAG {
+  return parseWorkflowSource(readFileSync(filePath, "utf8"));
 }
 
 export function workflowSchemaHash(): string {

--- a/homerail_manager/src/orchestration/workflow-spec-v1.ts
+++ b/homerail_manager/src/orchestration/workflow-spec-v1.ts
@@ -1,0 +1,1018 @@
+import { createHash } from "node:crypto";
+import { LineCounter, isNode, parseDocument, type Document } from "yaml";
+import { Value } from "@sinclair/typebox/value";
+import type {
+  DAGAgentConfig,
+  DAGGraphNode,
+  DAGEdge,
+  ParsedDAG,
+} from "./graph.js";
+import { parseDAGYaml } from "./yaml-loader.js";
+import { assertGraphValid } from "./graph-validator.js";
+import { validateJsonContractSchema } from "./json-contract.js";
+import {
+  WORKFLOW_API_VERSION,
+  WORKFLOW_COMPILER_VERSION,
+  WORKFLOW_KIND,
+  WorkflowSpecV1Schema,
+  type WorkflowSpecV1,
+  type WorkflowSpecV1Edge,
+  type WorkflowSpecV1Node,
+} from "./workflow-spec-v1-schema.js";
+
+export type WorkflowSourceVersion = typeof WORKFLOW_API_VERSION | "legacy/v0";
+export type WorkflowSourceFormat = "yaml" | "json";
+const FAILURE_PORT_NAMES = new Set(["failed", "failure", "rejected", "error"]);
+
+export interface WorkflowDiagnostic {
+  severity: "error" | "warning";
+  code: string;
+  path: string;
+  message: string;
+  line?: number;
+  column?: number;
+  hint?: string;
+}
+
+export interface CanonicalPort {
+  name: string;
+  contract?: string;
+  description?: string;
+}
+
+export interface CanonicalNode {
+  id: string;
+  kind: "agent" | "condition" | "join" | "foreach" | "while" | "terminal";
+  description?: string;
+  agent?: string;
+  depends_on: string[];
+  inputs: CanonicalPort[];
+  outputs: CanonicalPort[];
+  config?: Record<string, unknown>;
+  outcome?: "success" | "failure" | "cancelled";
+  reason?: string;
+}
+
+export interface CanonicalEdge {
+  id: string;
+  kind: "data" | "control" | "feedback";
+  from: { node: string; port: string };
+  to: { node: string; port: string };
+  condition: "on_success" | "on_failure" | "always";
+  retry: { max_retries: number };
+  max_traversals?: number;
+}
+
+export interface CanonicalWorkflowIR {
+  ir_version: "1";
+  source_api_version: WorkflowSourceVersion;
+  compiler_version: typeof WORKFLOW_COMPILER_VERSION;
+  workflow_id: string;
+  name: string;
+  description?: string;
+  labels: Record<string, string>;
+  annotations: Record<string, string>;
+  workspace: { mode: "isolated" | "shared" };
+  contracts: Record<string, unknown>;
+  agents: Record<string, {
+    description?: string;
+    system?: string;
+    skills: string[];
+  }>;
+  policies: {
+    max_nodes: number;
+    max_edges: number;
+    max_parallelism: number;
+    max_dispatches: number;
+    max_handoffs: number;
+    max_corrections_per_node: number;
+    max_edge_traversals: number;
+    max_tool_calls_per_node: number;
+  };
+  nodes: CanonicalNode[];
+  edges: CanonicalEdge[];
+  entry_nodes: string[];
+  terminal_nodes: string[];
+  feedback_edges: string[];
+  legacy_compat?: {
+    meta: Record<string, unknown>;
+    graph: Record<string, unknown>;
+    loop_sources: string[];
+  };
+}
+
+export interface WorkflowCompilationResult {
+  valid: boolean;
+  source_format: WorkflowSourceFormat;
+  source_api_version?: WorkflowSourceVersion;
+  diagnostics: WorkflowDiagnostic[];
+  canonical?: CanonicalWorkflowIR;
+  canonical_json?: string;
+  canonical_hash?: string;
+  summary?: {
+    workflow_id: string;
+    node_count: number;
+    edge_count: number;
+    entry_nodes: string[];
+    terminal_nodes: string[];
+  };
+}
+
+interface SourceContext {
+  document: Document.Parsed;
+  lineCounter: LineCounter;
+}
+
+function sourceFormat(source: string): WorkflowSourceFormat {
+  return source.trimStart().startsWith("{") ? "json" : "yaml";
+}
+
+function pointerParts(path: string): Array<string | number> {
+  if (!path || path === "/") return [];
+  return path
+    .split("/")
+    .slice(1)
+    .map((part) => part.replace(/~1/g, "/").replace(/~0/g, "~"))
+    .map((part) => /^\d+$/.test(part) ? Number(part) : part);
+}
+
+function sourcePosition(context: SourceContext, path: string): { line?: number; column?: number } {
+  let parts = pointerParts(path);
+  while (parts.length >= 0) {
+    const node = context.document.getIn(parts, true);
+    if (isNode(node) && node.range) {
+      const position = context.lineCounter.linePos(node.range[0]);
+      return { line: position.line, column: position.col };
+    }
+    if (parts.length === 0) break;
+    parts = parts.slice(0, -1);
+  }
+  return {};
+}
+
+function diagnostic(
+  context: SourceContext,
+  value: Omit<WorkflowDiagnostic, "line" | "column">,
+): WorkflowDiagnostic {
+  return { ...value, ...sourcePosition(context, value.path) };
+}
+
+function parseSource(source: string): {
+  context?: SourceContext;
+  value?: unknown;
+  diagnostics: WorkflowDiagnostic[];
+} {
+  const lineCounter = new LineCounter();
+  const document = parseDocument(source, {
+    lineCounter,
+    prettyErrors: false,
+    strict: true,
+    uniqueKeys: true,
+  });
+  const diagnostics: WorkflowDiagnostic[] = [];
+  for (const error of document.errors) {
+    const position = error.pos?.[0] !== undefined ? lineCounter.linePos(error.pos[0]) : undefined;
+    diagnostics.push({
+      severity: "error",
+      code: "DAG_PARSE_INVALID_SOURCE",
+      path: "/",
+      message: error.message,
+      ...(position ? { line: position.line, column: position.col } : {}),
+    });
+  }
+  for (const warning of document.warnings) {
+    const position = warning.pos?.[0] !== undefined ? lineCounter.linePos(warning.pos[0]) : undefined;
+    diagnostics.push({
+      severity: "error",
+      code: "DAG_PARSE_UNSUPPORTED_YAML",
+      path: "/",
+      message: warning.message,
+      ...(position ? { line: position.line, column: position.col } : {}),
+    });
+  }
+  if (diagnostics.length > 0) return { diagnostics };
+  try {
+    return {
+      context: { document, lineCounter },
+      value: document.toJS({ maxAliasCount: 0 }),
+      diagnostics,
+    };
+  } catch (error) {
+    return {
+      diagnostics: [{
+        severity: "error",
+        code: "DAG_PARSE_INVALID_SOURCE",
+        path: "/",
+        message: error instanceof Error ? error.message : String(error),
+      }],
+    };
+  }
+}
+
+function schemaErrorCode(message: string): string {
+  const normalized = message.toLowerCase();
+  if (normalized.includes("unexpected property")) return "DAG_SCHEMA_UNKNOWN_FIELD";
+  if (normalized.includes("required property")) return "DAG_SCHEMA_REQUIRED_FIELD";
+  return "DAG_SCHEMA_INVALID_FIELD";
+}
+
+function schemaDiagnostics(context: SourceContext, value: unknown): WorkflowDiagnostic[] {
+  return [...Value.Errors(WorkflowSpecV1Schema, value)].map((error) => diagnostic(context, {
+    severity: "error",
+    code: schemaErrorCode(error.message),
+    path: error.path || "/",
+    message: error.message,
+  }));
+}
+
+function splitPortReference(reference: string): { node: string; port: string } {
+  if (reference === "$run.input") return { node: "$run", port: "input" };
+  const index = reference.lastIndexOf(".");
+  return { node: reference.slice(0, index), port: reference.slice(index + 1) };
+}
+
+function portEntries(ports: Record<string, { contract?: string; description?: string }> | undefined): CanonicalPort[] {
+  return Object.entries(ports ?? {})
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([name, port]) => ({
+      name,
+      ...(port.contract ? { contract: port.contract } : {}),
+      ...(port.description ? { description: port.description } : {}),
+    }));
+}
+
+function nodePorts(node: WorkflowSpecV1Node, direction: "inputs" | "outputs"): Record<string, { contract?: string }> {
+  if (direction === "inputs") return node.inputs ?? {};
+  if (node.kind === "terminal") return {};
+  return node.outputs ?? {};
+}
+
+function isFeedbackEdge(edge: WorkflowSpecV1Edge): edge is Extract<WorkflowSpecV1Edge, { kind: "feedback" }> {
+  return "kind" in edge && edge.kind === "feedback";
+}
+
+function semanticDiagnostics(context: SourceContext, workflow: WorkflowSpecV1): WorkflowDiagnostic[] {
+  const diagnostics: WorkflowDiagnostic[] = [];
+  const nodes = workflow.spec.nodes;
+  const agents = workflow.spec.agents;
+  const contracts = workflow.spec.contracts ?? {};
+
+  const add = (path: string, code: string, message: string, hint?: string) => {
+    diagnostics.push(diagnostic(context, {
+      severity: "error",
+      code,
+      path,
+      message,
+      ...(hint ? { hint } : {}),
+    }));
+  };
+
+  for (const [contractName, contract] of Object.entries(contracts)) {
+    const validation = validateJsonContractSchema(contract);
+    if (!validation.valid) {
+      add(
+        `/spec/contracts/${contractName}`,
+        "DAG_SEMANTIC_INVALID_CONTRACT",
+        `invalid JSON Schema contract '${contractName}': ${validation.details}`,
+      );
+    }
+  }
+
+  for (const [nodeId, node] of Object.entries(nodes)) {
+    const nodePath = `/spec/nodes/${nodeId}`;
+    if (node.kind === "agent" && !agents[node.agent]) {
+      add(`${nodePath}/agent`, "DAG_SEMANTIC_UNKNOWN_AGENT", `unknown agent '${node.agent}'`);
+    }
+    for (const dependency of node.depends_on ?? []) {
+      if (!nodes[dependency]) {
+        add(`${nodePath}/depends_on`, "DAG_SEMANTIC_UNKNOWN_NODE", `unknown dependency '${dependency}'`);
+      } else if (dependency === nodeId) {
+        add(`${nodePath}/depends_on`, "DAG_SEMANTIC_SELF_DEPENDENCY", "a node cannot depend on itself");
+      }
+    }
+    for (const direction of ["inputs", "outputs"] as const) {
+      for (const [portName, port] of Object.entries(nodePorts(node, direction))) {
+        if (port.contract && !contracts[port.contract]) {
+          add(
+            `${nodePath}/${direction}/${portName}/contract`,
+            "DAG_SEMANTIC_UNKNOWN_CONTRACT",
+            `unknown contract '${port.contract}'`,
+          );
+        }
+      }
+    }
+    if (node.kind === "condition") {
+      const outputs = nodePorts(node, "outputs");
+      for (const [value, port] of Object.entries(node.config.routes)) {
+        if (!outputs[port]) {
+          add(`${nodePath}/config/routes/${value}`, "DAG_SEMANTIC_UNKNOWN_PORT", `unknown output port '${port}'`);
+        }
+      }
+      if (node.config.default && !outputs[node.config.default]) {
+        add(`${nodePath}/config/default`, "DAG_SEMANTIC_UNKNOWN_PORT", `unknown output port '${node.config.default}'`);
+      }
+    }
+    if (node.kind === "join") {
+      if (node.config.mode === "n_of_m" && node.config.threshold === undefined) {
+        add(`${nodePath}/config/threshold`, "DAG_SEMANTIC_REQUIRED_THRESHOLD", "n_of_m join requires threshold");
+      }
+      if (node.config.mode !== "n_of_m" && node.config.threshold !== undefined) {
+        add(`${nodePath}/config/threshold`, "DAG_SEMANTIC_INVALID_THRESHOLD", "threshold is only valid for n_of_m join");
+      }
+    }
+    if (node.kind === "foreach") {
+      const inputs = nodePorts(node, "inputs");
+      const outputs = nodePorts(node, "outputs");
+      if (!inputs[node.config.input]) {
+        add(`${nodePath}/config/input`, "DAG_SEMANTIC_UNKNOWN_PORT", `unknown input port '${node.config.input}'`);
+      }
+      for (const key of ["item_port", "done_port"] as const) {
+        const port = node.config[key];
+        if (!outputs[port]) add(`${nodePath}/config/${key}`, "DAG_SEMANTIC_UNKNOWN_PORT", `unknown output port '${port}'`);
+      }
+      if (!inputs[node.config.result_port]) {
+        add(`${nodePath}/config/result_port`, "DAG_SEMANTIC_UNKNOWN_PORT", `unknown input port '${node.config.result_port}'`);
+      }
+    }
+    if (node.kind === "while") {
+      const outputs = nodePorts(node, "outputs");
+      for (const key of ["continue_port", "done_port", "exhausted_port"] as const) {
+        const port = node.config[key];
+        if (port && !outputs[port]) add(`${nodePath}/config/${key}`, "DAG_SEMANTIC_UNKNOWN_PORT", `unknown output port '${port}'`);
+      }
+    }
+  }
+
+  const normalAdjacency = new Map<string, Set<string>>();
+  const reverseReachability = new Map<string, Set<string>>();
+  const incomingNodeEdges = new Map<string, number>();
+  const targetPorts = new Map<string, number>();
+  for (const nodeId of Object.keys(nodes)) {
+    normalAdjacency.set(nodeId, new Set());
+    reverseReachability.set(nodeId, new Set());
+    incomingNodeEdges.set(nodeId, 0);
+  }
+
+  workflow.spec.edges.forEach((edge, index) => {
+    const path = `/spec/edges/${index}`;
+    const source = splitPortReference(edge.from);
+    const target = splitPortReference(edge.to);
+    const sourceNode = source.node === "$run" ? undefined : nodes[source.node];
+    const targetNode = target.node === "$run" ? undefined : nodes[target.node];
+    if (source.node !== "$run" && !sourceNode) {
+      add(`${path}/from`, "DAG_SEMANTIC_UNKNOWN_NODE", `unknown source node '${source.node}'`);
+    }
+    if (source.node === "$run" && edge.from !== "$run.input") {
+      add(`${path}/from`, "DAG_SEMANTIC_INVALID_RUN_PORT", "the only reserved run source is '$run.input'");
+    }
+    if (target.node === "$run") {
+      add(`${path}/to`, "DAG_SEMANTIC_INVALID_RUN_TARGET", "'$run.input' cannot be an edge target");
+    } else if (!targetNode) {
+      add(`${path}/to`, "DAG_SEMANTIC_UNKNOWN_NODE", `unknown target node '${target.node}'`);
+    }
+    const sourcePort = sourceNode ? nodePorts(sourceNode, "outputs")[source.port] : undefined;
+    const targetPort = targetNode ? nodePorts(targetNode, "inputs")[target.port] : undefined;
+    if (sourceNode && !sourcePort) {
+      add(`${path}/from`, "DAG_SEMANTIC_UNKNOWN_PORT", `unknown output port '${edge.from}'`);
+    }
+    if (targetNode && !targetPort) {
+      add(`${path}/to`, "DAG_SEMANTIC_UNKNOWN_PORT", `unknown input port '${edge.to}'`);
+    }
+    if (sourcePort?.contract && targetPort?.contract && sourcePort.contract !== targetPort.contract) {
+      add(
+        path,
+        "DAG_SEMANTIC_CONTRACT_MISMATCH",
+        `contract '${sourcePort.contract}' is not compatible with '${targetPort.contract}'`,
+        "v1 edges must connect ports that reference the same named contract",
+      );
+    }
+    if (edge.from === "$run.input" && targetPort?.contract === undefined) {
+      add(`${path}/to`, "DAG_SEMANTIC_RUN_INPUT_CONTRACT_REQUIRED", "a $run.input target must declare a contract");
+    }
+    if (sourceNode && targetNode) {
+      incomingNodeEdges.set(target.node, (incomingNodeEdges.get(target.node) ?? 0) + 1);
+      if (!isFeedbackEdge(edge)) {
+        normalAdjacency.get(source.node)?.add(target.node);
+      }
+      reverseReachability.get(target.node)?.add(source.node);
+    }
+    const targetKey = `${target.node}.${target.port}`;
+    if (!isFeedbackEdge(edge)) {
+      targetPorts.set(targetKey, (targetPorts.get(targetKey) ?? 0) + 1);
+      if (targetNode?.kind !== "join" && (targetPorts.get(targetKey) ?? 0) > 1) {
+        add(`${path}/to`, "DAG_SEMANTIC_IMPLICIT_FAN_IN", `multiple edges target '${targetKey}'; use an explicit join node`);
+      }
+    }
+    if (isFeedbackEdge(edge) && targetNode && targetNode.kind !== "foreach" && targetNode.kind !== "while") {
+      add(`${path}/to`, "DAG_SEMANTIC_INVALID_FEEDBACK_TARGET", "feedback edges may target only foreach or while nodes");
+    }
+  });
+
+  for (const [nodeId, node] of Object.entries(nodes)) {
+    if (node.kind === "terminal") continue;
+    for (const port of Object.keys(nodePorts(node, "outputs"))) {
+      const outgoing = workflow.spec.edges.filter((edge) => splitPortReference(edge.from).node === nodeId && splitPortReference(edge.from).port === port);
+      if (outgoing.length === 0) {
+        add(`/spec/nodes/${nodeId}/outputs/${port}`, "DAG_SEMANTIC_UNROUTED_OUTPUT", `output port '${nodeId}.${port}' has no edge`);
+        continue;
+      }
+      if (outgoing.some((edge) => {
+        const target = splitPortReference(edge.to);
+        return nodes[target.node]?.kind === "terminal";
+      }) && outgoing.length > 1) {
+        add(
+          `/spec/nodes/${nodeId}/outputs/${port}`,
+          "DAG_SEMANTIC_AMBIGUOUS_TERMINAL",
+          `output port '${nodeId}.${port}' cannot target a terminal and another destination`,
+        );
+      }
+    }
+  }
+
+  for (const [nodeId, node] of Object.entries(nodes)) {
+    for (const dependency of node.depends_on ?? []) {
+      if (nodes[dependency]) {
+        normalAdjacency.get(dependency)?.add(nodeId);
+        reverseReachability.get(nodeId)?.add(dependency);
+        incomingNodeEdges.set(nodeId, (incomingNodeEdges.get(nodeId) ?? 0) + 1);
+      }
+    }
+  }
+
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+  const findCycle = (nodeId: string): boolean => {
+    if (visiting.has(nodeId)) return true;
+    if (visited.has(nodeId)) return false;
+    visiting.add(nodeId);
+    for (const next of normalAdjacency.get(nodeId) ?? []) {
+      if (findCycle(next)) return true;
+    }
+    visiting.delete(nodeId);
+    visited.add(nodeId);
+    return false;
+  };
+  for (const nodeId of Object.keys(nodes).sort()) {
+    if (findCycle(nodeId)) {
+      add("/spec/edges", "DAG_SEMANTIC_UNBOUNDED_CYCLE", "normal data and control edges must be acyclic; use a bounded feedback edge");
+      break;
+    }
+  }
+
+  const terminalNodes = Object.entries(nodes)
+    .filter(([, node]) => node.kind === "terminal")
+    .map(([id]) => id);
+  if (terminalNodes.length === 0) {
+    add("/spec/nodes", "DAG_SEMANTIC_TERMINAL_REQUIRED", "workflow must contain at least one terminal node");
+  } else {
+    const reachesTerminal = new Set(terminalNodes);
+    const queue = [...terminalNodes];
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      for (const predecessor of reverseReachability.get(current) ?? []) {
+        if (!reachesTerminal.has(predecessor)) {
+          reachesTerminal.add(predecessor);
+          queue.push(predecessor);
+        }
+      }
+    }
+    for (const [nodeId, node] of Object.entries(nodes)) {
+      if (node.kind !== "terminal" && !reachesTerminal.has(nodeId)) {
+        add(`/spec/nodes/${nodeId}`, "DAG_SEMANTIC_NO_TERMINAL_PATH", `node '${nodeId}' has no path to a terminal node`);
+      }
+    }
+  }
+
+  const policies = workflow.spec.policies;
+  if (policies?.max_nodes !== undefined && Object.keys(nodes).length > policies.max_nodes) {
+    add("/spec/policies/max_nodes", "DAG_POLICY_NODE_LIMIT", "workflow node count exceeds max_nodes");
+  }
+  if (policies?.max_edges !== undefined && workflow.spec.edges.length > policies.max_edges) {
+    add("/spec/policies/max_edges", "DAG_POLICY_EDGE_LIMIT", "workflow edge count exceeds max_edges");
+  }
+
+  return diagnostics;
+}
+
+function canonicalNode(id: string, node: WorkflowSpecV1Node): CanonicalNode {
+  const base = {
+    id,
+    kind: node.kind,
+    ...(node.description ? { description: node.description } : {}),
+    depends_on: [...(node.depends_on ?? [])].sort(),
+    inputs: portEntries(node.inputs),
+    outputs: node.kind === "terminal" ? [] : portEntries(node.outputs),
+  };
+  if (node.kind === "agent") return { ...base, agent: node.agent };
+  if (node.kind === "terminal") {
+    return {
+      ...base,
+      outcome: node.outcome,
+      ...(node.reason ? { reason: node.reason } : {}),
+    };
+  }
+  return { ...base, config: deepSort(node.config) as Record<string, unknown> };
+}
+
+function canonicalEdge(edge: WorkflowSpecV1Edge, index: number): CanonicalEdge {
+  const feedback = isFeedbackEdge(edge);
+  const sourcePort = splitPortReference(edge.from).port;
+  return {
+    id: `edge-${String(index + 1).padStart(4, "0")}`,
+    kind: feedback ? "feedback" : "data",
+    from: splitPortReference(edge.from),
+    to: splitPortReference(edge.to),
+    condition: feedback
+      ? "on_success"
+      : edge.condition ?? (FAILURE_PORT_NAMES.has(sourcePort.toLowerCase()) ? "on_failure" : "on_success"),
+    retry: { max_retries: feedback ? 0 : edge.retry?.max_retries ?? 0 },
+    ...(feedback ? { max_traversals: edge.max_traversals } : {}),
+  };
+}
+
+function deepSort(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(deepSort);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => [key, deepSort(entry)]),
+  );
+}
+
+function canonicalJson(canonical: CanonicalWorkflowIR): string {
+  return JSON.stringify(deepSort(canonical));
+}
+
+function hashCanonical(json: string): string {
+  return createHash("sha256").update(json).digest("hex");
+}
+
+function compileV1(workflow: WorkflowSpecV1): CanonicalWorkflowIR {
+  const nodes = Object.entries(workflow.spec.nodes)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([id, node]) => canonicalNode(id, node));
+  const dataEdges = workflow.spec.edges.map(canonicalEdge);
+  const controlEdges: CanonicalEdge[] = [];
+  for (const node of nodes) {
+    for (const dependency of node.depends_on) {
+      controlEdges.push({
+        id: "",
+        kind: "control",
+        from: { node: dependency, port: "done" },
+        to: { node: node.id, port: "task" },
+        condition: "on_success",
+        retry: { max_retries: 0 },
+      });
+    }
+  }
+  const edges = [...dataEdges, ...controlEdges]
+    .sort((left, right) => {
+      const leftKey = `${left.from.node}.${left.from.port}>${left.to.node}.${left.to.port}:${left.kind}`;
+      const rightKey = `${right.from.node}.${right.from.port}>${right.to.node}.${right.to.port}:${right.kind}`;
+      return leftKey.localeCompare(rightKey);
+    })
+    .map((edge, index) => ({ ...edge, id: `edge-${String(index + 1).padStart(4, "0")}` }));
+  const incoming = new Set(edges.filter((edge) => edge.from.node !== "$run" && edge.kind !== "feedback").map((edge) => edge.to.node));
+  return {
+    ir_version: "1",
+    source_api_version: WORKFLOW_API_VERSION,
+    compiler_version: WORKFLOW_COMPILER_VERSION,
+    workflow_id: workflow.metadata.id,
+    name: workflow.metadata.name,
+    ...(workflow.spec.description ? { description: workflow.spec.description } : {}),
+    labels: deepSort(workflow.metadata.labels ?? {}) as Record<string, string>,
+    annotations: deepSort(workflow.metadata.annotations ?? {}) as Record<string, string>,
+    workspace: { mode: workflow.spec.workspace?.mode ?? "isolated" },
+    contracts: deepSort(workflow.spec.contracts ?? {}) as Record<string, unknown>,
+    agents: Object.fromEntries(Object.entries(workflow.spec.agents)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([id, agent]) => [id, {
+        ...(agent.description ? { description: agent.description } : {}),
+        ...(agent.system ? { system: agent.system } : {}),
+        skills: [...(agent.skills ?? [])].sort(),
+      }])),
+    policies: {
+      max_nodes: workflow.spec.policies?.max_nodes ?? 1000,
+      max_edges: workflow.spec.policies?.max_edges ?? 10_000,
+      max_parallelism: workflow.spec.policies?.max_parallelism ?? 32,
+      max_dispatches: workflow.spec.policies?.max_dispatches ?? 30,
+      max_handoffs: workflow.spec.policies?.max_handoffs ?? 50,
+      max_corrections_per_node: workflow.spec.policies?.max_corrections_per_node ?? 2,
+      max_edge_traversals: workflow.spec.policies?.max_edge_traversals ?? 3,
+      max_tool_calls_per_node: workflow.spec.policies?.max_tool_calls_per_node ?? 0,
+    },
+    nodes,
+    edges,
+    entry_nodes: nodes.filter((node) => !incoming.has(node.id)).map((node) => node.id).sort(),
+    terminal_nodes: nodes.filter((node) => node.kind === "terminal").map((node) => node.id).sort(),
+    feedback_edges: edges.filter((edge) => edge.kind === "feedback").map((edge) => edge.id),
+  };
+}
+
+function legacyKind(node: DAGGraphNode): CanonicalNode["kind"] {
+  if (node.node_type === "condition_gateway") return "condition";
+  if (node.node_type === "join_gateway") return "join";
+  if (node.node_type === "loop_gateway") return "foreach";
+  if (node.node_type === "while_gateway") return "while";
+  return "agent";
+}
+
+function legacyTerminalId(edge: DAGEdge, index: number): string {
+  const raw = `terminal-${edge.from_node}-${edge.from_port}-${index + 1}`
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+  return raw || `terminal-${index + 1}`;
+}
+
+function compileLegacy(parsed: ParsedDAG): CanonicalWorkflowIR {
+  const inputPorts = new Map<string, Set<string>>();
+  for (const edge of parsed.graph.edges) {
+    if (edge.to_node) {
+      if (!inputPorts.has(edge.to_node)) inputPorts.set(edge.to_node, new Set());
+      inputPorts.get(edge.to_node)?.add(edge.to_port);
+    }
+  }
+  const nodes: CanonicalNode[] = parsed.graph.nodes.map((node) => ({
+    id: node.node_id,
+    kind: legacyKind(node),
+    ...(node.description ? { description: node.description } : {}),
+    ...(legacyKind(node) === "agent" ? { agent: node.agent } : {}),
+    depends_on: [...node.after].sort(),
+    inputs: [...(inputPorts.get(node.node_id) ?? [])].sort().map((name) => ({ name })),
+    outputs: Object.keys(node.outputs).sort().map((name) => ({ name })),
+    ...(legacyKind(node) !== "agent" ? { config: deepSort(node.gateway_config ?? {}) as Record<string, unknown> } : {}),
+  }));
+  const edges: CanonicalEdge[] = [];
+  parsed.graph.edges.forEach((edge, index) => {
+    if (!edge.to_node) {
+      const terminalId = legacyTerminalId(edge, index);
+      nodes.push({
+        id: terminalId,
+        kind: "terminal",
+        depends_on: [],
+        inputs: [{ name: edge.to_port || edge.from_port }],
+        outputs: [],
+        outcome: edge.condition === "on_failure" ? "failure" : "success",
+      });
+      edges.push({
+        id: "",
+        kind: "data",
+        from: { node: edge.from_node, port: edge.from_port },
+        to: { node: terminalId, port: edge.to_port || edge.from_port },
+        condition: edge.condition as CanonicalEdge["condition"],
+        retry: { max_retries: edge.retry_policy?.max_retries ?? 0 },
+      });
+      return;
+    }
+    edges.push({
+      id: "",
+      kind: edge.label === "after_dep" ? "control" : "data",
+      from: { node: edge.from_node, port: edge.from_port },
+      to: { node: edge.to_node, port: edge.to_port },
+      condition: edge.condition as CanonicalEdge["condition"],
+      retry: { max_retries: edge.retry_policy?.max_retries ?? 0 },
+    });
+  });
+  edges.sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
+  edges.forEach((edge, index) => { edge.id = `edge-${String(index + 1).padStart(4, "0")}`; });
+  nodes.sort((left, right) => left.id.localeCompare(right.id));
+  const incoming = new Set(edges.filter((edge) => edge.kind !== "feedback").map((edge) => edge.to.node));
+  const metaAgents = parsed.meta.agents ?? {};
+  return {
+    ir_version: "1",
+    source_api_version: "legacy/v0",
+    compiler_version: WORKFLOW_COMPILER_VERSION,
+    workflow_id: parsed.meta.workflow_id ?? parsed.meta.name,
+    name: parsed.meta.name,
+    ...(parsed.meta.description ? { description: parsed.meta.description } : {}),
+    labels: {},
+    annotations: {},
+    workspace: { mode: "isolated" },
+    contracts: {},
+    agents: Object.fromEntries(Object.entries(metaAgents)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([id, agent]) => [id, {
+        ...(agent.description ? { description: agent.description } : {}),
+        ...(agent.system ? { system: agent.system } : {}),
+        skills: [...(agent.skills ?? [])].sort(),
+      }])),
+    policies: {
+      max_nodes: 1000,
+      max_edges: 10_000,
+      max_parallelism: 32,
+      max_dispatches: 30,
+      max_handoffs: 50,
+      max_corrections_per_node: 2,
+      max_edge_traversals: 3,
+      max_tool_calls_per_node: 0,
+    },
+    nodes,
+    edges,
+    entry_nodes: nodes.filter((node) => !incoming.has(node.id)).map((node) => node.id).sort(),
+    terminal_nodes: nodes.filter((node) => node.kind === "terminal").map((node) => node.id).sort(),
+    feedback_edges: [],
+    legacy_compat: deepSort({
+      meta: parsed.meta,
+      graph: parsed.graph,
+      loop_sources: parsed.loop_sources,
+    }) as CanonicalWorkflowIR["legacy_compat"],
+  };
+}
+
+function resultForCanonical(
+  source_format: WorkflowSourceFormat,
+  diagnostics: WorkflowDiagnostic[],
+  canonical: CanonicalWorkflowIR,
+): WorkflowCompilationResult {
+  const json = canonicalJson(canonical);
+  return {
+    valid: diagnostics.every((entry) => entry.severity !== "error"),
+    source_format,
+    source_api_version: canonical.source_api_version,
+    diagnostics,
+    canonical,
+    canonical_json: json,
+    canonical_hash: hashCanonical(json),
+    summary: {
+      workflow_id: canonical.workflow_id,
+      node_count: canonical.nodes.length,
+      edge_count: canonical.edges.length,
+      entry_nodes: canonical.entry_nodes,
+      terminal_nodes: canonical.terminal_nodes,
+    },
+  };
+}
+
+export function compileWorkflowSource(source: string): WorkflowCompilationResult {
+  const format = sourceFormat(source);
+  const parsedSource = parseSource(source);
+  if (!parsedSource.context || parsedSource.value === undefined) {
+    return { valid: false, source_format: format, diagnostics: parsedSource.diagnostics };
+  }
+  if (!parsedSource.value || typeof parsedSource.value !== "object" || Array.isArray(parsedSource.value)) {
+    return {
+      valid: false,
+      source_format: format,
+      diagnostics: [diagnostic(parsedSource.context, {
+        severity: "error",
+        code: "DAG_SCHEMA_INVALID_ROOT",
+        path: "/",
+        message: "workflow source root must be an object",
+      })],
+    };
+  }
+  const record = parsedSource.value as Record<string, unknown>;
+  if (record.api_version === undefined) {
+    try {
+      const canonical = compileLegacy(parseDAGYaml(source));
+      return resultForCanonical(format, [{
+        severity: "warning",
+        code: "DAG_LEGACY_UNVERSIONED_SOURCE",
+        path: "/",
+        message: "unversioned workflow accepted through the legacy/v0 adapter",
+        hint: `new workflows should use api_version: ${WORKFLOW_API_VERSION}`,
+      }], canonical);
+    } catch (error) {
+      return {
+        valid: false,
+        source_format: format,
+        source_api_version: "legacy/v0",
+        diagnostics: [{
+          severity: "error",
+          code: "DAG_LEGACY_INVALID_WORKFLOW",
+          path: "/",
+          message: error instanceof Error ? error.message : String(error),
+        }],
+      };
+    }
+  }
+  if (record.api_version !== WORKFLOW_API_VERSION || record.kind !== WORKFLOW_KIND) {
+    return {
+      valid: false,
+      source_format: format,
+      diagnostics: [diagnostic(parsedSource.context, {
+        severity: "error",
+        code: "DAG_SCHEMA_UNSUPPORTED_VERSION",
+        path: record.api_version !== WORKFLOW_API_VERSION ? "/api_version" : "/kind",
+        message: `expected api_version '${WORKFLOW_API_VERSION}' and kind '${WORKFLOW_KIND}'`,
+      })],
+    };
+  }
+  const structural = schemaDiagnostics(parsedSource.context, parsedSource.value);
+  if (structural.length > 0) {
+    return {
+      valid: false,
+      source_format: format,
+      source_api_version: WORKFLOW_API_VERSION,
+      diagnostics: structural,
+    };
+  }
+  const workflow = parsedSource.value as WorkflowSpecV1;
+  const semantic = semanticDiagnostics(parsedSource.context, workflow);
+  if (semantic.length > 0) {
+    return {
+      valid: false,
+      source_format: format,
+      source_api_version: WORKFLOW_API_VERSION,
+      diagnostics: semantic,
+    };
+  }
+  return resultForCanonical(format, [], compileV1(workflow));
+}
+
+export function workflowSchemaHash(): string {
+  return createHash("sha256")
+    .update(JSON.stringify(deepSort(WorkflowSpecV1Schema)))
+    .digest("hex");
+}
+
+export function workflowSchemaResponse(): {
+  api_version: typeof WORKFLOW_API_VERSION;
+  kind: typeof WORKFLOW_KIND;
+  compiler_version: typeof WORKFLOW_COMPILER_VERSION;
+  schema_hash: string;
+  schema: typeof WorkflowSpecV1Schema;
+} {
+  return {
+    api_version: WORKFLOW_API_VERSION,
+    kind: WORKFLOW_KIND,
+    compiler_version: WORKFLOW_COMPILER_VERSION,
+    schema_hash: workflowSchemaHash(),
+    schema: WorkflowSpecV1Schema,
+  };
+}
+
+function runtimeNodeType(kind: CanonicalNode["kind"]): string {
+  if (kind === "condition") return "condition_gateway";
+  if (kind === "join") return "join_gateway";
+  if (kind === "foreach") return "loop_gateway";
+  if (kind === "while") return "while_gateway";
+  return "agent";
+}
+
+function runtimeGatewayConfig(node: CanonicalNode): Record<string, unknown> | undefined {
+  if (!node.config) return undefined;
+  if (node.kind === "condition") {
+    const config = node.config;
+    return {
+      type: "condition",
+      field: config.field,
+      routes: config.routes,
+      default_port: config.default,
+    };
+  }
+  if (node.kind === "join") return { type: "join", ...node.config };
+  if (node.kind === "foreach") return { type: "loop", ...node.config };
+  if (node.kind === "while") return { type: "while", ...node.config };
+  return undefined;
+}
+
+function runtimeOutputRoutes(
+  canonical: CanonicalWorkflowIR,
+  node: CanonicalNode,
+): Record<string, { to: string | string[]; condition: string; retry_policy?: { max_retries: number } }> {
+  const terminals = new Map(
+    canonical.nodes
+      .filter((candidate) => candidate.kind === "terminal")
+      .map((candidate) => [candidate.id, candidate]),
+  );
+  const routes: Record<string, { to: string | string[]; condition: string; retry_policy?: { max_retries: number } }> = {};
+  for (const port of node.outputs) {
+    const edges = canonical.edges.filter((edge) => edge.kind !== "control" && edge.from.node === node.id && edge.from.port === port.name);
+    if (edges.length === 0) continue;
+    const targets = edges.map((edge) => terminals.has(edge.to.node) ? "" : `${edge.to.node}.in:${edge.to.port}`);
+    routes[port.name] = {
+      to: targets.length === 1 ? targets[0] : targets,
+      condition: edges[0].condition,
+      ...(edges[0].retry.max_retries > 0 ? { retry_policy: { max_retries: edges[0].retry.max_retries } } : {}),
+    };
+  }
+  return routes;
+}
+
+export function projectCanonicalWorkflowToParsedDAG(canonical: CanonicalWorkflowIR): ParsedDAG {
+  const terminalById = new Map(
+    canonical.nodes
+      .filter((node) => node.kind === "terminal")
+      .map((node) => [node.id, node]),
+  );
+  const executableNodes = canonical.nodes.filter((node) => node.kind !== "terminal");
+  const runtimeEdges: DAGEdge[] = [];
+  const dependencyMap = new Map(executableNodes.map((node) => [node.id, new Set(node.depends_on)]));
+  const runInputTargets: Array<{ node: string; port: string; contract?: string }> = [];
+
+  for (const edge of canonical.edges) {
+    if (edge.kind === "control") {
+      if (dependencyMap.has(edge.to.node)) dependencyMap.get(edge.to.node)?.add(edge.from.node);
+      runtimeEdges.push({
+        from_node: edge.from.node,
+        from_port: edge.from.port,
+        to_node: edge.to.node,
+        to_port: edge.to.port,
+        condition: edge.condition,
+        label: "after_dep",
+      });
+      continue;
+    }
+    if (edge.from.node === "$run") {
+      const targetNode = canonical.nodes.find((node) => node.id === edge.to.node);
+      const contract = targetNode?.inputs.find((port) => port.name === edge.to.port)?.contract;
+      runInputTargets.push({ node: edge.to.node, port: edge.to.port, ...(contract ? { contract } : {}) });
+      continue;
+    }
+    const terminal = terminalById.get(edge.to.node);
+    if (!terminal && edge.kind !== "feedback" && dependencyMap.has(edge.to.node)) {
+      dependencyMap.get(edge.to.node)?.add(edge.from.node);
+    }
+    runtimeEdges.push({
+      from_node: edge.from.node,
+      from_port: edge.from.port,
+      to_node: terminal ? "" : edge.to.node,
+      to_port: terminal ? "" : edge.to.port,
+      condition: edge.condition,
+      ...(edge.kind === "feedback"
+        ? { retry_policy: { max_retries: edge.max_traversals ?? 1 } }
+        : edge.retry.max_retries > 0
+          ? { retry_policy: { max_retries: edge.retry.max_retries } }
+          : {}),
+      ...(terminal?.outcome ? { terminal_outcome: terminal.outcome } : {}),
+    });
+  }
+
+  // Data edges imply completion dependencies in v1. Materialize the current
+  // runtime's control edges so mailbox delivery and readiness remain atomic.
+  for (const [nodeId, dependencies] of dependencyMap) {
+    for (const dependency of dependencies) {
+      const exists = runtimeEdges.some((edge) =>
+        edge.label === "after_dep" && edge.from_node === dependency && edge.to_node === nodeId
+      );
+      if (!exists) {
+        runtimeEdges.push({
+          from_node: dependency,
+          from_port: "done",
+          to_node: nodeId,
+          to_port: "task",
+          condition: "on_success",
+          label: "after_dep",
+        });
+      }
+    }
+  }
+
+  const graphNodes: DAGGraphNode[] = executableNodes.map((node) => {
+    const inputContracts = Object.fromEntries(node.inputs.filter((port) => port.contract).map((port) => [port.name, port.contract!]));
+    const outputContracts = Object.fromEntries(node.outputs.filter((port) => port.contract).map((port) => [port.name, port.contract!]));
+    return {
+      node_id: node.id,
+      name: node.id,
+      description: node.description ?? "",
+      node_type: runtimeNodeType(node.kind),
+      agent: node.kind === "agent" ? node.agent ?? "" : "__gateway__",
+      after: [...(dependencyMap.get(node.id) ?? [])].sort(),
+      outputs: runtimeOutputRoutes(canonical, node),
+      gateway_config: runtimeGatewayConfig(node),
+      extra: {
+        workflow_spec_v1: {
+          input_contracts: inputContracts,
+          output_contracts: outputContracts,
+        },
+      },
+    };
+  });
+  const agents = Object.fromEntries(Object.entries(canonical.agents).map(([id, agent]) => [id, {
+    ...(agent.description ? { description: agent.description } : {}),
+    ...(agent.system ? { system: agent.system } : {}),
+    ...(agent.skills.length > 0 ? { skills: agent.skills } : {}),
+  } satisfies DAGAgentConfig]));
+  const graph = { nodes: graphNodes, edges: runtimeEdges };
+  assertGraphValid(graph);
+  return {
+    meta: {
+      name: canonical.name,
+      workflow_id: canonical.workflow_id,
+      description: canonical.description,
+      workspace: canonical.workspace,
+      limits: {
+        max_dispatches: canonical.policies.max_dispatches,
+        max_handoffs: canonical.policies.max_handoffs,
+        max_corrections_per_node: canonical.policies.max_corrections_per_node,
+        max_edge_traversals: canonical.policies.max_edge_traversals,
+        max_tool_calls_per_node: canonical.policies.max_tool_calls_per_node,
+      },
+      agents,
+      contracts: canonical.contracts,
+      run_input_targets: runInputTargets,
+      source_api_version: canonical.source_api_version,
+      compiler_version: canonical.compiler_version,
+    },
+    graph,
+    loop_sources: canonical.nodes
+      .filter((node) => node.kind === "foreach" || node.kind === "while")
+      .filter((node) => canonical.edges.some((edge) => edge.kind === "feedback" && edge.to.node === node.id))
+      .map((node) => node.id)
+      .sort(),
+  };
+}

--- a/homerail_manager/src/persistence/dag-workflows.ts
+++ b/homerail_manager/src/persistence/dag-workflows.ts
@@ -11,6 +11,14 @@ import {
 import type { DAGAgentConfig, ParsedDAG } from "../orchestration/graph.js";
 import { parseDAGYaml } from "../orchestration/yaml-loader.js";
 import { assertNoYamlProviderRuntime } from "../orchestration/runtime-selection.js";
+import {
+  compileWorkflowSource,
+  projectCanonicalWorkflowToParsedDAG,
+  type CanonicalWorkflowIR,
+  type WorkflowCompilationResult,
+  type WorkflowSourceFormat,
+  type WorkflowSourceVersion,
+} from "../orchestration/workflow-spec-v1.js";
 
 export interface DagWorkflow {
   workflow_id: string;
@@ -19,10 +27,27 @@ export interface DagWorkflow {
   source_path?: string;
   yaml_text: string;
   yaml_hash: string;
+  head_revision: number;
+  api_version: WorkflowSourceVersion;
+  canonical_hash: string;
+  compiler_version: string;
   node_ids: string[];
   agent_ids: string[];
   created_at: string;
   updated_at: string;
+}
+
+export interface DagWorkflowRevision {
+  workflow_id: string;
+  revision: number;
+  api_version: WorkflowSourceVersion;
+  source_format: WorkflowSourceFormat;
+  source_text: string;
+  source_hash: string;
+  canonical_json: string;
+  canonical_hash: string;
+  compiler_version: string;
+  created_at: string;
 }
 
 export interface DagRuntimeProfileEntry {
@@ -63,6 +88,10 @@ function _string(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
+function _rawString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
 function _stringArray(value: unknown): string[] {
   if (Array.isArray(value)) return value.filter((item): item is string => typeof item === "string");
   if (typeof value === "string" && value.trim()) {
@@ -96,12 +125,31 @@ function _workflowFromRow(row: Record<string, unknown>): DagWorkflow {
     name: _string(row.name) ?? _string(raw.name) ?? "",
     description: _string(row.description) ?? _string(raw.description),
     source_path: _string(row.source_path) ?? _string(raw.source_path),
-    yaml_text: _string(row.yaml_text) ?? _string(raw.yaml_text) ?? "",
+    yaml_text: _rawString(row.yaml_text) ?? _rawString(raw.yaml_text) ?? "",
     yaml_hash: _string(row.yaml_hash) ?? _string(raw.yaml_hash) ?? "",
+    head_revision: Number(row.head_revision ?? raw.head_revision ?? 0),
+    api_version: (_string(row.api_version) ?? _string(raw.api_version) ?? "legacy/v0") as WorkflowSourceVersion,
+    canonical_hash: _string(row.canonical_hash) ?? _string(raw.canonical_hash) ?? "",
+    compiler_version: _string(row.compiler_version) ?? _string(raw.compiler_version) ?? "1",
     node_ids: _stringArray(row.node_ids ?? raw.node_ids),
     agent_ids: _stringArray(row.agent_ids ?? raw.agent_ids),
     created_at: _string(row.created_at) ?? _string(raw.created_at) ?? nowIso(),
     updated_at: _string(row.updated_at) ?? _string(raw.updated_at) ?? nowIso(),
+  };
+}
+
+function _revisionFromRow(row: Record<string, unknown>): DagWorkflowRevision {
+  return {
+    workflow_id: _string(row.workflow_id) ?? "",
+    revision: Number(row.revision ?? 0),
+    api_version: (_string(row.api_version) ?? "legacy/v0") as WorkflowSourceVersion,
+    source_format: (_string(row.source_format) ?? "yaml") as WorkflowSourceFormat,
+    source_text: _rawString(row.source_text) ?? "",
+    source_hash: _string(row.source_hash) ?? "",
+    canonical_json: _rawString(row.canonical_json) ?? "",
+    canonical_hash: _string(row.canonical_hash) ?? "",
+    compiler_version: _string(row.compiler_version) ?? "1",
+    created_at: _string(row.created_at) ?? nowIso(),
   };
 }
 
@@ -165,15 +213,20 @@ function _writeWorkflow(workflow: DagWorkflow): void {
   getDb().prepare(`
     INSERT INTO dag_workflows(
       workflow_id, name, description, source_path, yaml_text, yaml_hash,
+      head_revision, api_version, canonical_hash, compiler_version,
       node_ids, agent_ids, created_at, updated_at, data
     )
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(workflow_id) DO UPDATE SET
       name = excluded.name,
       description = excluded.description,
       source_path = excluded.source_path,
       yaml_text = excluded.yaml_text,
       yaml_hash = excluded.yaml_hash,
+      head_revision = excluded.head_revision,
+      api_version = excluded.api_version,
+      canonical_hash = excluded.canonical_hash,
+      compiler_version = excluded.compiler_version,
       node_ids = excluded.node_ids,
       agent_ids = excluded.agent_ids,
       updated_at = excluded.updated_at,
@@ -185,12 +238,80 @@ function _writeWorkflow(workflow: DagWorkflow): void {
     workflow.source_path ?? null,
     workflow.yaml_text,
     workflow.yaml_hash,
+    workflow.head_revision,
+    workflow.api_version,
+    workflow.canonical_hash,
+    workflow.compiler_version,
     encodeJson(workflow.node_ids),
     encodeJson(workflow.agent_ids),
     workflow.created_at,
     workflow.updated_at,
     encodeJson(workflow),
   );
+}
+
+function _writeRevision(revision: DagWorkflowRevision): void {
+  getDb().prepare(`
+    INSERT INTO dag_workflow_revisions(
+      workflow_id, revision, api_version, source_format, source_text,
+      source_hash, canonical_json, canonical_hash, compiler_version, created_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    revision.workflow_id,
+    revision.revision,
+    revision.api_version,
+    revision.source_format,
+    revision.source_text,
+    revision.source_hash,
+    revision.canonical_json,
+    revision.canonical_hash,
+    revision.compiler_version,
+    revision.created_at,
+  );
+}
+
+function _requireCanonical(compilation: WorkflowCompilationResult): CanonicalWorkflowIR {
+  if (!compilation.valid || !compilation.canonical || !compilation.canonical_json || !compilation.canonical_hash) {
+    const details = compilation.diagnostics
+      .map((entry) => `${entry.code} ${entry.path}: ${entry.message}`)
+      .join("; ");
+    throw new Error(details || "DAG workflow compilation failed");
+  }
+  return compilation.canonical;
+}
+
+function _ensureStoredWorkflowRevisions(): void {
+  const db = getDb();
+  const rows = db.prepare("SELECT * FROM dag_workflows WHERE head_revision = 0 ORDER BY workflow_id")
+    .all() as Record<string, unknown>[];
+  for (const row of rows) {
+    const workflow = _workflowFromRow(row);
+    const compilation = compileWorkflowSource(workflow.yaml_text);
+    const canonical = _requireCanonical(compilation);
+    const now = workflow.created_at || nowIso();
+    const migrated: DagWorkflow = {
+      ...workflow,
+      head_revision: 1,
+      api_version: canonical.source_api_version,
+      canonical_hash: compilation.canonical_hash!,
+      compiler_version: canonical.compiler_version,
+    };
+    db.transaction(() => {
+      _writeWorkflow(migrated);
+      _writeRevision({
+        workflow_id: workflow.workflow_id,
+        revision: 1,
+        api_version: canonical.source_api_version,
+        source_format: compilation.source_format,
+        source_text: workflow.yaml_text,
+        source_hash: workflow.yaml_hash || _sha256(workflow.yaml_text),
+        canonical_json: compilation.canonical_json!,
+        canonical_hash: compilation.canonical_hash!,
+        compiler_version: canonical.compiler_version,
+        created_at: now,
+      });
+    })();
+  }
 }
 
 function _writeProfile(profile: DagRuntimeProfile): void {
@@ -224,32 +345,55 @@ function _writeProfile(profile: DagRuntimeProfile): void {
 export function upsertDagWorkflowFromYaml(input: {
   yaml_text: string;
   source_path?: string;
-}): { workflow: DagWorkflow; created: boolean; parsed: ParsedDAG } {
-  const parsed = parseDAGYaml(input.yaml_text);
-  assertNoYamlProviderRuntime(parsed);
-  const workflowId = _string(parsed.meta.workflow_id);
-  if (!workflowId) {
-    throw new Error("DAG YAML must define a stable workflow_id before it can be synced to the database.");
-  }
+}): { workflow: DagWorkflow; created: boolean; revision_created: boolean; parsed?: ParsedDAG } {
+  const compilation = compileWorkflowSource(input.yaml_text);
+  const canonical = _requireCanonical(compilation);
+  const parsed = canonical.source_api_version === "legacy/v0" ? parseDAGYaml(input.yaml_text) : undefined;
+  if (parsed) assertNoYamlProviderRuntime(parsed);
+  const workflowId = canonical.workflow_id;
+  if (!workflowId) throw new Error("DAG workflow must define a stable workflow id before it can be synced.");
   const existing = getDagWorkflow(workflowId);
   const now = nowIso();
+  const revisionCreated = !existing || existing.canonical_hash !== compilation.canonical_hash;
+  const headRevision = revisionCreated ? (existing?.head_revision ?? 0) + 1 : existing.head_revision;
   const workflow: DagWorkflow = {
     workflow_id: workflowId,
-    name: parsed.meta.name || workflowId,
-    description: parsed.meta.description,
+    name: canonical.name || workflowId,
+    description: canonical.description,
     source_path: input.source_path,
     yaml_text: input.yaml_text,
     yaml_hash: _sha256(input.yaml_text),
-    node_ids: parsed.graph.nodes.map((node) => node.node_id),
-    agent_ids: _workflowAgentIds(parsed),
+    head_revision: headRevision,
+    api_version: canonical.source_api_version,
+    canonical_hash: compilation.canonical_hash!,
+    compiler_version: canonical.compiler_version,
+    node_ids: canonical.nodes.filter((node) => node.kind !== "terminal").map((node) => node.id),
+    agent_ids: Object.keys(canonical.agents).sort(),
     created_at: existing?.created_at ?? now,
     updated_at: now,
   };
-  _writeWorkflow(workflow);
-  return { workflow, created: !existing, parsed };
+  getDb().transaction(() => {
+    _writeWorkflow(workflow);
+    if (revisionCreated) {
+      _writeRevision({
+        workflow_id: workflowId,
+        revision: headRevision,
+        api_version: canonical.source_api_version,
+        source_format: compilation.source_format,
+        source_text: input.yaml_text,
+        source_hash: workflow.yaml_hash,
+        canonical_json: compilation.canonical_json!,
+        canonical_hash: compilation.canonical_hash!,
+        compiler_version: canonical.compiler_version,
+        created_at: now,
+      });
+    }
+  })();
+  return { workflow, created: !existing, revision_created: revisionCreated, parsed };
 }
 
 export function listDagWorkflows(): DagWorkflow[] {
+  _ensureStoredWorkflowRevisions();
   return (getDb()
     .prepare("SELECT * FROM dag_workflows ORDER BY updated_at DESC, workflow_id")
     .all() as Record<string, unknown>[])
@@ -257,10 +401,28 @@ export function listDagWorkflows(): DagWorkflow[] {
 }
 
 export function getDagWorkflow(workflowId: string): DagWorkflow | undefined {
+  _ensureStoredWorkflowRevisions();
   const row = getDb()
     .prepare("SELECT * FROM dag_workflows WHERE workflow_id = ?")
     .get(workflowId) as Record<string, unknown> | undefined;
   return row ? _workflowFromRow(row) : undefined;
+}
+
+export function listDagWorkflowRevisions(workflowId: string): DagWorkflowRevision[] {
+  _ensureStoredWorkflowRevisions();
+  return (getDb().prepare(`
+    SELECT * FROM dag_workflow_revisions
+    WHERE workflow_id = ?
+    ORDER BY revision DESC
+  `).all(workflowId) as Record<string, unknown>[]).map(_revisionFromRow);
+}
+
+export function getDagWorkflowRevision(workflowId: string, revision: number): DagWorkflowRevision | undefined {
+  _ensureStoredWorkflowRevisions();
+  const row = getDb().prepare(`
+    SELECT * FROM dag_workflow_revisions WHERE workflow_id = ? AND revision = ?
+  `).get(workflowId, revision) as Record<string, unknown> | undefined;
+  return row ? _revisionFromRow(row) : undefined;
 }
 
 function _parseProfileYaml(yamlText: string, workflowIdOverride?: string): Omit<DagRuntimeProfile, "profile_key" | "created_at" | "updated_at"> {
@@ -411,9 +573,24 @@ export function resolveDagRuntimeProfile(profile: DagRuntimeProfile): DagRuntime
 }
 
 export function parseStoredDagWorkflow(workflow: DagWorkflow): ParsedDAG {
-  const parsed = parseDAGYaml(workflow.yaml_text);
+  const parsed = workflow.api_version === "homerail.ai/v1"
+    ? (() => {
+        const revision = getDagWorkflowRevision(workflow.workflow_id, workflow.head_revision);
+        if (!revision) throw new Error(`DAG workflow revision not found: ${workflow.workflow_id}@${workflow.head_revision}`);
+        return projectCanonicalWorkflowToParsedDAG(JSON.parse(revision.canonical_json) as CanonicalWorkflowIR);
+      })()
+    : parseDAGYaml(workflow.yaml_text);
   assertNoYamlProviderRuntime(parsed);
-  return parsed;
+  return {
+    ...parsed,
+    meta: {
+      ...parsed.meta,
+      workflow_revision: workflow.head_revision,
+      canonical_hash: workflow.canonical_hash,
+      compiler_version: workflow.compiler_version,
+      source_api_version: workflow.api_version,
+    },
+  };
 }
 
 export function applyDagRuntimeProfile(parsed: ParsedDAG, profile: DagRuntimeProfileResolved): ParsedDAG {
@@ -436,5 +613,5 @@ export function applyDagRuntimeProfile(parsed: ParsedDAG, profile: DagRuntimePro
 }
 
 export function _clearDagWorkflowTablesForTest(): void {
-  clearTables(["dag_runtime_profiles", "dag_workflows"]);
+  clearTables(["dag_runtime_profiles", "dag_workflow_revisions", "dag_workflows"]);
 }

--- a/homerail_manager/src/persistence/db.ts
+++ b/homerail_manager/src/persistence/db.ts
@@ -35,6 +35,7 @@ const CLEARABLE_TABLES = new Set([
   "dag_handoffs",
   "dag_events",
   "dag_runs",
+  "dag_workflow_revisions",
   "dag_runtime_profiles",
   "dag_workflows",
   "experience_ingest_jobs",
@@ -704,6 +705,24 @@ function initializeSchema(db: SqliteDatabase, filePath: string): void {
       data TEXT NOT NULL
     );
 
+    CREATE TABLE IF NOT EXISTS dag_workflow_revisions (
+      workflow_id TEXT NOT NULL,
+      revision INTEGER NOT NULL,
+      api_version TEXT NOT NULL,
+      source_format TEXT NOT NULL,
+      source_text TEXT NOT NULL,
+      source_hash TEXT NOT NULL,
+      canonical_json TEXT NOT NULL,
+      canonical_hash TEXT NOT NULL,
+      compiler_version TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      PRIMARY KEY(workflow_id, revision),
+      UNIQUE(workflow_id, canonical_hash),
+      FOREIGN KEY(workflow_id) REFERENCES dag_workflows(workflow_id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_dag_workflow_revisions_hash
+      ON dag_workflow_revisions(workflow_id, canonical_hash);
+
     CREATE TABLE IF NOT EXISTS dag_runtime_profiles (
       profile_key TEXT PRIMARY KEY,
       workflow_id TEXT NOT NULL,
@@ -1008,8 +1027,13 @@ function initializeSchema(db: SqliteDatabase, filePath: string): void {
   `);
   db.prepare("INSERT OR IGNORE INTO schema_migrations(version, applied_at) VALUES (?, ?)").run(1, nowIso());
   ensureExpandedColumns(db);
+  ensureColumn(db, "dag_workflows", "head_revision", "INTEGER NOT NULL DEFAULT 0");
+  ensureColumn(db, "dag_workflows", "api_version", "TEXT");
+  ensureColumn(db, "dag_workflows", "canonical_hash", "TEXT");
+  ensureColumn(db, "dag_workflows", "compiler_version", "TEXT");
   seedBuiltinProviderCatalog(db);
   db.prepare("INSERT OR IGNORE INTO schema_migrations(version, applied_at) VALUES (?, ?)").run(2, nowIso());
+  db.prepare("INSERT OR IGNORE INTO schema_migrations(version, applied_at) VALUES (?, ?)").run(3, nowIso());
   chmodPrivate(filePath);
 }
 

--- a/homerail_manager/src/persistence/store.ts
+++ b/homerail_manager/src/persistence/store.ts
@@ -20,6 +20,13 @@ interface SerializableRun {
   runId: string;
   workflowId?: string;
   workflowName?: string;
+  workflowRevision?: number;
+  canonicalHash?: string;
+  compilerVersion?: string;
+  sourceApiVersion?: string;
+  contracts?: Record<string, unknown>;
+  runInputTargets?: Array<{ node: string; port: string; contract?: string }>;
+  initialPrompt?: string;
   nodeCount?: number;
   agents?: Record<string, { agent_type?: string; model?: string; system?: string; description?: string; skills?: string[]; extra?: Record<string, unknown> }>;
   workspace?: Record<string, unknown>;
@@ -184,6 +191,13 @@ export function serializeRunMetadata(run: SerializableRun): PersistedRunMetadata
     runId: run.runId,
     workflowId: run.workflowId,
     workflowName: run.workflowName,
+    workflowRevision: run.workflowRevision,
+    canonicalHash: run.canonicalHash,
+    compilerVersion: run.compilerVersion,
+    sourceApiVersion: run.sourceApiVersion,
+    contracts: run.contracts,
+    runInputTargets: run.runInputTargets,
+    initialPrompt: run.initialPrompt,
     nodeCount: run.nodeCount,
     agents: run.agents,
     workspace: run.workspace,

--- a/homerail_manager/src/persistence/types.ts
+++ b/homerail_manager/src/persistence/types.ts
@@ -42,6 +42,13 @@ export interface PersistedRunMetadata {
   runId: string;
   workflowId?: string;
   workflowName?: string;
+  workflowRevision?: number;
+  canonicalHash?: string;
+  compilerVersion?: string;
+  sourceApiVersion?: string;
+  contracts?: Record<string, unknown>;
+  runInputTargets?: Array<{ node: string; port: string; contract?: string }>;
+  initialPrompt?: string;
   nodeCount?: number;
   agents?: Record<string, { agent_type?: string; model?: string; system?: string; description?: string; skills?: string[]; extra?: Record<string, unknown> }>;
   workspace?: Record<string, unknown>;

--- a/homerail_manager/src/runtime/active-runs.ts
+++ b/homerail_manager/src/runtime/active-runs.ts
@@ -891,10 +891,17 @@ export function autoHandoffAfterCorrectionExhausted(
   const run = store.get(runId);
   if (!run || run.status !== "active" || !run.dagRun.nodeStates.has(nodeId)) return undefined;
   const port = _defaultSuccessPort(run, nodeId);
-  const next = handoffActiveRun(runId, nodeId, port, {
-    auto_handoff: true,
-    reason,
-  });
+  let next: ActiveRun | undefined;
+  try {
+    next = handoffActiveRun(runId, nodeId, port, {
+      auto_handoff: true,
+      reason,
+    });
+  } catch (error) {
+    const failedRun = store.get(runId);
+    if (failedRun?.status === "failed") return failedRun;
+    throw error;
+  }
   if (next) {
     emit("dag:node_auto_handoff", { runId, nodeId, port, reason });
   }

--- a/homerail_manager/src/runtime/active-runs.ts
+++ b/homerail_manager/src/runtime/active-runs.ts
@@ -45,6 +45,7 @@ import {
 } from "../persistence/dag-session-index.js";
 import { checkpointForkSession } from "../persistence/dag-session-files.js";
 import WebSocket from "ws";
+import { validateJsonContract } from "../orchestration/json-contract.js";
 
 export interface InjectResult {
   runId: string;
@@ -62,6 +63,13 @@ export interface ActiveRun {
   runId: string;
   workflowId?: string;
   workflowName?: string;
+  workflowRevision?: number;
+  canonicalHash?: string;
+  compilerVersion?: string;
+  sourceApiVersion?: string;
+  contracts?: Record<string, unknown>;
+  runInputTargets?: Array<{ node: string; port: string; contract?: string }>;
+  initialPrompt?: string;
   nodeCount?: number;
   agents?: Record<string, DAGAgentConfig>;
   workspace?: Record<string, unknown>;
@@ -356,11 +364,25 @@ export function createActiveRun(
   options: CreateActiveRunOptions = {},
 ): ActiveRun {
   const dagRun = createDAGRun(parsedDAG, runId);
-  seedInitialPrompt(dagRun, options.initialPrompt);
+  seedInitialPrompt(
+    dagRun,
+    options.initialPrompt,
+    parsedDAG.meta.run_input_targets,
+    parsedDAG.meta.contracts,
+  );
   const run: ActiveRun = {
     runId,
     workflowId: parsedDAG.meta.workflow_id,
     workflowName: parsedDAG.meta.name,
+    workflowRevision: parsedDAG.meta.workflow_revision,
+    canonicalHash: parsedDAG.meta.canonical_hash,
+    compilerVersion: parsedDAG.meta.compiler_version,
+    sourceApiVersion: parsedDAG.meta.source_api_version,
+    contracts: parsedDAG.meta.contracts ? { ...parsedDAG.meta.contracts } : undefined,
+    runInputTargets: parsedDAG.meta.run_input_targets
+      ? parsedDAG.meta.run_input_targets.map((target) => ({ ...target }))
+      : undefined,
+    initialPrompt: options.initialPrompt,
     nodeCount: parsedDAG.graph.nodes.length,
     agents: parsedDAG.meta.agents
       ? { ...parsedDAG.meta.agents }
@@ -404,8 +426,28 @@ export function createActiveRun(
 export function seedInitialPrompt(
   dagRun: DAGRun,
   prompt: string | undefined,
+  targets?: Array<{ node: string; port: string; contract?: string }>,
+  contracts?: Record<string, unknown>,
 ): void {
   if (prompt === undefined || prompt.trim().length === 0) return;
+  if (targets && targets.length > 0) {
+    const payload = _structuredGatewayValue(prompt);
+    for (const target of targets) {
+      if (target.contract) {
+        const schema = contracts?.[target.contract];
+        const validation = validateJsonContract(schema, payload);
+        if (!validation.valid) {
+          throw new Error(`DAG_RUN_INPUT_CONTRACT_VIOLATION ${target.node}.${target.port}: ${validation.details}`);
+        }
+      }
+      const mailbox = dagRun.mailboxes.get(target.node);
+      if (!mailbox) throw new Error(`DAG run input targets unknown node: ${target.node}`);
+      const values = mailbox.get(target.port) ?? [];
+      values.push(payload);
+      mailbox.set(target.port, values);
+    }
+    return;
+  }
   for (const nodeId of getReadyNodes(dagRun)) {
     const mailbox = dagRun.mailboxes.get(nodeId);
     if (!mailbox) continue;
@@ -562,10 +604,20 @@ export function restoreActiveRun(
   }
 
   const { dagRun, nodes } = _rebuildDagRunFromPersisted(metadata, metadata.graph);
+  seedInitialPrompt(dagRun, metadata.initialPrompt, metadata.runInputTargets, metadata.contracts);
   const run: ActiveRun = {
     runId: metadata.runId,
     workflowId: metadata.workflowId,
     workflowName: metadata.workflowName,
+    workflowRevision: metadata.workflowRevision,
+    canonicalHash: metadata.canonicalHash,
+    compilerVersion: metadata.compilerVersion,
+    sourceApiVersion: metadata.sourceApiVersion,
+    contracts: metadata.contracts ? { ...metadata.contracts } : undefined,
+    runInputTargets: metadata.runInputTargets
+      ? metadata.runInputTargets.map((target) => ({ ...target }))
+      : undefined,
+    initialPrompt: metadata.initialPrompt,
     nodeCount: metadata.nodeCount,
     agents: metadata.agents
       ? { ...metadata.agents }
@@ -961,6 +1013,11 @@ export function handoffActiveRun(
 ): ActiveRun | undefined {
   const run = store.get(runId);
   if (!run) return undefined;
+  const contractViolation = _handoffContractViolation(run, fromNode, port, content);
+  if (contractViolation) {
+    failActiveRun(runId, fromNode, contractViolation);
+    throw new Error(contractViolation);
+  }
   if (run.counters.handoffs >= run.limits.max_handoffs) {
     abortActiveRun(runId, `max_handoffs (${run.limits.max_handoffs}) exceeded`, fromNode);
     throw new Error(`max_handoffs (${run.limits.max_handoffs}) exceeded`);
@@ -984,7 +1041,15 @@ export function handoffActiveRun(
   }
 
   const transition = handoff(run.dagRun, fromNode, port, content);
-  _markNodeSessionStatus(run, fromNode, transition.terminalFailure ? "failed" : "completed");
+  _markNodeSessionStatus(
+    run,
+    fromNode,
+    transition.terminalOutcome === "cancelled"
+      ? "cancelled"
+      : transition.terminalFailure
+        ? "failed"
+        : "completed",
+  );
   appendHandoff(runId, { runId, fromNode, port, content, timestamp: Date.now() });
   writeRunMetadata(runId, serializeRunMetadata(run));
   _emitNodeStateChanges(run, before);
@@ -1000,7 +1065,14 @@ export function handoffActiveRun(
   }
 
   if (run.status === "active" && isRunTerminal(run.dagRun)) {
-    if (transition.terminalFailure) {
+    if (transition.terminalOutcome === "cancelled") {
+      run.status = "cancelled";
+      run.completedAt = Date.now();
+      writeRunMetadata(runId, serializeRunMetadata(run));
+      _emitStatusUpdate(run);
+      emit("dag:run_cancelled", { runId, nodeId: fromNode, reason: `terminal cancelled handoff on port ${port}` });
+      deprovisionProvisionedForRun(runId);
+    } else if (transition.terminalFailure) {
       run.status = "failed";
       run.completedAt = Date.now();
       writeRunMetadata(runId, serializeRunMetadata(run));
@@ -1013,6 +1085,26 @@ export function handoffActiveRun(
   }
 
   return run;
+}
+
+function _handoffContractViolation(
+  run: ActiveRun,
+  fromNode: string,
+  port: string,
+  content: unknown,
+): string | undefined {
+  const node = run.dagRun.graph.nodes.find((candidate) => candidate.node_id === fromNode);
+  const workflowSpec = node?.extra?.workflow_spec_v1;
+  if (!workflowSpec || typeof workflowSpec !== "object" || Array.isArray(workflowSpec)) return undefined;
+  const outputContracts = (workflowSpec as Record<string, unknown>).output_contracts;
+  if (!outputContracts || typeof outputContracts !== "object" || Array.isArray(outputContracts)) return undefined;
+  const contractName = (outputContracts as Record<string, unknown>)[port];
+  if (typeof contractName !== "string" || !contractName) return undefined;
+  const schema = run.contracts?.[contractName];
+  if (!schema) return `DAG_HANDOFF_CONTRACT_VIOLATION ${fromNode}.${port}: contract '${contractName}' is missing`;
+  const validation = validateJsonContract(schema, content);
+  if (validation.valid) return undefined;
+  return `DAG_HANDOFF_CONTRACT_VIOLATION ${fromNode}.${port} (${contractName}): ${validation.details}`;
 }
 
 export function getActiveRunCount(): number {
@@ -1259,7 +1351,8 @@ function _conditionGatewayPort(config: DAGGatewayConfig | undefined, input: unkn
 
 function _loopGatewayItems(config: DAGGatewayConfig | undefined, inputs: Record<string, unknown[]>): unknown[] {
   if (Array.isArray(config?.items)) return config.items;
-  const fromItemsPort = inputs.items
+  const inputPort = config?.input || "items";
+  const fromItemsPort = inputs[inputPort]
     ?.map(_structuredGatewayValue)
     .find((value) => Array.isArray(value));
   if (Array.isArray(fromItemsPort)) return fromItemsPort;
@@ -1377,6 +1470,11 @@ function _executeGatewayNode(runId: string, run: ActiveRun, node: DAGGraphNode):
   if (node.node_type === "loop_gateway") {
     const inputs = _nodeInputs(run.dagRun, node.node_id);
     const items = _loopGatewayItems(node.gateway_config, inputs);
+    const maxItems = Math.max(1, Math.floor(node.gateway_config?.max_items ?? 10_000));
+    if (items.length > maxItems) {
+      abortActiveRun(runId, `foreach max_items (${maxItems}) exceeded`, node.node_id);
+      return false;
+    }
     const index = run.counters.gateway_iterations[node.node_id] ?? 0;
     const itemPort = node.gateway_config?.item_port || "next_item";
     const resultPort = node.gateway_config?.result_port || "result";

--- a/homerail_manager/src/server/dag-workflows.ts
+++ b/homerail_manager/src/server/dag-workflows.ts
@@ -1,6 +1,8 @@
 import * as http from "node:http";
 import {
   getDagWorkflow,
+  getDagWorkflowRevision,
+  listDagWorkflowRevisions,
   listDagRuntimeProfiles,
   listDagWorkflows,
   upsertDagRuntimeProfileFromYaml,
@@ -11,6 +13,10 @@ import {
   instantiateDAGPattern,
   listDAGPatterns,
 } from "../orchestration/dag-patterns.js";
+import {
+  compileWorkflowSource,
+  workflowSchemaResponse,
+} from "../orchestration/workflow-spec-v1.js";
 
 interface BaseResponse {
   success: boolean;
@@ -64,11 +70,28 @@ function stringField(body: Record<string, unknown>, ...names: string[]): string 
   return undefined;
 }
 
+function sourceField(body: Record<string, unknown>, ...names: string[]): string | undefined {
+  for (const name of names) {
+    const value = body[name];
+    if (typeof value === "string" && value.trim()) return value;
+  }
+  return undefined;
+}
+
 function workflowIdFromPath(pathname: string): string | undefined {
   const prefix = "/api/dag/workflows/";
   if (!pathname.startsWith(prefix)) return undefined;
   const id = pathname.slice(prefix.length);
   return id && !id.includes("/") ? decodeURIComponent(id) : undefined;
+}
+
+function workflowRevisionPath(pathname: string): { workflowId: string; revision?: number } | undefined {
+  const match = pathname.match(/^\/api\/dag\/workflows\/([^/]+)\/revisions(?:\/(\d+))?$/);
+  if (!match) return undefined;
+  return {
+    workflowId: decodeURIComponent(match[1]),
+    ...(match[2] ? { revision: Number(match[2]) } : {}),
+  };
 }
 
 function patternPath(pathname: string): { id: string; action?: "instantiate" } | undefined {
@@ -92,6 +115,40 @@ function objectField(body: Record<string, unknown>, name: string): Record<string
 export function dagWorkflowRoutesHandler(req: http.IncomingMessage, res: http.ServerResponse): boolean {
   const url = new URL(req.url || "/", "http://localhost");
   const pathname = url.pathname;
+
+  if (pathname === "/api/dag/schema" && req.method === "GET") {
+    const data = workflowSchemaResponse();
+    const etag = `"${data.schema_hash}"`;
+    res.setHeader("Cache-Control", "public, max-age=300");
+    res.setHeader("ETag", etag);
+    if (req.headers["if-none-match"] === etag) {
+      res.writeHead(304);
+      res.end();
+    } else {
+      ok(res, "WorkflowSpec v1 schema retrieved", data);
+    }
+    return true;
+  }
+
+  if (pathname === "/api/dag/validate" && req.method === "POST") {
+    readJsonBody(req)
+      .then((body) => {
+        const source = sourceField(body, "source", "yaml_text", "yaml", "content");
+        if (!source) {
+          badRequest(res, "Missing required field: source");
+          return;
+        }
+        const result = compileWorkflowSource(source);
+        json(res, 200, {
+          success: result.valid,
+          message: result.valid ? "DAG workflow is valid" : "DAG workflow validation failed",
+          data: result,
+          ...(result.valid ? {} : { error: "DAG workflow validation failed" }),
+        });
+      })
+      .catch((err) => badRequest(res, err instanceof Error ? err.message : String(err)));
+    return true;
+  }
 
   if (pathname === "/api/dag/patterns" && req.method === "GET") {
     const patterns = listDAGPatterns();
@@ -137,6 +194,33 @@ export function dagWorkflowRoutesHandler(req: http.IncomingMessage, res: http.Se
     return true;
   }
 
+  const revisionRoute = workflowRevisionPath(pathname);
+  if (revisionRoute && req.method === "GET") {
+    const workflow = getDagWorkflow(revisionRoute.workflowId);
+    if (!workflow) {
+      notFound(res, `DAG workflow not found: ${revisionRoute.workflowId}`);
+      return true;
+    }
+    if (revisionRoute.revision !== undefined) {
+      const revision = getDagWorkflowRevision(revisionRoute.workflowId, revisionRoute.revision);
+      if (!revision) notFound(res, `DAG workflow revision not found: ${revisionRoute.workflowId}@${revisionRoute.revision}`);
+      else ok(res, "DAG workflow revision retrieved", revision);
+      return true;
+    }
+    const revisions = listDagWorkflowRevisions(revisionRoute.workflowId).map((revision) => ({
+      workflow_id: revision.workflow_id,
+      revision: revision.revision,
+      api_version: revision.api_version,
+      source_format: revision.source_format,
+      source_hash: revision.source_hash,
+      canonical_hash: revision.canonical_hash,
+      compiler_version: revision.compiler_version,
+      created_at: revision.created_at,
+    }));
+    ok(res, `Found ${revisions.length} DAG workflow revision(s)`, { revisions, total: revisions.length });
+    return true;
+  }
+
   const workflowId = workflowIdFromPath(pathname);
   if (workflowId && req.method === "GET") {
     const workflow = getDagWorkflow(workflowId);
@@ -148,7 +232,7 @@ export function dagWorkflowRoutesHandler(req: http.IncomingMessage, res: http.Se
   if (pathname === "/api/dag/workflows/sync" && req.method === "POST") {
     readJsonBody(req)
       .then((body) => {
-        const yamlText = stringField(body, "yaml_text", "yaml", "content");
+        const yamlText = sourceField(body, "yaml_text", "yaml", "content");
         if (!yamlText) {
           badRequest(res, "Missing required field: yaml_text");
           return;
@@ -158,6 +242,7 @@ export function dagWorkflowRoutesHandler(req: http.IncomingMessage, res: http.Se
         created(res, result.created ? "DAG workflow synced" : "DAG workflow updated", {
           workflow: result.workflow,
           created: result.created,
+          revision_created: result.revision_created,
           warning: "workflow_id is the stable database identity. Editing YAML should keep workflow_id unchanged unless creating a new workflow/version.",
         });
       })

--- a/homerail_manager/src/server/host-codex-manager-agent.ts
+++ b/homerail_manager/src/server/host-codex-manager-agent.ts
@@ -601,6 +601,41 @@ function createManagerTools(state: {
       },
     },
     {
+      ...managerAgentToolSpec("get_dag_schema"),
+      async handler() {
+        const body = await requestManager(state.restUrl, "/dag/schema");
+        return { content: [{ type: "text", text: short(body, 50000) }] };
+      },
+    },
+    {
+      ...managerAgentToolSpec("validate_dag_workflow"),
+      async handler(args) {
+        const source = typeof args.source === "string" ? args.source : "";
+        if (!source.trim()) throw new Error("validate_dag_workflow requires source");
+        const body = await requestManager(state.restUrl, "/dag/validate", {
+          method: "POST",
+          body: JSON.stringify({ source }),
+        });
+        return { content: [{ type: "text", text: short(body, 50000) }] };
+      },
+    },
+    {
+      ...managerAgentToolSpec("sync_dag_workflow"),
+      async handler(args) {
+        const source = typeof args.source === "string" ? args.source : "";
+        if (!source.trim()) throw new Error("sync_dag_workflow requires source");
+        const body = await requestManager(state.restUrl, "/dag/workflows/sync", {
+          method: "POST",
+          body: JSON.stringify({
+            yaml_text: source,
+            source_path: typeof args.source_path === "string" ? args.source_path : "manager-agent",
+          }),
+        });
+        state.objectiveToolCalls.push({ name: "sync_dag_workflow", success: true });
+        return { content: [{ type: "text", text: short(body, 30000) }] };
+      },
+    },
+    {
       name: "create_change",
       description: "Create a project change record. Use create_and_run to actually start a DAG run.",
       input_schema: {
@@ -1126,6 +1161,12 @@ function toolCallCommentary(name: string): string | undefined {
       return "正在选择合适的 DAG 模式。";
     case "instantiate_dag_pattern":
       return "正在生成并同步 DAG 模式。";
+    case "get_dag_schema":
+      return "正在读取 DAG 规范。";
+    case "validate_dag_workflow":
+      return "正在验证 DAG 定义。";
+    case "sync_dag_workflow":
+      return "正在保存 DAG 定义。";
     case "create_and_run":
       return "正在启动 DAG。";
     case "invoke_run":

--- a/homerail_manager/tests/dag-correction-retry.test.ts
+++ b/homerail_manager/tests/dag-correction-retry.test.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { DAGDispatcher, DispatchEnvelope, DispatchResult } from "../src/orchestration/dag-dispatcher.js";
+import { parseWorkflowSource } from "../src/orchestration/workflow-spec-v1.js";
 import { parseDAGYaml } from "../src/orchestration/yaml-loader.js";
 import { _clearListeners } from "../src/events/bus.js";
 import { closeDb } from "../src/persistence/db.js";
@@ -103,6 +104,53 @@ describe("DAG correction and dispatch retry", () => {
     const run = autoHandoffAfterCorrectionExhausted("run-auto-handoff", "start", "missing handoff again");
     expect(run?.status).toBe("completed");
     expect(run?.dagRun.nodeStates.get("start")).toBe("COMPLETED");
+  });
+
+  it("fails the run without throwing when an exhausted auto-handoff violates a v1 contract", () => {
+    const parsed = parseWorkflowSource(`
+api_version: homerail.ai/v1
+kind: Workflow
+metadata: { id: correction-contract, name: Correction Contract }
+spec:
+  contracts:
+    Text: { type: string }
+  agents:
+    worker: { system: Return text. }
+  nodes:
+    start:
+      kind: agent
+      agent: worker
+      outputs:
+        done: { contract: Text }
+    terminal:
+      kind: terminal
+      outcome: success
+      inputs:
+        result: { contract: Text }
+  edges:
+    - { from: start.done, to: terminal.result }
+  policies:
+    max_corrections_per_node: 0
+`);
+    parsed.meta.agents!.worker!.agent_type = "deterministic";
+    createActiveRun("run-auto-handoff-contract", parsed);
+    dispatchReadyNodes(
+      "run-auto-handoff-contract",
+      new FlakyDispatcher({ status: "dispatched", targetType: "fake", targetId: "first" }),
+    );
+
+    expect(requestNodeCorrection(
+      "run-auto-handoff-contract",
+      "start",
+      "missing handoff",
+    ).status).toBe("exhausted");
+    expect(() => autoHandoffAfterCorrectionExhausted(
+      "run-auto-handoff-contract",
+      "start",
+      "missing handoff",
+    )).not.toThrow();
+    expect(getActiveRun("run-auto-handoff-contract")?.status).toBe("failed");
+    expect(getActiveRun("run-auto-handoff-contract")?.dagRun.nodeStates.get("start")).toBe("FAILED");
   });
 
   it("retries retryable dispatch failures once before marking the node running", () => {

--- a/homerail_manager/tests/dag-patterns-api.test.ts
+++ b/homerail_manager/tests/dag-patterns-api.test.ts
@@ -54,11 +54,12 @@ describe("DAG patterns API", () => {
 
     const detailResponse = await fetch(`${baseUrl}/api/dag/patterns/ratchet`);
     const detailBody = await detailResponse.json() as {
-      data: { required_primitives: string[]; workflow_template: { nodes: Record<string, unknown> } };
+      data: { required_primitives: string[]; workflow_template: { api_version: string; spec: { nodes: Record<string, unknown> } } };
     };
     expect(detailResponse.status).toBe(200);
     expect(detailBody.data.required_primitives).toContain("while_gateway");
-    expect(detailBody.data.workflow_template.nodes).toHaveProperty("target_gate");
+    expect(detailBody.data.workflow_template.api_version).toBe("homerail.ai/v1");
+    expect(detailBody.data.workflow_template.spec.nodes).toHaveProperty("target_gate");
   });
 
   it("instantiates a typed pattern and returns validated YAML without persisting it", async () => {
@@ -80,7 +81,12 @@ describe("DAG patterns API", () => {
     expect(response.status).toBe(200);
     expect(body.success).toBe(true);
     expect(body.data.parameters.threshold).toBe(3);
-    expect(body.data.workflow).toMatchObject({ workflow_id: "api-quorum", pattern: { id: "quorum" } });
+    expect(body.data.workflow).toMatchObject({
+      api_version: "homerail.ai/v1",
+      kind: "Workflow",
+      metadata: { id: "api-quorum" },
+      spec: { pattern: { id: "quorum" } },
+    });
     expect(body.data.yaml_text).toContain("threshold: 3");
     expect(body.data.validation.valid).toBe(true);
   });

--- a/homerail_manager/tests/dag-patterns.test.ts
+++ b/homerail_manager/tests/dag-patterns.test.ts
@@ -47,6 +47,14 @@ describe("built-in DAG patterns", () => {
         version: summary.version,
         source: DAG_PATTERN_SOURCE.url,
       });
+      expect(instance.workflow).toMatchObject({
+        api_version: "homerail.ai/v1",
+        kind: "Workflow",
+        metadata: { id: `pattern-${summary.id}` },
+        spec: { pattern: { id: summary.id } },
+      });
+      expect(instance.yaml_text).toMatch(/^api_version: homerail\.ai\/v1/m);
+      expect(instance.yaml_text).not.toMatch(/^workflow_id:/m);
       expect(instance.yaml_text).not.toMatch(/provider:|model:|api_key:/);
       expect(instance.yaml_text).not.toContain("{{");
     }
@@ -88,10 +96,10 @@ describe("built-in DAG patterns", () => {
       (edge) => edge.from_node === "plan" && edge.from_port === "planned" && edge.label !== "after_dep",
     );
 
-    expect(planEdges.map((edge) => [edge.from_port, edge.to_node, edge.to_port])).toEqual([
+    expect(planEdges.map((edge) => [edge.from_port, edge.to_node, edge.to_port]).sort((left, right) => left[1].localeCompare(right[1]))).toEqual([
       ["planned", "worker_one", "order"],
-      ["planned", "worker_two", "order"],
       ["planned", "worker_three", "order"],
+      ["planned", "worker_two", "order"],
     ]);
     expect(pattern.parsed.meta.agents.orchestrator?.system).toContain("work_orders object is keyed");
     expect(pattern.parsed.meta.agents.worker?.system).toContain("may arrive as a JSON string");

--- a/homerail_manager/tests/dag-workflow-revisions.test.ts
+++ b/homerail_manager/tests/dag-workflow-revisions.test.ts
@@ -1,0 +1,148 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  _clearDagWorkflowTablesForTest,
+  getDagWorkflow,
+  getDagWorkflowRevision,
+  listDagWorkflowRevisions,
+  upsertDagWorkflowFromYaml,
+} from "../src/persistence/dag-workflows.js";
+import { closeDb, encodeJson, getDb } from "../src/persistence/db.js";
+
+const LEGACY_SOURCE = `
+name: Revision Test
+workflow_id: revision-test
+agents:
+  worker:
+    system: Work.
+nodes:
+  execute:
+    agent: worker
+    outputs:
+      done:
+        to: ""
+`;
+
+describe("DAG workflow revisions", () => {
+  let tmpHome: string;
+  let oldHome: string | undefined;
+
+  beforeEach(() => {
+    oldHome = process.env.HOMERAIL_HOME;
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-workflow-revisions-"));
+    process.env.HOMERAIL_HOME = tmpHome;
+    closeDb();
+    _clearDagWorkflowTablesForTest();
+  });
+
+  afterEach(() => {
+    _clearDagWorkflowTablesForTest();
+    closeDb();
+    if (oldHome === undefined) delete process.env.HOMERAIL_HOME;
+    else process.env.HOMERAIL_HOME = oldHome;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("creates revisions only when canonical semantics change", () => {
+    const first = upsertDagWorkflowFromYaml({ yaml_text: LEGACY_SOURCE });
+    expect(first.workflow.head_revision).toBe(1);
+    expect(first.revision_created).toBe(true);
+
+    const formattingOnly = upsertDagWorkflowFromYaml({ yaml_text: `\n\n${LEGACY_SOURCE.trim()}\n\n` });
+    expect(formattingOnly.workflow.head_revision).toBe(1);
+    expect(formattingOnly.revision_created).toBe(false);
+    expect(formattingOnly.workflow.yaml_hash).not.toBe(first.workflow.yaml_hash);
+    expect(listDagWorkflowRevisions("revision-test")).toHaveLength(1);
+
+    const semantic = upsertDagWorkflowFromYaml({
+      yaml_text: LEGACY_SOURCE.replace("Work.", "Work and return evidence."),
+    });
+    expect(semantic.workflow.head_revision).toBe(2);
+    expect(semantic.revision_created).toBe(true);
+    const revisions = listDagWorkflowRevisions("revision-test");
+    expect(revisions.map((revision) => revision.revision)).toEqual([2, 1]);
+    expect(revisions[0].canonical_hash).not.toBe(revisions[1].canonical_hash);
+    expect(getDagWorkflowRevision("revision-test", 1)?.source_text).toBe(LEGACY_SOURCE);
+  });
+
+  it("migrates an existing mutable workflow row to legacy revision 1", () => {
+    const now = new Date().toISOString();
+    getDb().prepare(`
+      INSERT INTO dag_workflows(
+        workflow_id, name, description, source_path, yaml_text, yaml_hash,
+        node_ids, agent_ids, created_at, updated_at, data
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      "revision-test",
+      "Revision Test",
+      null,
+      null,
+      LEGACY_SOURCE,
+      "legacy-source-hash",
+      encodeJson(["execute"]),
+      encodeJson(["worker"]),
+      now,
+      now,
+      encodeJson({ workflow_id: "revision-test", name: "Revision Test" }),
+    );
+
+    const workflow = getDagWorkflow("revision-test");
+    expect(workflow).toMatchObject({
+      head_revision: 1,
+      api_version: "legacy/v0",
+      compiler_version: "1",
+    });
+    expect(workflow?.canonical_hash).toMatch(/^[a-f0-9]{64}$/);
+    expect(listDagWorkflowRevisions("revision-test")).toEqual([
+      expect.objectContaining({
+        workflow_id: "revision-test",
+        revision: 1,
+        api_version: "legacy/v0",
+        source_hash: "legacy-source-hash",
+      }),
+    ]);
+  });
+
+  it("persists strict v1 source and canonical provenance", () => {
+    const source = `
+api_version: homerail.ai/v1
+kind: Workflow
+metadata: { id: v1-revision, name: V1 Revision }
+spec:
+  contracts:
+    Data: { type: object }
+  agents:
+    worker: { system: Work. }
+  nodes:
+    execute:
+      kind: agent
+      agent: worker
+      inputs: { task: { contract: Data } }
+      outputs: { result: { contract: Data } }
+    done:
+      kind: terminal
+      outcome: success
+      inputs: { result: { contract: Data } }
+  edges:
+    - { from: $run.input, to: execute.task }
+    - { from: execute.result, to: done.result }
+`;
+    const result = upsertDagWorkflowFromYaml({ yaml_text: source });
+    expect(result.parsed).toBeUndefined();
+    expect(result.workflow).toMatchObject({
+      workflow_id: "v1-revision",
+      head_revision: 1,
+      api_version: "homerail.ai/v1",
+      compiler_version: "1",
+      node_ids: ["execute"],
+      agent_ids: ["worker"],
+    });
+    expect(getDagWorkflowRevision("v1-revision", 1)).toMatchObject({
+      api_version: "homerail.ai/v1",
+      source_format: "yaml",
+      canonical_hash: result.workflow.canonical_hash,
+    });
+  });
+});

--- a/homerail_manager/tests/dag-workflows.test.ts
+++ b/homerail_manager/tests/dag-workflows.test.ts
@@ -12,6 +12,7 @@ import {
   upsertDagWorkflowFromYaml,
 } from "../src/persistence/dag-workflows.js";
 import { closeDb } from "../src/persistence/db.js";
+import { loadRunMetadata } from "../src/persistence/store.js";
 import {
   _clearAllSettings,
   createSetting,
@@ -82,7 +83,7 @@ describe("DAG workflow persistence", () => {
       is_active: true,
       is_default: true,
     });
-    upsertDagWorkflowFromYaml({ yaml_text: WORKFLOW_YAML, source_path: "assets/orchestrations/db-workflow.yaml" });
+    const synced = upsertDagWorkflowFromYaml({ yaml_text: WORKFLOW_YAML, source_path: "assets/orchestrations/db-workflow.yaml" });
     upsertDagRuntimeProfileFromYaml({
       yaml_text: `
 profile_id: qwen-main
@@ -102,6 +103,28 @@ default:
     });
 
     expect(result.workflowId).toBe("db-workflow");
+    expect(result).toMatchObject({
+      workflowRevision: 1,
+      canonicalHash: synced.workflow.canonical_hash,
+      compilerVersion: "1",
+      sourceApiVersion: "legacy/v0",
+    });
+    expect(loadRunMetadata(result.runId)).toMatchObject({
+      workflowId: "db-workflow",
+      workflowRevision: 1,
+      canonicalHash: synced.workflow.canonical_hash,
+      compilerVersion: "1",
+      sourceApiVersion: "legacy/v0",
+    });
+
+    const updated = upsertDagWorkflowFromYaml({
+      yaml_text: WORKFLOW_YAML.replace("Plan and hand off.", "Plan, verify, and hand off."),
+    });
+    expect(updated.workflow.head_revision).toBe(2);
+    expect(loadRunMetadata(result.runId)).toMatchObject({
+      workflowRevision: 1,
+      canonicalHash: synced.workflow.canonical_hash,
+    });
     expect(dispatcher.dispatched).toHaveLength(1);
     expect(dispatcher.dispatched[0].agentConfig.llm_setting_id).toBe(setting.id);
     expect(dispatcher.dispatched[0].agentConfig).toMatchObject({

--- a/homerail_manager/tests/manager-chat.test.ts
+++ b/homerail_manager/tests/manager-chat.test.ts
@@ -1159,6 +1159,9 @@ describe("/api/manager/chat", () => {
       "list_dag_patterns",
       "get_dag_pattern",
       "instantiate_dag_pattern",
+      "get_dag_schema",
+      "validate_dag_workflow",
+      "sync_dag_workflow",
       "update_voice_memo",
       "validate_widget_file",
       "write_widget_file",
@@ -1215,6 +1218,20 @@ describe("/api/manager/chat", () => {
     );
     expect(instantiated.result.is_error).toBeFalsy();
     expect(instantiated.result.content[0].text).toContain('"synced":true');
+
+    const schema = await _invokeHostCodexVoiceToolForTest(
+      "get_dag_schema",
+      {},
+      { managerRestUrl },
+    );
+    expect(schema.result.content[0].text).toContain("homerail.ai/v1");
+
+    const validation = await _invokeHostCodexVoiceToolForTest(
+      "validate_dag_workflow",
+      { source: "api_version: homerail.ai/v1\nkind: Workflow\n" },
+      { managerRestUrl },
+    );
+    expect(validation.result.content[0].text).toContain("DAG_SCHEMA_REQUIRED_FIELD");
 
     const workflow = await fetch(`http://127.0.0.1:${port}/api/dag/workflows/host-skill-heartbeat`);
     expect(workflow.status).toBe(200);

--- a/homerail_manager/tests/workflow-spec-api.test.ts
+++ b/homerail_manager/tests/workflow-spec-api.test.ts
@@ -1,0 +1,164 @@
+import * as fs from "node:fs";
+import * as http from "node:http";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { closeDb } from "../src/persistence/db.js";
+import { createServer } from "../src/server/http.js";
+import { workflowSchemaHash } from "../src/orchestration/workflow-spec-v1.js";
+
+async function listen(server: http.Server): Promise<number> {
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address !== "object") throw new Error("server did not bind");
+  return address.port;
+}
+
+async function close(server: http.Server): Promise<void> {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+const VALID_SOURCE = `
+api_version: homerail.ai/v1
+kind: Workflow
+metadata:
+  id: api-validation
+  name: API Validation
+spec:
+  contracts:
+    Input:
+      type: object
+  agents:
+    worker:
+      system: Return the input.
+  nodes:
+    execute:
+      kind: agent
+      agent: worker
+      inputs:
+        task: { contract: Input }
+      outputs:
+        result: { contract: Input }
+    done:
+      kind: terminal
+      outcome: success
+      inputs:
+        result: { contract: Input }
+  edges:
+    - { from: $run.input, to: execute.task }
+    - { from: execute.result, to: done.result }
+`;
+
+describe("WorkflowSpec API", () => {
+  let server: http.Server;
+  let baseUrl: string;
+  let tmpHome: string;
+  let oldHome: string | undefined;
+
+  beforeEach(async () => {
+    oldHome = process.env.HOMERAIL_HOME;
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-workflow-spec-api-"));
+    process.env.HOMERAIL_HOME = tmpHome;
+    closeDb();
+    server = createServer(0, undefined, undefined, false);
+    baseUrl = `http://127.0.0.1:${await listen(server)}`;
+  });
+
+  afterEach(async () => {
+    await close(server);
+    closeDb();
+    if (oldHome === undefined) delete process.env.HOMERAIL_HOME;
+    else process.env.HOMERAIL_HOME = oldHome;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("serves the exact validator schema with stable cache metadata", async () => {
+    const response = await fetch(`${baseUrl}/api/dag/schema`);
+    const body = await response.json() as {
+      success: boolean;
+      data: { api_version: string; schema_hash: string; schema: Record<string, unknown> };
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data.api_version).toBe("homerail.ai/v1");
+    expect(body.data.schema_hash).toBe(workflowSchemaHash());
+    expect(response.headers.get("etag")).toBe(`"${body.data.schema_hash}"`);
+    expect(JSON.stringify(body.data.schema)).not.toContain("api_key");
+
+    const cached = await fetch(`${baseUrl}/api/dag/schema`, {
+      headers: { "If-None-Match": response.headers.get("etag")! },
+    });
+    expect(cached.status).toBe(304);
+  });
+
+  it("returns structured validation results for AI and CLI clients", async () => {
+    const valid = await fetch(`${baseUrl}/api/dag/validate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ source: VALID_SOURCE }),
+    });
+    const validBody = await valid.json() as {
+      success: boolean;
+      data: { valid: boolean; canonical_hash: string; summary: { node_count: number } };
+    };
+    expect(valid.status).toBe(200);
+    expect(validBody.success).toBe(true);
+    expect(validBody.data.valid).toBe(true);
+    expect(validBody.data.canonical_hash).toMatch(/^[a-f0-9]{64}$/);
+    expect(validBody.data.summary.node_count).toBe(2);
+
+    const invalid = await fetch(`${baseUrl}/api/dag/validate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ source: VALID_SOURCE.replace("agent: worker", "agent: missing") }),
+    });
+    const invalidBody = await invalid.json() as {
+      success: boolean;
+      data: { diagnostics: Array<{ code: string; path: string; line: number }> };
+    };
+    expect(invalid.status).toBe(200);
+    expect(invalidBody.success).toBe(false);
+    expect(invalidBody.data.diagnostics).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        code: "DAG_SEMANTIC_UNKNOWN_AGENT",
+        path: "/spec/nodes/execute/agent",
+        line: expect.any(Number),
+      }),
+    ]));
+  });
+
+  it("exposes immutable workflow revision provenance after sync", async () => {
+    const sync = await fetch(`${baseUrl}/api/dag/workflows/sync`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ yaml_text: VALID_SOURCE }),
+    });
+    const syncBody = await sync.json() as {
+      data: { workflow: { head_revision: number; canonical_hash: string }; revision_created: boolean };
+    };
+    expect(sync.status).toBe(201);
+    expect(syncBody.data.workflow.head_revision).toBe(1);
+    expect(syncBody.data.revision_created).toBe(true);
+
+    const list = await fetch(`${baseUrl}/api/dag/workflows/api-validation/revisions`);
+    const listBody = await list.json() as {
+      data: { revisions: Array<{ revision: number; canonical_hash: string }>; total: number };
+    };
+    expect(list.status).toBe(200);
+    expect(listBody.data).toMatchObject({ total: 1 });
+    expect(listBody.data.revisions[0]).toMatchObject({
+      revision: 1,
+      canonical_hash: syncBody.data.workflow.canonical_hash,
+    });
+
+    const detail = await fetch(`${baseUrl}/api/dag/workflows/api-validation/revisions/1`);
+    const detailBody = await detail.json() as {
+      data: { revision: number; source_text: string; canonical_json: string };
+    };
+    expect(detail.status).toBe(200);
+    expect(detailBody.data.revision).toBe(1);
+    expect(detailBody.data.source_text).toBe(VALID_SOURCE);
+    expect(JSON.parse(detailBody.data.canonical_json)).toMatchObject({ workflow_id: "api-validation" });
+  });
+});

--- a/homerail_manager/tests/workflow-spec-runtime.test.ts
+++ b/homerail_manager/tests/workflow-spec-runtime.test.ts
@@ -203,9 +203,15 @@ describe("WorkflowSpec v1 runtime projection", () => {
     );
 
     expect(executor.tick("v1-example-fanout")).toBe(1);
-    handoffActiveRun("v1-example-fanout", "plan", "plan", "Check build and tests");
+    handoffActiveRun("v1-example-fanout", "plan", "plan", {
+      objective: "Check build and tests",
+      steps: [
+        "build",
+        { id: "2", description: "test" },
+      ],
+    });
     expect(executor.tick("v1-example-fanout")).toBe(2);
-    handoffActiveRun("v1-example-fanout", "worker_one", "result", { status: "done", evidence: "build passed" });
+    handoffActiveRun("v1-example-fanout", "worker_one", "result", { status: "success", evidence: "build passed" });
     handoffActiveRun("v1-example-fanout", "worker_two", "result", { status: "done", evidence: "tests passed" });
     expect(executor.tick("v1-example-fanout")).toBe(1);
 

--- a/homerail_manager/tests/workflow-spec-runtime.test.ts
+++ b/homerail_manager/tests/workflow-spec-runtime.test.ts
@@ -3,8 +3,14 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ChangeOrchestrator } from "../src/orchestration/change-orchestrator.js";
-import { FakeDAGDispatcher } from "../src/orchestration/dag-dispatcher.js";
+import {
+  FakeDAGDispatcher,
+  type DAGDispatcher,
+  type DispatchEnvelope,
+  type DispatchResult,
+} from "../src/orchestration/dag-dispatcher.js";
 import { GraphExecutor } from "../src/orchestration/graph-executor.js";
+import { parseWorkflowSourceFile } from "../src/orchestration/workflow-spec-v1.js";
 import {
   _clearDagWorkflowTablesForTest,
   upsertDagRuntimeProfileFromYaml,
@@ -46,6 +52,24 @@ spec:
     - { from: $run.input, to: execute.task }
     - { from: execute.result, to: terminal.result }
 `;
+}
+
+function publicV1Asset(file: string) {
+  const parsed = parseWorkflowSourceFile(path.resolve("..", "assets", "orchestrations", file));
+  parsed.meta.agents = Object.fromEntries(Object.entries(parsed.meta.agents ?? {}).map(([id, agent]) => [
+    id,
+    { ...agent, agent_type: "deterministic" },
+  ]));
+  return parsed;
+}
+
+class RepeatableDispatcher implements DAGDispatcher {
+  dispatched: DispatchEnvelope[] = [];
+
+  dispatch(envelope: DispatchEnvelope): DispatchResult {
+    this.dispatched.push(envelope);
+    return { status: "dispatched", targetType: "fake", targetId: `fake-${this.dispatched.length}` };
+  }
 }
 
 describe("WorkflowSpec v1 runtime projection", () => {
@@ -168,6 +192,81 @@ describe("WorkflowSpec v1 runtime projection", () => {
     });
     const envelope = buildCurrentDispatchEnvelope("v1-cold-recovery", "execute");
     expect(envelope).toMatchObject({ ok: true, envelope: { inputs: { task: ["recover me"] } } });
+  });
+
+  it("runs the public fan-out and join example to success", () => {
+    const executor = new GraphExecutor(new RepeatableDispatcher());
+    executor.createRun(
+      "v1-example-fanout",
+      publicV1Asset("workflow-spec-v1-fanout.yaml.template"),
+      "Review the release",
+    );
+
+    expect(executor.tick("v1-example-fanout")).toBe(1);
+    handoffActiveRun("v1-example-fanout", "plan", "plan", "Check build and tests");
+    expect(executor.tick("v1-example-fanout")).toBe(2);
+    handoffActiveRun("v1-example-fanout", "worker_one", "result", { status: "done", evidence: "build passed" });
+    handoffActiveRun("v1-example-fanout", "worker_two", "result", { status: "done", evidence: "tests passed" });
+    expect(executor.tick("v1-example-fanout")).toBe(1);
+
+    expect(getActiveRun("v1-example-fanout")?.status).toBe("completed");
+  });
+
+  it("runs the public condition example through its success terminal", () => {
+    const executor = new GraphExecutor(new RepeatableDispatcher());
+    executor.createRun(
+      "v1-example-condition",
+      publicV1Asset("workflow-spec-v1-condition.yaml.template"),
+      "Approve a reversible release",
+    );
+
+    expect(executor.tick("v1-example-condition")).toBe(1);
+    handoffActiveRun("v1-example-condition", "classify", "decision", {
+      route: "approve",
+      reason: "all checks passed",
+    });
+    expect(executor.tick("v1-example-condition")).toBe(1);
+
+    expect(getActiveRun("v1-example-condition")?.status).toBe("completed");
+  });
+
+  it("runs the public foreach example and validates its collected summary", () => {
+    const executor = new GraphExecutor(new RepeatableDispatcher());
+    executor.createRun(
+      "v1-example-foreach",
+      publicV1Asset("workflow-spec-v1-foreach.yaml.template"),
+      JSON.stringify(["alpha", "beta"]),
+    );
+
+    expect(executor.tick("v1-example-foreach")).toBe(2);
+    handoffActiveRun("v1-example-foreach", "worker", "result", { item: "alpha", result: "done" });
+    expect(executor.tick("v1-example-foreach")).toBe(2);
+    handoffActiveRun("v1-example-foreach", "worker", "result", { item: "beta", result: "done" });
+    expect(executor.tick("v1-example-foreach")).toBe(1);
+
+    expect(getActiveRun("v1-example-foreach")?.status).toBe("completed");
+    expect(getActiveRun("v1-example-foreach")?.counters.gateway_results.each).toEqual([
+      { item: "alpha", result: "done" },
+      { item: "beta", result: "done" },
+    ]);
+  });
+
+  it("runs the public bounded-while example to explicit exhaustion", () => {
+    const executor = new GraphExecutor(new RepeatableDispatcher());
+    executor.createRun(
+      "v1-example-while",
+      publicV1Asset("workflow-spec-v1-bounded-while.yaml.template"),
+      JSON.stringify({ score: 10 }),
+    );
+
+    expect(executor.tick("v1-example-while")).toBe(2);
+    for (const score of [20, 30, 40]) {
+      handoffActiveRun("v1-example-while", "improve", "measured", { score });
+      executor.tick("v1-example-while");
+    }
+
+    expect(getActiveRun("v1-example-while")?.status).toBe("failed");
+    expect(getActiveRun("v1-example-while")?.counters.gateway_iterations.target).toBe(3);
   });
 });
 

--- a/homerail_manager/tests/workflow-spec-runtime.test.ts
+++ b/homerail_manager/tests/workflow-spec-runtime.test.ts
@@ -1,0 +1,183 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ChangeOrchestrator } from "../src/orchestration/change-orchestrator.js";
+import { FakeDAGDispatcher } from "../src/orchestration/dag-dispatcher.js";
+import { GraphExecutor } from "../src/orchestration/graph-executor.js";
+import {
+  _clearDagWorkflowTablesForTest,
+  upsertDagRuntimeProfileFromYaml,
+  upsertDagWorkflowFromYaml,
+} from "../src/persistence/dag-workflows.js";
+import { closeDb } from "../src/persistence/db.js";
+import { loadRunMetadata } from "../src/persistence/store.js";
+import {
+  _clearActiveRuns,
+  buildCurrentDispatchEnvelope,
+  getActiveRun,
+  handoffActiveRun,
+  recoverAllActiveRuns,
+} from "../src/runtime/active-runs.js";
+
+function workflowSource(outcome: "success" | "failure" | "cancelled" = "success"): string {
+  return `
+api_version: homerail.ai/v1
+kind: Workflow
+metadata: { id: v1-runtime-${outcome}, name: V1 Runtime ${outcome} }
+spec:
+  contracts:
+    Text:
+      type: string
+      maxLength: 100
+  agents:
+    worker: { system: Return a short result. }
+  nodes:
+    execute:
+      kind: agent
+      agent: worker
+      inputs: { task: { contract: Text } }
+      outputs: { result: { contract: Text } }
+    terminal:
+      kind: terminal
+      outcome: ${outcome}
+      inputs: { result: { contract: Text } }
+  edges:
+    - { from: $run.input, to: execute.task }
+    - { from: execute.result, to: terminal.result }
+`;
+}
+
+describe("WorkflowSpec v1 runtime projection", () => {
+  let tmpHome: string;
+  let oldHome: string | undefined;
+
+  beforeEach(() => {
+    oldHome = process.env.HOMERAIL_HOME;
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-workflow-spec-runtime-"));
+    process.env.HOMERAIL_HOME = tmpHome;
+    closeDb();
+    _clearActiveRuns();
+    _clearDagWorkflowTablesForTest();
+  });
+
+  afterEach(() => {
+    _clearActiveRuns();
+    _clearDagWorkflowTablesForTest();
+    closeDb();
+    if (oldHome === undefined) delete process.env.HOMERAIL_HOME;
+    else process.env.HOMERAIL_HOME = oldHome;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("runs a synced v1 workflow from its immutable canonical revision", () => {
+    const synced = upsertDagWorkflowFromYaml({ yaml_text: workflowSource() });
+    syncDeterministicProfile("v1-runtime-success");
+    const dispatcher = new FakeDAGDispatcher();
+    const orchestrator = new ChangeOrchestrator(new GraphExecutor(dispatcher));
+    const created = orchestrator.createAndRun({
+      workflowId: "v1-runtime-success",
+      runId: "v1-runtime-run",
+      prompt: "hello",
+      profile: "deterministic",
+    });
+
+    expect(created).toMatchObject({
+      workflowRevision: 1,
+      canonicalHash: synced.workflow.canonical_hash,
+      sourceApiVersion: "homerail.ai/v1",
+      dispatched: 1,
+    });
+    expect(dispatcher.dispatched[0].inputs).toMatchObject({ task: ["hello"] });
+
+    const completed = handoffActiveRun(created.runId, "execute", "result", "verified");
+    expect(completed?.status).toBe("completed");
+    expect(loadRunMetadata(created.runId)).toMatchObject({
+      status: "completed",
+      workflowRevision: 1,
+      canonicalHash: synced.workflow.canonical_hash,
+      contracts: { Text: { type: "string", maxLength: 100 } },
+    });
+  });
+
+  it("fails the node when a handoff violates its named contract", () => {
+    upsertDagWorkflowFromYaml({ yaml_text: workflowSource() });
+    syncDeterministicProfile("v1-runtime-success");
+    const orchestrator = new ChangeOrchestrator(new GraphExecutor(new FakeDAGDispatcher()));
+    const created = orchestrator.createAndRun({
+      workflowId: "v1-runtime-success",
+      runId: "v1-contract-failure",
+      prompt: "hello",
+      profile: "deterministic",
+    });
+
+    expect(() => handoffActiveRun(created.runId, "execute", "result", { invalid: true }))
+      .toThrow("DAG_HANDOFF_CONTRACT_VIOLATION execute.result (Text)");
+    expect(getActiveRun(created.runId)?.status).toBe("failed");
+    expect(loadRunMetadata(created.runId)?.nodeStates.execute).toBe("FAILED");
+  });
+
+  it.each([
+    ["failure", "failed"],
+    ["cancelled", "cancelled"],
+  ] as const)("honors explicit %s terminal outcome independently of port naming", (outcome, expected) => {
+    upsertDagWorkflowFromYaml({ yaml_text: workflowSource(outcome) });
+    syncDeterministicProfile(`v1-runtime-${outcome}`);
+    const orchestrator = new ChangeOrchestrator(new GraphExecutor(new FakeDAGDispatcher()));
+    const created = orchestrator.createAndRun({
+      workflowId: `v1-runtime-${outcome}`,
+      runId: `v1-terminal-${outcome}`,
+      prompt: "hello",
+      profile: "deterministic",
+    });
+
+    handoffActiveRun(created.runId, "execute", "result", "finished");
+    expect(getActiveRun(created.runId)?.status).toBe(expected);
+  });
+
+  it("rejects run input that does not satisfy the entry contract", () => {
+    upsertDagWorkflowFromYaml({ yaml_text: workflowSource() });
+    syncDeterministicProfile("v1-runtime-success");
+    const orchestrator = new ChangeOrchestrator(new GraphExecutor(new FakeDAGDispatcher()));
+
+    expect(() => orchestrator.createRun({
+      workflowId: "v1-runtime-success",
+      runId: "v1-invalid-input",
+      prompt: JSON.stringify({ not: "text" }),
+      profile: "deterministic",
+    })).toThrow("DAG_RUN_INPUT_CONTRACT_VIOLATION execute.task");
+  });
+
+  it("cold-recovers v1 provenance, contracts, and reserved run input", () => {
+    const synced = upsertDagWorkflowFromYaml({ yaml_text: workflowSource() });
+    syncDeterministicProfile("v1-runtime-success");
+    const orchestrator = new ChangeOrchestrator(new GraphExecutor(new FakeDAGDispatcher()));
+    orchestrator.createRun({
+      workflowId: "v1-runtime-success",
+      runId: "v1-cold-recovery",
+      prompt: "recover me",
+      profile: "deterministic",
+    });
+
+    _clearActiveRuns();
+    expect(recoverAllActiveRuns()).toMatchObject({ recovered: ["v1-cold-recovery"] });
+    expect(getActiveRun("v1-cold-recovery")).toMatchObject({
+      workflowRevision: 1,
+      canonicalHash: synced.workflow.canonical_hash,
+      sourceApiVersion: "homerail.ai/v1",
+    });
+    const envelope = buildCurrentDispatchEnvelope("v1-cold-recovery", "execute");
+    expect(envelope).toMatchObject({ ok: true, envelope: { inputs: { task: ["recover me"] } } });
+  });
+});
+
+function syncDeterministicProfile(workflowId: string): void {
+  upsertDagRuntimeProfileFromYaml({
+    workflow_id: workflowId,
+    yaml_text: `
+profile_id: deterministic
+default:
+  agent_type: deterministic
+`,
+  });
+}

--- a/homerail_manager/tests/workflow-spec-v1-parity.test.ts
+++ b/homerail_manager/tests/workflow-spec-v1-parity.test.ts
@@ -1,0 +1,186 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import YAML from "yaml";
+
+import { FakeDAGDispatcher } from "../src/orchestration/dag-dispatcher.js";
+import type { ParsedDAG } from "../src/orchestration/graph.js";
+import { assertRuntimeGraphParity } from "../src/orchestration/runtime-graph-parity.js";
+import {
+  canonicalWorkflowToV1Document,
+  compileWorkflowSource,
+  projectCanonicalWorkflowToParsedDAG,
+} from "../src/orchestration/workflow-spec-v1.js";
+import { parseDAGYaml } from "../src/orchestration/yaml-loader.js";
+import { _clearListeners } from "../src/events/bus.js";
+import { closeDb } from "../src/persistence/db.js";
+import { _clearAllPersistence } from "../src/persistence/store.js";
+import {
+  _clearActiveRuns,
+  createActiveRun,
+  dispatchReadyNodes,
+  getActiveRun,
+  handoffActiveRun,
+} from "../src/runtime/active-runs.js";
+
+const PUBLIC_LEGACY_ASSETS = [
+  "local-harness-cli-deploy-diagnosis.yaml.template",
+  "pattern-quorum-offline.yaml",
+  "pattern-ratchet-exhaustion-offline.yaml",
+  "public-dev-5node.yaml.template",
+  "public-two-node.yaml.template",
+] as const;
+
+function convertLegacySource(source: string): { legacy: ParsedDAG; v1: ParsedDAG } {
+  const legacy = parseDAGYaml(source);
+  const legacyCompilation = compileWorkflowSource(source);
+  expect(legacyCompilation.valid, legacyCompilation.diagnostics.map((entry) => entry.message).join("\n")).toBe(true);
+  expect(legacyCompilation.canonical).toBeDefined();
+
+  const v1Source = YAML.stringify(canonicalWorkflowToV1Document(legacyCompilation.canonical!));
+  const v1Compilation = compileWorkflowSource(v1Source);
+  expect(v1Compilation.valid, v1Compilation.diagnostics.map((entry) => entry.message).join("\n")).toBe(true);
+  expect(v1Compilation.source_api_version).toBe("homerail.ai/v1");
+  expect(v1Compilation.canonical).toBeDefined();
+  return {
+    legacy,
+    v1: projectCanonicalWorkflowToParsedDAG(v1Compilation.canonical!),
+  };
+}
+
+function loadLegacyAndV1(file: string): { legacy: ParsedDAG; v1: ParsedDAG } {
+  const source = fs.readFileSync(path.resolve("..", "assets", "orchestrations", file), "utf8");
+  return convertLegacySource(source);
+}
+
+function nodeStates(runId: string): Record<string, string> {
+  return Object.fromEntries(getActiveRun(runId)?.dagRun.nodeStates ?? []);
+}
+
+describe("WorkflowSpec v1 legacy runtime parity", () => {
+  let tmpHome: string;
+  let oldHome: string | undefined;
+
+  beforeEach(() => {
+    oldHome = process.env.HOMERAIL_HOME;
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-workflow-parity-"));
+    process.env.HOMERAIL_HOME = tmpHome;
+    closeDb();
+    _clearActiveRuns();
+    _clearAllPersistence();
+    _clearListeners();
+  });
+
+  afterEach(() => {
+    _clearActiveRuns();
+    _clearAllPersistence();
+    _clearListeners();
+    closeDb();
+    if (oldHome === undefined) delete process.env.HOMERAIL_HOME;
+    else process.env.HOMERAIL_HOME = oldHome;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it.each(PUBLIC_LEGACY_ASSETS)("preserves the public asset runtime graph: %s", (file) => {
+    const { legacy, v1 } = loadLegacyAndV1(file);
+
+    expect(() => assertRuntimeGraphParity(file, legacy, v1)).not.toThrow();
+  });
+
+  it("preserves quorum branch selection and skipped descendants", () => {
+    const { legacy, v1 } = loadLegacyAndV1("pattern-quorum-offline.yaml");
+    createActiveRun("quorum-legacy", legacy);
+    createActiveRun("quorum-v1", v1);
+
+    for (const runId of ["quorum-legacy", "quorum-v1"]) {
+      handoffActiveRun(runId, "collect_signal", "collected", "normalized-signal");
+      handoffActiveRun(runId, "voter_one", "vote", "act");
+      handoffActiveRun(runId, "voter_two", "vote", "act");
+      handoffActiveRun(runId, "voter_three", "vote", "stop");
+      expect(dispatchReadyNodes(runId, new FakeDAGDispatcher())).toBe(1);
+    }
+
+    expect(nodeStates("quorum-v1")).toEqual(nodeStates("quorum-legacy"));
+    expect(nodeStates("quorum-v1")).toMatchObject({
+      quorum: "COMPLETED",
+      conduct: "READY",
+      stopped: "SKIPPED",
+    });
+    expect(getActiveRun("quorum-v1")?.dagRun.mailboxes.get("conduct"))
+      .toEqual(getActiveRun("quorum-legacy")?.dagRun.mailboxes.get("conduct"));
+  });
+
+  it("preserves whole-payload condition routing when field is omitted", () => {
+    const source = `
+name: whole-payload-condition
+agents:
+  worker: { system: Work. }
+nodes:
+  start:
+    agent: worker
+    outputs:
+      decision: { to: gate.in:decision }
+  gate:
+    type: condition_gateway
+    gateway_config:
+      routes: { approve: approved, reject: rejected }
+      default_port: rejected
+    after: [start]
+    outputs:
+      approved: { to: good.in:task }
+      rejected: { to: bad.in:task }
+  good:
+    agent: worker
+    after: [gate]
+    outputs:
+      done: { to: "" }
+  bad:
+    agent: worker
+    after: [gate]
+    outputs:
+      done: { to: "" }
+`;
+    const { legacy, v1 } = convertLegacySource(source);
+    createActiveRun("condition-legacy", legacy);
+    createActiveRun("condition-v1", v1);
+
+    for (const runId of ["condition-legacy", "condition-v1"]) {
+      handoffActiveRun(runId, "start", "decision", "approve");
+      expect(dispatchReadyNodes(runId, new FakeDAGDispatcher())).toBe(1);
+    }
+
+    expect(nodeStates("condition-v1")).toEqual(nodeStates("condition-legacy"));
+    expect(nodeStates("condition-v1")).toMatchObject({
+      gate: "COMPLETED",
+      good: "READY",
+      bad: "SKIPPED",
+    });
+  });
+
+  it("preserves ratchet feedback bounds and exhaustion routing", () => {
+    const { legacy, v1 } = loadLegacyAndV1("pattern-ratchet-exhaustion-offline.yaml");
+    createActiveRun("ratchet-legacy", legacy);
+    createActiveRun("ratchet-v1", v1);
+
+    for (const runId of ["ratchet-legacy", "ratchet-v1"]) {
+      handoffActiveRun(runId, "baseline", "measured", "not-done");
+      expect(dispatchReadyNodes(runId, new FakeDAGDispatcher())).toBe(1);
+      handoffActiveRun(runId, "improve", "measured", "not-done");
+      expect(dispatchReadyNodes(runId, new FakeDAGDispatcher())).toBe(1);
+      handoffActiveRun(runId, "improve", "measured", "not-done");
+      expect(dispatchReadyNodes(runId, new FakeDAGDispatcher())).toBe(1);
+    }
+
+    expect(nodeStates("ratchet-v1")).toEqual(nodeStates("ratchet-legacy"));
+    expect(nodeStates("ratchet-v1")).toMatchObject({
+      target_gate: "COMPLETED",
+      achieved: "SKIPPED",
+      stopped: "READY",
+    });
+    expect(getActiveRun("ratchet-v1")?.counters.gateway_iterations)
+      .toEqual(getActiveRun("ratchet-legacy")?.counters.gateway_iterations);
+    expect(getActiveRun("ratchet-v1")?.dagRun.mailboxes.get("stopped"))
+      .toEqual(getActiveRun("ratchet-legacy")?.dagRun.mailboxes.get("stopped"));
+  });
+});

--- a/homerail_manager/tests/workflow-spec-v1.test.ts
+++ b/homerail_manager/tests/workflow-spec-v1.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 import YAML from "yaml";
+import * as path from "node:path";
 import { Value } from "@sinclair/typebox/value";
-import { compileWorkflowSource } from "../src/orchestration/workflow-spec-v1.js";
+import { compileWorkflowSource, parseWorkflowSourceFile } from "../src/orchestration/workflow-spec-v1.js";
 import { WorkflowSpecV1Schema } from "../src/orchestration/workflow-spec-v1-schema.js";
 
 const MINIMAL_WORKFLOW = {
@@ -240,5 +241,23 @@ nodes:
       expect.objectContaining({ severity: "warning", code: "DAG_LEGACY_UNVERSIONED_SOURCE" }),
     ]);
     expect(result.canonical?.terminal_nodes).toHaveLength(1);
+  });
+
+  it("loads the tracked v1 template through the same path used to create runs", () => {
+    const parsed = parseWorkflowSourceFile(path.resolve(
+      "..",
+      "assets",
+      "orchestrations",
+      "workflow-spec-v1-minimal.yaml.template",
+    ));
+
+    expect(parsed.meta).toMatchObject({
+      workflow_id: "workflow-spec-v1-minimal",
+      source_api_version: "homerail.ai/v1",
+    });
+    expect(parsed.graph.nodes.map((node) => node.node_id)).toEqual(["execute"]);
+    expect(parsed.graph.edges).toEqual(expect.arrayContaining([
+      expect.objectContaining({ from_node: "execute", from_port: "result", to_node: "" }),
+    ]));
   });
 });

--- a/homerail_manager/tests/workflow-spec-v1.test.ts
+++ b/homerail_manager/tests/workflow-spec-v1.test.ts
@@ -1,9 +1,18 @@
 import { describe, expect, it } from "vitest";
 import YAML from "yaml";
+import * as fs from "node:fs";
 import * as path from "node:path";
 import { Value } from "@sinclair/typebox/value";
 import { compileWorkflowSource, parseWorkflowSourceFile } from "../src/orchestration/workflow-spec-v1.js";
 import { WorkflowSpecV1Schema } from "../src/orchestration/workflow-spec-v1-schema.js";
+
+const PUBLIC_V1_ASSETS = [
+  "workflow-spec-v1-minimal.yaml.template",
+  "workflow-spec-v1-fanout.yaml.template",
+  "workflow-spec-v1-condition.yaml.template",
+  "workflow-spec-v1-foreach.yaml.template",
+  "workflow-spec-v1-bounded-while.yaml.template",
+] as const;
 
 const MINIMAL_WORKFLOW = {
   api_version: "homerail.ai/v1",
@@ -259,5 +268,14 @@ nodes:
     expect(parsed.graph.edges).toEqual(expect.arrayContaining([
       expect.objectContaining({ from_node: "execute", from_port: "result", to_node: "" }),
     ]));
+  });
+
+  it.each(PUBLIC_V1_ASSETS)("compiles the public v1 asset: %s", (file) => {
+    const source = fs.readFileSync(path.resolve("..", "assets", "orchestrations", file), "utf8");
+    const result = compileWorkflowSource(source);
+
+    expect(result.valid, result.diagnostics.map((item) => `${item.code} ${item.path}: ${item.message}`).join("\n")).toBe(true);
+    expect(result.source_api_version).toBe("homerail.ai/v1");
+    expect(result.canonical_hash).toMatch(/^[a-f0-9]{64}$/);
   });
 });

--- a/homerail_manager/tests/workflow-spec-v1.test.ts
+++ b/homerail_manager/tests/workflow-spec-v1.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from "vitest";
+import YAML from "yaml";
+import { Value } from "@sinclair/typebox/value";
+import { compileWorkflowSource } from "../src/orchestration/workflow-spec-v1.js";
+import { WorkflowSpecV1Schema } from "../src/orchestration/workflow-spec-v1-schema.js";
+
+const MINIMAL_WORKFLOW = {
+  api_version: "homerail.ai/v1",
+  kind: "Workflow",
+  metadata: {
+    id: "bounded-review",
+    name: "Bounded Review",
+  },
+  spec: {
+    description: "Execute one task and finish with explicit evidence.",
+    workspace: { mode: "isolated" },
+    contracts: {
+      Task: {
+        type: "object",
+        additionalProperties: false,
+        required: ["objective"],
+        properties: { objective: { type: "string", maxLength: 1000 } },
+      },
+      Result: {
+        type: "object",
+        additionalProperties: false,
+        required: ["status"],
+        properties: { status: { type: "string", enum: ["success", "failure"] } },
+      },
+    },
+    agents: {
+      worker: {
+        system: "Execute the supplied task and return structured evidence.",
+        skills: ["homerail-dag-ops"],
+      },
+    },
+    nodes: {
+      execute: {
+        kind: "agent",
+        agent: "worker",
+        inputs: { task: { contract: "Task" } },
+        outputs: { result: { contract: "Result" } },
+      },
+      done: {
+        kind: "terminal",
+        outcome: "success",
+        inputs: { result: { contract: "Result" } },
+      },
+    },
+    edges: [
+      { from: "$run.input", to: "execute.task" },
+      { from: "execute.result", to: "done.result" },
+    ],
+  },
+} as const;
+
+describe("WorkflowSpec v1", () => {
+  it("defines a strict schema branch for every v1 node kind", () => {
+    const document = {
+      api_version: "homerail.ai/v1",
+      kind: "Workflow",
+      metadata: { id: "all-node-kinds", name: "All Node Kinds" },
+      spec: {
+        contracts: { Data: { type: "object" } },
+        agents: { worker: { system: "Work." } },
+        nodes: {
+          worker: {
+            kind: "agent",
+            agent: "worker",
+            inputs: { task: { contract: "Data" } },
+            outputs: { result: { contract: "Data" } },
+          },
+          gate: {
+            kind: "condition",
+            inputs: { signal: { contract: "Data" } },
+            outputs: { yes: { contract: "Data" }, no: { contract: "Data" } },
+            config: { field: "status", routes: { yes: "yes", no: "no" }, default: "no" },
+          },
+          join: {
+            kind: "join",
+            inputs: { votes: { contract: "Data" } },
+            outputs: { passed: { contract: "Data" }, failed: { contract: "Data" } },
+            config: { mode: "n_of_m", field: "vote", threshold: 2 },
+          },
+          each: {
+            kind: "foreach",
+            inputs: { items: { contract: "Data" }, result: { contract: "Data" } },
+            outputs: { next: { contract: "Data" }, done: { contract: "Data" } },
+            config: { input: "items", item_port: "next", result_port: "result", done_port: "done", max_items: 100 },
+          },
+          bounded: {
+            kind: "while",
+            inputs: { state: { contract: "Data" } },
+            outputs: { again: { contract: "Data" }, done: { contract: "Data" } },
+            config: {
+              field: "complete",
+              operator: "truthy",
+              continue_port: "again",
+              done_port: "done",
+              max_iterations: 3,
+            },
+          },
+          terminal: {
+            kind: "terminal",
+            outcome: "success",
+            inputs: { result: { contract: "Data" } },
+          },
+        },
+        edges: [],
+      },
+    };
+
+    expect(Value.Check(WorkflowSpecV1Schema, document)).toBe(true);
+    for (const [nodeId, node] of Object.entries(document.spec.nodes)) {
+      const invalid = structuredClone(document) as any;
+      invalid.spec.nodes[nodeId] = { ...node, unsupported_field: true };
+      expect(Value.Check(WorkflowSpecV1Schema, invalid), nodeId).toBe(false);
+    }
+  });
+
+  it("compiles equivalent YAML and JSON to byte-identical canonical IR", () => {
+    const yaml = compileWorkflowSource(YAML.stringify(MINIMAL_WORKFLOW));
+    const json = compileWorkflowSource(JSON.stringify(MINIMAL_WORKFLOW, null, 2));
+
+    expect(yaml.valid, yaml.diagnostics.map((item) => item.message).join("\n")).toBe(true);
+    expect(json.valid, json.diagnostics.map((item) => item.message).join("\n")).toBe(true);
+    expect(yaml.canonical_json).toBe(json.canonical_json);
+    expect(yaml.canonical_hash).toMatch(/^[a-f0-9]{64}$/);
+    expect(yaml.canonical_hash).toBe(json.canonical_hash);
+    expect(yaml.summary).toEqual({
+      workflow_id: "bounded-review",
+      node_count: 2,
+      edge_count: 2,
+      entry_nodes: ["execute"],
+      terminal_nodes: ["done"],
+    });
+  });
+
+  it("rejects unknown and provider-specific fields with source positions", () => {
+    const source = YAML.stringify({
+      ...MINIMAL_WORKFLOW,
+      spec: {
+        ...MINIMAL_WORKFLOW.spec,
+        agents: {
+          worker: {
+            ...MINIMAL_WORKFLOW.spec.agents.worker,
+            model: "provider-owned-model",
+          },
+        },
+      },
+    });
+    const result = compileWorkflowSource(source);
+
+    expect(result.valid).toBe(false);
+    expect(result.diagnostics).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        severity: "error",
+        code: "DAG_SCHEMA_UNKNOWN_FIELD",
+        path: "/spec/agents/worker/model",
+        line: expect.any(Number),
+        column: expect.any(Number),
+      }),
+    ]));
+  });
+
+  it("reports port contract mismatches before runtime", () => {
+    const workflow = structuredClone(MINIMAL_WORKFLOW) as any;
+    workflow.spec.nodes.done.inputs.result.contract = "Task";
+    const result = compileWorkflowSource(YAML.stringify(workflow));
+
+    expect(result.valid).toBe(false);
+    expect(result.diagnostics).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: "DAG_SEMANTIC_CONTRACT_MISMATCH", path: "/spec/edges/1" }),
+    ]));
+  });
+
+  it("requires explicit terminals and rejects normal cycles", () => {
+    const workflow = structuredClone(MINIMAL_WORKFLOW) as any;
+    delete workflow.spec.nodes.done;
+    workflow.spec.nodes.execute.inputs.feedback = { contract: "Result" };
+    workflow.spec.edges[1] = { from: "execute.result", to: "execute.feedback" };
+    const result = compileWorkflowSource(YAML.stringify(workflow));
+
+    expect(result.valid).toBe(false);
+    expect(result.diagnostics.map((item) => item.code)).toEqual(expect.arrayContaining([
+      "DAG_SEMANTIC_UNBOUNDED_CYCLE",
+      "DAG_SEMANTIC_TERMINAL_REQUIRED",
+    ]));
+  });
+
+  it("accepts bounded feedback only when it targets a loop node", () => {
+    const workflow = structuredClone(MINIMAL_WORKFLOW) as any;
+    workflow.spec.nodes.loop = {
+      kind: "while",
+      inputs: { state: { contract: "Result" } },
+      outputs: {
+        again: { contract: "Result" },
+        complete: { contract: "Result" },
+      },
+      config: {
+        field: "status",
+        operator: "ne",
+        value: "success",
+        continue_port: "again",
+        done_port: "complete",
+        max_iterations: 3,
+      },
+    };
+    workflow.spec.nodes.execute.inputs.feedback = { contract: "Result" };
+    workflow.spec.edges = [
+      { from: "$run.input", to: "execute.task" },
+      { from: "execute.result", to: "loop.state" },
+      { kind: "feedback", from: "loop.again", to: "loop.state", max_traversals: 3 },
+      { from: "loop.complete", to: "done.result" },
+    ];
+    const result = compileWorkflowSource(YAML.stringify(workflow));
+
+    expect(result.valid, result.diagnostics.map((item) => item.message).join("\n")).toBe(true);
+    expect(result.canonical?.feedback_edges).toHaveLength(1);
+  });
+
+  it("accepts existing unversioned workflows through an isolated legacy adapter", () => {
+    const result = compileWorkflowSource(`
+name: Legacy Review
+workflow_id: legacy-review
+agents:
+  worker:
+    system: Do the work.
+nodes:
+  execute:
+    agent: worker
+    outputs:
+      done:
+        to: ""
+`);
+
+    expect(result.valid, result.diagnostics.map((item) => item.message).join("\n")).toBe(true);
+    expect(result.source_api_version).toBe("legacy/v0");
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({ severity: "warning", code: "DAG_LEGACY_UNVERSIONED_SOURCE" }),
+    ]);
+    expect(result.canonical?.terminal_nodes).toHaveLength(1);
+  });
+});

--- a/homerail_protocol/src/manager-agent-prompt.ts
+++ b/homerail_protocol/src/manager-agent-prompt.ts
@@ -48,7 +48,7 @@ export function buildManagerAgentSystemPrompt(input: ManagerAgentPromptInput = {
     `You are the HomeRail Manager Agent running as ${placement}.`,
     "Your job is to convert user requests into real HomeRail Manager actions using the provided tools.",
     "HomeRail skills are available through the skill catalog below. When a request matches a skill, call read_skill before acting and follow its instructions. Skill metadata is always available; load full bodies only when relevant.",
-    "For reusable DAG work, read homerail-dag-patterns, inspect list_dag_patterns, inspect the selected pattern with get_dag_pattern, then call instantiate_dag_pattern and create_and_run. Use list_orchestrations for concrete repo-local templates. Do not force a design pattern when a simple linear DAG is clearer.",
+    "For reusable DAG work, read homerail-dag-patterns, inspect list_dag_patterns, inspect the selected pattern with get_dag_pattern, then call instantiate_dag_pattern and create_and_run. Use list_orchestrations for concrete repo-local templates. For a custom DAG, call get_dag_schema before authoring, validate_dag_workflow, then sync_dag_workflow before execution. Do not force a design pattern when a simple linear DAG is clearer.",
     "Never claim a DAG started unless create_and_run or invoke_run returned a real run id.",
     "Do not use shell, curl, npm, node, or a locally started manager server to create DAG runs; those do not count as Manager Agent tool execution.",
     "Do not edit files, commit, push, or call external services unless the user explicitly requests it.",

--- a/homerail_protocol/src/manager-agent-tools.ts
+++ b/homerail_protocol/src/manager-agent-tools.ts
@@ -26,6 +26,9 @@ export const MANAGER_AGENT_COMMON_TOOL_NAMES = [
   "list_dag_patterns",
   "get_dag_pattern",
   "instantiate_dag_pattern",
+  "get_dag_schema",
+  "validate_dag_workflow",
+  "sync_dag_workflow",
   "create_change",
   "create_and_run",
   "invoke_run",
@@ -244,6 +247,36 @@ export const MANAGER_AGENT_TOOL_SPECS: Record<ManagerAgentToolName, AgentToolDef
         sync: { type: "boolean" },
       },
       required: ["pattern_id"],
+      additionalProperties: false,
+    },
+  },
+  get_dag_schema: {
+    name: "get_dag_schema",
+    description: "Fetch the live WorkflowSpec v1 JSON Schema and compiler version before authoring a custom DAG.",
+    input_schema: emptyObjectSchema,
+  },
+  validate_dag_workflow: {
+    name: "validate_dag_workflow",
+    description: "Validate custom WorkflowSpec YAML or JSON without syncing or running it; returns structured source diagnostics and canonical metadata.",
+    input_schema: {
+      type: "object",
+      properties: {
+        source: { type: "string", maxLength: 262144 },
+      },
+      required: ["source"],
+      additionalProperties: false,
+    },
+  },
+  sync_dag_workflow: {
+    name: "sync_dag_workflow",
+    description: "Sync a previously validated WorkflowSpec or legacy DAG source into Manager and create an immutable semantic revision when needed.",
+    input_schema: {
+      type: "object",
+      properties: {
+        source: { type: "string", maxLength: 262144 },
+        source_path: { type: "string", maxLength: 1024 },
+      },
+      required: ["source"],
       additionalProperties: false,
     },
   },

--- a/homerail_protocol/tests/manager-agent.test.ts
+++ b/homerail_protocol/tests/manager-agent.test.ts
@@ -111,6 +111,9 @@ describe("Manager Agent harness contract", () => {
       "list_dag_patterns",
       "get_dag_pattern",
       "instantiate_dag_pattern",
+      "get_dag_schema",
+      "validate_dag_workflow",
+      "sync_dag_workflow",
     ]));
     expect(chatNames).not.toContain("write_widget_file");
     expect(voiceNames).toContain("write_widget_file");
@@ -130,6 +133,9 @@ describe("Manager Agent harness contract", () => {
       pattern_id: { type: "string" },
       parameters: { type: "object", additionalProperties: true },
       sync: { type: "boolean" },
+    });
+    expect(managerAgentToolSpec("validate_dag_workflow").input_schema.properties).toMatchObject({
+      source: { type: "string", maxLength: 262144 },
     });
     expect(managerAgentToolSpec("write_widget_file").input_schema.properties).toMatchObject({
       widget_type: { type: "string", enum: MANAGER_AGENT_WIDGET_FILE_TYPES },

--- a/skills/homerail-dag-patterns/SKILL.md
+++ b/skills/homerail-dag-patterns/SKILL.md
@@ -30,6 +30,16 @@ When running as the HomeRail Manager Agent, use Manager tools rather than shell,
 5. Use `get_run_status` for progress. Never claim the DAG started without the
    real run id returned by `create_and_run`.
 
+When adapting a pattern or authoring a custom workflow instead of using the
+generated instance unchanged:
+
+1. Call `get_dag_schema`; do not rely on a remembered WorkflowSpec shape.
+2. Emit `api_version: homerail.ai/v1` with explicit top-level edges and terminal
+   nodes.
+3. Call `validate_dag_workflow` and repair every structured diagnostic.
+4. Call `sync_dag_workflow` only after validation returns `valid: true`.
+5. Use the returned workflow revision and canonical hash as provenance.
+
 For a simple one-step or linear task, do not force a pattern. Use an existing
 concrete orchestration or ask for the missing execution boundary.
 
@@ -84,6 +94,10 @@ Preserve the invariant that made the pattern useful:
 Do not put provider, model, API key, or base URL fields in generated workflow
 YAML. Bind models through HomeRail database settings and runtime profiles.
 
+Pattern instances are strict WorkflowSpec v1 documents. Keep the
+`api_version`/`kind`/`metadata`/`spec` envelope, named port contracts, top-level
+`spec.edges`, and explicit terminal outcomes when adapting them.
+
 ## Compose Patterns
 
 Compose only at explicit boundaries. Common combinations:
@@ -102,19 +116,22 @@ clear stop predicate.
 
 ## Use Gateway Semantics Correctly
 
-- `condition_gateway`: route one structured value by field and exact case.
-- `loop_gateway`: iterate a finite item list and emit `done` after the last item;
+- `condition`: route one structured value by field and exact case.
+- `foreach`: iterate a finite item list and emit `done` after the last item;
   set `result_port` to include every ordered iteration result in the final payload.
-- `join_gateway`: aggregate all arrived inputs using `all`, `any`, or `n_of_m`;
+- `join`: aggregate all arrived inputs using `all`, `any`, or `n_of_m`;
   configure `field`, `success_values`, and threshold explicitly.
-- `while_gateway`: compare the latest feedback value, emit `continue` while
+- `while`: compare the latest feedback value, emit `continue` while
   unmatched, and emit `exhausted` after `max_iterations`.
-- `retry_policy.max_retries`: bound feedback-edge traversals independently of
-  the run-wide edge limit.
+- A `kind: feedback` edge must declare `max_traversals` independently of the
+  run-wide edge limit.
+- `terminal` declares `outcome: success | failure | cancelled` and never calls
+  a model.
 
-Use `after` for completion dependencies and explicit output edges for data.
-Join nodes wait for all `after` dependencies before aggregating. While feedback
-edges must return directly to the while gateway.
+Data edges imply completion dependencies. Use `depends_on` only for a
+control-only barrier that carries no payload. Join nodes wait for all declared
+inputs before aggregating. Feedback edges must return directly to a `foreach`
+or `while` node and remain statically bounded.
 
 ## Validate Before Running
 
@@ -122,6 +139,8 @@ Inspect generated YAML, then sync and run it only when its task-specific prompts
 and runtime profile are complete:
 
 ```bash
+hr dag schema
+hr --json dag validate /tmp/release-decision.yaml
 hr dag sync /tmp/release-decision.yaml
 hr profile sync <profile.yaml> --workflow release-decision
 hr run --workflow release-decision --profile <profile-id> --prompt "<task>"
@@ -133,7 +152,9 @@ Require all of the following before calling the adaptation useful:
 
 - `hr patterns instantiate` reports a valid graph.
 - The YAML contains pattern id, version, source, and resolved parameters.
-- Every branch reaches a terminal node or a bounded feedback edge.
+- Every branch reaches an explicit terminal node, possibly through a bounded
+  feedback edge.
+- Sync returns the expected immutable revision and canonical hash.
 - A deterministic or fake-dispatch test exercises the topology.
 - A real model-backed run exercises task semantics before production use.
 - Terminal status and non-empty handoffs support the claimed result.


### PR DESCRIPTION
## Status

Draft implementation. Do not merge yet. WorkflowSpec v1 is runnable, built-in patterns emit strict v1, and public legacy assets now have runtime parity coverage. Cross-platform and model-backed validation remain pending.

## Implemented

- Accepted WorkflowSpec v1 envelope, explicit edge, terminal, contract, and runtime-profile boundaries
- Typed TypeBox schema as the TypeScript and public JSON Schema source of truth
- YAML/JSON diagnostics with paths and source positions
- Deterministic CanonicalWorkflowIR JSON and SHA-256 hashes
- Isolated legacy/v0 adapter
- Immutable workflow revisions with formatting-only sync idempotency
- Run revision/hash/compiler provenance through cold recovery
- Runtime projection for $run.input, named JSON Schema contracts, bounded feedback, and success/failure/cancelled terminals
- Manager schema, validation, and revision APIs
- hr dag schema and hr dag validate
- Manager Agent schema, validation, and sync tools
- All nine built-in pattern catalog templates and generated instances emit strict v1
- Reusable runtime graph parity checks for built-ins and all five public legacy assets
- Executable legacy/v1 transition parity for quorum, whole-payload condition routing, and bounded ratchet exhaustion
- Practical authoring guide plus runnable minimal, fan-out/join, condition, foreach, and bounded-while v1 templates
- Bounded JSON Schema oneOf support for legitimate small payload unions
- Contract-invalid correction exhaustion fails the run without terminating Manager

## Validation

- Root typecheck: passed across all six packages
- Manager: 301/301 passed
- Protocol: 94/94 passed
- CLI: 183/183 passed
- Node: 158 passed, 1 skipped
- Worker: 169 passed, 1 skipped
- Agent UI build: passed
- Real Docker lifecycle: 1/1 passed after explicitly pre-pulling node:22-alpine
- Worker Docker image: built successfully from this branch
- Claude SDK + Kimi minimal v1: completed, exact handoff, scorecard 9/9
- Claude SDK + Kimi condition v1: completed through approved terminal, scorecard 9/9
- Claude SDK + Kimi fan-out/join v1: 4/4 nodes, 4 non-empty handoffs, scorecard 9/9
- Draft CI jobs: skipped as intended after PR #20

Live validation found and fixed two real defects: legacy condition/while gateways with no field were initially rewritten as field: status, and a contract-invalid auto-handoff could terminate Manager after correction exhaustion. Model-backed runs also refined the public WorkOrder/Verdict contracts without embedding provider configuration.

Local Agent UI tests remain blocked by the machine Node/jsdom/localStorage environment before relevant test execution; this branch has no Agent UI source changes.

## Pending

- Windows validation
- Isolated remote-runner model matrix
- Decide which legacy assets remain compatibility fixtures until runtime profiles and scorecards have independent v1 documents
- Finalize migration policy and remaining authoring guidance

Graph Patch and dynamic graph mutation remain explicitly out of scope.

