### PR TITLE
ci: skip checks for draft pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
   push:
     branches: [main]
   workflow_dispatch:
@@ -33,7 +34,9 @@ concurrency:
 jobs:
   core-linux:
     name: Core (Linux, Node ${{ matrix.node-version }})
-    if: github.event_name != 'workflow_dispatch' || !inputs.live_patterns
+    if: >-
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+      (github.event_name != 'workflow_dispatch' || !inputs.live_patterns)
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
@@ -69,7 +72,9 @@ jobs:
 
   core-windows:
     name: Core (Windows, Node 24)
-    if: github.event_name != 'workflow_dispatch' || !inputs.live_patterns
+    if: >-
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+      (github.event_name != 'workflow_dispatch' || !inputs.live_patterns)
     runs-on: windows-latest
     timeout-minutes: 25
     steps:
@@ -101,7 +106,9 @@ jobs:
 
   agent-ui-coverage:
     name: Agent UI coverage
-    if: github.event_name != 'workflow_dispatch' || !inputs.live_patterns
+    if: >-
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+      (github.event_name != 'workflow_dispatch' || !inputs.live_patterns)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -129,7 +136,9 @@ jobs:
 
   docker-smoke:
     name: Docker smoke
-    if: github.event_name != 'workflow_dispatch' || !inputs.live_patterns
+    if: >-
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+      (github.event_name != 'workflow_dispatch' || !inputs.live_patterns)
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
@@ -163,6 +172,7 @@ jobs:
        inputs.live_patterns &&
        github.actor == 'xiaotianfotos') ||
       (github.event_name == 'pull_request' &&
+       github.event.pull_request.draft == false &&
        github.actor == 'xiaotianfotos' &&
        github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: [self-hosted, Linux, X64, homerail-live-112]


### PR DESCRIPTION
## Summary

- skip every CI job while a pull request is in Draft state
- run full CI when a pull request is marked ready for review
- trigger on converted-to-draft so the existing concurrency group cancels in-progress CI
- keep main pushes and manual live DAG validation unchanged

## Validation

- `git diff --check`
- actionlint 1.7.12 with the repository self-hosted runner label config
- static assertion that all five jobs include the Draft guard
- this PR is opened as Draft first to verify all jobs are skipped without allocating runners

After Draft behavior is verified, the PR will be marked ready so the normal CI path runs once before owner merge.