### PR TITLE
fix: recover stale DAG runs and improve model settings

### DIFF
--- a/agent-ui/src/api/agent/agent-settings-api.ts
+++ b/agent-ui/src/api/agent/agent-settings-api.ts
@@ -19,32 +19,28 @@ import type {
   ProjectListResponse,
   ProjectResponse,
   ProjectStorageListResponse,
-  UpdateProjectRequest,
+  UpdateProjectRequest
 } from '../types/project.types'
 import type { NodeListResponse } from '../types/node.types'
 import type {
   GitRepositoryInfo,
   GitServer,
   GitServerCreateRequest,
-  GitUserInfo,
+  GitUserInfo
 } from '../types/infrastructure.types'
 import type {
   ProviderListResponse,
   Skill,
   SkillListParams,
-  SkillListResponse,
+  SkillListResponse
 } from '../types/orchestration-v2.types'
-import type {
-  AgentProject,
-  AgentProjectListParams,
-  AgentStorageInfo,
-} from './agent.types'
+import type { AgentProject, AgentProjectListParams, AgentStorageInfo } from './agent.types'
 import {
   asAgentRecord,
   getAgentArray,
   getAgentDataPayload,
   getAgentString,
-  normalizeProject,
+  normalizeProject
 } from './agent.types'
 import {
   getVoiceSettings as _getVoiceSettings,
@@ -53,29 +49,27 @@ import {
   testVoiceConnection as _testVoiceConnection,
   type VoiceSettings,
   type UpdateVoiceSettingsRequest,
-  type VoiceTtsOutputChannel,
+  type VoiceTtsOutputChannel
 } from '../services/voice-api'
-import {
-  getExperienceGraphSummary as _getExperienceGraphSummary,
-} from '../services/experience-api'
+import { getExperienceGraphSummary as _getExperienceGraphSummary } from '../services/experience-api'
 import type { ExperienceGraphSummary } from '../types/experience.types'
 import {
   getAssetDiagnostics as _getAssetDiagnostics,
   getOrchestrationTemplates as _getOrchestrationTemplates,
   type AssetDiagnostics,
-  type OrchestrationTemplate,
+  type OrchestrationTemplate
 } from '../services/asset-diagnostics-api'
 import {
   getVoiceAgentConfig as _getVoiceAgentConfig,
   updateVoiceAgentConfig as _updateVoiceAgentConfig,
   type VoiceAgentConfig,
-  type UpdateVoiceAgentConfigRequest,
+  type UpdateVoiceAgentConfigRequest
 } from './agent-voice-api'
 import {
   listMemories as _listMemories,
   getMemoryStats as _getMemoryStats,
   createMemory as _createMemory,
-  deleteMemory as _deleteMemory,
+  deleteMemory as _deleteMemory
 } from '../services/memory-api'
 import {
   listLLMSettings as _listLLMSettings,
@@ -84,18 +78,20 @@ import {
   deleteLLMSetting as _deleteLLMSetting,
   type LLMSetting,
   type CreateLLMSettingsRequest,
-  type UpdateLLMSettingsRequest,
+  type UpdateLLMSettingsRequest
 } from '../services/llm-settings-api'
 import {
   listProviders as _listProviders,
   createProvider as _createProvider,
+  updateProvider as _updateProvider,
+  deleteProvider as _deleteProvider
 } from '../services/providers-api'
 import {
   listGitServers as _listGitServers,
   createGitServer as _createGitServer,
   deleteGitServer as _deleteGitServer,
   verifyGitServer as _verifyGitServer,
-  listGitServerRepos as _listGitServerRepos,
+  listGitServerRepos as _listGitServerRepos
 } from '../services/git-credentials-api'
 import {
   listMCPServers as _listMCPServers,
@@ -106,13 +102,19 @@ import {
   type MCPServer,
   type MCPServerType,
   type AddMCPServerRequest,
-  type UpdateMCPServerRequest,
+  type UpdateMCPServerRequest
 } from '../services/mcp-api'
 
 export type { LLMSetting, CreateLLMSettingsRequest, UpdateLLMSettingsRequest }
 export type { GitServer, GitServerCreateRequest }
 export type { MCPServer, MCPServerType, AddMCPServerRequest, UpdateMCPServerRequest }
-export type { VoiceSettings, VoiceTtsOutputChannel, ExperienceGraphSummary, AssetDiagnostics, OrchestrationTemplate }
+export type {
+  VoiceSettings,
+  VoiceTtsOutputChannel,
+  ExperienceGraphSummary,
+  AssetDiagnostics,
+  OrchestrationTemplate
+}
 
 export interface GitServerListResponse {
   success: boolean
@@ -210,31 +212,43 @@ export async function listProjects(params?: ProjectListParams): Promise<ProjectL
   if (params?.limit !== undefined) queryParams.append('limit', String(params.limit))
   if (params?.offset !== undefined) queryParams.append('offset', String(params.offset))
   const queryString = queryParams.toString()
-  return http.get<ProjectListResponse['data']>(`/api/projects${queryString ? `?${queryString}` : ''}`) as Promise<ProjectListResponse>
+  return http.get<ProjectListResponse['data']>(
+    `/api/projects${queryString ? `?${queryString}` : ''}`
+  ) as Promise<ProjectListResponse>
 }
 
 export async function createProject(data: CreateProjectRequest): Promise<ProjectResponse> {
   return http.post<ProjectResponse['data']>('/api/projects', data) as Promise<ProjectResponse>
 }
 
-export async function updateProject(projectId: string, data: UpdateProjectRequest): Promise<ProjectResponse> {
-  return http.put<ProjectResponse['data']>(`/api/projects/${encodeURIComponent(projectId)}`, data) as Promise<ProjectResponse>
+export async function updateProject(
+  projectId: string,
+  data: UpdateProjectRequest
+): Promise<ProjectResponse> {
+  return http.put<ProjectResponse['data']>(
+    `/api/projects/${encodeURIComponent(projectId)}`,
+    data
+  ) as Promise<ProjectResponse>
 }
 
 export async function deleteProject(
-  projectId: string,
+  projectId: string
 ): Promise<BaseResponse<{ id: string; summary?: Record<string, unknown> | null }>> {
   return http.delete<{ id: string; summary?: Record<string, unknown> | null }>(
-    `/api/projects/${encodeURIComponent(projectId)}`,
+    `/api/projects/${encodeURIComponent(projectId)}`
   ) as Promise<BaseResponse<{ id: string; summary?: Record<string, unknown> | null }>>
 }
 
 export async function listProjectStorages(projectId: string): Promise<ProjectStorageListResponse> {
-  return http.get<ProjectStorageListResponse['data']>(`/api/projects/${encodeURIComponent(projectId)}/storages`) as Promise<ProjectStorageListResponse>
+  return http.get<ProjectStorageListResponse['data']>(
+    `/api/projects/${encodeURIComponent(projectId)}/storages`
+  ) as Promise<ProjectStorageListResponse>
 }
 
 export async function listProjectDirectoryRoots(): Promise<ProjectDirectoryRootsResponse> {
-  return http.get<ProjectDirectoryRootsResponse['data']>('/api/projects/directories/roots') as Promise<ProjectDirectoryRootsResponse>
+  return http.get<ProjectDirectoryRootsResponse['data']>(
+    '/api/projects/directories/roots'
+  ) as Promise<ProjectDirectoryRootsResponse>
 }
 
 export async function browseProjectDirectories(params: {
@@ -246,11 +260,12 @@ export async function browseProjectDirectories(params: {
   const queryParams = new URLSearchParams()
   if (params.path) queryParams.append('path', params.path)
   if (params.server_id) queryParams.append('server_id', params.server_id)
-  if (params.show_hidden !== undefined) queryParams.append('show_hidden', String(params.show_hidden))
+  if (params.show_hidden !== undefined)
+    queryParams.append('show_hidden', String(params.show_hidden))
   if (params.limit !== undefined) queryParams.append('limit', String(params.limit))
   const queryString = queryParams.toString()
   return http.get<ProjectDirectoryBrowseResponse['data']>(
-    `/api/projects/directories/browse${queryString ? `?${queryString}` : ''}`,
+    `/api/projects/directories/browse${queryString ? `?${queryString}` : ''}`
   ) as Promise<ProjectDirectoryBrowseResponse>
 }
 
@@ -262,11 +277,16 @@ export async function listGitServers(activeOnly = true): Promise<GitServerListRe
   return _listGitServers(activeOnly)
 }
 
-export async function createGitServer(data: GitServerCreateRequest): Promise<GitServerDetailResponse> {
+export async function createGitServer(
+  data: GitServerCreateRequest
+): Promise<GitServerDetailResponse> {
   return _createGitServer(data)
 }
 
-export async function deleteGitServer(serverId: string, force = false): Promise<BaseResponse<{ server_id: string }>> {
+export async function deleteGitServer(
+  serverId: string,
+  force = false
+): Promise<BaseResponse<{ server_id: string }>> {
   return _deleteGitServer(serverId, force)
 }
 
@@ -277,44 +297,54 @@ export async function verifyGitServer(serverId: string): Promise<GitVerifyRespon
 export async function listGitServerRepos(
   serverId: string,
   page = 1,
-  perPage = 30,
+  perPage = 30
 ): Promise<GitServerReposResponse> {
   return _listGitServerRepos(serverId, page, perPage)
 }
 
-export async function listSkills(params?: SkillListParams): Promise<BaseResponse<SkillListResponse>> {
+export async function listSkills(
+  params?: SkillListParams
+): Promise<BaseResponse<SkillListResponse>> {
   const queryParams = new URLSearchParams()
   if (params?.search) queryParams.append('search', params.search)
   if (params?.status) queryParams.append('status', params.status)
   if (params?.limit !== undefined) queryParams.append('limit', String(params.limit))
   if (params?.offset !== undefined) queryParams.append('offset', String(params.offset))
   const queryString = queryParams.toString()
-  return http.get<SkillListResponse>(`/api/skills${queryString ? `?${queryString}` : ''}`) as Promise<BaseResponse<SkillListResponse>>
+  return http.get<SkillListResponse>(
+    `/api/skills${queryString ? `?${queryString}` : ''}`
+  ) as Promise<BaseResponse<SkillListResponse>>
 }
 
 export async function listProviders(): Promise<BaseResponse<ProviderListResponse>> {
   return _listProviders()
 }
 
-export async function uploadSkill(file: File, name?: string, description?: string): Promise<BaseResponse<Skill>> {
+export async function uploadSkill(
+  file: File,
+  name?: string,
+  description?: string
+): Promise<BaseResponse<Skill>> {
   const formData = new FormData()
   formData.append('file', file)
   if (name) formData.append('name', name)
   if (description) formData.append('description', description)
   return http.post<Skill>('/api/skills', formData, {
-    headers: { 'Content-Type': 'multipart/form-data' },
+    headers: { 'Content-Type': 'multipart/form-data' }
   }) as Promise<BaseResponse<Skill>>
 }
 
 export async function deleteSkill(skillId: string): Promise<BaseResponse<{ id: string }>> {
-  return http.delete<{ id: string }>(`/api/skills/${encodeURIComponent(skillId)}`) as Promise<BaseResponse<{ id: string }>>
+  return http.delete<{ id: string }>(`/api/skills/${encodeURIComponent(skillId)}`) as Promise<
+    BaseResponse<{ id: string }>
+  >
 }
 
 export async function listVoiceModels(
   service: 'omni' | 'llm' | 'asr' | 'tts',
   baseUrl?: string,
   token?: string,
-  llmSettingId?: string,
+  llmSettingId?: string
 ) {
   return _listVoiceModels(service, baseUrl, token, llmSettingId)
 }
@@ -323,7 +353,7 @@ export async function testVoiceConnection(
   service: 'omni' | 'llm' | 'asr' | 'tts',
   baseUrl?: string,
   token?: string,
-  llmSettingId?: string,
+  llmSettingId?: string
 ) {
   return _testVoiceConnection(service, baseUrl, token, llmSettingId)
 }
@@ -340,21 +370,22 @@ export async function getOrchestrationTemplates(all = false) {
   return _getOrchestrationTemplates(all)
 }
 
-export async function getVoiceUiRulesAsset(createTemplate = false): Promise<BaseResponse<VoiceUiRulesAsset>> {
+export async function getVoiceUiRulesAsset(
+  createTemplate = false
+): Promise<BaseResponse<VoiceUiRulesAsset>> {
   return http.get<VoiceUiRulesAsset>('/api/voice-agent/ui-rules', {
-    params: { create: createTemplate ? '1' : undefined },
+    params: { create: createTemplate ? '1' : undefined }
   }) as Promise<BaseResponse<VoiceUiRulesAsset>>
 }
 
-export async function updateVoiceUiRulesAsset(request: UpdateVoiceUiRulesAssetRequest): Promise<BaseResponse<VoiceUiRulesAsset>> {
-  return http.put<VoiceUiRulesAsset>('/api/voice-agent/ui-rules', request) as Promise<BaseResponse<VoiceUiRulesAsset>>
+export async function updateVoiceUiRulesAsset(
+  request: UpdateVoiceUiRulesAssetRequest
+): Promise<BaseResponse<VoiceUiRulesAsset>> {
+  return http.put<VoiceUiRulesAsset>('/api/voice-agent/ui-rules', request) as Promise<
+    BaseResponse<VoiceUiRulesAsset>
+  >
 }
-export {
-  listMemories,
-  getMemoryStats,
-  createMemory,
-  deleteMemory,
-} from '../services/memory-api'
+export { listMemories, getMemoryStats, createMemory, deleteMemory } from '../services/memory-api'
 
 /**
  * Agent Settings API facade
@@ -385,7 +416,7 @@ export const agentSettingsApi = {
   async listProjects(params?: AgentProjectListParams): Promise<AgentProject[]> {
     const raw = await listProjects(params)
     const data = asAgentRecord(getAgentDataPayload(raw))
-    return getAgentArray(data.projects).map((project) => normalizeProject(project))
+    return getAgentArray(data.projects).map(project => normalizeProject(project))
   },
 
   /**
@@ -395,7 +426,7 @@ export const agentSettingsApi = {
   async updateProject(projectId: string, data: Partial<AgentProject>): Promise<AgentProject> {
     const raw = await updateProject(projectId, {
       name: data.name,
-      description: data.description,
+      description: data.description
     })
     return normalizeProject(getAgentDataPayload(raw))
   },
@@ -407,12 +438,12 @@ export const agentSettingsApi = {
   async listStorages(projectId: string): Promise<AgentStorageInfo[]> {
     const raw = await listProjectStorages(projectId)
     const data = asAgentRecord(getAgentDataPayload(raw))
-    return getAgentArray(data.storages).map((storage) => {
+    return getAgentArray(data.storages).map(storage => {
       const record = asAgentRecord(storage)
       return {
         id: getAgentString(record.id),
         name: getAgentString(record.name),
-        type: getAgentString(record.storage_type),
+        type: getAgentString(record.storage_type)
       }
     })
   },
@@ -437,7 +468,7 @@ export const agentSettingsApi = {
     service: 'omni' | 'llm' | 'asr' | 'tts',
     baseUrl?: string,
     token?: string,
-    llmSettingId?: string,
+    llmSettingId?: string
   ) {
     return listVoiceModels(service, baseUrl, token, llmSettingId)
   },
@@ -446,7 +477,7 @@ export const agentSettingsApi = {
     service: 'omni' | 'llm' | 'asr' | 'tts',
     baseUrl?: string,
     token?: string,
-    llmSettingId?: string,
+    llmSettingId?: string
   ) {
     return testVoiceConnection(service, baseUrl, token, llmSettingId)
   },
@@ -477,6 +508,17 @@ export const agentSettingsApi = {
 
   async createProvider(data: import('../types/orchestration-v2.types').CreateProviderRequest) {
     return _createProvider(data)
+  },
+
+  async updateProvider(
+    providerId: string,
+    data: import('../types/orchestration-v2.types').UpdateProviderRequest
+  ) {
+    return _updateProvider(providerId, data)
+  },
+
+  async deleteProvider(providerId: string, options: { cascade?: boolean } = {}) {
+    return _deleteProvider(providerId, options)
   },
 
   /**
@@ -642,5 +684,5 @@ export const agentSettingsApi = {
    */
   async deleteMemory(memoryId: number, userId?: string) {
     return _deleteMemory(memoryId, userId)
-  },
+  }
 }

--- a/agent-ui/src/api/services/llm-settings-api.ts
+++ b/agent-ui/src/api/services/llm-settings-api.ts
@@ -8,9 +8,7 @@
  */
 
 import { http } from '../clients/http-client'
-import type {
-  BaseResponse
-} from '../types/common.types'
+import type { BaseResponse } from '../types/common.types'
 
 // ============================================================================
 // 类型定义
@@ -26,7 +24,14 @@ export interface LLMSetting {
   endpoint_id?: string
   endpoint_name?: string
   plan_type: 'api_billing' | 'token_plan' | 'coding_plan' | 'agent_plan' | 'subscription' | 'custom'
-  protocol: 'openai_compatible' | 'anthropic_compatible' | 'dashscope_native' | 'volcengine_doubao_voice' | 'volcengine_ark_voice' | 'volcengine_openspeech' | 'custom'
+  protocol:
+    | 'openai_compatible'
+    | 'anthropic_compatible'
+    | 'dashscope_native'
+    | 'volcengine_doubao_voice'
+    | 'volcengine_ark_voice'
+    | 'volcengine_openspeech'
+    | 'custom'
   auth_type?: 'bearer' | 'api-key' | 'x-api-key' | 'subscription-key' | 'custom'
   key_hint?: string
   base_url?: string
@@ -103,7 +108,6 @@ export interface CreateLLMSettingsRequest {
 }
 
 export interface UpdateLLMSettingsRequest {
-  provider_id?: string
   model_name?: string
   models?: string[]
   display_name?: string
@@ -145,25 +149,33 @@ export interface UpdateLLMSettingsRequest {
 /**
  * 获取所有模型配置
  */
-export async function listLLMSettings(providerId?: string): Promise<BaseResponse<LLMSettingsListResponse>> {
-  const url = providerId
-    ? `/api/llm/settings?provider_id=${providerId}`
-    : '/api/llm/settings'
-  return http.get<BaseResponse<LLMSettingsListResponse>>(url) as unknown as Promise<BaseResponse<LLMSettingsListResponse>>
+export async function listLLMSettings(
+  providerId?: string
+): Promise<BaseResponse<LLMSettingsListResponse>> {
+  const url = providerId ? `/api/llm/settings?provider_id=${providerId}` : '/api/llm/settings'
+  return http.get<BaseResponse<LLMSettingsListResponse>>(url) as unknown as Promise<
+    BaseResponse<LLMSettingsListResponse>
+  >
 }
 
 /**
  * 获取单个模型配置详情
  */
 export async function getLLMSetting(settingId: string): Promise<BaseResponse<LLMSetting>> {
-  return http.get<BaseResponse<LLMSetting>>(`/api/llm/settings/${settingId}`) as unknown as Promise<BaseResponse<LLMSetting>>
+  return http.get<BaseResponse<LLMSetting>>(`/api/llm/settings/${settingId}`) as unknown as Promise<
+    BaseResponse<LLMSetting>
+  >
 }
 
 /**
  * 创建模型配置
  */
-export async function createLLMSetting(data: CreateLLMSettingsRequest): Promise<BaseResponse<LLMSetting>> {
-  return http.post<BaseResponse<LLMSetting>>('/api/llm/settings', data) as unknown as Promise<BaseResponse<LLMSetting>>
+export async function createLLMSetting(
+  data: CreateLLMSettingsRequest
+): Promise<BaseResponse<LLMSetting>> {
+  return http.post<BaseResponse<LLMSetting>>('/api/llm/settings', data) as unknown as Promise<
+    BaseResponse<LLMSetting>
+  >
 }
 
 /**
@@ -173,14 +185,19 @@ export async function updateLLMSetting(
   settingId: string,
   data: UpdateLLMSettingsRequest
 ): Promise<BaseResponse<LLMSetting>> {
-  return http.put<BaseResponse<LLMSetting>>(`/api/llm/settings/${settingId}`, data) as unknown as Promise<BaseResponse<LLMSetting>>
+  return http.put<BaseResponse<LLMSetting>>(
+    `/api/llm/settings/${settingId}`,
+    data
+  ) as unknown as Promise<BaseResponse<LLMSetting>>
 }
 
 /**
  * 删除模型配置
  */
 export async function deleteLLMSetting(settingId: string): Promise<BaseResponse<{ id: string }>> {
-  return http.delete<BaseResponse<{ id: string }>>(`/api/llm/settings/${settingId}`) as unknown as Promise<BaseResponse<{ id: string }>>
+  return http.delete<BaseResponse<{ id: string }>>(
+    `/api/llm/settings/${settingId}`
+  ) as unknown as Promise<BaseResponse<{ id: string }>>
 }
 
 // ============================================================================

--- a/agent-ui/src/api/services/llm-settings-api.ts
+++ b/agent-ui/src/api/services/llm-settings-api.ts
@@ -96,7 +96,8 @@ export interface CreateLLMSettingsRequest {
   tts_voice?: string
   tts_format?: string
   tts_sample_rate?: number
-  api_key: string
+  api_key?: string
+  reuse_existing_api_key?: boolean
   is_default?: boolean
   is_active?: boolean
   supports_llm?: boolean

--- a/agent-ui/src/api/services/providers-api.ts
+++ b/agent-ui/src/api/services/providers-api.ts
@@ -7,9 +7,7 @@
  */
 
 import { http } from '../clients/http-client'
-import type {
-  BaseResponse
-} from '../types/common.types'
+import type { BaseResponse } from '../types/common.types'
 import type {
   Provider,
   ProviderListResponse,
@@ -27,7 +25,9 @@ import type {
  * 获取所有供应商
  */
 export async function listProviders(): Promise<BaseResponse<ProviderListResponse>> {
-  return http.get<ProviderListResponse>('/api/llm/providers') as Promise<BaseResponse<ProviderListResponse>>
+  return http.get<ProviderListResponse>('/api/llm/providers') as Promise<
+    BaseResponse<ProviderListResponse>
+  >
 }
 
 /**
@@ -51,14 +51,22 @@ export async function updateProvider(
   providerId: string,
   data: UpdateProviderRequest
 ): Promise<BaseResponse<Provider>> {
-  return http.put<Provider>(`/api/llm/providers/${providerId}`, data) as Promise<BaseResponse<Provider>>
+  return http.put<Provider>(`/api/llm/providers/${providerId}`, data) as Promise<
+    BaseResponse<Provider>
+  >
 }
 
 /**
  * 删除供应商
  */
-export async function deleteProvider(providerId: string): Promise<BaseResponse<{ id: string }>> {
-  return http.delete<{ id: string }>(`/api/llm/providers/${providerId}`) as Promise<BaseResponse<{ id: string }>>
+export async function deleteProvider(
+  providerId: string,
+  options: { cascade?: boolean } = {}
+): Promise<BaseResponse<{ id: string; cascade: boolean }>> {
+  const query = options.cascade ? '?cascade=true' : ''
+  return http.delete<{ id: string; cascade: boolean }>(
+    `/api/llm/providers/${providerId}${query}`
+  ) as Promise<BaseResponse<{ id: string; cascade: boolean }>>
 }
 
 // ============================================================================
@@ -68,20 +76,27 @@ export async function deleteProvider(providerId: string): Promise<BaseResponse<{
 /**
  * 获取供应商的可用模型列表（从 catalog 预设）
  */
-export async function getProviderModels(providerId: string): Promise<BaseResponse<ProviderModelsResponse>> {
-  return http.get<ProviderModelsResponse>(`/api/llm/providers/${providerId}/models`) as Promise<BaseResponse<ProviderModelsResponse>>
+export async function getProviderModels(
+  providerId: string
+): Promise<BaseResponse<ProviderModelsResponse>> {
+  return http.get<ProviderModelsResponse>(`/api/llm/providers/${providerId}/models`) as Promise<
+    BaseResponse<ProviderModelsResponse>
+  >
 }
 
 /**
  * 动态探测供应商可用模型（后端代理调 /v1/models）
  * 用户填入 API Key 后调用，返回实际可用的模型 ID 列表。
  */
-export async function probeModels(baseUrl: string, apiKey: string): Promise<{ models: string[]; error?: string }> {
+export async function probeModels(
+  baseUrl: string,
+  apiKey: string
+): Promise<{ models: string[]; error?: string }> {
   const res = await http.post<any>('/api/llm/models/probe', { base_url: baseUrl, api_key: apiKey })
   const data = res.data ?? res
   return {
     models: Array.isArray(data?.models) ? data.models : [],
-    error: typeof data?.error === 'string' ? data.error : undefined,
+    error: typeof data?.error === 'string' ? data.error : undefined
   }
 }
 
@@ -89,7 +104,9 @@ export async function probeModels(baseUrl: string, apiKey: string): Promise<{ mo
  * 获取常见供应商的常用模型列表（静态 fallback）
  */
 export async function getCommonModels(): Promise<BaseResponse<CommonModelsResponse>> {
-  return http.get<CommonModelsResponse>('/api/llm/models/common') as Promise<BaseResponse<CommonModelsResponse>>
+  return http.get<CommonModelsResponse>('/api/llm/models/common') as Promise<
+    BaseResponse<CommonModelsResponse>
+  >
 }
 
 // Export API object

--- a/agent-ui/src/api/types/orchestration-v2.types.ts
+++ b/agent-ui/src/api/types/orchestration-v2.types.ts
@@ -196,17 +196,41 @@ export interface Provider {
   chat_completions_base_url?: string
   responses_base_url?: string
   anthropic_base_url?: string
+  voice_adapter?: ProviderEndpointPreset['voice_adapter']
+  tts_http_url?: string
+  tts_realtime_url?: string
+  asr_realtime_url?: string
+  asr_async_url?: string
   docs_url?: string
   source?: 'builtin' | 'custom'
   readonly?: boolean
+  supports_llm?: boolean
+  supports_asr?: boolean
+  supports_tts?: boolean
+  supports_audio_input?: boolean
+  supports_image_input?: boolean
+  supports_video_input?: boolean
   endpoints?: ProviderEndpointPreset[]
   is_active?: boolean
   created_at?: string
   updated_at?: string
 }
 
-export type ProviderPlanType = 'api_billing' | 'token_plan' | 'coding_plan' | 'agent_plan' | 'subscription' | 'custom'
-export type ProviderProtocol = 'openai_compatible' | 'anthropic_compatible' | 'dashscope_native' | 'volcengine_doubao_voice' | 'volcengine_ark_voice' | 'volcengine_openspeech' | 'custom'
+export type ProviderPlanType =
+  | 'api_billing'
+  | 'token_plan'
+  | 'coding_plan'
+  | 'agent_plan'
+  | 'subscription'
+  | 'custom'
+export type ProviderProtocol =
+  | 'openai_compatible'
+  | 'anthropic_compatible'
+  | 'dashscope_native'
+  | 'volcengine_doubao_voice'
+  | 'volcengine_ark_voice'
+  | 'volcengine_openspeech'
+  | 'custom'
 export type ProviderAuthType = 'bearer' | 'api-key' | 'x-api-key' | 'subscription-key' | 'custom'
 
 export interface ProviderModelPreset {
@@ -235,7 +259,13 @@ export interface ProviderEndpointPreset {
   responses_base_url?: string
   anthropic_base_url?: string
   resource_id?: string
-  voice_adapter?: 'openai_audio' | 'mimo_audio' | 'volcengine_doubao_voice' | 'volcengine_ark_voice' | 'volcengine_openspeech' | 'custom'
+  voice_adapter?:
+    | 'openai_audio'
+    | 'mimo_audio'
+    | 'volcengine_doubao_voice'
+    | 'volcengine_ark_voice'
+    | 'volcengine_openspeech'
+    | 'custom'
   tts_http_url?: string
   tts_realtime_url?: string
   tts_bidirectional_url?: string
@@ -270,6 +300,11 @@ export interface CreateProviderRequest {
   chat_completions_base_url?: string
   responses_base_url?: string
   anthropic_base_url?: string
+  voice_adapter?: ProviderEndpointPreset['voice_adapter']
+  tts_http_url?: string
+  tts_realtime_url?: string
+  asr_realtime_url?: string
+  asr_async_url?: string
   status?: 'active' | 'paused'
   supports_llm?: boolean
   supports_asr?: boolean
@@ -287,6 +322,11 @@ export interface UpdateProviderRequest {
   chat_completions_base_url?: string
   responses_base_url?: string
   anthropic_base_url?: string
+  voice_adapter?: ProviderEndpointPreset['voice_adapter']
+  tts_http_url?: string
+  tts_realtime_url?: string
+  asr_realtime_url?: string
+  asr_async_url?: string
   status?: 'active' | 'paused'
   supports_llm?: boolean
   supports_asr?: boolean

--- a/agent-ui/src/components/agent/onboarding/OnboardingStepForm.vue
+++ b/agent-ui/src/components/agent/onboarding/OnboardingStepForm.vue
@@ -215,9 +215,7 @@ function selectCredential(key: string): void {
 }
 
 // ── 自定义 / 本地部署表单状态 ─────────────────────────────────
-// 本地部署（如 vLLM）后端统一用 base_url 拼接 /v1/audio/transcriptions（ASR）
-// 和 /v1/audio/speech（TTS），所以三个能力都填 base_url + model，
-// 不需要分别填 realtime/http URL。
+// 本地 OpenAI Audio 服务从 /v1 Base URL 派生标准 HTTP/WS 端点并持久化。
 interface CustomFields {
   baseUrl: string  // vLLM OpenAI 兼容接入地址（不含 /v1）
   model: string
@@ -229,6 +227,16 @@ const customFields = ref<CustomFields>({
   model: '',
   voice: '',
 })
+
+function voiceApiBase(value: string): string {
+  const normalized = value.trim().replace(/\/+$/, '')
+  if (!normalized) return ''
+  return normalized.endsWith('/v1') ? normalized : `${normalized}/v1`
+}
+
+function voiceEndpoint(baseUrl: string, path: string): string {
+  return `${baseUrl}/${path.replace(/^\/+/, '')}`
+}
 
 // 自定义凭证的元信息
 const customProviderId = computed(() => `local-${props.capability.replace('supports_', '')}`)
@@ -376,10 +384,10 @@ async function submitCustom(): Promise<LLMSetting | undefined> {
   const pname = customProviderName.value
   const model = f.model.trim()
   const displayName = `${pname} · ${model}`
-  const baseUrl = f.baseUrl.trim()
+  const rawBaseUrl = f.baseUrl.trim()
+  const baseUrl = props.capability === 'supports_llm' ? rawBaseUrl : voiceApiBase(rawBaseUrl)
 
-  // 本地 vLLM 部署：后端用 base_url 拼接 /v1/audio/transcriptions（ASR）
-  // 和 /v1/audio/speech（TTS），protocol 对 ASR/TTS 无实质影响，统一用 openai_compatible。
+  // 本地语音服务使用 OpenAI Audio 兼容协议，并保存可覆盖的标准 HTTP/WS 端点。
   const protocol: ProviderProtocol = 'openai_compatible'
 
   const caps = {
@@ -404,7 +412,21 @@ async function submitCustom(): Promise<LLMSetting | undefined> {
     base_url: baseUrl,
     // LLM 同时填 chat_completions_base_url；ASR/TTS 后端只用 base_url
     chat_completions_base_url: props.capability === 'supports_llm' ? baseUrl : undefined,
-    voice_adapter: 'custom',
+    voice_adapter: props.capability === 'supports_llm' ? 'custom' : 'openai_audio',
+    ...(props.capability === 'supports_tts'
+      ? {
+          tts_http_url: voiceEndpoint(baseUrl, 'audio/speech'),
+          tts_realtime_url: voiceEndpoint(baseUrl, 'audio/speech/stream'),
+        }
+      : {}),
+    ...(props.capability === 'supports_asr'
+      ? {
+          asr_async_url: voiceEndpoint(baseUrl, 'audio/transcriptions'),
+          asr_realtime_url: voiceEndpoint(baseUrl, 'realtime')
+            .replace(/^http:/, 'ws:')
+            .replace(/^https:/, 'wss:'),
+        }
+      : {}),
     // TTS 音色（后端 TTS payload 会带上）
     ...(props.capability === 'supports_tts' && f.voice.trim() ? { tts_voice: f.voice.trim() } : {}),
     // 本地服务通常无需 Key，留空则传占位（api_key 字段后端必填）

--- a/agent-ui/src/components/agent/settings/CustomProviderManager.vue
+++ b/agent-ui/src/components/agent/settings/CustomProviderManager.vue
@@ -1,0 +1,488 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { Bot, Loader2, Mic, Plus, Trash2, Volume2 } from 'lucide-vue-next'
+import { useI18n } from 'vue-i18n'
+import { agentSettingsApi } from '@/api/agent'
+import type { LLMSetting } from '@/api/services/llm-settings-api'
+import type { Provider } from '@/api/types/orchestration-v2.types'
+import { useToast } from '@/components/controls/useToast'
+import CapabilityToggle from './CapabilityToggle.vue'
+import InlineDeleteConfirm from './InlineDeleteConfirm.vue'
+import type { ModelPurpose } from './ModelForm.vue'
+
+const props = defineProps<{
+  providers: Provider[]
+  settings: LLMSetting[]
+}>()
+
+const emit = defineEmits<{
+  refresh: []
+  notice: [message: string]
+  addModel: [purpose: ModelPurpose, providerId: string]
+}>()
+
+const { t } = useI18n()
+const { showToast } = useToast()
+const selectedId = ref('')
+const creating = ref(false)
+const createRequested = ref(false)
+const saving = ref(false)
+const providerId = ref('')
+const providerName = ref('')
+const defaultModel = ref('')
+const baseUrl = ref('')
+const chatCompletionsBaseUrl = ref('')
+const responsesBaseUrl = ref('')
+const anthropicBaseUrl = ref('')
+const ttsHttpUrl = ref('')
+const ttsStreamingUrl = ref('')
+const asrHttpUrl = ref('')
+const asrRealtimeUrl = ref('')
+const supportsLlm = ref(true)
+const supportsAsr = ref(false)
+const supportsTts = ref(false)
+const deleteConfirmOpen = ref(false)
+
+const customProviders = computed(() =>
+  props.providers.filter(provider => provider.source === 'custom')
+)
+const selectedProvider = computed(
+  () => customProviders.value.find(provider => provider.id === selectedId.value) ?? null
+)
+const referencedSettings = computed(() =>
+  props.settings.filter(setting => setting.provider_id === selectedId.value)
+)
+const referenceCount = computed(() => referencedSettings.value.length)
+const referencedModelNames = computed(() =>
+  referencedSettings.value.map(setting => setting.display_name || setting.model_name).join(', ')
+)
+
+function voiceApiBase(value: string): string {
+  const normalized = value.trim().replace(/\/+$/, '')
+  if (!normalized) return ''
+  return normalized.endsWith('/v1') ? normalized : `${normalized}/v1`
+}
+
+function voiceEndpoint(path: string): string {
+  const base = voiceApiBase(baseUrl.value)
+  return base ? `${base}/${path.replace(/^\/+/, '')}` : ''
+}
+
+function realtimeWsEndpoint(): string {
+  return voiceEndpoint('realtime')
+    .replace(/^http:/, 'ws:')
+    .replace(/^https:/, 'wss:')
+}
+
+const defaultTtsHttpUrl = computed(() => voiceEndpoint('audio/speech'))
+const defaultTtsStreamingUrl = computed(() => voiceEndpoint('audio/speech/stream'))
+const defaultAsrHttpUrl = computed(() => voiceEndpoint('audio/transcriptions'))
+const defaultAsrRealtimeUrl = computed(realtimeWsEndpoint)
+
+function normalizeVoiceBaseUrl(): void {
+  if (!supportsLlm.value && (supportsAsr.value || supportsTts.value)) {
+    baseUrl.value = voiceApiBase(baseUrl.value)
+  }
+}
+
+function loadProvider(provider: Provider): void {
+  deleteConfirmOpen.value = false
+  creating.value = false
+  createRequested.value = false
+  selectedId.value = provider.id
+  providerId.value = provider.id
+  providerName.value = provider.name
+  defaultModel.value = provider.default_model ?? ''
+  baseUrl.value = provider.base_url ?? ''
+  chatCompletionsBaseUrl.value = provider.chat_completions_base_url ?? ''
+  responsesBaseUrl.value = provider.responses_base_url ?? ''
+  anthropicBaseUrl.value = provider.anthropic_base_url ?? ''
+  const endpoint = provider.endpoints?.[0]
+  ttsHttpUrl.value = provider.tts_http_url ?? endpoint?.tts_http_url ?? ''
+  ttsStreamingUrl.value = provider.tts_realtime_url ?? endpoint?.tts_realtime_url ?? ''
+  asrHttpUrl.value = provider.asr_async_url ?? endpoint?.asr_async_url ?? ''
+  asrRealtimeUrl.value = provider.asr_realtime_url ?? endpoint?.asr_realtime_url ?? ''
+  const configuredModels = props.settings.filter(setting => setting.provider_id === provider.id)
+  supportsLlm.value = configuredModels.length
+    ? configuredModels.some(setting => setting.supports_llm)
+    : provider.supports_llm !== false
+  supportsAsr.value = configuredModels.length
+    ? configuredModels.some(setting => setting.supports_asr)
+    : Boolean(provider.supports_asr)
+  supportsTts.value = configuredModels.length
+    ? configuredModels.some(setting => setting.supports_tts)
+    : Boolean(provider.supports_tts)
+}
+
+function startCreate(): void {
+  deleteConfirmOpen.value = false
+  creating.value = true
+  createRequested.value = true
+  selectedId.value = ''
+  providerId.value = ''
+  providerName.value = ''
+  defaultModel.value = ''
+  baseUrl.value = ''
+  chatCompletionsBaseUrl.value = ''
+  responsesBaseUrl.value = ''
+  anthropicBaseUrl.value = ''
+  ttsHttpUrl.value = ''
+  ttsStreamingUrl.value = ''
+  asrHttpUrl.value = ''
+  asrRealtimeUrl.value = ''
+  supportsLlm.value = true
+  supportsAsr.value = false
+  supportsTts.value = false
+}
+
+watch(
+  [customProviders, () => props.settings],
+  ([providers]) => {
+    if (createRequested.value) return
+    const selected = providers.find(provider => provider.id === selectedId.value) ?? providers[0]
+    if (selected) loadProvider(selected)
+    else creating.value = true
+  },
+  { immediate: true }
+)
+
+const canSave = computed(() =>
+  Boolean(
+    providerId.value.trim() &&
+    providerName.value.trim() &&
+    defaultModel.value.trim() &&
+    baseUrl.value.trim() &&
+    (supportsLlm.value || supportsAsr.value || supportsTts.value)
+  )
+)
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+async function save(): Promise<void> {
+  if (!canSave.value || saving.value) return
+  saving.value = true
+  const id = providerId.value.trim()
+  normalizeVoiceBaseUrl()
+  const payload = {
+    name: providerName.value.trim(),
+    default_model: defaultModel.value.trim(),
+    base_url: baseUrl.value.trim(),
+    chat_completions_base_url: chatCompletionsBaseUrl.value.trim() || undefined,
+    responses_base_url: responsesBaseUrl.value.trim() || undefined,
+    anthropic_base_url: anthropicBaseUrl.value.trim() || undefined,
+    voice_adapter:
+      supportsAsr.value || supportsTts.value ? ('openai_audio' as const) : ('custom' as const),
+    tts_http_url: supportsTts.value ? ttsHttpUrl.value.trim() || defaultTtsHttpUrl.value : '',
+    tts_realtime_url: supportsTts.value
+      ? ttsStreamingUrl.value.trim() || defaultTtsStreamingUrl.value
+      : '',
+    asr_async_url: supportsAsr.value ? asrHttpUrl.value.trim() || defaultAsrHttpUrl.value : '',
+    asr_realtime_url: supportsAsr.value
+      ? asrRealtimeUrl.value.trim() || defaultAsrRealtimeUrl.value
+      : '',
+    status: 'active' as const,
+    supports_llm: supportsLlm.value,
+    supports_asr: supportsAsr.value,
+    supports_tts: supportsTts.value,
+    supports_audio_input: supportsAsr.value,
+    supports_image_input: false,
+    supports_video_input: false
+  }
+  try {
+    if (creating.value) await agentSettingsApi.createProvider({ id, ...payload })
+    else await agentSettingsApi.updateProvider(id, payload)
+    creating.value = false
+    createRequested.value = false
+    selectedId.value = id
+    emit('refresh')
+    emit('notice', t('settings.models.providers.saved'))
+  } catch (error) {
+    showToast(messageOf(error), 'error', 6000)
+  } finally {
+    saving.value = false
+  }
+}
+
+const deleteConfirmMessage = computed(() => {
+  const provider = selectedProvider.value
+  if (!provider) return ''
+  return referenceCount.value > 0
+    ? t('settings.models.providers.deleteCascadeConfirm', {
+        name: provider.name,
+        count: referenceCount.value,
+        models: referencedModelNames.value
+      })
+    : t('settings.models.providers.deleteConfirm', { name: provider.name })
+})
+
+function toggleDeleteConfirm(): void {
+  if (saving.value) return
+  deleteConfirmOpen.value = !deleteConfirmOpen.value
+}
+
+async function confirmRemove(): Promise<void> {
+  const provider = selectedProvider.value
+  if (!provider || saving.value) return
+  const cascade = referenceCount.value > 0
+  saving.value = true
+  try {
+    await agentSettingsApi.deleteProvider(provider.id, { cascade })
+    deleteConfirmOpen.value = false
+    selectedId.value = ''
+    createRequested.value = false
+    emit('refresh')
+    emit('notice', t('settings.models.providers.deleted'))
+  } catch (error) {
+    showToast(messageOf(error), 'error', 6000)
+  } finally {
+    saving.value = false
+  }
+}
+
+const addOptions = [
+  { purpose: 'llm' as const, icon: Bot },
+  { purpose: 'asr' as const, icon: Mic },
+  { purpose: 'tts' as const, icon: Volume2 }
+]
+</script>
+
+<template>
+  <section class="rounded-lg border border-white/10 bg-[#252525]">
+    <header
+      class="flex flex-wrap items-center justify-between gap-3 border-b border-white/10 px-4 py-3"
+    >
+      <div>
+        <h2 class="font-semibold">{{ t('settings.models.providers.title') }}</h2>
+        <p class="mt-1 text-xs text-gray-500">{{ t('settings.models.providers.subtitle') }}</p>
+      </div>
+      <button
+        type="button"
+        class="inline-flex items-center gap-2 rounded-md border border-white/12 px-3 py-2 text-sm text-gray-200 hover:bg-white/5"
+        @click="startCreate"
+      >
+        <Plus class="h-4 w-4" />
+        {{ t('settings.models.providers.add') }}
+      </button>
+    </header>
+
+    <div class="grid min-h-80 md:grid-cols-[220px_minmax(0,1fr)]">
+      <nav
+        class="border-b border-white/10 p-2 md:border-b-0 md:border-r"
+        :aria-label="t('settings.models.providers.title')"
+      >
+        <button
+          v-for="provider in customProviders"
+          :key="provider.id"
+          type="button"
+          class="flex w-full items-center justify-between gap-2 rounded px-3 py-2.5 text-left text-sm"
+          :class="
+            selectedId === provider.id && !creating
+              ? 'bg-cyan-300/10 text-cyan-50'
+              : 'text-gray-400 hover:bg-white/5 hover:text-gray-200'
+          "
+          @click="loadProvider(provider)"
+        >
+          <span class="truncate">{{ provider.name }}</span>
+          <span class="text-[10px] text-gray-600">{{
+            settings.filter(setting => setting.provider_id === provider.id).length
+          }}</span>
+        </button>
+        <div v-if="!customProviders.length" class="px-3 py-6 text-center text-xs text-gray-600">
+          {{ t('settings.models.providers.empty') }}
+        </div>
+      </nav>
+
+      <form class="space-y-4 p-4" @submit.prevent="save">
+        <div class="grid gap-3 sm:grid-cols-2">
+          <label class="space-y-1">
+            <span class="text-xs text-gray-500">Provider ID</span>
+            <input
+              v-model="providerId"
+              :disabled="!creating"
+              class="h-10 w-full rounded-md border border-white/10 bg-[#343434] px-3 text-sm outline-none disabled:text-gray-500"
+              placeholder="custom-openai"
+            />
+          </label>
+          <label class="space-y-1">
+            <span class="text-xs text-gray-500">{{ t('settings.models.form.displayName') }}</span>
+            <input
+              v-model="providerName"
+              class="h-10 w-full rounded-md border border-white/10 bg-[#343434] px-3 text-sm outline-none focus:border-cyan-400/40"
+            />
+          </label>
+        </div>
+        <div class="grid gap-3 sm:grid-cols-2">
+          <label class="space-y-1">
+            <span class="text-xs text-gray-500">Base URL</span>
+            <input
+              v-model="baseUrl"
+              class="h-10 w-full rounded-md border border-white/10 bg-[#343434] px-3 text-sm outline-none focus:border-cyan-400/40"
+              placeholder="https://api.example.com/v1"
+              @blur="normalizeVoiceBaseUrl"
+            />
+          </label>
+          <label class="space-y-1">
+            <span class="text-xs text-gray-500">{{
+              t('settings.models.providers.defaultModel')
+            }}</span>
+            <input
+              v-model="defaultModel"
+              class="h-10 w-full rounded-md border border-white/10 bg-[#343434] px-3 text-sm outline-none focus:border-cyan-400/40"
+            />
+          </label>
+        </div>
+        <details v-if="supportsLlm" class="border-t border-white/8 pt-3">
+          <summary class="cursor-pointer text-xs text-gray-500">
+            {{ t('settings.models.providers.protocolUrls') }}
+          </summary>
+          <div class="mt-3 grid gap-3">
+            <input
+              v-model="chatCompletionsBaseUrl"
+              class="h-9 rounded-md border border-white/10 bg-[#343434] px-3 text-xs"
+              placeholder="Chat Completions URL"
+            />
+            <input
+              v-model="responsesBaseUrl"
+              class="h-9 rounded-md border border-white/10 bg-[#343434] px-3 text-xs"
+              placeholder="Responses URL"
+            />
+            <input
+              v-model="anthropicBaseUrl"
+              class="h-9 rounded-md border border-white/10 bg-[#343434] px-3 text-xs"
+              placeholder="Anthropic URL"
+            />
+          </div>
+        </details>
+        <div v-if="supportsTts || supportsAsr" class="space-y-3 border-t border-white/8 pt-4">
+          <div class="text-xs text-gray-500">
+            {{ t('settings.models.providers.voiceEndpoints') }}
+          </div>
+          <div v-if="supportsTts" class="grid gap-3 sm:grid-cols-2">
+            <label class="space-y-1">
+              <span class="text-xs text-gray-500">{{
+                t('settings.models.providers.ttsHttp')
+              }}</span>
+              <input
+                v-model="ttsHttpUrl"
+                data-testid="provider-tts-http-url"
+                class="h-9 w-full rounded-md border border-white/10 bg-[#343434] px-3 font-mono text-xs outline-none focus:border-cyan-400/40"
+                :placeholder="defaultTtsHttpUrl"
+              />
+            </label>
+            <label class="space-y-1">
+              <span class="text-xs text-gray-500">{{
+                t('settings.models.providers.ttsStreamingHttp')
+              }}</span>
+              <input
+                v-model="ttsStreamingUrl"
+                data-testid="provider-tts-streaming-url"
+                class="h-9 w-full rounded-md border border-white/10 bg-[#343434] px-3 font-mono text-xs outline-none focus:border-cyan-400/40"
+                :placeholder="defaultTtsStreamingUrl"
+              />
+            </label>
+          </div>
+          <div v-if="supportsAsr" class="grid gap-3 sm:grid-cols-2">
+            <label class="space-y-1">
+              <span class="text-xs text-gray-500">{{
+                t('settings.models.providers.asrHttp')
+              }}</span>
+              <input
+                v-model="asrHttpUrl"
+                data-testid="provider-asr-http-url"
+                class="h-9 w-full rounded-md border border-white/10 bg-[#343434] px-3 font-mono text-xs outline-none focus:border-cyan-400/40"
+                :placeholder="defaultAsrHttpUrl"
+              />
+            </label>
+            <label class="space-y-1">
+              <span class="text-xs text-gray-500">{{
+                t('settings.models.providers.asrRealtimeWs')
+              }}</span>
+              <input
+                v-model="asrRealtimeUrl"
+                data-testid="provider-asr-realtime-url"
+                class="h-9 w-full rounded-md border border-white/10 bg-[#343434] px-3 font-mono text-xs outline-none focus:border-cyan-400/40"
+                :placeholder="defaultAsrRealtimeUrl"
+              />
+            </label>
+          </div>
+        </div>
+        <div class="space-y-2">
+          <div class="text-xs text-gray-500">{{ t('settings.models.form.capabilities') }}</div>
+          <div class="flex flex-wrap gap-2">
+            <CapabilityToggle capability="llm" v-model="supportsLlm" />
+            <CapabilityToggle capability="asr" v-model="supportsAsr" />
+            <CapabilityToggle capability="tts" v-model="supportsTts" />
+          </div>
+        </div>
+        <div v-if="!creating && selectedProvider" class="space-y-3 border-t border-white/8 pt-4">
+          <div>
+            <div class="text-xs text-gray-500">
+              {{ t('settings.models.providers.references', { count: referenceCount }) }}
+            </div>
+            <div v-if="referenceCount" class="mt-2 flex flex-wrap gap-1.5">
+              <span
+                v-for="setting in referencedSettings"
+                :key="setting.id"
+                class="rounded border border-amber-400/20 bg-amber-400/5 px-2 py-1 text-xs text-amber-200"
+              >
+                {{ setting.display_name || setting.model_name }}
+              </span>
+            </div>
+          </div>
+          <div class="flex flex-wrap justify-end gap-2">
+            <button
+              v-for="option in addOptions"
+              :key="option.purpose"
+              type="button"
+              class="inline-flex h-8 items-center gap-1.5 rounded-md border border-white/10 px-2.5 text-xs text-gray-300 hover:bg-white/5"
+              @click="emit('addModel', option.purpose, selectedProvider.id)"
+            >
+              <component :is="option.icon" class="h-3.5 w-3.5" />
+              {{ option.purpose.toUpperCase() }}
+            </button>
+          </div>
+        </div>
+        <div class="flex flex-wrap items-end justify-between gap-3 pt-2">
+          <div v-if="!creating" class="flex flex-wrap items-end gap-2">
+            <button
+              type="button"
+              data-testid="delete-custom-provider"
+              class="inline-flex items-center gap-2 rounded-md border border-red-500/25 px-3 py-2 text-xs text-red-300 disabled:cursor-not-allowed disabled:opacity-35"
+              :class="deleteConfirmOpen ? 'bg-red-500/10' : ''"
+              :disabled="saving"
+              @click="toggleDeleteConfirm"
+            >
+              <Loader2 v-if="saving" class="h-3.5 w-3.5 animate-spin" />
+              <Trash2 v-else class="h-3.5 w-3.5" />
+              {{
+                referenceCount
+                  ? t('settings.models.providers.deleteCascade', { count: referenceCount })
+                  : t('settings.actions.delete')
+              }}
+            </button>
+            <InlineDeleteConfirm
+              v-if="deleteConfirmOpen"
+              test-id="delete-custom-provider-confirm"
+              :message="deleteConfirmMessage"
+              :loading="saving"
+              class="w-80 max-w-full"
+              @confirm="confirmRemove"
+              @cancel="deleteConfirmOpen = false"
+            />
+          </div>
+          <span v-else />
+          <button
+            type="submit"
+            class="inline-flex items-center gap-2 rounded-md bg-cyan-500 px-4 py-2 text-sm font-medium text-white hover:bg-cyan-400 disabled:opacity-40"
+            :disabled="!canSave || saving"
+          >
+            <Loader2 v-if="saving" class="h-4 w-4 animate-spin" />
+            {{ t('settings.actions.save') }}
+          </button>
+        </div>
+      </form>
+    </div>
+  </section>
+</template>

--- a/agent-ui/src/components/agent/settings/CustomProviderManager.vue
+++ b/agent-ui/src/components/agent/settings/CustomProviderManager.vue
@@ -42,6 +42,7 @@ const supportsLlm = ref(true)
 const supportsAsr = ref(false)
 const supportsTts = ref(false)
 const deleteConfirmOpen = ref(false)
+const loadedDraftSignature = ref('')
 
 const customProviders = computed(() =>
   props.providers.filter(provider => provider.source === 'custom')
@@ -79,6 +80,29 @@ const defaultTtsStreamingUrl = computed(() => voiceEndpoint('audio/speech/stream
 const defaultAsrHttpUrl = computed(() => voiceEndpoint('audio/transcriptions'))
 const defaultAsrRealtimeUrl = computed(realtimeWsEndpoint)
 
+function draftSignature(): string {
+  return JSON.stringify({
+    providerId: providerId.value,
+    providerName: providerName.value,
+    defaultModel: defaultModel.value,
+    baseUrl: baseUrl.value,
+    chatCompletionsBaseUrl: chatCompletionsBaseUrl.value,
+    responsesBaseUrl: responsesBaseUrl.value,
+    anthropicBaseUrl: anthropicBaseUrl.value,
+    ttsHttpUrl: ttsHttpUrl.value,
+    ttsStreamingUrl: ttsStreamingUrl.value,
+    asrHttpUrl: asrHttpUrl.value,
+    asrRealtimeUrl: asrRealtimeUrl.value,
+    supportsLlm: supportsLlm.value,
+    supportsAsr: supportsAsr.value,
+    supportsTts: supportsTts.value
+  })
+}
+
+const isDirty = computed(
+  () => !creating.value && Boolean(loadedDraftSignature.value) && draftSignature() !== loadedDraftSignature.value
+)
+
 function normalizeVoiceBaseUrl(): void {
   if (!supportsLlm.value && (supportsAsr.value || supportsTts.value)) {
     baseUrl.value = voiceApiBase(baseUrl.value)
@@ -112,6 +136,7 @@ function loadProvider(provider: Provider): void {
   supportsTts.value = configuredModels.length
     ? configuredModels.some(setting => setting.supports_tts)
     : Boolean(provider.supports_tts)
+  loadedDraftSignature.value = draftSignature()
 }
 
 function startCreate(): void {
@@ -133,6 +158,7 @@ function startCreate(): void {
   supportsLlm.value = true
   supportsAsr.value = false
   supportsTts.value = false
+  loadedDraftSignature.value = draftSignature()
 }
 
 watch(
@@ -140,8 +166,8 @@ watch(
   ([providers]) => {
     if (createRequested.value) return
     const selected = providers.find(provider => provider.id === selectedId.value) ?? providers[0]
-    if (selected) loadProvider(selected)
-    else creating.value = true
+    if (selected && (selected.id !== selectedId.value || !isDirty.value)) loadProvider(selected)
+    else if (!selected) creating.value = true
   },
   { immediate: true }
 )
@@ -174,14 +200,18 @@ async function save(): Promise<void> {
     anthropic_base_url: anthropicBaseUrl.value.trim() || undefined,
     voice_adapter:
       supportsAsr.value || supportsTts.value ? ('openai_audio' as const) : ('custom' as const),
-    tts_http_url: supportsTts.value ? ttsHttpUrl.value.trim() || defaultTtsHttpUrl.value : '',
+    tts_http_url: supportsTts.value
+      ? ttsHttpUrl.value.trim() || defaultTtsHttpUrl.value
+      : undefined,
     tts_realtime_url: supportsTts.value
       ? ttsStreamingUrl.value.trim() || defaultTtsStreamingUrl.value
-      : '',
-    asr_async_url: supportsAsr.value ? asrHttpUrl.value.trim() || defaultAsrHttpUrl.value : '',
+      : undefined,
+    asr_async_url: supportsAsr.value
+      ? asrHttpUrl.value.trim() || defaultAsrHttpUrl.value
+      : undefined,
     asr_realtime_url: supportsAsr.value
       ? asrRealtimeUrl.value.trim() || defaultAsrRealtimeUrl.value
-      : '',
+      : undefined,
     status: 'active' as const,
     supports_llm: supportsLlm.value,
     supports_asr: supportsAsr.value,
@@ -196,6 +226,7 @@ async function save(): Promise<void> {
     creating.value = false
     createRequested.value = false
     selectedId.value = id
+    loadedDraftSignature.value = draftSignature()
     emit('refresh')
     emit('notice', t('settings.models.providers.saved'))
   } catch (error) {

--- a/agent-ui/src/components/agent/settings/EditModelForm.vue
+++ b/agent-ui/src/components/agent/settings/EditModelForm.vue
@@ -1,0 +1,222 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { Loader2, LockKeyhole } from 'lucide-vue-next'
+import { useI18n } from 'vue-i18n'
+import type { LLMSetting } from '@/api/services/llm-settings-api'
+import CapabilityBadge from './CapabilityBadge.vue'
+import CapabilityToggle from './CapabilityToggle.vue'
+
+export interface EditModelPayload {
+  id: string
+  displayName?: string
+  apiKey?: string
+  isDefault: boolean
+  isActive: boolean
+  supportsAudioInput: boolean
+  supportsImageInput: boolean
+  supportsVideoInput: boolean
+  ttsVoice?: string
+  ttsFormat?: string
+  ttsSampleRate?: number
+}
+
+const props = defineProps<{
+  setting: LLMSetting
+  submitting?: boolean
+}>()
+
+const emit = defineEmits<{
+  submit: [payload: EditModelPayload]
+  cancel: []
+}>()
+
+const { t } = useI18n()
+const displayName = ref('')
+const apiKey = ref('')
+const isDefault = ref(false)
+const isActive = ref(true)
+const supportsAudioInput = ref(false)
+const supportsImageInput = ref(false)
+const supportsVideoInput = ref(false)
+const ttsVoice = ref('')
+const ttsFormat = ref('')
+const ttsSampleRate = ref<number | undefined>()
+
+const primaryCapabilities = computed(() =>
+  [
+    { key: 'llm' as const, active: props.setting.supports_llm },
+    { key: 'asr' as const, active: props.setting.supports_asr },
+    { key: 'tts' as const, active: props.setting.supports_tts }
+  ].filter(item => item.active)
+)
+
+watch(
+  () => props.setting,
+  setting => {
+    displayName.value = setting.display_name ?? ''
+    apiKey.value = ''
+    isDefault.value = setting.is_default
+    isActive.value = setting.is_active
+    supportsAudioInput.value = setting.supports_audio_input
+    supportsImageInput.value = setting.supports_image_input
+    supportsVideoInput.value = setting.supports_video_input
+    ttsVoice.value = setting.tts_voice ?? ''
+    ttsFormat.value = setting.tts_format ?? ''
+    ttsSampleRate.value = setting.tts_sample_rate
+  },
+  { immediate: true }
+)
+
+function optionalText(value: string): string | undefined {
+  return value.trim() || undefined
+}
+
+function submit(): void {
+  emit('submit', {
+    id: props.setting.id,
+    displayName: optionalText(displayName.value),
+    apiKey: optionalText(apiKey.value),
+    isDefault: isDefault.value,
+    isActive: isActive.value,
+    supportsAudioInput: supportsAudioInput.value,
+    supportsImageInput: supportsImageInput.value,
+    supportsVideoInput: supportsVideoInput.value,
+    ttsVoice: optionalText(ttsVoice.value),
+    ttsFormat: optionalText(ttsFormat.value),
+    ttsSampleRate: ttsSampleRate.value
+  })
+}
+</script>
+
+<template>
+  <div class="space-y-5 p-5">
+    <section class="space-y-3 border-b border-white/8 pb-5">
+      <div class="text-xs font-medium text-gray-400">{{ t('settings.models.edit.provider') }}</div>
+      <div
+        class="flex min-h-11 items-center justify-between gap-3 rounded-md border border-white/10 bg-white/[0.025] px-3"
+      >
+        <div class="min-w-0">
+          <div class="truncate text-sm text-gray-100">{{ setting.provider_name }}</div>
+          <div class="truncate text-[11px] text-gray-500">
+            {{ setting.provider_id }} · {{ setting.endpoint_name || setting.endpoint_id }}
+          </div>
+        </div>
+        <span class="inline-flex flex-shrink-0 items-center gap-1 text-xs text-gray-500">
+          <LockKeyhole class="h-3.5 w-3.5" />
+          {{ t('settings.models.readOnly') }}
+        </span>
+      </div>
+    </section>
+
+    <section class="grid gap-3 sm:grid-cols-2">
+      <label class="space-y-1">
+        <span class="text-xs text-gray-500">{{ t('settings.models.form.modelName') }}</span>
+        <div
+          class="flex h-10 items-center rounded-md border border-white/8 bg-white/[0.02] px-3 font-mono text-sm text-gray-400"
+        >
+          {{ setting.model_name }}
+        </div>
+      </label>
+      <label class="space-y-1">
+        <span class="text-xs text-gray-500">{{ t('settings.models.form.aliasPlaceholder') }}</span>
+        <input
+          v-model="displayName"
+          class="h-10 w-full rounded-md border border-white/10 bg-[#343434] px-3 text-sm outline-none focus:border-cyan-400/40"
+        />
+      </label>
+    </section>
+
+    <section class="space-y-2">
+      <div class="text-xs font-medium text-gray-400">
+        {{ t('settings.models.form.capabilities') }}
+      </div>
+      <div class="flex flex-wrap gap-2">
+        <CapabilityBadge
+          v-for="cap in primaryCapabilities"
+          :key="cap.key"
+          :capability="cap.key"
+          :active="true"
+        />
+        <template v-if="setting.supports_llm">
+          <CapabilityToggle capability="vision" v-model="supportsImageInput" />
+          <CapabilityToggle capability="audio" v-model="supportsAudioInput" />
+          <CapabilityToggle capability="video" v-model="supportsVideoInput" />
+        </template>
+      </div>
+    </section>
+
+    <section v-if="setting.supports_tts" class="grid gap-3 sm:grid-cols-3">
+      <label class="space-y-1">
+        <span class="text-xs text-gray-500">{{ t('settings.models.form.voice') }}</span>
+        <input
+          v-model="ttsVoice"
+          class="h-10 w-full rounded-md border border-white/10 bg-[#343434] px-3 text-sm outline-none focus:border-cyan-400/40"
+        />
+      </label>
+      <label class="space-y-1">
+        <span class="text-xs text-gray-500">{{ t('settings.models.edit.format') }}</span>
+        <input
+          v-model="ttsFormat"
+          class="h-10 w-full rounded-md border border-white/10 bg-[#343434] px-3 text-sm outline-none focus:border-cyan-400/40"
+        />
+      </label>
+      <label class="space-y-1">
+        <span class="text-xs text-gray-500">{{ t('settings.models.edit.sampleRate') }}</span>
+        <input
+          v-model.number="ttsSampleRate"
+          type="number"
+          min="1"
+          class="h-10 w-full rounded-md border border-white/10 bg-[#343434] px-3 text-sm outline-none focus:border-cyan-400/40"
+        />
+      </label>
+    </section>
+
+    <label class="block space-y-1">
+      <span class="text-xs font-medium text-gray-400">API Key</span>
+      <input
+        v-model="apiKey"
+        type="password"
+        class="h-10 w-full rounded-md border border-white/10 bg-[#343434] px-3 text-sm outline-none focus:border-cyan-400/40"
+        :placeholder="t('settings.models.form.keepKey')"
+      />
+    </label>
+
+    <div class="flex items-center gap-6">
+      <label class="flex cursor-pointer items-center gap-2">
+        <input
+          v-model="isDefault"
+          type="checkbox"
+          class="h-4 w-4 rounded border-white/20 bg-[#343434]"
+        />
+        <span class="text-sm text-gray-300">{{ t('settings.models.setDefault') }}</span>
+      </label>
+      <label class="flex cursor-pointer items-center gap-2">
+        <input
+          v-model="isActive"
+          type="checkbox"
+          class="h-4 w-4 rounded border-white/20 bg-[#343434]"
+        />
+        <span class="text-sm text-gray-300">{{ t('settings.actions.enable') }}</span>
+      </label>
+    </div>
+
+    <div class="flex justify-end gap-2 pt-2">
+      <button
+        type="button"
+        class="rounded-md border border-white/10 px-4 py-2 text-sm text-gray-400 hover:bg-white/5"
+        @click="emit('cancel')"
+      >
+        {{ t('settings.actions.cancel') }}
+      </button>
+      <button
+        type="button"
+        class="inline-flex items-center gap-2 rounded-md bg-cyan-500 px-4 py-2 text-sm font-medium text-white hover:bg-cyan-400 disabled:opacity-50"
+        :disabled="submitting"
+        @click="submit"
+      >
+        <Loader2 v-if="submitting" class="h-4 w-4 animate-spin" />
+        {{ t('settings.actions.save') }}
+      </button>
+    </div>
+  </div>
+</template>

--- a/agent-ui/src/components/agent/settings/InlineDeleteConfirm.vue
+++ b/agent-ui/src/components/agent/settings/InlineDeleteConfirm.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import { Loader2, Trash2 } from 'lucide-vue-next'
+import { useI18n } from 'vue-i18n'
+
+defineProps<{
+  message: string
+  loading?: boolean
+  testId: string
+}>()
+
+defineEmits<{
+  confirm: []
+  cancel: []
+}>()
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <div
+    :data-testid="testId"
+    class="rounded-lg border border-red-300/20 bg-[#170d10]/98 p-3 shadow-xl shadow-black/30 backdrop-blur-md"
+    @click.stop
+  >
+    <div class="flex items-start gap-2.5">
+      <span class="mt-0.5 rounded-full bg-red-400/15 p-1.5 text-red-200">
+        <Trash2 class="h-3.5 w-3.5" />
+      </span>
+      <p class="min-w-0 flex-1 text-xs leading-relaxed text-white/65">{{ message }}</p>
+    </div>
+    <div class="mt-3 flex gap-2">
+      <button
+        type="button"
+        :data-testid="`${testId}-confirm`"
+        class="flex-1 rounded-md bg-red-500/20 px-3 py-1.5 text-xs font-medium text-red-100 transition hover:bg-red-500/30 disabled:opacity-45"
+        :disabled="loading"
+        @click="$emit('confirm')"
+      >
+        <Loader2 v-if="loading" class="mr-1 inline h-3 w-3 animate-spin" />
+        {{ t('settings.actions.delete') }}
+      </button>
+      <button
+        type="button"
+        :data-testid="`${testId}-cancel`"
+        class="flex-1 rounded-md border border-white/10 bg-white/[0.04] px-3 py-1.5 text-xs text-white/65 transition hover:bg-white/[0.08]"
+        :disabled="loading"
+        @click="$emit('cancel')"
+      >
+        {{ t('settings.actions.cancel') }}
+      </button>
+    </div>
+  </div>
+</template>

--- a/agent-ui/src/components/agent/settings/ModelForm.vue
+++ b/agent-ui/src/components/agent/settings/ModelForm.vue
@@ -50,6 +50,7 @@ export interface ModelFormPayload {
   ttsFormat?: string
   ttsSampleRate?: number
   apiKey: string
+  reuseExistingApiKey: boolean
   isDefault: boolean
   isActive: boolean
   capabilities: ModelCapabilities
@@ -648,7 +649,8 @@ async function submit(): Promise<void> {
       ttsVoice: ep.tts_voice,
       ttsFormat: ep.tts_format,
       ttsSampleRate: ep.tts_sample_rate,
-      apiKey: reusingCredential.value ? '__reuse_existing__' : apiKey.value.trim(),
+      apiKey: reusingCredential.value ? '' : apiKey.value.trim(),
+      reuseExistingApiKey: reusingCredential.value,
       isDefault: isDefault.value,
       isActive: isActive.value,
       capabilities: effectiveCapabilities.value,

--- a/agent-ui/src/components/agent/settings/ModelForm.vue
+++ b/agent-ui/src/components/agent/settings/ModelForm.vue
@@ -11,20 +11,19 @@
 
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { Loader2, Minus, Plus, Search, RefreshCw } from 'lucide-vue-next'
+import { KeyRound, Loader2, Minus, Plus, Search, RefreshCw } from 'lucide-vue-next'
 import { probeModels } from '@/api/services/providers-api'
 import type { LLMSetting } from '@/api/services/llm-settings-api'
 import type {
   Provider,
   ProviderEndpointPreset,
   ProviderModelPreset,
-  ProviderProtocol,
+  ProviderProtocol
 } from '@/api/types/orchestration-v2.types'
 import { createProtocolLabels } from '@/lib/protocol-labels'
 import CapabilityToggle from './CapabilityToggle.vue'
 
 export interface ModelFormPayload {
-  id?: string
   providerId: string
   providerName: string
   endpointId?: string
@@ -89,9 +88,13 @@ export interface ModelCapabilities {
   supports_video_input: boolean
 }
 
+export type ModelPurpose = 'llm' | 'asr' | 'tts'
+
 const props = defineProps<{
   providers: Provider[]
-  editing: LLMSetting | null
+  settings?: LLMSetting[]
+  purpose: ModelPurpose
+  initialProviderId?: string
   submitting?: boolean
 }>()
 
@@ -101,23 +104,19 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
-const {
-  planLabel: localizedPlanLabel,
-  protocolLabel: localizedProtocolLabel,
-} = createProtocolLabels(t)
+const { planLabel: localizedPlanLabel, protocolLabel: localizedProtocolLabel } =
+  createProtocolLabels(t)
 
 // ── 状态 ──────────────────────────────────────────────────────
-const isCustom = ref(false)
-const customProviderId = ref('')
-const customProviderName = ref('')
 // 凭证选择：providerId + planType + endpoint boundary 唯一标识一个凭证类型
 const selectedProviderId = ref('')
 const selectedPlanType = ref<string>('')
-const selectedEndpointId = ref('')  // 该 plan 下的代表 endpoint（用于取 base_url）
+const selectedEndpointId = ref('') // 该 plan 下的代表 endpoint（用于取 base_url）
 // 选中的模型 + 各自别名：modelId → alias（空字符串=无别名）
 const selectedModels = ref<Map<string, string>>(new Map())
 const displayName = ref('')
 const apiKey = ref('')
+const useNewApiKey = ref(false)
 const isDefault = ref(false)
 const isActive = ref(true)
 const saving = ref(false)
@@ -129,27 +128,46 @@ const probeError = ref<string | null>(null)
 let probeTimer: number | undefined
 const searchQuery = ref('')
 
-const customProtocol = ref<ProviderProtocol>('openai_compatible')
-const customChatCompletionsBaseUrl = ref('')
-const customResponsesBaseUrl = ref('')
-const customAnthropicBaseUrl = ref('')
-const customModelInput = ref('')
-
-function trimmedOrUndefined(value: string | undefined): string | undefined {
-  const trimmed = value?.trim()
-  return trimmed ? trimmed : undefined
+function modelSupportsPurpose(model: ProviderModelPreset): boolean {
+  if (props.purpose === 'asr') return Boolean(model.supports_asr)
+  if (props.purpose === 'tts') return Boolean(model.supports_tts)
+  return model.supports_llm !== false
 }
 
-function firstUrl(...values: Array<string | undefined>): string {
-  return values.map(value => value?.trim()).find(Boolean) ?? ''
+function settingSupportsPurpose(setting: LLMSetting): boolean {
+  if (props.purpose === 'asr') return setting.supports_asr
+  if (props.purpose === 'tts') return setting.supports_tts
+  return setting.supports_llm
 }
 
-const customBaseUrl = computed(() => {
-  if (customProtocol.value === 'anthropic_compatible') {
-    return firstUrl(customAnthropicBaseUrl.value, customChatCompletionsBaseUrl.value, customResponsesBaseUrl.value)
+function providerModelSupportsPurpose(provider: Provider, model: ProviderModelPreset): boolean {
+  if (provider.source !== 'custom') return modelSupportsPurpose(model)
+  const matchingSettings = (props.settings ?? []).filter(
+    setting => setting.provider_id === provider.id && setting.model_name === model.id
+  )
+  return matchingSettings.length
+    ? matchingSettings.some(settingSupportsPurpose)
+    : modelSupportsPurpose(model)
+}
+
+function endpointSupportsPurpose(endpoint: ProviderEndpointPreset): boolean {
+  if (props.purpose === 'asr') return Boolean(endpoint.supports_asr)
+  if (props.purpose === 'tts') return Boolean(endpoint.supports_tts)
+  return endpoint.supports_llm !== false
+}
+
+function credentialSupportsPurpose(credential: CredentialOption): boolean {
+  if (credential.provider.source === 'custom') {
+    const providerSettings = (props.settings ?? []).filter(
+      setting => setting.provider_id === credential.provider.id
+    )
+    if (providerSettings.length) return providerSettings.some(settingSupportsPurpose)
   }
-  return firstUrl(customChatCompletionsBaseUrl.value, customResponsesBaseUrl.value, customAnthropicBaseUrl.value)
-})
+  return (
+    credential.models.some(model => providerModelSupportsPurpose(credential.provider, model)) ||
+    credential.endpoints.some(endpointSupportsPurpose)
+  )
+}
 
 // ── 凭证选项（供应商 + 计费方式 去重）────────────────────────
 interface CredentialOption {
@@ -165,12 +183,14 @@ interface CredentialOption {
 }
 
 function isArkVoiceEndpoint(ep?: ProviderEndpointPreset | null): boolean {
-  return ep?.protocol === 'volcengine_doubao_voice' ||
+  return (
+    ep?.protocol === 'volcengine_doubao_voice' ||
     ep?.protocol === 'volcengine_ark_voice' ||
     ep?.protocol === 'volcengine_openspeech' ||
     ep?.voice_adapter === 'volcengine_doubao_voice' ||
     ep?.voice_adapter === 'volcengine_ark_voice' ||
     ep?.voice_adapter === 'volcengine_openspeech'
+  )
 }
 
 function credentialBoundaryKey(ep: ProviderEndpointPreset): string {
@@ -178,7 +198,7 @@ function credentialBoundaryKey(ep: ProviderEndpointPreset): string {
     ep.plan_type,
     ep.auth_type ?? '',
     ep.key_hint ?? '',
-    isArkVoiceEndpoint(ep) ? ep.voice_adapter ?? ep.protocol : 'llm',
+    isArkVoiceEndpoint(ep) ? (ep.voice_adapter ?? ep.protocol) : 'llm'
   ].join('|')
 }
 
@@ -220,7 +240,7 @@ const allCredentials = computed<CredentialOption[]>(() => {
         planType,
         endpoints,
         models: Array.from(modelMap.values()),
-        protocols,
+        protocols
       })
     }
   }
@@ -229,13 +249,20 @@ const allCredentials = computed<CredentialOption[]>(() => {
 
 const filteredCredentials = computed<CredentialOption[]>(() => {
   const q = searchQuery.value.trim().toLowerCase()
-  if (!q) return allCredentials.value
-  return allCredentials.value.filter(({ provider, planType }) => {
-    return (
-      provider.name.toLowerCase().includes(q) ||
-      localizedPlanLabel(planType).toLowerCase().includes(q)
+  return allCredentials.value
+    .filter(credentialSupportsPurpose)
+    .map(credential => ({
+      ...credential,
+      models: credential.models.filter(model =>
+        providerModelSupportsPurpose(credential.provider, model)
+      )
+    }))
+    .filter(
+      ({ provider, planType }) =>
+        !q ||
+        provider.name.toLowerCase().includes(q) ||
+        localizedPlanLabel(planType).toLowerCase().includes(q)
     )
-  })
 })
 
 const groupedCredentials = computed(() => {
@@ -250,23 +277,35 @@ const groupedCredentials = computed(() => {
 
 // ── 当前选中的凭证 ────────────────────────────────────────────
 const selectedCredential = computed<CredentialOption | null>(() => {
-  if (isCustom.value || !selectedProviderId.value || !selectedPlanType.value) return null
-  return allCredentials.value.find(
-    c => c.provider.id === selectedProviderId.value &&
-      c.planType === selectedPlanType.value &&
-      (!selectedEndpointId.value || c.endpoints.some(ep => ep.id === selectedEndpointId.value))
-  ) ?? null
+  if (!selectedProviderId.value || !selectedPlanType.value) return null
+  return (
+    allCredentials.value.find(
+      c =>
+        c.provider.id === selectedProviderId.value &&
+        c.planType === selectedPlanType.value &&
+        (!selectedEndpointId.value || c.endpoints.some(ep => ep.id === selectedEndpointId.value))
+    ) ?? null
+  )
 })
 
 function isSelectedCredentialOption(item: CredentialOption): boolean {
-  return selectedProviderId.value === item.provider.id &&
+  return (
+    selectedProviderId.value === item.provider.id &&
     selectedPlanType.value === item.planType &&
     item.endpoints.some(ep => ep.id === selectedEndpointId.value)
+  )
 }
 
-function endpointForModel(modelId: string, cred = selectedCredential.value): ProviderEndpointPreset | null {
+function endpointForModel(
+  modelId: string,
+  cred = selectedCredential.value
+): ProviderEndpointPreset | null {
   if (!cred) return null
-  return cred.endpoints.find(ep => ep.models.some(model => model.id === modelId)) ?? cred.endpoints[0] ?? null
+  return (
+    cred.endpoints.find(ep => ep.models.some(model => model.id === modelId)) ??
+    cred.endpoints[0] ??
+    null
+  )
 }
 
 const selectedPrimaryModelEndpoint = computed<ProviderEndpointPreset | null>(() => {
@@ -279,13 +318,53 @@ const representativeEndpoint = computed<ProviderEndpointPreset | null>(() => {
   return selectedPrimaryModelEndpoint.value ?? selectedCredential.value?.endpoints[0] ?? null
 })
 
+function reusableSettingForEndpoint(
+  endpoint: ProviderEndpointPreset
+): LLMSetting | undefined {
+  return (props.settings ?? []).find(
+    setting =>
+      setting.provider_id === selectedProviderId.value &&
+      (setting.endpoint_id ?? 'custom') === endpoint.id &&
+      Boolean(setting.api_key_display)
+  )
+}
+
+const endpointsForSelectedModels = computed<ProviderEndpointPreset[]>(() => {
+  const selected = Array.from(selectedModels.value.keys())
+  const endpoints = selected.length
+    ? selected
+        .map(modelId => endpointForModel(modelId))
+        .filter((endpoint): endpoint is ProviderEndpointPreset => Boolean(endpoint))
+    : representativeEndpoint.value
+      ? [representativeEndpoint.value]
+      : []
+  return Array.from(new Map(endpoints.map(endpoint => [endpoint.id, endpoint])).values())
+})
+
+const reusableCredentialSettings = computed<LLMSetting[]>(() =>
+  endpointsForSelectedModels.value
+    .map(reusableSettingForEndpoint)
+    .filter((setting): setting is LLMSetting => Boolean(setting))
+)
+
+const canReuseCredential = computed(
+  () =>
+    endpointsForSelectedModels.value.length > 0 &&
+    reusableCredentialSettings.value.length === endpointsForSelectedModels.value.length
+)
+
+const reusingCredential = computed(() => canReuseCredential.value && !useNewApiKey.value)
+const reusableCredentialDisplay = computed(
+  () => reusableCredentialSettings.value[0]?.api_key_display || '****'
+)
+
 const endpointUrlRows = computed(() => {
   const ep = representativeEndpoint.value
   if (!ep) return []
   return [
     { label: 'Chat Completions', value: ep.chat_completions_base_url || ep.base_url },
     { label: 'OpenAI Responses', value: ep.responses_base_url },
-    { label: 'Anthropic Messages', value: ep.anthropic_base_url },
+    { label: 'Anthropic Messages', value: ep.anthropic_base_url }
   ].filter(row => Boolean(row.value))
 })
 
@@ -298,7 +377,10 @@ const selectedModelPresets = computed(() => {
 
 const selectedPrimaryModelPreset = computed(() => selectedModelPresets.value[0] ?? null)
 
-function modelPresetFor(modelId: string, cred = selectedCredential.value): ProviderModelPreset | null {
+function modelPresetFor(
+  modelId: string,
+  cred = selectedCredential.value
+): ProviderModelPreset | null {
   return cred?.models.find(model => model.id === modelId) ?? null
 }
 
@@ -309,17 +391,19 @@ const isArkVoiceCredential = computed(() => isArkVoiceEndpoint(representativeEnd
 interface DisplayModel {
   id: string
   display_name: string
-  probed: boolean  // 是否来自动态探测（非 catalog 预设）
+  probed: boolean // 是否来自动态探测（非 catalog 预设）
 }
 
 const displayModels = computed<DisplayModel[]>(() => {
   const cred = selectedCredential.value
   if (!cred) return []
-  const result: DisplayModel[] = cred.models.map(m => ({
-    id: m.id,
-    display_name: m.display_name || m.id,
-    probed: false,
-  }))
+  const result: DisplayModel[] = cred.models
+    .filter(model => providerModelSupportsPurpose(cred.provider, model))
+    .map(m => ({
+      id: m.id,
+      display_name: m.display_name || m.id,
+      probed: false
+    }))
   // probe 发现的新模型（catalog 没有的）追加
   const known = new Set(result.map(m => m.id))
   for (const id of probedModels.value) {
@@ -341,7 +425,7 @@ const selectedModelRows = computed(() =>
       id: modelId,
       displayName: display?.display_name || modelPresetFor(modelId)?.display_name || modelId,
       alias,
-      probed: Boolean(display?.probed),
+      probed: Boolean(display?.probed)
     }
   })
 )
@@ -376,18 +460,20 @@ watch([apiKey, selectedEndpointId], ([key]) => {
   if (probeTimer) window.clearTimeout(probeTimer)
   probedModels.value = []
   probeError.value = null
-  if (!key?.trim() || isCustom.value || isArkVoiceCredential.value) return
-  probeTimer = window.setTimeout(() => { void runProbe() }, 600)
+  if (!key?.trim() || isArkVoiceCredential.value) return
+  probeTimer = window.setTimeout(() => {
+    void runProbe()
+  }, 600)
 })
 
 function endpointDefaultCapabilities(ep?: ProviderEndpointPreset | null): ModelCapabilities {
   return {
-    supports_llm: ep?.supports_llm ?? true,
-    supports_asr: ep?.supports_asr ?? false,
-    supports_tts: ep?.supports_tts ?? false,
-    supports_audio_input: ep?.supports_audio_input ?? false,
-    supports_image_input: ep?.supports_image_input ?? false,
-    supports_video_input: ep?.supports_video_input ?? false,
+    supports_llm: props.purpose === 'llm',
+    supports_asr: props.purpose === 'asr',
+    supports_tts: props.purpose === 'tts',
+    supports_audio_input: props.purpose !== 'tts' && (ep?.supports_audio_input ?? false),
+    supports_image_input: props.purpose === 'llm' && (ep?.supports_image_input ?? false),
+    supports_video_input: props.purpose === 'llm' && (ep?.supports_video_input ?? false)
   }
 }
 
@@ -395,27 +481,32 @@ function modelBaseCapabilities(modelId: string): ModelCapabilities {
   const preset = modelPresetFor(modelId)
   if (!preset) return endpointDefaultCapabilities(endpointForModel(modelId))
   return {
-    supports_llm: preset.supports_llm !== false,
-    supports_asr: Boolean(preset.supports_asr),
-    supports_tts: Boolean(preset.supports_tts),
-    supports_audio_input: Boolean(preset.supports_audio_input),
-    supports_image_input: Boolean(preset.supports_image_input),
-    supports_video_input: Boolean(preset.supports_video_input),
+    supports_llm: props.purpose === 'llm',
+    supports_asr: props.purpose === 'asr',
+    supports_tts: props.purpose === 'tts',
+    supports_audio_input: props.purpose !== 'tts' && Boolean(preset.supports_audio_input),
+    supports_image_input: props.purpose === 'llm' && Boolean(preset.supports_image_input),
+    supports_video_input: props.purpose === 'llm' && Boolean(preset.supports_video_input)
   }
 }
 
 function mergeCapabilities(models: ModelCapabilities[]): ModelCapabilities {
-  if (!models.length) return {
-    supports_llm: true, supports_asr: false, supports_tts: false,
-    supports_audio_input: false, supports_image_input: false, supports_video_input: false,
-  }
+  if (!models.length)
+    return {
+      supports_llm: props.purpose === 'llm',
+      supports_asr: props.purpose === 'asr',
+      supports_tts: props.purpose === 'tts',
+      supports_audio_input: false,
+      supports_image_input: false,
+      supports_video_input: false
+    }
   return {
     supports_llm: models.some(capabilities => capabilities.supports_llm),
     supports_asr: models.some(capabilities => capabilities.supports_asr),
     supports_tts: models.some(capabilities => capabilities.supports_tts),
     supports_audio_input: models.some(capabilities => capabilities.supports_audio_input),
     supports_image_input: models.some(capabilities => capabilities.supports_image_input),
-    supports_video_input: models.some(capabilities => capabilities.supports_video_input),
+    supports_video_input: models.some(capabilities => capabilities.supports_video_input)
   }
 }
 
@@ -431,7 +522,7 @@ const inferredCapabilities = computed<ModelCapabilities>(() => {
 const capabilityOverrides = ref<Partial<ModelCapabilities>>({})
 const effectiveCapabilities = computed<ModelCapabilities>(() => ({
   ...inferredCapabilities.value,
-  ...capabilityOverrides.value,
+  ...capabilityOverrides.value
 }))
 
 function setCapability(key: keyof ModelCapabilities, value: boolean): void {
@@ -441,25 +532,36 @@ function setCapability(key: keyof ModelCapabilities, value: boolean): void {
 function effectiveCapabilitiesForModel(modelId: string): ModelCapabilities {
   return {
     ...modelBaseCapabilities(modelId),
-    ...capabilityOverrides.value,
+    ...capabilityOverrides.value
   }
 }
 
 // ── 凭证选择 ─────────────────────────────────────────────────
 function selectCredential(opt: CredentialOption): void {
-  isCustom.value = false
   selectedProviderId.value = opt.provider.id
   selectedPlanType.value = opt.planType
   selectedEndpointId.value = opt.endpoints[0]?.id ?? ''
   // 默认不选中任何模型，用户自行点选（去掉推荐逻辑）
   selectedModels.value = new Map()
   capabilityOverrides.value = {}
+  apiKey.value = ''
+  useNewApiKey.value = false
 }
+
+watch(
+  [() => props.initialProviderId, allCredentials],
+  ([providerId, credentials]) => {
+    if (!providerId || selectedProviderId.value) return
+    const credential = credentials.find(item => item.provider.id === providerId)
+    if (credential) selectCredential(credential)
+  },
+  { immediate: true }
+)
 
 function addModel(modelId: string): void {
   if (selectedModels.value.has(modelId)) return
   const next = new Map(selectedModels.value)
-  next.set(modelId, '')  // 初始别名空
+  next.set(modelId, '') // 初始别名空
   selectedModels.value = next
 }
 
@@ -475,102 +577,12 @@ function setModelAlias(modelId: string, alias: string): void {
   selectedModels.value = next
 }
 
-// ── 自定义供应商 ──────────────────────────────────────────────
-function enableCustomMode(): void {
-  isCustom.value = true
-  selectedProviderId.value = ''
-  selectedPlanType.value = ''
-  selectedModels.value = new Map()
-  customProviderId.value = ''
-  customProviderName.value = ''
-  customProtocol.value = 'openai_compatible'
-  customChatCompletionsBaseUrl.value = ''
-  customResponsesBaseUrl.value = ''
-  customAnthropicBaseUrl.value = ''
-  customModelInput.value = ''
-}
-
-// ── 编辑回填 ──────────────────────────────────────────────────
-function loadEditing(setting: LLMSetting): void {
-  const provider = props.providers.find(p => p.id === setting.provider_id)
-  const hasEndpoints = (provider?.endpoints?.length ?? 0) > 0
-  isCustom.value = !hasEndpoints
-  apiKey.value = ''
-  displayName.value = setting.display_name ?? ''
-  isDefault.value = setting.is_default
-  isActive.value = setting.is_active
-
-  if (hasEndpoints) {
-    selectedProviderId.value = setting.provider_id
-    selectedPlanType.value = setting.plan_type
-    // 回填选中的模型；单配置编辑时把 display_name 放进第一个模型别名。
-    const models = setting.models ?? [setting.model_name]
-    selectedModels.value = new Map(models.map((m: string, index: number) => [
-      m,
-      index === 0 ? setting.display_name ?? '' : '',
-    ]))
-    // 找代表 endpoint
-    const ep = provider?.endpoints?.find(e => e.id === setting.endpoint_id)
-      ?? provider?.endpoints?.find(e => e.plan_type === setting.plan_type)
-      ?? provider?.endpoints?.[0]
-    selectedEndpointId.value = ep?.id ?? ''
-    capabilityOverrides.value = {
-      supports_llm: setting.supports_llm,
-      supports_asr: setting.supports_asr,
-      supports_tts: setting.supports_tts,
-      supports_audio_input: setting.supports_audio_input,
-      supports_image_input: setting.supports_image_input,
-      supports_video_input: setting.supports_video_input,
-    }
-  } else {
-    customProviderId.value = setting.provider_id
-    customProviderName.value = setting.provider_name ?? provider?.name ?? ''
-    customProtocol.value = setting.protocol
-    const fallbackBaseUrl = setting.base_url ?? ''
-    customChatCompletionsBaseUrl.value = setting.chat_completions_base_url ??
-      (setting.protocol === 'openai_compatible' ? fallbackBaseUrl : '')
-    customResponsesBaseUrl.value = setting.responses_base_url ?? ''
-    customAnthropicBaseUrl.value = setting.anthropic_base_url ??
-      (setting.protocol === 'anthropic_compatible' ? fallbackBaseUrl : '')
-    customModelInput.value = setting.model_name
-  }
-}
-
-function reset(): void {
-  isCustom.value = false
-  selectedProviderId.value = ''
-  selectedPlanType.value = ''
-  selectedEndpointId.value = ''
-  selectedModels.value = new Map()
-  displayName.value = ''
-  apiKey.value = ''
-  isDefault.value = false
-  isActive.value = true
-  searchQuery.value = ''
-  capabilityOverrides.value = {}
-  customProviderId.value = ''
-  customProviderName.value = ''
-  customProtocol.value = 'openai_compatible'
-  customChatCompletionsBaseUrl.value = ''
-  customResponsesBaseUrl.value = ''
-  customAnthropicBaseUrl.value = ''
-  customModelInput.value = ''
-}
-
-watch(() => props.editing, (setting) => {
-  if (setting) loadEditing(setting)
-  else reset()
-}, { immediate: true })
-
 // ── 提交 ──────────────────────────────────────────────────────
 const selectedModelList = computed(() => Array.from(selectedModels.value.keys()))
 const isSubmitting = computed(() => saving.value || Boolean(props.submitting))
 
 const canSubmit = computed(() => {
-  if (!props.editing && !apiKey.value.trim()) return false
-  if (isCustom.value) {
-    return !!(customProviderId.value.trim()) && !!customBaseUrl.value && !!customModelInput.value.trim()
-  }
+  if (!reusingCredential.value && !apiKey.value.trim()) return false
   return !!selectedCredential.value && selectedModels.value.size > 0
 })
 
@@ -597,7 +609,7 @@ function buildModelConfig(modelId: string): ModelFormModelConfig {
     ttsVoice: ep.tts_voice,
     ttsFormat: ep.tts_format,
     ttsSampleRate: ep.tts_sample_rate,
-    capabilities: effectiveCapabilitiesForModel(modelId),
+    capabilities: effectiveCapabilitiesForModel(modelId)
   }
 }
 
@@ -605,70 +617,43 @@ async function submit(): Promise<void> {
   if (!canSubmit.value || isSubmitting.value) return
   saving.value = true
   try {
-    if (isCustom.value) {
-      const pid = customProviderId.value.trim()
-      emit('submit', {
-        id: props.editing?.id,
-        providerId: pid,
-        providerName: customProviderName.value.trim() || pid,
-        endpointId: `${pid}_custom`,
-        endpointName: 'custom',
-        modelName: customModelInput.value.trim(),
-        displayName: displayName.value.trim(),
-        protocol: customProtocol.value,
-        planType: 'custom',
-        baseUrl: customBaseUrl.value,
-        chatCompletionsBaseUrl: trimmedOrUndefined(customChatCompletionsBaseUrl.value),
-        responsesBaseUrl: trimmedOrUndefined(customResponsesBaseUrl.value),
-        anthropicBaseUrl: trimmedOrUndefined(customAnthropicBaseUrl.value),
-        apiKey: apiKey.value.trim(),
-        isDefault: isDefault.value,
-        isActive: isActive.value,
-        capabilities: {
-          supports_llm: true, supports_asr: false, supports_tts: false,
-          supports_audio_input: false, supports_image_input: false, supports_video_input: false,
-        },
-      })
-    } else {
-      const cred = selectedCredential.value!
-      const ep = selectedPrimaryModelEndpoint.value ?? representativeEndpoint.value!
-      const models = selectedModelList.value
-      const modelConfigs = models.map(buildModelConfig)
-      const primaryDisplayName = modelConfigs[0]?.displayName || displayName.value.trim()
-      emit('submit', {
-        id: props.editing?.id,
-        providerId: cred.provider.id,
-        providerName: cred.provider.name,
-        endpointId: ep.id,
-        endpointName: ep.name,
-        modelName: models[0],
-        models,
-        displayName: primaryDisplayName,
-        protocol: ep.protocol,
-        planType: cred.planType as LLMSetting['plan_type'],
-        authType: ep.auth_type,
-        keyHint: ep.key_hint,
-        baseUrl: ep.base_url,
-        chatCompletionsBaseUrl: ep.chat_completions_base_url,
-        responsesBaseUrl: ep.responses_base_url,
-        anthropicBaseUrl: ep.anthropic_base_url,
-        resourceId: selectedPrimaryModelPreset.value?.resource_id ?? ep.resource_id,
-        voiceAdapter: ep.voice_adapter,
-        ttsHttpUrl: ep.tts_http_url,
-        ttsRealtimeUrl: ep.tts_realtime_url,
-        ttsBidirectionalUrl: ep.tts_bidirectional_url,
-        asrRealtimeUrl: ep.asr_realtime_url,
-        asrAsyncUrl: ep.asr_async_url,
-        ttsVoice: ep.tts_voice,
-        ttsFormat: ep.tts_format,
-        ttsSampleRate: ep.tts_sample_rate,
-        apiKey: apiKey.value.trim(),
-        isDefault: isDefault.value,
-        isActive: isActive.value,
-        capabilities: effectiveCapabilities.value,
-        modelConfigs,
-      })
-    }
+    const cred = selectedCredential.value!
+    const ep = selectedPrimaryModelEndpoint.value ?? representativeEndpoint.value!
+    const models = selectedModelList.value
+    const modelConfigs = models.map(buildModelConfig)
+    const primaryDisplayName = modelConfigs[0]?.displayName || displayName.value.trim()
+    emit('submit', {
+      providerId: cred.provider.id,
+      providerName: cred.provider.name,
+      endpointId: ep.id,
+      endpointName: ep.name,
+      modelName: models[0],
+      models,
+      displayName: primaryDisplayName,
+      protocol: ep.protocol,
+      planType: cred.planType as LLMSetting['plan_type'],
+      authType: ep.auth_type,
+      keyHint: ep.key_hint,
+      baseUrl: ep.base_url,
+      chatCompletionsBaseUrl: ep.chat_completions_base_url,
+      responsesBaseUrl: ep.responses_base_url,
+      anthropicBaseUrl: ep.anthropic_base_url,
+      resourceId: selectedPrimaryModelPreset.value?.resource_id ?? ep.resource_id,
+      voiceAdapter: ep.voice_adapter,
+      ttsHttpUrl: ep.tts_http_url,
+      ttsRealtimeUrl: ep.tts_realtime_url,
+      ttsBidirectionalUrl: ep.tts_bidirectional_url,
+      asrRealtimeUrl: ep.asr_realtime_url,
+      asrAsyncUrl: ep.asr_async_url,
+      ttsVoice: ep.tts_voice,
+      ttsFormat: ep.tts_format,
+      ttsSampleRate: ep.tts_sample_rate,
+      apiKey: reusingCredential.value ? '__reuse_existing__' : apiKey.value.trim(),
+      isDefault: isDefault.value,
+      isActive: isActive.value,
+      capabilities: effectiveCapabilities.value,
+      modelConfigs
+    })
   } finally {
     saving.value = false
   }
@@ -678,12 +663,16 @@ async function submit(): Promise<void> {
 <template>
   <div class="space-y-5 p-5">
     <!-- ═══ 内置凭证列表（供应商+计费方式）══════════════════════ -->
-    <template v-if="!isCustom">
+    <div class="contents">
       <div>
         <div class="mb-2 flex items-center justify-between">
-          <span class="text-xs font-medium text-gray-400">{{ t('settings.models.form.credentialType') }}</span>
+          <span class="text-xs font-medium text-gray-400">{{
+            t('settings.models.form.credentialType')
+          }}</span>
           <div class="relative">
-            <Search class="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-gray-600" />
+            <Search
+              class="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-gray-600"
+            />
             <input
               v-model="searchQuery"
               class="h-8 w-44 rounded-lg border border-white/10 bg-[#343434] pl-7 pr-2 text-xs text-gray-200 outline-none focus:border-cyan-400/40"
@@ -692,9 +681,13 @@ async function submit(): Promise<void> {
           </div>
         </div>
 
-        <div class="max-h-64 space-y-3 overflow-y-auto rounded-xl border border-white/8 bg-black/20 p-3">
+        <div
+          class="max-h-64 space-y-3 overflow-y-auto rounded-xl border border-white/8 bg-black/20 p-3"
+        >
           <div v-for="group in groupedCredentials" :key="group.provider.id">
-            <div class="mb-1.5 px-1 text-[11px] font-semibold uppercase tracking-wider text-gray-500">
+            <div
+              class="mb-1.5 px-1 text-[11px] font-semibold uppercase tracking-wider text-gray-500"
+            >
               {{ group.provider.name }}
             </div>
             <div class="space-y-1.5">
@@ -718,14 +711,23 @@ async function submit(): Promise<void> {
                       : 'border-white/25'
                   ]"
                 >
-                  <span v-if="isSelectedCredentialOption(item)" class="h-1.5 w-1.5 rounded-full bg-black" />
+                  <span
+                    v-if="isSelectedCredentialOption(item)"
+                    class="h-1.5 w-1.5 rounded-full bg-black"
+                  />
                 </span>
                 <div class="min-w-0 flex-1">
-                  <div class="text-sm font-medium text-gray-200">{{ localizedPlanLabel(item.planType) }}</div>
+                  <div class="text-sm font-medium text-gray-200">
+                    {{ localizedPlanLabel(item.planType) }}
+                  </div>
                   <div class="mt-0.5 flex items-center gap-2 text-[11px] text-gray-500">
-                    <span>{{ t('settings.models.modelsCount', { count: item.models.length }) }}</span>
+                    <span>{{
+                      t('settings.models.modelsCount', { count: item.models.length })
+                    }}</span>
                     <span>·</span>
-                    <span>{{ item.protocols.map(p => localizedProtocolLabel(p)).join(' / ') }}</span>
+                    <span>{{
+                      item.protocols.map(p => localizedProtocolLabel(p)).join(' / ')
+                    }}</span>
                   </div>
                 </div>
               </button>
@@ -738,46 +740,51 @@ async function submit(): Promise<void> {
         </div>
 
         <!-- 底部信息：协议 + 接入地址 -->
-        <div v-if="selectedCredential" class="mt-3 space-y-1.5 rounded-lg border border-white/8 bg-white/[0.02] px-3 py-2.5">
+        <div
+          v-if="selectedCredential"
+          class="mt-3 space-y-1.5 rounded-lg border border-white/8 bg-white/[0.02] px-3 py-2.5"
+        >
           <div class="flex items-center gap-2 text-[11px] text-gray-500">
             <span>{{ t('settings.models.form.supportedProtocols') }}</span>
             <span
               v-for="p in selectedCredential.protocols"
               :key="p"
               class="rounded bg-white/5 px-1.5 py-0.5 text-gray-300"
-            >{{ localizedProtocolLabel(p) }}</span>
+              >{{ localizedProtocolLabel(p) }}</span
+            >
           </div>
-          <div v-for="row in endpointUrlRows" :key="row.label" class="flex items-center gap-2 text-[11px] text-gray-500">
+          <div
+            v-for="row in endpointUrlRows"
+            :key="row.label"
+            class="flex items-center gap-2 text-[11px] text-gray-500"
+          >
             <span>{{ row.label }}：</span>
             <span class="truncate font-mono text-gray-400">{{ row.value }}</span>
           </div>
           <template v-if="isArkVoiceCredential">
             <div class="flex items-center gap-2 text-[11px] text-gray-500">
               <span>TTS HTTP：</span>
-              <span class="truncate font-mono text-gray-400">{{ representativeEndpoint?.tts_http_url }}</span>
+              <span class="truncate font-mono text-gray-400">{{
+                representativeEndpoint?.tts_http_url
+              }}</span>
             </div>
             <div class="flex items-center gap-2 text-[11px] text-gray-500">
               <span>ASR Batch WS：</span>
-              <span class="truncate font-mono text-gray-400">{{ representativeEndpoint?.asr_realtime_url }}</span>
+              <span class="truncate font-mono text-gray-400">{{
+                representativeEndpoint?.asr_realtime_url
+              }}</span>
             </div>
           </template>
         </div>
-
-        <button
-          type="button"
-          class="mt-3 flex items-center gap-1.5 text-xs text-gray-500 transition-colors hover:text-gray-300"
-          @click="enableCustomMode"
-        >
-          <Plus class="h-3.5 w-3.5" />
-          {{ t('settings.models.form.newCustomProvider') }}
-        </button>
       </div>
 
       <!-- ═══ 模型多选（catalog 预设 + 动态探测）════════════════ -->
       <div v-if="selectedCredential" class="space-y-2">
         <div class="flex items-center justify-between">
-          <span class="text-xs font-medium text-gray-400">{{ editing ? t('settings.models.form.currentModel') : t('settings.models.form.availableModels') }}</span>
-          <div v-if="!editing" class="flex items-center gap-2">
+          <span class="text-xs font-medium text-gray-400">{{
+            t('settings.models.form.availableModels')
+          }}</span>
+          <div class="flex items-center gap-2">
             <span v-if="probing" class="flex items-center gap-1 text-[11px] text-cyan-300/70">
               <Loader2 class="h-3 w-3 animate-spin" /> {{ t('settings.models.form.probing') }}
             </span>
@@ -793,13 +800,18 @@ async function submit(): Promise<void> {
             >
               <RefreshCw class="h-3 w-3" />
             </button>
-            <span class="text-[11px] text-gray-500">{{ t('settings.models.form.pendingCount', { count: selectedModels.size }) }}</span>
+            <span class="text-[11px] text-gray-500">{{
+              t('settings.models.form.pendingCount', { count: selectedModels.size })
+            }}</span>
           </div>
         </div>
-        <div v-if="!editing && probeError" class="rounded-md border border-amber-400/20 bg-amber-400/5 px-3 py-1.5 text-[11px] text-amber-300/70">
+        <div
+          v-if="probeError"
+          class="rounded-md border border-amber-400/20 bg-amber-400/5 px-3 py-1.5 text-[11px] text-amber-300/70"
+        >
           {{ t('settings.models.form.probeFailed', { error: probeError }) }}
         </div>
-        <div v-if="!editing && availableDisplayModels.length" class="grid gap-2 sm:grid-cols-2">
+        <div v-if="availableDisplayModels.length" class="grid gap-2 sm:grid-cols-2">
           <button
             v-for="m in availableDisplayModels"
             :key="m.id"
@@ -814,22 +826,36 @@ async function submit(): Promise<void> {
           >
             <span class="min-w-0">
               <span class="block truncate">{{ m.display_name }}</span>
-              <span v-if="m.probed" class="mt-0.5 block text-[9px] text-emerald-300/55">{{ t('settings.models.form.probed') }}</span>
+              <span v-if="m.probed" class="mt-0.5 block text-[9px] text-emerald-300/55">{{
+                t('settings.models.form.probed')
+              }}</span>
             </span>
-            <span class="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full border border-cyan-300/25 bg-cyan-300/10 text-cyan-100">
+            <span
+              class="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full border border-cyan-300/25 bg-cyan-300/10 text-cyan-100"
+            >
               <Plus class="h-3.5 w-3.5" />
             </span>
           </button>
         </div>
-        <div v-else-if="!editing" class="rounded-lg border border-white/8 bg-black/15 px-3 py-4 text-center text-xs text-gray-500">
+        <div
+          v-else
+          class="rounded-lg border border-white/8 bg-black/15 px-3 py-4 text-center text-xs text-gray-500"
+        >
           {{ t('settings.models.form.allAdded') }}
         </div>
 
         <!-- 已配置模型列表（每个模型提交为一个独立配置，共用同一个 key）-->
-        <div v-if="selectedModels.size > 0" class="space-y-2 rounded-lg border border-white/8 bg-black/20 p-3">
+        <div
+          v-if="selectedModels.size > 0"
+          class="space-y-2 rounded-lg border border-white/8 bg-black/20 p-3"
+        >
           <div class="flex items-center justify-between gap-3">
-            <div class="text-[11px] text-gray-500">{{ editing ? t('settings.models.form.modelConfig') : t('settings.models.form.pendingConfigs') }}</div>
-            <div class="text-[11px] text-gray-600">{{ t('settings.models.modelsCount', { count: selectedModels.size }) }}</div>
+            <div class="text-[11px] text-gray-500">
+              {{ t('settings.models.form.pendingConfigs') }}
+            </div>
+            <div class="text-[11px] text-gray-600">
+              {{ t('settings.models.modelsCount', { count: selectedModels.size }) }}
+            </div>
           </div>
           <div
             v-for="model in selectedModelRows"
@@ -856,100 +882,110 @@ async function submit(): Promise<void> {
           </div>
         </div>
       </div>
-    </template>
-
-    <!-- ═══ 自定义供应商 ═════════════════════════════════════════ -->
-    <template v-else>
-      <div class="space-y-3 rounded-xl border border-white/8 bg-black/20 p-4">
-        <div class="flex items-center justify-between">
-          <span class="text-xs font-medium text-gray-400">{{ t('settings.models.form.customProvider') }}</span>
-          <button
-            type="button"
-            class="text-xs text-cyan-300/70 hover:text-cyan-200"
-            @click="reset"
-          >
-            {{ t('settings.models.form.backToBuiltIn') }}
-          </button>
-        </div>
-        <div class="grid gap-3 sm:grid-cols-2">
-          <label class="space-y-1">
-            <span class="text-xs text-gray-500">Provider ID</span>
-            <input v-model="customProviderId" class="h-10 w-full rounded-lg border border-white/10 bg-[#343434] px-3 text-sm outline-none focus:border-cyan-400/40" :placeholder="t('settings.models.form.providerIdExample')" />
-          </label>
-          <label class="space-y-1">
-            <span class="text-xs text-gray-500">{{ t('settings.models.form.displayName') }}</span>
-            <input v-model="customProviderName" class="h-10 w-full rounded-lg border border-white/10 bg-[#343434] px-3 text-sm outline-none focus:border-cyan-400/40" :placeholder="t('settings.models.form.displayNameExample')" />
-          </label>
-        </div>
-        <label class="space-y-1">
-          <span class="text-xs text-gray-500">{{ t('settings.models.form.apiFormat') }}</span>
-          <select v-model="customProtocol" class="h-10 w-full rounded-lg border border-white/10 bg-[#343434] px-3 text-sm outline-none focus:border-cyan-400/40">
-            <option value="openai_compatible">Chat Completions</option>
-            <option value="anthropic_compatible">Anthropic</option>
-          </select>
-        </label>
-        <div class="grid gap-3">
-          <label class="space-y-1">
-            <span class="text-xs text-gray-500">Chat Completions URL</span>
-            <input v-model="customChatCompletionsBaseUrl" class="h-10 w-full rounded-lg border border-white/10 bg-[#343434] px-3 text-sm outline-none focus:border-cyan-400/40" placeholder="https://api.example.com/v1" />
-          </label>
-          <label class="space-y-1">
-            <span class="text-xs text-gray-500">OpenAI Responses URL</span>
-            <input v-model="customResponsesBaseUrl" class="h-10 w-full rounded-lg border border-white/10 bg-[#343434] px-3 text-sm outline-none focus:border-cyan-400/40" placeholder="https://api.example.com/v1/responses" />
-          </label>
-          <label class="space-y-1">
-            <span class="text-xs text-gray-500">Anthropic Messages URL</span>
-            <input v-model="customAnthropicBaseUrl" class="h-10 w-full rounded-lg border border-white/10 bg-[#343434] px-3 text-sm outline-none focus:border-cyan-400/40" placeholder="https://api.example.com/anthropic" />
-          </label>
-        </div>
-        <label class="space-y-1">
-          <span class="text-xs text-gray-500">{{ t('settings.models.form.modelName') }}</span>
-          <input v-model="customModelInput" class="h-10 w-full rounded-lg border border-white/10 bg-[#343434] px-3 text-sm outline-none focus:border-cyan-400/40" :placeholder="t('settings.models.form.modelId')" />
-        </label>
-      </div>
-    </template>
+    </div>
 
     <!-- ═══ API Key ═════════════════════════════════════════════ -->
-    <label class="block space-y-1">
-      <span class="text-xs font-medium text-gray-400">API Key</span>
+    <div
+      v-if="reusingCredential"
+      data-testid="reused-provider-credential"
+      class="flex items-center gap-3 rounded-lg border border-emerald-400/20 bg-emerald-400/[0.05] px-3 py-2.5"
+    >
+      <KeyRound class="h-4 w-4 flex-shrink-0 text-emerald-300/80" />
+      <div class="min-w-0 flex-1">
+        <div class="text-xs font-medium text-emerald-100/90">
+          {{ t('settings.models.form.reuseCredential') }}
+        </div>
+        <div class="mt-0.5 truncate font-mono text-[11px] text-gray-500">
+          {{ reusableCredentialDisplay }}
+        </div>
+      </div>
+      <button
+        type="button"
+        class="flex-shrink-0 text-xs text-gray-400 transition-colors hover:text-gray-200"
+        @click="useNewApiKey = true"
+      >
+        {{ t('settings.models.form.useDifferentKey') }}
+      </button>
+    </div>
+    <label v-else class="block space-y-1">
+      <span class="flex items-center justify-between gap-3 text-xs font-medium text-gray-400">
+        <span>API Key</span>
+        <button
+          v-if="canReuseCredential"
+          type="button"
+          class="font-normal text-cyan-300/70 transition-colors hover:text-cyan-200"
+          @click.prevent="useNewApiKey = false"
+        >
+          {{ t('settings.models.form.useSavedKey') }}
+        </button>
+      </span>
       <input
         v-model="apiKey"
         type="password"
         class="h-10 w-full rounded-lg border border-white/10 bg-[#343434] px-3 text-sm outline-none focus:border-cyan-400/40"
-        :placeholder="editing ? t('settings.models.form.keepKey') : (representativeEndpoint?.key_hint || 'sk-...')"
+        :placeholder="representativeEndpoint?.key_hint || 'sk-...'"
       />
     </label>
 
     <!-- ═══ 能力（自动填 + 手动微调）════════════════════════════ -->
-    <div v-if="!isCustom" class="space-y-2">
+    <div class="space-y-2">
       <div class="flex items-center justify-between">
-        <span class="text-xs font-medium text-gray-400">{{ t('settings.models.form.capabilities') }}</span>
+        <span class="text-xs font-medium text-gray-400">{{
+          t('settings.models.form.capabilities')
+        }}</span>
       </div>
       <div class="flex flex-wrap gap-2">
-        <CapabilityToggle capability="llm" :model-value="effectiveCapabilities.supports_llm" @update:model-value="setCapability('supports_llm', $event)" />
-        <CapabilityToggle capability="vision" :model-value="effectiveCapabilities.supports_image_input" @update:model-value="setCapability('supports_image_input', $event)" />
-        <CapabilityToggle capability="asr" :model-value="effectiveCapabilities.supports_asr" @update:model-value="setCapability('supports_asr', $event)" />
-        <CapabilityToggle capability="tts" :model-value="effectiveCapabilities.supports_tts" @update:model-value="setCapability('supports_tts', $event)" />
-        <CapabilityToggle capability="audio" :model-value="effectiveCapabilities.supports_audio_input" @update:model-value="setCapability('supports_audio_input', $event)" />
-        <CapabilityToggle capability="video" :model-value="effectiveCapabilities.supports_video_input" @update:model-value="setCapability('supports_video_input', $event)" />
+        <span
+          class="rounded-full border border-cyan-300/30 bg-cyan-300/10 px-2.5 py-1 text-xs font-medium uppercase text-cyan-100"
+          >{{ purpose }}</span
+        >
+        <template v-if="purpose === 'llm'">
+          <CapabilityToggle
+            capability="vision"
+            :model-value="effectiveCapabilities.supports_image_input"
+            @update:model-value="setCapability('supports_image_input', $event)"
+          />
+          <CapabilityToggle
+            capability="audio"
+            :model-value="effectiveCapabilities.supports_audio_input"
+            @update:model-value="setCapability('supports_audio_input', $event)"
+          />
+          <CapabilityToggle
+            capability="video"
+            :model-value="effectiveCapabilities.supports_video_input"
+            @update:model-value="setCapability('supports_video_input', $event)"
+          />
+        </template>
       </div>
     </div>
 
     <!-- ═══ 开关 ════════════════════════════════════════════════ -->
     <div class="flex items-center gap-6">
       <label class="flex cursor-pointer items-center gap-2">
-        <input type="checkbox" v-model="isDefault" class="h-4 w-4 rounded border-white/20 bg-[#343434]" />
+        <input
+          type="checkbox"
+          v-model="isDefault"
+          class="h-4 w-4 rounded border-white/20 bg-[#343434]"
+        />
         <span class="text-sm text-gray-300">{{ t('settings.models.setDefault') }}</span>
       </label>
       <label class="flex cursor-pointer items-center gap-2">
-        <input type="checkbox" v-model="isActive" class="h-4 w-4 rounded border-white/20 bg-[#343434]" />
+        <input
+          type="checkbox"
+          v-model="isActive"
+          class="h-4 w-4 rounded border-white/20 bg-[#343434]"
+        />
         <span class="text-sm text-gray-300">{{ t('settings.actions.enable') }}</span>
       </label>
     </div>
 
     <!-- ═══ 操作 ════════════════════════════════════════════════ -->
     <div class="flex justify-end gap-2 pt-2">
-      <button type="button" class="rounded-lg border border-white/10 px-4 py-2 text-sm text-gray-400 transition-colors hover:bg-white/5 hover:text-gray-200" @click="emit('cancel')">
+      <button
+        type="button"
+        class="rounded-lg border border-white/10 px-4 py-2 text-sm text-gray-400 transition-colors hover:bg-white/5 hover:text-gray-200"
+        @click="emit('cancel')"
+      >
         {{ t('settings.actions.cancel') }}
       </button>
       <button
@@ -957,12 +993,14 @@ async function submit(): Promise<void> {
         :disabled="!canSubmit || isSubmitting"
         :class="[
           'flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-all',
-          canSubmit && !isSubmitting ? 'bg-cyan-500 text-white hover:bg-cyan-400' : 'cursor-not-allowed bg-gray-700 text-gray-500'
+          canSubmit && !isSubmitting
+            ? 'bg-cyan-500 text-white hover:bg-cyan-400'
+            : 'cursor-not-allowed bg-gray-700 text-gray-500'
         ]"
         @click="submit"
       >
         <Loader2 v-if="isSubmitting" class="h-4 w-4 animate-spin" />
-        {{ editing ? t('settings.actions.save') : t('settings.actions.add') }}
+        {{ t('settings.actions.add') }}
       </button>
     </div>
   </div>

--- a/agent-ui/src/components/agent/settings/ModelForms.test.ts
+++ b/agent-ui/src/components/agent/settings/ModelForms.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createApp, nextTick, type App } from 'vue'
+import { createApp, defineComponent, h, nextTick, ref, type App } from 'vue'
 import { i18n } from '@/plugins/i18n'
 import type { LLMSetting } from '@/api/services/llm-settings-api'
 import type { Provider } from '@/api/types/orchestration-v2.types'
@@ -239,7 +239,8 @@ describe('model purpose forms', () => {
     await nextTick()
 
     expect(submitted?.modelName).toBe('second-chat-model')
-    expect(submitted?.apiKey).toBe('__reuse_existing__')
+    expect(submitted?.apiKey).toBe('')
+    expect(submitted?.reuseExistingApiKey).toBe(true)
   })
 
   it('uses a separate edit form with a read-only provider binding', async () => {
@@ -301,6 +302,29 @@ describe('model purpose forms', () => {
     })
   })
 
+  it('keeps an unsaved provider draft when unrelated settings refresh', async () => {
+    const settings = ref<LLMSetting[]>([customSetting])
+    const Wrapper = defineComponent({
+      setup: () => () =>
+        h(CustomProviderManager, {
+          providers: [customProvider],
+          settings: settings.value
+        })
+    })
+    const root = await mount(Wrapper, {})
+    const nameInput = Array.from(root.querySelectorAll<HTMLInputElement>('input')).find(
+      input => input.value === customProvider.name
+    )!
+
+    nameInput.value = 'Unsaved provider name'
+    nameInput.dispatchEvent(new Event('input'))
+    await nextTick()
+    settings.value = [{ ...customSetting, is_active: false }]
+    await nextTick()
+
+    expect(nameInput.value).toBe('Unsaved provider name')
+  })
+
   it('derives and saves HTTP and WebSocket endpoints for an ASR provider', async () => {
     const root = await mount(CustomProviderManager, {
       providers: [asrProvider],
@@ -334,5 +358,30 @@ describe('model purpose forms', () => {
         asr_realtime_url: 'ws://192.168.100.10:5002/v1/realtime'
       })
     )
+  })
+
+  it('keeps saved voice endpoints when a provider capability is disabled', async () => {
+    const root = await mount(CustomProviderManager, {
+      providers: [asrProvider],
+      settings: [asrSetting]
+    })
+    const capabilityButton = (name: string) =>
+      Array.from(root.querySelectorAll<HTMLButtonElement>('button')).find(
+        button => button.textContent?.trim() === name
+      )!
+
+    capabilityButton('LLM').click()
+    capabilityButton('ASR').click()
+    await nextTick()
+    Array.from(root.querySelectorAll<HTMLButtonElement>('button'))
+      .find(button => button.textContent?.trim() === '保存')!
+      .click()
+    await nextTick()
+    await nextTick()
+
+    const payload = vi.mocked(agentSettingsApi.updateProvider).mock.calls.at(-1)?.[1]
+    expect(payload).toMatchObject({ supports_llm: true, supports_asr: false })
+    expect(payload?.asr_async_url).toBeUndefined()
+    expect(payload?.asr_realtime_url).toBeUndefined()
   })
 })

--- a/agent-ui/src/components/agent/settings/ModelForms.test.ts
+++ b/agent-ui/src/components/agent/settings/ModelForms.test.ts
@@ -1,0 +1,338 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, type App } from 'vue'
+import { i18n } from '@/plugins/i18n'
+import type { LLMSetting } from '@/api/services/llm-settings-api'
+import type { Provider } from '@/api/types/orchestration-v2.types'
+import { agentSettingsApi } from '@/api/agent'
+import CustomProviderManager from './CustomProviderManager.vue'
+import EditModelForm, { type EditModelPayload } from './EditModelForm.vue'
+import ModelForm, { type ModelFormPayload } from './ModelForm.vue'
+
+vi.mock('@/api/services/providers-api', () => ({
+  probeModels: vi.fn(async () => ({ models: [] }))
+}))
+
+vi.mock('@/api/agent', () => ({
+  agentSettingsApi: {
+    deleteProvider: vi.fn(async () => ({ success: true })),
+    updateProvider: vi.fn(async () => ({ success: true }))
+  }
+}))
+
+vi.mock('@/components/controls/useToast', () => ({
+  useToast: () => ({ showToast: vi.fn() })
+}))
+
+const provider: Provider = {
+  id: 'mixed-provider',
+  name: 'Mixed Provider',
+  source: 'builtin',
+  readonly: true,
+  endpoints: [
+    {
+      id: 'mixed-api',
+      provider_id: 'mixed-provider',
+      name: 'Mixed API',
+      plan_type: 'api_billing',
+      protocol: 'openai_compatible',
+      auth_type: 'bearer',
+      base_url: 'https://mixed.example/v1',
+      default_model: 'chat-model',
+      supports_llm: true,
+      supports_asr: true,
+      models: [
+        { id: 'chat-model', display_name: 'Chat Model', supports_llm: true },
+        {
+          id: 'speech-model',
+          display_name: 'Speech Model',
+          supports_llm: false,
+          supports_asr: true
+        }
+      ]
+    }
+  ]
+}
+
+const setting: LLMSetting = {
+  id: 'setting-1',
+  provider_id: provider.id,
+  provider_name: provider.name,
+  provider_source: 'builtin',
+  provider_readonly: true,
+  endpoint_id: 'mixed-api',
+  endpoint_name: 'Mixed API',
+  plan_type: 'api_billing',
+  protocol: 'openai_compatible',
+  model_name: 'chat-model',
+  display_name: 'Chat Model',
+  api_key_display: '****',
+  supports_llm: true,
+  supports_asr: false,
+  supports_tts: false,
+  supports_audio_input: false,
+  supports_image_input: true,
+  supports_video_input: false,
+  is_active: true,
+  is_default: true,
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z'
+}
+
+const customProvider: Provider = {
+  id: 'local-gemma4-omni',
+  name: 'Local Gemma4 12B Omni',
+  default_model: 'gemma4-12b',
+  base_url: 'http://127.0.0.1:9000/v1',
+  source: 'custom',
+  readonly: false,
+  endpoints: []
+}
+
+const customSetting: LLMSetting = {
+  ...setting,
+  id: 'gemma-setting',
+  provider_id: customProvider.id,
+  provider_name: customProvider.name,
+  provider_source: 'custom',
+  provider_readonly: false,
+  endpoint_id: 'local-gemma4-omni_custom',
+  endpoint_name: 'Custom endpoint',
+  plan_type: 'custom',
+  protocol: 'custom',
+  model_name: 'gemma4-12b',
+  display_name: 'Gemma4 12B Omni'
+}
+
+const asrProvider: Provider = {
+  id: 'local-asr',
+  name: 'Local ASR',
+  default_model: 'qwen3-asr-realtime',
+  base_url: 'http://192.168.100.10:5002',
+  source: 'custom',
+  readonly: false,
+  supports_llm: false,
+  supports_asr: true,
+  endpoints: []
+}
+
+const asrSetting: LLMSetting = {
+  ...customSetting,
+  id: 'asr-setting',
+  provider_id: asrProvider.id,
+  provider_name: asrProvider.name,
+  model_name: 'qwen3-asr-realtime',
+  display_name: 'qwen3-asr-realtime',
+  supports_llm: false,
+  supports_asr: true,
+  supports_audio_input: true,
+  supports_image_input: false
+}
+
+let app: App<Element> | null = null
+
+async function mount(component: object, props: Record<string, unknown>) {
+  const root = document.createElement('div')
+  document.body.appendChild(root)
+  app = createApp(component, props)
+  app.use(i18n)
+  app.mount(root)
+  await nextTick()
+  return root
+}
+
+beforeEach(() => {
+  i18n.global.locale.value = 'zh-Hans'
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  app?.unmount()
+  app = null
+  document.body.innerHTML = ''
+})
+
+describe('model purpose forms', () => {
+  it('filters preset models and fixes primary capabilities from the ASR purpose', async () => {
+    let submitted: ModelFormPayload | undefined
+    const root = await mount(ModelForm, {
+      providers: [provider],
+      purpose: 'asr',
+      onSubmit: (payload: ModelFormPayload) => {
+        submitted = payload
+      }
+    })
+
+    const credential = Array.from(root.querySelectorAll('button')).find(button =>
+      button.textContent?.includes('API 计费')
+    )
+    expect(credential).toBeTruthy()
+    credential!.click()
+    await nextTick()
+
+    expect(root.textContent).toContain('Speech Model')
+    expect(root.textContent).not.toContain('Chat Model')
+    const speechModel = Array.from(root.querySelectorAll('button')).find(button =>
+      button.textContent?.includes('Speech Model')
+    )
+    speechModel!.click()
+    await nextTick()
+
+    const keyInput = root.querySelector<HTMLInputElement>('input[type="password"]')!
+    keyInput.value = 'asr-secret'
+    keyInput.dispatchEvent(new Event('input'))
+    await nextTick()
+
+    const submit = Array.from(root.querySelectorAll('button')).find(
+      button => button.textContent?.trim() === '添加'
+    )
+    submit!.click()
+    await nextTick()
+
+    expect(submitted?.modelName).toBe('speech-model')
+    expect(submitted?.capabilities).toMatchObject({
+      supports_llm: false,
+      supports_asr: true,
+      supports_tts: false
+    })
+  })
+
+  it('reuses a saved provider credential when adding another model on the same endpoint', async () => {
+    let submitted: ModelFormPayload | undefined
+    const providerWithAnotherModel: Provider = {
+      ...provider,
+      endpoints: provider.endpoints.map(endpoint => ({
+        ...endpoint,
+        models: [
+          ...endpoint.models,
+          { id: 'second-chat-model', display_name: 'Second Chat Model', supports_llm: true }
+        ]
+      }))
+    }
+    const root = await mount(ModelForm, {
+      providers: [providerWithAnotherModel],
+      settings: [setting],
+      purpose: 'llm',
+      onSubmit: (payload: ModelFormPayload) => {
+        submitted = payload
+      }
+    })
+
+    const credential = Array.from(root.querySelectorAll('button')).find(button =>
+      button.textContent?.includes('API 计费')
+    )!
+    credential.click()
+    await nextTick()
+
+    expect(root.querySelector('[data-testid="reused-provider-credential"]')).toBeTruthy()
+    expect(root.querySelector('input[type="password"]')).toBeNull()
+
+    const model = Array.from(root.querySelectorAll('button')).find(button =>
+      button.textContent?.includes('Second Chat Model')
+    )!
+    model.click()
+    await nextTick()
+
+    const submit = Array.from(root.querySelectorAll('button')).find(
+      button => button.textContent?.trim() === '添加'
+    )!
+    submit.click()
+    await nextTick()
+
+    expect(submitted?.modelName).toBe('second-chat-model')
+    expect(submitted?.apiKey).toBe('__reuse_existing__')
+  })
+
+  it('uses a separate edit form with a read-only provider binding', async () => {
+    let submitted: EditModelPayload | undefined
+    const root = await mount(EditModelForm, {
+      setting,
+      onSubmit: (payload: EditModelPayload) => {
+        submitted = payload
+      }
+    })
+
+    expect(root.textContent).toContain('Mixed Provider')
+    expect(root.querySelectorAll('select')).toHaveLength(0)
+    expect(root.textContent).toContain('只读')
+
+    const save = Array.from(root.querySelectorAll('button')).find(
+      button => button.textContent?.trim() === '保存'
+    )
+    save!.click()
+    await nextTick()
+
+    expect(submitted?.id).toBe('setting-1')
+    expect(submitted).not.toHaveProperty('providerId')
+    expect(submitted).not.toHaveProperty('provider_id')
+  })
+
+  it('shows referenced models and explicitly cascades provider deletion', async () => {
+    const nativeConfirm = vi.spyOn(window, 'confirm')
+    const root = await mount(CustomProviderManager, {
+      providers: [customProvider],
+      settings: [customSetting]
+    })
+
+    expect(root.textContent).toContain('Gemma4 12B Omni')
+    const remove = Array.from(root.querySelectorAll('button')).find(button =>
+      button.textContent?.includes('删除供应商及 1 个模型')
+    )
+    expect(remove).toBeTruthy()
+    expect(remove!.disabled).toBe(false)
+
+    remove!.click()
+    await nextTick()
+
+    const inlineConfirm = root.querySelector<HTMLElement>(
+      '[data-testid="delete-custom-provider-confirm"]'
+    )
+    expect(inlineConfirm?.textContent).toContain('Gemma4 12B Omni')
+    expect(nativeConfirm).not.toHaveBeenCalled()
+    expect(agentSettingsApi.deleteProvider).not.toHaveBeenCalled()
+
+    root
+      .querySelector<HTMLButtonElement>('[data-testid="delete-custom-provider-confirm-confirm"]')!
+      .click()
+    await nextTick()
+    await nextTick()
+
+    expect(agentSettingsApi.deleteProvider).toHaveBeenCalledWith(customProvider.id, {
+      cascade: true
+    })
+  })
+
+  it('derives and saves HTTP and WebSocket endpoints for an ASR provider', async () => {
+    const root = await mount(CustomProviderManager, {
+      providers: [asrProvider],
+      settings: [asrSetting]
+    })
+
+    expect(
+      root.querySelector<HTMLInputElement>('[data-testid="provider-asr-http-url"]')?.placeholder
+    ).toBe('http://192.168.100.10:5002/v1/audio/transcriptions')
+    expect(
+      root.querySelector<HTMLInputElement>('[data-testid="provider-asr-realtime-url"]')?.placeholder
+    ).toBe('ws://192.168.100.10:5002/v1/realtime')
+    expect(root.textContent).not.toContain('各协议接入地址')
+    expect(root.querySelector('input[placeholder="Chat Completions URL"]')).toBeNull()
+    expect(root.querySelector('input[placeholder="Responses URL"]')).toBeNull()
+    expect(root.querySelector('input[placeholder="Anthropic URL"]')).toBeNull()
+
+    const save = Array.from(root.querySelectorAll('button')).find(
+      button => button.textContent?.trim() === '保存'
+    )!
+    save.click()
+    await nextTick()
+    await nextTick()
+
+    expect(agentSettingsApi.updateProvider).toHaveBeenCalledWith(
+      asrProvider.id,
+      expect.objectContaining({
+        base_url: 'http://192.168.100.10:5002/v1',
+        voice_adapter: 'openai_audio',
+        asr_async_url: 'http://192.168.100.10:5002/v1/audio/transcriptions',
+        asr_realtime_url: 'ws://192.168.100.10:5002/v1/realtime'
+      })
+    )
+  })
+})

--- a/agent-ui/src/components/agent/settings/ModelSettings.test.ts
+++ b/agent-ui/src/components/agent/settings/ModelSettings.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, nextTick, type App } from 'vue'
 import { i18n } from '@/plugins/i18n'
+import { agentSettingsApi } from '@/api/agent'
+import type { LLMSetting } from '@/api/services/llm-settings-api'
 import ModelSettings from './ModelSettings.vue'
 
 const managerStore = {
@@ -12,19 +14,21 @@ const managerStore = {
   managerProviderLabel: (provider: string) => provider,
   managerModelLabel: (_provider: string, model: string) => model,
   setManagerRuntime: vi.fn(),
-  loadManagerRuntimeOptions: vi.fn(() => Promise.resolve()),
+  loadManagerRuntimeOptions: vi.fn(() => Promise.resolve())
 }
 
 vi.mock('@/stores/agent-store', () => ({
-  useAgentStore: () => managerStore,
+  useAgentStore: () => managerStore
 }))
 
 vi.mock('@/components/controls/useToast', () => ({
-  useToast: () => ({ showToast: vi.fn() }),
+  useToast: () => ({ showToast: vi.fn() })
 }))
 
 vi.mock('@/api/agent', () => ({
-  agentSettingsApi: {},
+  agentSettingsApi: {
+    deleteLLMSetting: vi.fn(async () => ({ success: true }))
+  }
 }))
 
 function codexModel(model: string, displayName: string, isDefault = false) {
@@ -36,7 +40,7 @@ function codexModel(model: string, displayName: string, isDefault = false) {
     is_default: isDefault,
     default_reasoning_effort: 'medium',
     supported_reasoning_efforts: ['low', 'medium', 'high', 'xhigh'],
-    service_tiers: [],
+    service_tiers: []
   }
 }
 
@@ -44,7 +48,7 @@ const codexModels = [
   codexModel('gpt-5.5', 'GPT-5.5', true),
   codexModel('gpt-5.4', 'GPT-5.4'),
   codexModel('gpt-5.4-mini', 'GPT-5.4-Mini'),
-  codexModel('gpt-5.3-codex-spark', 'GPT-5.3-Codex-Spark'),
+  codexModel('gpt-5.3-codex-spark', 'GPT-5.3-Codex-Spark')
 ]
 
 function managerConfig(harness: 'codex_appserver' | 'claude_agent_sdk') {
@@ -57,21 +61,49 @@ function managerConfig(harness: 'codex_appserver' | 'claude_agent_sdk') {
     reasoning_effort: 'xhigh' as const,
     service_tier: null,
     system_prompt: '',
-    session_policy: {},
+    session_policy: {}
   }
 }
 
 let app: App<Element> | null = null
 
-async function mountSettings(harness: 'codex_appserver' | 'claude_agent_sdk') {
+const modelSetting: LLMSetting = {
+  id: 'setting-1',
+  provider_id: 'local-llm',
+  provider_name: 'Local LLM',
+  provider_source: 'custom',
+  provider_readonly: false,
+  endpoint_id: 'local-llm_custom',
+  endpoint_name: 'Custom endpoint',
+  plan_type: 'custom',
+  protocol: 'custom',
+  model_name: 'qwen3.6',
+  display_name: 'Qwen 3.6',
+  api_key_display: '****',
+  supports_llm: true,
+  supports_asr: false,
+  supports_tts: false,
+  supports_audio_input: false,
+  supports_image_input: false,
+  supports_video_input: false,
+  is_active: true,
+  is_default: false,
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z'
+}
+
+async function mountSettings(
+  harness: 'codex_appserver' | 'claude_agent_sdk',
+  llmSettings: LLMSetting[] = []
+) {
   const root = document.createElement('div')
   document.body.appendChild(root)
   app = createApp(ModelSettings, {
     providers: [],
-    llmSettings: [],
+    llmSettings,
     managerConfig: managerConfig(harness),
     codexModels,
-    loading: false,
+    loading: false
   })
   app.use(i18n)
   app.mount(root)
@@ -81,6 +113,7 @@ async function mountSettings(harness: 'codex_appserver' | 'claude_agent_sdk') {
 
 beforeEach(() => {
   i18n.global.locale.value = 'zh-Hans'
+  vi.clearAllMocks()
 })
 
 afterEach(() => {
@@ -90,14 +123,47 @@ afterEach(() => {
 })
 
 describe('ModelSettings detected Codex runtime', () => {
+  it('opens a purpose menu beside Add model', async () => {
+    const root = await mountSettings('claude_agent_sdk')
+    const menuButton = root.querySelector<HTMLButtonElement>(
+      '[data-testid="add-model-menu-button"]'
+    )!
+
+    menuButton.click()
+    await nextTick()
+
+    expect(root.querySelector('[data-testid="add-model-purpose-llm"]')?.textContent).toContain(
+      '大语言模型'
+    )
+    expect(root.querySelector('[data-testid="add-model-purpose-asr"]')?.textContent).toContain(
+      'ASR'
+    )
+    expect(root.querySelector('[data-testid="add-model-purpose-tts"]')?.textContent).toContain(
+      'TTS'
+    )
+  })
+
   it('renders the active Codex runtime and full catalog as read-only', async () => {
     const root = await mountSettings('codex_appserver')
-    const codexItem = root.querySelector<HTMLElement>('[data-testid="agent-settings-model-item-codex"]')
+    const codexItem = root.querySelector<HTMLElement>(
+      '[data-testid="agent-settings-model-item-codex"]'
+    )
 
-    expect(root.querySelector('[data-testid="agent-settings-manager-runtime-provider-readonly"]')?.textContent).toContain('Codex')
-    expect(root.querySelector('[data-testid="agent-settings-manager-runtime-model-readonly"]')?.textContent).toContain('GPT-5.5')
-    expect(root.querySelector('[data-testid="agent-settings-manager-runtime-model-readonly"]')?.textContent).toContain('标准')
-    expect(root.querySelector('[data-testid="agent-settings-manager-runtime-count"]')?.textContent).toContain('4 个可用模型')
+    expect(
+      root.querySelector('[data-testid="agent-settings-manager-runtime-provider-readonly"]')
+        ?.textContent
+    ).toContain('Codex')
+    expect(
+      root.querySelector('[data-testid="agent-settings-manager-runtime-model-readonly"]')
+        ?.textContent
+    ).toContain('GPT-5.5')
+    expect(
+      root.querySelector('[data-testid="agent-settings-manager-runtime-model-readonly"]')
+        ?.textContent
+    ).toContain('标准')
+    expect(
+      root.querySelector('[data-testid="agent-settings-manager-runtime-count"]')?.textContent
+    ).toContain('4 个可用模型')
     expect(codexItem?.textContent).toContain('自动检测')
     expect(codexItem?.textContent).toContain('只读')
     expect(codexItem?.textContent).toContain('GPT-5.5, GPT-5.4, GPT-5.4-Mini, GPT-5.3-Codex-Spark')
@@ -110,5 +176,28 @@ describe('ModelSettings detected Codex runtime', () => {
 
     expect(root.querySelector('[data-testid="agent-settings-model-item-codex"]')).not.toBeNull()
     expect(root.querySelectorAll('select')).toHaveLength(2)
+  })
+
+  it('uses an adjacent inline confirmation before deleting a model', async () => {
+    const nativeConfirm = vi.spyOn(window, 'confirm')
+    const root = await mountSettings('claude_agent_sdk', [modelSetting])
+
+    root.querySelector<HTMLButtonElement>('[data-testid="delete-model-setting-1"]')!.click()
+    await nextTick()
+
+    const inlineConfirm = root.querySelector<HTMLElement>(
+      '[data-testid="delete-model-confirm-setting-1"]'
+    )
+    expect(inlineConfirm?.textContent).toContain('Qwen 3.6')
+    expect(nativeConfirm).not.toHaveBeenCalled()
+    expect(agentSettingsApi.deleteLLMSetting).not.toHaveBeenCalled()
+
+    root
+      .querySelector<HTMLButtonElement>('[data-testid="delete-model-confirm-setting-1-confirm"]')!
+      .click()
+    await nextTick()
+    await nextTick()
+
+    expect(agentSettingsApi.deleteLLMSetting).toHaveBeenCalledWith('setting-1')
   })
 })

--- a/agent-ui/src/components/agent/settings/ModelSettings.vue
+++ b/agent-ui/src/components/agent/settings/ModelSettings.vue
@@ -211,6 +211,7 @@ async function handleSubmit(payload: ModelFormPayload): Promise<void> {
         tts_format: model.ttsFormat,
         tts_sample_rate: model.ttsSampleRate,
         api_key: payload.apiKey,
+        reuse_existing_api_key: payload.reuseExistingApiKey,
         is_default: payload.isDefault && index === 0,
         is_active: payload.isActive,
         ...model.capabilities

--- a/agent-ui/src/components/agent/settings/ModelSettings.vue
+++ b/agent-ui/src/components/agent/settings/ModelSettings.vue
@@ -2,11 +2,15 @@
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import {
+  Bot,
+  ChevronDown,
   Loader2,
   LockKeyhole,
+  Mic,
   Pencil,
   Plus,
   Trash2,
+  Volume2
 } from 'lucide-vue-next'
 import { agentSettingsApi } from '@/api/agent'
 import type { CodexModel, VoiceAgentConfig } from '@/api/agent'
@@ -16,8 +20,12 @@ import type { LLMSetting } from '@/api/services/llm-settings-api'
 import type { Provider } from '@/api/types/orchestration-v2.types'
 import { createProtocolLabels } from '@/lib/protocol-labels'
 import CapabilityBadge from './CapabilityBadge.vue'
+import CustomProviderManager from './CustomProviderManager.vue'
+import EditModelForm from './EditModelForm.vue'
+import type { EditModelPayload } from './EditModelForm.vue'
+import InlineDeleteConfirm from './InlineDeleteConfirm.vue'
 import ModelForm from './ModelForm.vue'
-import type { ModelFormPayload } from './ModelForm.vue'
+import type { ModelFormPayload, ModelPurpose } from './ModelForm.vue'
 
 const props = defineProps<{
   providers: Provider[]
@@ -40,16 +48,28 @@ const { showToast } = useToast()
 const dialogOpen = ref(false)
 const editingSetting = ref<LLMSetting | null>(null)
 const savingId = ref<string | null>(null)
+const createMenuOpen = ref(false)
+const createPurpose = ref<ModelPurpose>('llm')
+const createProviderId = ref('')
+const deleteConfirmId = ref<string | null>(null)
 
 const activeSettings = computed(() => props.llmSettings.filter(s => s.is_active))
 const inactiveSettings = computed(() => props.llmSettings.filter(s => !s.is_active))
 const currentManagerUsesCodex = computed(() => props.managerConfig?.harness === 'codex_appserver')
-const showCodexRuntime = computed(() => currentManagerUsesCodex.value || props.codexModels.length > 0)
-const activeManagerSettings = computed(() => activeSettings.value.filter(setting =>
-  setting.supports_llm && !setting.supports_asr && !setting.supports_tts
-))
-const availableManagerModelCount = computed(() => activeManagerSettings.value.length + props.codexModels.length)
-const configuredModelCount = computed(() => props.llmSettings.length + (showCodexRuntime.value ? 1 : 0))
+const showCodexRuntime = computed(
+  () => currentManagerUsesCodex.value || props.codexModels.length > 0
+)
+const activeManagerSettings = computed(() =>
+  activeSettings.value.filter(
+    setting => setting.supports_llm && !setting.supports_asr && !setting.supports_tts
+  )
+)
+const availableManagerModelCount = computed(
+  () => activeManagerSettings.value.length + props.codexModels.length
+)
+const configuredModelCount = computed(
+  () => props.llmSettings.length + (showCodexRuntime.value ? 1 : 0)
+)
 
 function codexModelLabel(modelName: string | null | undefined): string {
   if (!modelName) return '-'
@@ -61,9 +81,9 @@ const currentCodexModelName = computed(() => {
   if (currentManagerUsesCodex.value && props.managerConfig?.model_name) {
     return props.managerConfig.model_name
   }
-  return props.codexModels.find(model => model.is_default)?.model
-    || props.codexModels[0]?.model
-    || null
+  return (
+    props.codexModels.find(model => model.is_default)?.model || props.codexModels[0]?.model || null
+  )
 })
 const currentCodexModelLabel = computed(() => codexModelLabel(currentCodexModelName.value))
 const currentCodexServiceTierLabel = computed(() => {
@@ -72,9 +92,9 @@ const currentCodexServiceTierLabel = computed(() => {
   const model = props.codexModels.find(item => item.model === currentCodexModelName.value)
   return model?.service_tiers.find(tier => tier.id === serviceTier)?.name || serviceTier
 })
-const codexModelSummary = computed(() => props.codexModels
-  .map(model => model.display_name || model.model)
-  .join(', '))
+const codexModelSummary = computed(() =>
+  props.codexModels.map(model => model.display_name || model.model).join(', ')
+)
 
 function handleManagerProviderChange(event: Event): void {
   store.setManagerRuntime((event.target as HTMLSelectElement).value)
@@ -84,7 +104,20 @@ function handleManagerModelChange(event: Event): void {
   store.setManagerRuntime(store.managerProviderName, (event.target as HTMLSelectElement).value)
 }
 
-function openCreate(): void {
+const purposeOptions = computed(() => [
+  { id: 'llm' as const, label: t('settings.models.purposes.llm'), icon: Bot },
+  { id: 'asr' as const, label: t('settings.models.purposes.asr'), icon: Mic },
+  { id: 'tts' as const, label: t('settings.models.purposes.tts'), icon: Volume2 }
+])
+
+function toggleCreateMenu(): void {
+  createMenuOpen.value = !createMenuOpen.value
+}
+
+function openCreate(purpose: ModelPurpose, providerId = ''): void {
+  createPurpose.value = purpose
+  createProviderId.value = providerId
+  createMenuOpen.value = false
   editingSetting.value = null
   dialogOpen.value = true
 }
@@ -123,55 +156,13 @@ async function runAction<T>(key: string, action: () => Promise<T>): Promise<T | 
 
 async function handleSubmit(payload: ModelFormPayload): Promise<void> {
   await runAction('dialog', async () => {
-    if (payload.id) {
-      await agentSettingsApi.updateLLMSetting(payload.id, {
-        provider_id: payload.providerId,
-        model_name: payload.modelName,
-        models: payload.models,
-        display_name: payload.displayName || undefined,
-        endpoint_id: payload.endpointId,
-        endpoint_name: payload.endpointName,
-        plan_type: payload.planType,
-        protocol: payload.protocol,
-        auth_type: payload.authType,
-        key_hint: payload.keyHint,
-        base_url: payload.baseUrl,
-        chat_completions_base_url: payload.chatCompletionsBaseUrl,
-        responses_base_url: payload.responsesBaseUrl,
-        anthropic_base_url: payload.anthropicBaseUrl,
-        resource_id: payload.resourceId,
-        voice_adapter: payload.voiceAdapter,
-        tts_http_url: payload.ttsHttpUrl,
-        tts_realtime_url: payload.ttsRealtimeUrl,
-        tts_bidirectional_url: payload.ttsBidirectionalUrl,
-        asr_realtime_url: payload.asrRealtimeUrl,
-        asr_async_url: payload.asrAsyncUrl,
-        tts_voice: payload.ttsVoice,
-        tts_format: payload.ttsFormat,
-        tts_sample_rate: payload.ttsSampleRate,
-        api_key: payload.apiKey || undefined,
-        is_default: payload.isDefault,
-        is_active: payload.isActive,
-        ...payload.capabilities,
-      })
-    } else {
-      const isCustomNew = !props.providers.some(p => p.id === payload.providerId)
-      if (isCustomNew) {
-        await agentSettingsApi.createProvider({
-          id: payload.providerId,
-          name: payload.providerName,
-          default_model: payload.modelName,
-          base_url: payload.baseUrl,
-          chat_completions_base_url: payload.chatCompletionsBaseUrl,
-          responses_base_url: payload.responsesBaseUrl,
-          anthropic_base_url: payload.anthropicBaseUrl,
-          status: 'active',
-          ...payload.capabilities,
-        })
-      }
-      const modelConfigs = payload.modelConfigs?.length
-        ? payload.modelConfigs
-        : [{
+    if (!props.providers.some(provider => provider.id === payload.providerId)) {
+      throw new Error(t('settings.models.providers.createFirst'))
+    }
+    const modelConfigs = payload.modelConfigs?.length
+      ? payload.modelConfigs
+      : [
+          {
             modelName: payload.modelName,
             displayName: payload.displayName,
             endpointId: payload.endpointId,
@@ -191,47 +182,67 @@ async function handleSubmit(payload: ModelFormPayload): Promise<void> {
             ttsVoice: payload.ttsVoice,
             ttsFormat: payload.ttsFormat,
             ttsSampleRate: payload.ttsSampleRate,
-            capabilities: payload.capabilities,
-          }]
-      for (const [index, model] of modelConfigs.entries()) {
-        await agentSettingsApi.createLLMSetting({
-          provider_id: payload.providerId,
-          model_name: model.modelName,
-          display_name: model.displayName || undefined,
-          endpoint_id: model.endpointId,
-          endpoint_name: model.endpointName,
-          plan_type: payload.planType,
-          protocol: model.protocol,
-          auth_type: payload.authType,
-          key_hint: payload.keyHint,
-          base_url: model.baseUrl,
-          chat_completions_base_url: model.chatCompletionsBaseUrl,
-          responses_base_url: model.responsesBaseUrl,
-          anthropic_base_url: model.anthropicBaseUrl,
-          resource_id: model.resourceId,
-          voice_adapter: model.voiceAdapter,
-          tts_http_url: model.ttsHttpUrl,
-          tts_realtime_url: model.ttsRealtimeUrl,
-          tts_bidirectional_url: model.ttsBidirectionalUrl,
-          asr_realtime_url: model.asrRealtimeUrl,
-          asr_async_url: model.asrAsyncUrl,
-          tts_voice: model.ttsVoice,
-          tts_format: model.ttsFormat,
-          tts_sample_rate: model.ttsSampleRate,
-          api_key: payload.apiKey,
-          is_default: payload.isDefault && index === 0,
-          is_active: payload.isActive,
-          ...model.capabilities,
-        })
-      }
+            capabilities: payload.capabilities
+          }
+        ]
+    for (const [index, model] of modelConfigs.entries()) {
+      await agentSettingsApi.createLLMSetting({
+        provider_id: payload.providerId,
+        model_name: model.modelName,
+        display_name: model.displayName || undefined,
+        endpoint_id: model.endpointId,
+        endpoint_name: model.endpointName,
+        plan_type: payload.planType,
+        protocol: model.protocol,
+        auth_type: payload.authType,
+        key_hint: payload.keyHint,
+        base_url: model.baseUrl,
+        chat_completions_base_url: model.chatCompletionsBaseUrl,
+        responses_base_url: model.responsesBaseUrl,
+        anthropic_base_url: model.anthropicBaseUrl,
+        resource_id: model.resourceId,
+        voice_adapter: model.voiceAdapter,
+        tts_http_url: model.ttsHttpUrl,
+        tts_realtime_url: model.ttsRealtimeUrl,
+        tts_bidirectional_url: model.ttsBidirectionalUrl,
+        asr_realtime_url: model.asrRealtimeUrl,
+        asr_async_url: model.asrAsyncUrl,
+        tts_voice: model.ttsVoice,
+        tts_format: model.ttsFormat,
+        tts_sample_rate: model.ttsSampleRate,
+        api_key: payload.apiKey,
+        is_default: payload.isDefault && index === 0,
+        is_active: payload.isActive,
+        ...model.capabilities
+      })
     }
     emit('refresh')
     await store.loadManagerRuntimeOptions()
     dialogOpen.value = false
     editingSetting.value = null
-    emit('set-notice', payload.id
-      ? t('settings.models.updated')
-      : t('settings.models.added', { count: payload.modelConfigs?.length || 1 }))
+    emit('set-notice', t('settings.models.added', { count: payload.modelConfigs?.length || 1 }))
+  })
+}
+
+async function handleEditSubmit(payload: EditModelPayload): Promise<void> {
+  await runAction('dialog', async () => {
+    await agentSettingsApi.updateLLMSetting(payload.id, {
+      display_name: payload.displayName,
+      api_key: payload.apiKey,
+      is_default: payload.isDefault,
+      is_active: payload.isActive,
+      supports_audio_input: payload.supportsAudioInput,
+      supports_image_input: payload.supportsImageInput,
+      supports_video_input: payload.supportsVideoInput,
+      tts_voice: payload.ttsVoice,
+      tts_format: payload.ttsFormat,
+      tts_sample_rate: payload.ttsSampleRate
+    })
+    emit('refresh')
+    await store.loadManagerRuntimeOptions()
+    dialogOpen.value = false
+    editingSetting.value = null
+    emit('set-notice', t('settings.models.updated'))
   })
 }
 
@@ -251,24 +262,35 @@ async function setDefault(setting: LLMSetting): Promise<void> {
   })
 }
 
-async function remove(setting: LLMSetting): Promise<void> {
-  if (!window.confirm(t('settings.models.deleteConfirm', { name: setting.display_name || setting.model_name }))) return
+function toggleDeleteConfirm(settingId: string): void {
+  if (savingId.value) return
+  deleteConfirmId.value = deleteConfirmId.value === settingId ? null : settingId
+}
+
+function cancelDelete(): void {
+  deleteConfirmId.value = null
+}
+
+async function confirmRemove(setting: LLMSetting): Promise<void> {
   await runAction(`delete-${setting.id}`, async () => {
     await agentSettingsApi.deleteLLMSetting(setting.id)
+    deleteConfirmId.value = null
     emit('refresh')
     await store.loadManagerRuntimeOptions()
     emit('set-notice', t('settings.models.deleted'))
   })
 }
 
-function capabilityList(setting: LLMSetting): Array<{ key: 'llm' | 'asr' | 'tts' | 'audio' | 'vision' | 'video'; active: boolean }> {
+function capabilityList(
+  setting: LLMSetting
+): Array<{ key: 'llm' | 'asr' | 'tts' | 'audio' | 'vision' | 'video'; active: boolean }> {
   return [
     { key: 'llm', active: setting.supports_llm },
     { key: 'vision', active: setting.supports_image_input },
     { key: 'asr', active: setting.supports_asr },
     { key: 'tts', active: setting.supports_tts },
     { key: 'audio', active: setting.supports_audio_input },
-    { key: 'video', active: setting.supports_video_input },
+    { key: 'video', active: setting.supports_video_input }
   ]
 }
 </script>
@@ -281,7 +303,11 @@ function capabilityList(setting: LLMSetting): Array<{ key: 'llm' | 'asr' | 'tts'
           <h2 class="font-semibold">{{ t('settings.models.runtimeTitle') }}</h2>
           <div class="mt-1 text-xs text-gray-500">{{ t('settings.models.runtimeSubtitle') }}</div>
         </div>
-        <span data-testid="agent-settings-manager-runtime-count" class="rounded-full border border-white/10 px-3 py-1 text-xs text-gray-400">{{ t('settings.models.available', { count: availableManagerModelCount }) }}</span>
+        <span
+          data-testid="agent-settings-manager-runtime-count"
+          class="rounded-full border border-white/10 px-3 py-1 text-xs text-gray-400"
+          >{{ t('settings.models.available', { count: availableManagerModelCount }) }}</span
+        >
       </div>
       <div v-if="currentManagerUsesCodex" class="mt-4 grid gap-3 md:grid-cols-2">
         <div
@@ -300,7 +326,9 @@ function capabilityList(setting: LLMSetting): Array<{ key: 'llm' | 'asr' | 'tts'
         >
           <span>{{ currentCodexModelLabel }}</span>
           <span class="text-xs text-gray-500">
-            <template v-if="managerConfig?.reasoning_effort">{{ managerConfig.reasoning_effort }} · </template>{{ currentCodexServiceTierLabel }}
+            <template v-if="managerConfig?.reasoning_effort"
+              >{{ managerConfig.reasoning_effort }} · </template
+            >{{ currentCodexServiceTierLabel }}
           </span>
         </div>
       </div>
@@ -311,7 +339,11 @@ function capabilityList(setting: LLMSetting): Array<{ key: 'llm' | 'asr' | 'tts'
           :disabled="store.managerRuntimeLoading"
           @change="handleManagerProviderChange"
         >
-          <option v-for="provider in store.managerProviderOptions" :key="provider" :value="provider">
+          <option
+            v-for="provider in store.managerProviderOptions"
+            :key="provider"
+            :value="provider"
+          >
             {{ store.managerProviderLabel(provider) }}
           </option>
         </select>
@@ -334,23 +366,67 @@ function capabilityList(setting: LLMSetting): Array<{ key: 'llm' | 'asr' | 'tts'
       </div>
     </div>
 
+    <CustomProviderManager
+      :providers="providers"
+      :settings="llmSettings"
+      @refresh="emit('refresh')"
+      @notice="emit('set-notice', $event)"
+      @add-model="openCreate"
+    />
+
     <div class="rounded-lg border border-white/10 bg-[#252525]">
-      <div class="flex flex-wrap items-center justify-between gap-3 border-b border-white/10 px-4 py-3">
+      <div
+        class="flex flex-wrap items-center justify-between gap-3 border-b border-white/10 px-4 py-3"
+      >
         <div>
           <h2 class="font-semibold">{{ t('settings.models.configuredTitle') }}</h2>
-          <div class="mt-1 text-xs text-gray-500">{{ t('settings.models.summary', { providers: providers.length, models: configuredModelCount }) }}</div>
+          <div class="mt-1 text-xs text-gray-500">
+            {{
+              t('settings.models.summary', {
+                providers: providers.length,
+                models: configuredModelCount
+              })
+            }}
+          </div>
         </div>
-        <button
-          class="inline-flex items-center gap-2 rounded-md bg-blue-500 px-3 py-2 text-sm text-white hover:bg-blue-400 disabled:opacity-50"
-          :disabled="loading"
-          @click="openCreate"
-        >
-          <Plus class="h-4 w-4" />
-          {{ t('settings.models.addModel') }}
-        </button>
+        <div class="relative">
+          <button
+            data-testid="add-model-menu-button"
+            class="inline-flex items-center gap-2 rounded-md bg-blue-500 px-3 py-2 text-sm text-white hover:bg-blue-400 disabled:opacity-50"
+            :disabled="loading"
+            aria-haspopup="menu"
+            :aria-expanded="createMenuOpen"
+            @click="toggleCreateMenu"
+          >
+            <Plus class="h-4 w-4" />
+            {{ t('settings.models.addModel') }}
+            <ChevronDown class="h-3.5 w-3.5" />
+          </button>
+          <div
+            v-if="createMenuOpen"
+            class="absolute right-0 top-full z-20 mt-2 w-56 rounded-md border border-white/12 bg-[#202426] p-1.5 shadow-2xl"
+            role="menu"
+          >
+            <button
+              v-for="option in purposeOptions"
+              :key="option.id"
+              :data-testid="`add-model-purpose-${option.id}`"
+              type="button"
+              class="flex w-full items-center gap-3 rounded px-3 py-2.5 text-left text-sm text-gray-200 hover:bg-white/7"
+              role="menuitem"
+              @click="openCreate(option.id)"
+            >
+              <component :is="option.icon" class="h-4 w-4 text-cyan-200/80" />
+              <span>{{ option.label }}</span>
+            </button>
+          </div>
+        </div>
       </div>
 
-      <div v-if="loading && !configuredModelCount" class="px-4 py-8 text-center text-sm text-gray-500">
+      <div
+        v-if="loading && !configuredModelCount"
+        class="px-4 py-8 text-center text-sm text-gray-500"
+      >
         <Loader2 class="mx-auto h-5 w-5 animate-spin" />
         <div class="mt-2">{{ t('settings.models.loading') }}</div>
       </div>
@@ -369,9 +445,19 @@ function capabilityList(setting: LLMSetting): Array<{ key: 'llm' | 'asr' | 'tts'
             <div class="min-w-0 flex-1">
               <div class="flex flex-wrap items-center gap-2">
                 <span class="font-medium">Codex</span>
-                <span v-if="currentManagerUsesCodex" class="rounded-full bg-emerald-400/10 px-2 py-0.5 text-[10px] text-emerald-200">{{ t('settings.models.currentManager') }}</span>
-                <span v-if="codexModels.length" class="rounded-full bg-cyan-400/10 px-2 py-0.5 text-[10px] text-cyan-200">{{ t('settings.models.autoDetected') }}</span>
-                <span class="rounded-full bg-white/5 px-2 py-0.5 text-[10px] text-gray-300">{{ t('settings.models.readOnly') }}</span>
+                <span
+                  v-if="currentManagerUsesCodex"
+                  class="rounded-full bg-emerald-400/10 px-2 py-0.5 text-[10px] text-emerald-200"
+                  >{{ t('settings.models.currentManager') }}</span
+                >
+                <span
+                  v-if="codexModels.length"
+                  class="rounded-full bg-cyan-400/10 px-2 py-0.5 text-[10px] text-cyan-200"
+                  >{{ t('settings.models.autoDetected') }}</span
+                >
+                <span class="rounded-full bg-white/5 px-2 py-0.5 text-[10px] text-gray-300">{{
+                  t('settings.models.readOnly')
+                }}</span>
               </div>
               <div class="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500">
                 <span>OpenAI Codex</span>
@@ -379,17 +465,31 @@ function capabilityList(setting: LLMSetting): Array<{ key: 'llm' | 'asr' | 'tts'
                 <span>{{ t('settings.models.localCli') }}</span>
                 <template v-if="codexModels.length">
                   <span>·</span>
-                  <span>{{ t('settings.models.availableModelList', { count: codexModels.length, models: codexModelSummary }) }}</span>
+                  <span>{{
+                    t('settings.models.availableModelList', {
+                      count: codexModels.length,
+                      models: codexModelSummary
+                    })
+                  }}</span>
                 </template>
                 <template v-else-if="currentCodexModelName">
                   <span>·</span>
-                  <span>{{ t('settings.models.currentModel', { model: currentCodexModelLabel }) }}</span>
+                  <span>{{
+                    t('settings.models.currentModel', { model: currentCodexModelLabel })
+                  }}</span>
                 </template>
               </div>
               <div class="mt-2 flex flex-wrap items-center gap-2">
                 <CapabilityBadge capability="llm" :active="true" />
-                <span v-if="currentManagerUsesCodex" class="rounded-full bg-white/5 px-2 py-0.5 text-[10px] text-gray-300">
-                  {{ currentCodexModelLabel }}<template v-if="managerConfig?.reasoning_effort"> · {{ managerConfig.reasoning_effort }}</template> · {{ currentCodexServiceTierLabel }}
+                <span
+                  v-if="currentManagerUsesCodex"
+                  class="rounded-full bg-white/5 px-2 py-0.5 text-[10px] text-gray-300"
+                >
+                  {{ currentCodexModelLabel
+                  }}<template v-if="managerConfig?.reasoning_effort">
+                    · {{ managerConfig.reasoning_effort }}</template
+                  >
+                  · {{ currentCodexServiceTierLabel }}
                 </span>
               </div>
             </div>
@@ -411,8 +511,15 @@ function capabilityList(setting: LLMSetting): Array<{ key: 'llm' | 'asr' | 'tts'
             <div class="min-w-0 flex-1">
               <div class="flex items-center gap-2">
                 <span class="font-medium">{{ setting.display_name || setting.model_name }}</span>
-                <span v-if="setting.is_default" class="rounded-full bg-emerald-400/10 px-2 py-0.5 text-[10px] text-emerald-200">{{ t('settings.models.default') }}</span>
-                <span class="rounded-full bg-emerald-500/10 px-2 py-0.5 text-[10px] text-emerald-200">{{ t('settings.models.active') }}</span>
+                <span
+                  v-if="setting.is_default"
+                  class="rounded-full bg-emerald-400/10 px-2 py-0.5 text-[10px] text-emerald-200"
+                  >{{ t('settings.models.default') }}</span
+                >
+                <span
+                  class="rounded-full bg-emerald-500/10 px-2 py-0.5 text-[10px] text-emerald-200"
+                  >{{ t('settings.models.active') }}</span
+                >
               </div>
               <div class="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500">
                 <span>{{ setting.provider_name }}</span>
@@ -420,7 +527,12 @@ function capabilityList(setting: LLMSetting): Array<{ key: 'llm' | 'asr' | 'tts'
                 <span>{{ localizedPlanLabel(setting.plan_type) }}</span>
                 <span>·</span>
                 <span v-if="setting.models && setting.models.length > 1" class="text-gray-400">
-                  {{ t('settings.models.modelList', { count: setting.models.length, models: setting.models.slice(0, 3).join(', ') }) }}{{ setting.models.length > 3 ? '...' : '' }}
+                  {{
+                    t('settings.models.modelList', {
+                      count: setting.models.length,
+                      models: setting.models.slice(0, 3).join(', ')
+                    })
+                  }}{{ setting.models.length > 3 ? '...' : '' }}
                 </span>
                 <span v-else>{{ setting.model_name }}</span>
                 <span>·</span>
@@ -433,8 +545,14 @@ function capabilityList(setting: LLMSetting): Array<{ key: 'llm' | 'asr' | 'tts'
                   :capability="cap.key"
                   :active="cap.active"
                 />
-                <span v-if="setting.plan_type === 'custom' || setting.endpoint_id?.endsWith('_custom')" class="rounded-full bg-amber-400/10 px-2 py-0.5 text-[10px] text-amber-200">{{ t('settings.models.custom') }}</span>
-                <span class="rounded-full bg-white/5 px-2 py-0.5 text-[10px] text-gray-300">{{ localizedPlanLabel(setting.plan_type) }}</span>
+                <span
+                  v-if="setting.plan_type === 'custom' || setting.endpoint_id?.endsWith('_custom')"
+                  class="rounded-full bg-amber-400/10 px-2 py-0.5 text-[10px] text-amber-200"
+                  >{{ t('settings.models.custom') }}</span
+                >
+                <span class="rounded-full bg-white/5 px-2 py-0.5 text-[10px] text-gray-300">{{
+                  localizedPlanLabel(setting.plan_type)
+                }}</span>
               </div>
             </div>
 
@@ -444,10 +562,15 @@ function capabilityList(setting: LLMSetting): Array<{ key: 'llm' | 'asr' | 'tts'
                 :disabled="savingId === `default-${setting.id}`"
                 @click="setDefault(setting)"
               >
-                <Loader2 v-if="savingId === `default-${setting.id}`" class="inline h-3 w-3 animate-spin" />
+                <Loader2
+                  v-if="savingId === `default-${setting.id}`"
+                  class="inline h-3 w-3 animate-spin"
+                />
                 <span v-else>{{ t('settings.models.setDefault') }}</span>
               </button>
               <button
+                :data-testid="`edit-model-${setting.id}`"
+                :title="t('settings.models.editTitle')"
                 class="rounded-md border border-white/10 px-3 py-1.5 text-xs text-gray-300 hover:bg-white/5"
                 @click="openEdit(setting)"
               >
@@ -458,23 +581,51 @@ function capabilityList(setting: LLMSetting): Array<{ key: 'llm' | 'asr' | 'tts'
                 :disabled="savingId === `active-${setting.id}`"
                 @click="toggleActive(setting)"
               >
-                <Loader2 v-if="savingId === `active-${setting.id}`" class="inline h-3 w-3 animate-spin" />
+                <Loader2
+                  v-if="savingId === `active-${setting.id}`"
+                  class="inline h-3 w-3 animate-spin"
+                />
                 <span v-else>{{ t('settings.actions.disable') }}</span>
               </button>
-              <button
-                class="rounded-md border border-red-500/30 px-2 py-1.5 text-red-300 hover:bg-red-500/10"
-                :disabled="savingId === `delete-${setting.id}`"
-                @click="remove(setting)"
-              >
-                <Loader2 v-if="savingId === `delete-${setting.id}`" class="inline h-4 w-4 animate-spin" />
-                <Trash2 v-else class="h-4 w-4" />
-              </button>
+              <div>
+                <button
+                  :data-testid="`delete-model-${setting.id}`"
+                  class="rounded-md border border-red-500/30 px-2 py-1.5 text-red-300 hover:bg-red-500/10"
+                  :class="deleteConfirmId === setting.id ? 'bg-red-500/10' : ''"
+                  :disabled="savingId === `delete-${setting.id}`"
+                  @click="toggleDeleteConfirm(setting.id)"
+                >
+                  <Loader2
+                    v-if="savingId === `delete-${setting.id}`"
+                    class="inline h-4 w-4 animate-spin"
+                  />
+                  <Trash2 v-else class="h-4 w-4" />
+                </button>
+              </div>
             </div>
           </div>
+          <InlineDeleteConfirm
+            v-if="deleteConfirmId === setting.id"
+            :test-id="`delete-model-confirm-${setting.id}`"
+            :message="
+              t('settings.models.deleteConfirm', {
+                name: setting.display_name || setting.model_name
+              })
+            "
+            :loading="savingId === `delete-${setting.id}`"
+            class="ml-auto mt-3 w-72 max-w-full"
+            @confirm="confirmRemove(setting)"
+            @cancel="cancelDelete"
+          />
         </div>
 
-        <div v-if="inactiveSettings.length" class="border-t border-dashed border-white/10 px-4 py-2">
-          <div class="text-xs text-gray-500">{{ t('settings.models.inactive', { count: inactiveSettings.length }) }}</div>
+        <div
+          v-if="inactiveSettings.length"
+          class="border-t border-dashed border-white/10 px-4 py-2"
+        >
+          <div class="text-xs text-gray-500">
+            {{ t('settings.models.inactive', { count: inactiveSettings.length }) }}
+          </div>
         </div>
         <div
           v-for="setting in inactiveSettings"
@@ -484,11 +635,22 @@ function capabilityList(setting: LLMSetting): Array<{ key: 'llm' | 'asr' | 'tts'
         >
           <div class="flex flex-col gap-2 xl:flex-row xl:items-center xl:justify-between">
             <div class="min-w-0 flex-1">
-              <div class="text-sm font-medium text-gray-400">{{ setting.display_name || setting.model_name }}</div>
+              <div class="text-sm font-medium text-gray-400">
+                {{ setting.display_name || setting.model_name }}
+              </div>
               <div class="mt-0.5 text-xs text-gray-600">
                 {{ setting.provider_name }}
-                <span v-if="setting.plan_type === 'custom' || setting.endpoint_id?.endsWith('_custom')" class="ml-1 rounded bg-amber-400/10 px-1 text-amber-200/70">{{ t('settings.models.custom') }}</span>
-                · {{ localizedPlanLabel(setting.plan_type) }} · {{ setting.models && setting.models.length > 1 ? t('settings.models.modelsCount', { count: setting.models.length }) : setting.model_name }}
+                <span
+                  v-if="setting.plan_type === 'custom' || setting.endpoint_id?.endsWith('_custom')"
+                  class="ml-1 rounded bg-amber-400/10 px-1 text-amber-200/70"
+                  >{{ t('settings.models.custom') }}</span
+                >
+                · {{ localizedPlanLabel(setting.plan_type) }} ·
+                {{
+                  setting.models && setting.models.length > 1
+                    ? t('settings.models.modelsCount', { count: setting.models.length })
+                    : setting.model_name
+                }}
               </div>
             </div>
             <div class="flex items-center gap-2">
@@ -497,18 +659,42 @@ function capabilityList(setting: LLMSetting): Array<{ key: 'llm' | 'asr' | 'tts'
                 :disabled="savingId === `active-${setting.id}`"
                 @click="toggleActive(setting)"
               >
-                <Loader2 v-if="savingId === `active-${setting.id}`" class="inline h-3 w-3 animate-spin" />
+                <Loader2
+                  v-if="savingId === `active-${setting.id}`"
+                  class="inline h-3 w-3 animate-spin"
+                />
                 <span v-else>{{ t('settings.actions.enable') }}</span>
               </button>
-              <button
-                class="rounded-md border border-red-500/30 px-2 py-1.5 text-red-300/70 hover:bg-red-500/10"
-                :disabled="savingId === `delete-${setting.id}`"
-                @click="remove(setting)"
-              >
-                <Trash2 class="h-4 w-4" />
-              </button>
+              <div>
+                <button
+                  :data-testid="`delete-model-${setting.id}`"
+                  class="rounded-md border border-red-500/30 px-2 py-1.5 text-red-300/70 hover:bg-red-500/10"
+                  :class="deleteConfirmId === setting.id ? 'bg-red-500/10' : ''"
+                  :disabled="savingId === `delete-${setting.id}`"
+                  @click="toggleDeleteConfirm(setting.id)"
+                >
+                  <Loader2
+                    v-if="savingId === `delete-${setting.id}`"
+                    class="inline h-4 w-4 animate-spin"
+                  />
+                  <Trash2 v-else class="h-4 w-4" />
+                </button>
+              </div>
             </div>
           </div>
+          <InlineDeleteConfirm
+            v-if="deleteConfirmId === setting.id"
+            :test-id="`delete-model-confirm-${setting.id}`"
+            :message="
+              t('settings.models.deleteConfirm', {
+                name: setting.display_name || setting.model_name
+              })
+            "
+            :loading="savingId === `delete-${setting.id}`"
+            class="ml-auto mt-3 w-72 max-w-full"
+            @confirm="confirmRemove(setting)"
+            @cancel="cancelDelete"
+          />
         </div>
       </template>
     </div>
@@ -519,16 +705,42 @@ function capabilityList(setting: LLMSetting): Array<{ key: 'llm' | 'asr' | 'tts'
         <div v-if="dialogOpen" class="settings-model-overlay" @click="closeDialog" />
       </transition>
       <transition name="settings-panel">
-        <div v-if="dialogOpen" class="settings-model-panel" data-testid="agent-settings-model-dialog" @click.stop>
+        <div
+          v-if="dialogOpen"
+          class="settings-model-panel"
+          data-testid="agent-settings-model-dialog"
+          @click.stop
+        >
           <div class="flex h-full flex-col">
-            <div class="flex items-center justify-between border-b border-cyan-200/10 px-5 py-4 flex-shrink-0">
-              <h2 class="text-base font-semibold text-cyan-50">{{ editingSetting ? t('settings.models.editTitle') : t('settings.models.addTitle') }}</h2>
-              <button class="rounded-md border border-cyan-200/14 px-3 py-1.5 text-sm text-gray-400 transition-colors hover:bg-cyan-200/10 hover:text-white" @click="closeDialog">{{ t('settings.actions.close') }}</button>
+            <div
+              class="flex items-center justify-between border-b border-cyan-200/10 px-5 py-4 flex-shrink-0"
+            >
+              <h2 class="text-base font-semibold text-cyan-50">
+                {{
+                  editingSetting ? t('settings.models.editTitle') : t('settings.models.addTitle')
+                }}
+              </h2>
+              <button
+                class="rounded-md border border-cyan-200/14 px-3 py-1.5 text-sm text-gray-400 transition-colors hover:bg-cyan-200/10 hover:text-white"
+                @click="closeDialog"
+              >
+                {{ t('settings.actions.close') }}
+              </button>
             </div>
             <div class="min-h-0 flex-1 overflow-y-auto">
+              <EditModelForm
+                v-if="editingSetting"
+                :setting="editingSetting"
+                :submitting="savingId === 'dialog'"
+                @submit="handleEditSubmit"
+                @cancel="closeDialog"
+              />
               <ModelForm
+                v-else
                 :providers="providers"
-                :editing="editingSetting"
+                :settings="llmSettings"
+                :purpose="createPurpose"
+                :initial-provider-id="createProviderId"
                 :submitting="savingId === 'dialog'"
                 @submit="handleSubmit"
                 @cancel="closeDialog"

--- a/agent-ui/src/locales/en-US/settings.json
+++ b/agent-ui/src/locales/en-US/settings.json
@@ -44,6 +44,7 @@
     "verify": "Verify",
     "enable": "Enable",
     "disable": "Disable",
+    "delete": "Delete",
     "operationFailed": "Operation failed"
   },
   "git": {
@@ -85,6 +86,11 @@
     "configuredTitle": "Configured models",
     "summary": "{providers} providers · {models} model settings",
     "addModel": "Add model",
+    "purposes": {
+      "llm": "Language model",
+      "asr": "Speech recognition (ASR)",
+      "tts": "Speech synthesis (TTS)"
+    },
     "loading": "Loading...",
     "empty": "No model settings yet. Use Add model to create one.",
     "default": "Default",
@@ -100,6 +106,31 @@
     "added": "Added {count} model settings",
     "deleteConfirm": "Delete model setting {name}?",
     "deleted": "Model setting deleted",
+    "edit": {
+      "provider": "Provider and credential",
+      "format": "Audio format",
+      "sampleRate": "Sample rate"
+    },
+    "providers": {
+      "title": "Custom providers",
+      "subtitle": "Define a provider first, then fetch and add models for a specific purpose.",
+      "add": "Add provider",
+      "empty": "No custom providers",
+      "defaultModel": "Default model",
+      "protocolUrls": "Protocol-specific URLs",
+      "voiceEndpoints": "Voice endpoints",
+      "ttsHttp": "TTS speech HTTP",
+      "ttsStreamingHttp": "TTS streaming HTTP",
+      "asrHttp": "ASR transcription HTTP",
+      "asrRealtimeWs": "ASR realtime WebSocket",
+      "references": "{count} model settings use this provider",
+      "saved": "Custom provider saved",
+      "deleted": "Custom provider deleted",
+      "deleteConfirm": "Delete custom provider {name}?",
+      "deleteCascade": "Delete provider and {count} model | Delete provider and {count} models",
+      "deleteCascadeConfirm": "Delete custom provider {name} and this {count} model setting: {models}? This cannot be undone. | Delete custom provider {name} and these {count} model settings: {models}? This cannot be undone.",
+      "createFirst": "Create the provider before adding models"
+    },
     "form": {
       "credentialType": "Select credential type",
       "search": "Search providers or plans...",
@@ -128,8 +159,16 @@
       "modelName": "Model name",
       "modelId": "Model ID",
       "keepKey": "Leave blank to keep the existing key",
+      "reuseCredential": "Reuse the saved credential for this provider",
+      "useDifferentKey": "Use another key",
+      "useSavedKey": "Use saved key",
       "capabilities": "Model capabilities",
-      "probeFailedFallback": "Discovery failed"
+      "probeFailedFallback": "Discovery failed",
+      "serviceUrl": "Service URL",
+      "voice": "Voice",
+      "voicePlaceholder": "Optional voice ID",
+      "discoverModels": "Fetch the provider model list, then select a model",
+      "fetchModels": "Fetch models"
     },
     "plans": {
       "apiBilling": "API billing",

--- a/agent-ui/src/locales/zh-Hans/settings.json
+++ b/agent-ui/src/locales/zh-Hans/settings.json
@@ -44,6 +44,7 @@
     "verify": "验证",
     "enable": "启用",
     "disable": "停用",
+    "delete": "删除",
     "operationFailed": "操作失败"
   },
   "git": {
@@ -85,6 +86,11 @@
     "configuredTitle": "已配置模型",
     "summary": "{providers} 个供应商 · {models} 个模型配置",
     "addModel": "添加模型",
+    "purposes": {
+      "llm": "大语言模型",
+      "asr": "语音识别（ASR）",
+      "tts": "语音合成（TTS）"
+    },
     "loading": "加载中...",
     "empty": "暂无模型配置，点击右上角添加。",
     "default": "默认",
@@ -100,6 +106,31 @@
     "added": "已添加 {count} 个模型配置",
     "deleteConfirm": "删除模型配置 {name}？",
     "deleted": "模型配置已删除",
+    "edit": {
+      "provider": "供应商与凭证",
+      "format": "音频格式",
+      "sampleRate": "采样率"
+    },
+    "providers": {
+      "title": "自定义供应商",
+      "subtitle": "先定义供应商，再按用途获取并添加模型。",
+      "add": "添加供应商",
+      "empty": "暂无自定义供应商",
+      "defaultModel": "默认模型",
+      "protocolUrls": "各协议接入地址",
+      "voiceEndpoints": "语音服务端点",
+      "ttsHttp": "TTS 语音合成 HTTP",
+      "ttsStreamingHttp": "TTS 流式合成 HTTP",
+      "asrHttp": "ASR 转写 HTTP",
+      "asrRealtimeWs": "ASR 实时 WebSocket",
+      "references": "有 {count} 个模型配置使用此供应商",
+      "saved": "自定义供应商已保存",
+      "deleted": "自定义供应商已删除",
+      "deleteConfirm": "删除自定义供应商 {name}？",
+      "deleteCascade": "删除供应商及 {count} 个模型",
+      "deleteCascadeConfirm": "确定删除自定义供应商 {name} 及以下 {count} 个模型配置吗：{models}？此操作无法撤销。",
+      "createFirst": "请先创建供应商，再添加模型"
+    },
     "form": {
       "credentialType": "选择凭证类型",
       "search": "搜索供应商/计费...",
@@ -128,8 +159,16 @@
       "modelName": "模型名称",
       "modelId": "模型 ID",
       "keepKey": "留空则保留原 Key",
+      "reuseCredential": "复用该供应商已保存的凭据",
+      "useDifferentKey": "使用其他 Key",
+      "useSavedKey": "使用已保存的 Key",
       "capabilities": "模型能力",
-      "probeFailedFallback": "探测失败"
+      "probeFailedFallback": "探测失败",
+      "serviceUrl": "服务地址",
+      "voice": "音色",
+      "voicePlaceholder": "可选音色 ID",
+      "discoverModels": "先获取供应商模型列表，再选择要添加的模型",
+      "fetchModels": "获取模型"
     },
     "plans": {
       "apiBilling": "API 计费",

--- a/agent-ui/src/locales/zh-Hant/settings.json
+++ b/agent-ui/src/locales/zh-Hant/settings.json
@@ -44,6 +44,7 @@
     "verify": "驗證",
     "enable": "啓用",
     "disable": "停用",
+    "delete": "刪除",
     "operationFailed": "操作失敗"
   },
   "git": {
@@ -85,6 +86,11 @@
     "configuredTitle": "已配置模型",
     "summary": "{providers} 個供應商 · {models} 個模型配置",
     "addModel": "添加模型",
+    "purposes": {
+      "llm": "大語言模型",
+      "asr": "語音識別（ASR）",
+      "tts": "語音合成（TTS）"
+    },
     "loading": "加載中...",
     "empty": "暫無模型配置，點擊右上角添加。",
     "default": "默認",
@@ -100,6 +106,31 @@
     "added": "已添加 {count} 個模型配置",
     "deleteConfirm": "刪除模型配置 {name}？",
     "deleted": "模型配置已刪除",
+    "edit": {
+      "provider": "供應商與憑證",
+      "format": "音訊格式",
+      "sampleRate": "採樣率"
+    },
+    "providers": {
+      "title": "自定義供應商",
+      "subtitle": "先定義供應商，再按用途獲取並添加模型。",
+      "add": "添加供應商",
+      "empty": "暫無自定義供應商",
+      "defaultModel": "默認模型",
+      "protocolUrls": "各協議接入地址",
+      "voiceEndpoints": "語音服務端點",
+      "ttsHttp": "TTS 語音合成 HTTP",
+      "ttsStreamingHttp": "TTS 串流合成 HTTP",
+      "asrHttp": "ASR 轉寫 HTTP",
+      "asrRealtimeWs": "ASR 即時 WebSocket",
+      "references": "有 {count} 個模型配置使用此供應商",
+      "saved": "自定義供應商已保存",
+      "deleted": "自定義供應商已刪除",
+      "deleteConfirm": "刪除自定義供應商 {name}？",
+      "deleteCascade": "刪除供應商及 {count} 個模型",
+      "deleteCascadeConfirm": "確定刪除自定義供應商 {name} 及以下 {count} 個模型配置嗎：{models}？此操作無法撤銷。",
+      "createFirst": "請先創建供應商，再添加模型"
+    },
     "form": {
       "credentialType": "選擇憑證類型",
       "search": "搜索供應商/計費...",
@@ -128,8 +159,16 @@
       "modelName": "模型名稱",
       "modelId": "模型 ID",
       "keepKey": "留空則保留原 Key",
+      "reuseCredential": "重用該供應商已儲存的憑證",
+      "useDifferentKey": "使用其他 Key",
+      "useSavedKey": "使用已儲存的 Key",
       "capabilities": "模型能力",
-      "probeFailedFallback": "探測失敗"
+      "probeFailedFallback": "探測失敗",
+      "serviceUrl": "服務地址",
+      "voice": "音色",
+      "voicePlaceholder": "可選音色 ID",
+      "discoverModels": "先獲取供應商模型列表，再選擇要添加的模型",
+      "fetchModels": "獲取模型"
     },
     "plans": {
       "apiBilling": "API 計費",

--- a/homerail_manager/src/config/env.ts
+++ b/homerail_manager/src/config/env.ts
@@ -3,7 +3,15 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 
 export function getHomerailHome(): string {
-  return process.env.HOMERAIL_HOME || path.join(os.homedir(), ".homerail");
+  const configured = process.env.HOMERAIL_HOME || path.join(os.homedir(), ".homerail");
+  if (process.env.VITEST && process.env.HOMERAIL_ALLOW_UNSAFE_TEST_HOME !== "1") {
+    const relative = path.relative(path.resolve(os.tmpdir()), path.resolve(configured));
+    const isTemporary = relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+    if (!isTemporary) {
+      throw new Error(`Vitest refused non-temporary HOMERAIL_HOME: ${configured}`);
+    }
+  }
+  return configured;
 }
 
 export const DEFAULT_MANAGER_PORT = 19191;

--- a/homerail_manager/src/orchestration/dag-engine.ts
+++ b/homerail_manager/src/orchestration/dag-engine.ts
@@ -187,11 +187,34 @@ function _skipDependentNodes(run: DAGRun, unavailableNodeId: string, sourceWasSk
     if (edge.from_node !== unavailableNodeId) continue;
     if (!sourceWasSkipped && edge.condition !== "on_success") continue;
     if (!edge.to_node) continue;
-    if (run.nodeStates.get(edge.to_node) !== "PENDING") continue;
+    const state = run.nodeStates.get(edge.to_node);
+    if (state !== "PENDING" && state !== "READY") continue;
+    // An explicit on_failure/always route from the failed node is allowed to
+    // wake the same target; a plain after dependency is not.
+    if (!sourceWasSkipped) {
+      const hasFailureRoute = run.graph.edges.some((candidate) =>
+        candidate.from_node === unavailableNodeId &&
+        candidate.to_node === edge.to_node &&
+        candidate.label !== "after_dep" &&
+        (candidate.condition === "on_failure" || candidate.condition === "always")
+      );
+      if (hasFailureRoute || run.inputSatisfied.get(edge.to_node)?.has(unavailableNodeId)) continue;
+    }
     if (_hasAlternativePath(run, edge.to_node, unavailableNodeId)) continue;
     run.nodeStates.set(edge.to_node, "SKIPPED");
     _skipDependentNodes(run, edge.to_node, true);
   }
+}
+
+export function reconcileFailedDependencies(run: DAGRun): string[] {
+  const before = new Map(run.nodeStates);
+  for (const [nodeId, state] of before) {
+    if (state === "FAILED") _skipDependentNodes(run, nodeId);
+  }
+  return Array.from(run.nodeStates.entries())
+    .filter(([nodeId, state]) => state === "SKIPPED" && before.get(nodeId) !== "SKIPPED")
+    .map(([nodeId]) => nodeId)
+    .sort();
 }
 
 function _wakeLoopSource(run: DAGRun, nodeId: string): void {

--- a/homerail_manager/src/persistence/llm-settings.ts
+++ b/homerail_manager/src/persistence/llm-settings.ts
@@ -75,6 +75,7 @@ export interface LLMSettingInput extends ModelCapabilities {
   /** 该凭证可用的模型列表（多模型凭证）。若提供，model_name 取第一个作为主模型。 */
   models?: string[];
   api_key: string;
+  reuse_existing_api_key?: boolean;
   display_name?: string;
   alias?: string;
   endpoint_id?: string;
@@ -1041,6 +1042,7 @@ export function updateProvider(id: string, patch: Partial<Omit<ProviderInput, "i
   if (_isReadonlyProvider(id) || findCatalogProvider(id)) {
     throw new Error(`Cannot update built-in provider: ${id}`);
   }
+  const previousEndpoint = _customEndpointForProvider(existing);
   const provider = upsertProvider({
     id,
     name: patch.name ?? existing.name,
@@ -1063,21 +1065,51 @@ export function updateProvider(id: string, patch: Partial<Omit<ProviderInput, "i
     supports_video_input: patch.supports_video_input ?? existing.supports_video_input,
   });
   const endpoint = _customEndpointForProvider(provider);
-  if (endpoint) {
+  if (endpoint && previousEndpoint) {
     const settings = _readSettings();
     let changed = false;
     const updatedAt = new Date().toISOString();
     for (const setting of settings) {
       if (setting.provider_id !== id) continue;
-      setting.base_url = endpoint.base_url;
-      setting.chat_completions_base_url = endpoint.chat_completions_base_url;
-      setting.responses_base_url = endpoint.responses_base_url;
-      setting.anthropic_base_url = endpoint.anthropic_base_url;
-      setting.voice_adapter = endpoint.voice_adapter;
-      setting.tts_http_url = endpoint.tts_http_url;
-      setting.tts_realtime_url = endpoint.tts_realtime_url;
-      setting.asr_realtime_url = endpoint.asr_realtime_url;
-      setting.asr_async_url = endpoint.asr_async_url;
+      if (setting.endpoint_id && setting.endpoint_id !== previousEndpoint.id) continue;
+      const inherited = <T>(current: T | undefined, previous: T | undefined, next: T | undefined) =>
+        current === undefined || current === previous ? next : current;
+      const nextValues = {
+        base_url: inherited(setting.base_url, previousEndpoint.base_url, endpoint.base_url),
+        chat_completions_base_url: inherited(
+          setting.chat_completions_base_url,
+          previousEndpoint.chat_completions_base_url,
+          endpoint.chat_completions_base_url,
+        ),
+        responses_base_url: inherited(
+          setting.responses_base_url,
+          previousEndpoint.responses_base_url,
+          endpoint.responses_base_url,
+        ),
+        anthropic_base_url: inherited(
+          setting.anthropic_base_url,
+          previousEndpoint.anthropic_base_url,
+          endpoint.anthropic_base_url,
+        ),
+        voice_adapter: inherited(setting.voice_adapter, previousEndpoint.voice_adapter, endpoint.voice_adapter),
+        tts_http_url: inherited(setting.tts_http_url, previousEndpoint.tts_http_url, endpoint.tts_http_url),
+        tts_realtime_url: inherited(
+          setting.tts_realtime_url,
+          previousEndpoint.tts_realtime_url,
+          endpoint.tts_realtime_url,
+        ),
+        asr_realtime_url: inherited(
+          setting.asr_realtime_url,
+          previousEndpoint.asr_realtime_url,
+          endpoint.asr_realtime_url,
+        ),
+        asr_async_url: inherited(setting.asr_async_url, previousEndpoint.asr_async_url, endpoint.asr_async_url),
+      };
+      const settingChanged = Object.entries(nextValues).some(
+        ([field, value]) => setting[field as keyof typeof nextValues] !== value,
+      );
+      if (!settingChanged) continue;
+      Object.assign(setting, nextValues);
       setting.updated_at = updatedAt;
       changed = true;
     }
@@ -1377,7 +1409,10 @@ export function createSetting(input: LLMSettingInput): LLMSetting {
   // 只复用同 credential/endpoint 的 key。Provider 相同但计费方式不同
   // （例如 Xiaomi API 计费 vs Token Plan）必须使用不同 key。
   // 占位标记 "local-no-key" 用于本地无鉴权服务，保持原行为不强制复用。
-  if (!input.api_key || input.api_key === "__reuse_existing__") {
+  if (input.api_key === "__reuse_existing__") {
+    throw new Error("Reserved API key value: __reuse_existing__; use reuse_existing_api_key instead");
+  }
+  if (input.reuse_existing_api_key) {
     const donor = settings.find(
       (s) =>
         s.provider_id === input.provider_id &&
@@ -1389,6 +1424,8 @@ export function createSetting(input: LLMSettingInput): LLMSetting {
       throw new Error("Missing required field: api_key (no existing key to reuse for this credential)");
     }
     input = { ...input, api_key: donor.api_key };
+  } else if (!input.api_key) {
+    throw new Error("Missing required field: api_key");
   } else if (input.api_key === "local-no-key") {
     // 本地服务无鉴权：允许空 key 占位通过
   }

--- a/homerail_manager/src/persistence/llm-settings.ts
+++ b/homerail_manager/src/persistence/llm-settings.ts
@@ -42,6 +42,11 @@ export interface ProviderInfo extends ModelCapabilities {
   chat_completions_base_url?: string;
   responses_base_url?: string;
   anthropic_base_url?: string;
+  voice_adapter?: ProviderEndpointPreset["voice_adapter"];
+  tts_http_url?: string;
+  tts_realtime_url?: string;
+  asr_realtime_url?: string;
+  asr_async_url?: string;
   docs_url?: string;
   source?: "builtin" | "custom";
   readonly?: boolean;
@@ -57,6 +62,11 @@ export interface ProviderInput extends ModelCapabilities {
   chat_completions_base_url?: string;
   responses_base_url?: string;
   anthropic_base_url?: string;
+  voice_adapter?: ProviderEndpointPreset["voice_adapter"];
+  tts_http_url?: string;
+  tts_realtime_url?: string;
+  asr_realtime_url?: string;
+  asr_async_url?: string;
 }
 
 export interface LLMSettingInput extends ModelCapabilities {
@@ -248,6 +258,13 @@ function _normalizeProvider(raw: unknown): ProviderInfo | undefined {
       : undefined,
     responses_base_url: typeof rec.responses_base_url === "string" ? rec.responses_base_url : undefined,
     anthropic_base_url: typeof rec.anthropic_base_url === "string" ? rec.anthropic_base_url : undefined,
+    voice_adapter: typeof rec.voice_adapter === "string"
+      ? rec.voice_adapter as ProviderEndpointPreset["voice_adapter"]
+      : undefined,
+    tts_http_url: typeof rec.tts_http_url === "string" ? rec.tts_http_url : undefined,
+    tts_realtime_url: typeof rec.tts_realtime_url === "string" ? rec.tts_realtime_url : undefined,
+    asr_realtime_url: typeof rec.asr_realtime_url === "string" ? rec.asr_realtime_url : undefined,
+    asr_async_url: typeof rec.asr_async_url === "string" ? rec.asr_async_url : undefined,
     docs_url: typeof rec.docs_url === "string" ? rec.docs_url : undefined,
     supports_llm: typeof rec.supports_llm === "boolean" ? rec.supports_llm : undefined,
     supports_asr: typeof rec.supports_asr === "boolean" ? rec.supports_asr : undefined,
@@ -424,6 +441,7 @@ function _providerFromDbRow(
     .map((endpointRow) => _providerEndpointFromDbRow(endpointRow, modelRowsByEndpoint.get(String(endpointRow.id)) ?? []))
     .filter((endpoint): endpoint is ProviderEndpointPreset => endpoint !== undefined);
   const source = _rowString(row, "source") === "builtin" ? "builtin" : "custom";
+  const primaryEndpoint = endpoints[0];
   const provider: ProviderInfo = {
     ...raw,
     id,
@@ -434,6 +452,11 @@ function _providerFromDbRow(
     chat_completions_base_url: _rowNullableString(row, "chat_completions_base_url") ?? raw.chat_completions_base_url,
     responses_base_url: _rowNullableString(row, "responses_base_url") ?? raw.responses_base_url,
     anthropic_base_url: _rowNullableString(row, "anthropic_base_url") ?? raw.anthropic_base_url,
+    voice_adapter: primaryEndpoint?.voice_adapter ?? raw.voice_adapter,
+    tts_http_url: primaryEndpoint?.tts_http_url ?? raw.tts_http_url,
+    tts_realtime_url: primaryEndpoint?.tts_realtime_url ?? raw.tts_realtime_url,
+    asr_realtime_url: primaryEndpoint?.asr_realtime_url ?? raw.asr_realtime_url,
+    asr_async_url: primaryEndpoint?.asr_async_url ?? raw.asr_async_url,
     docs_url: _rowNullableString(row, "docs_url") ?? raw.docs_url,
     source,
     readonly: _rowBool(row.readonly, source === "builtin") ?? false,
@@ -933,6 +956,12 @@ function _customEndpointForProvider(provider: ProviderInfo): ProviderEndpointPre
     chat_completions_base_url: provider.chat_completions_base_url,
     responses_base_url: provider.responses_base_url,
     anthropic_base_url: provider.anthropic_base_url,
+    voice_adapter: provider.voice_adapter ??
+      (provider.supports_asr || provider.supports_tts ? "openai_audio" : "custom"),
+    tts_http_url: provider.tts_http_url,
+    tts_realtime_url: provider.tts_realtime_url,
+    asr_realtime_url: provider.asr_realtime_url,
+    asr_async_url: provider.asr_async_url,
     auth_type: "bearer",
     key_hint: "API key",
     default_model: provider.default_model,
@@ -988,6 +1017,11 @@ export function upsertProvider(input: ProviderInput): ProviderInfo {
     chat_completions_base_url: input.chat_completions_base_url,
     responses_base_url: input.responses_base_url,
     anthropic_base_url: input.anthropic_base_url,
+    voice_adapter: input.voice_adapter,
+    tts_http_url: input.tts_http_url,
+    tts_realtime_url: input.tts_realtime_url,
+    asr_realtime_url: input.asr_realtime_url,
+    asr_async_url: input.asr_async_url,
     supports_llm: input.supports_llm,
     supports_asr: input.supports_asr,
     supports_tts: input.supports_tts,
@@ -1001,14 +1035,73 @@ export function upsertProvider(input: ProviderInput): ProviderInfo {
   return getProvider(id) ?? _providerWithEndpointFallback(provider);
 }
 
-export function deleteProvider(id: string): boolean {
+export function updateProvider(id: string, patch: Partial<Omit<ProviderInput, "id">>): ProviderInfo {
+  const existing = getProvider(id);
+  if (!existing) throw new Error(`Provider not found: ${id}`);
+  if (_isReadonlyProvider(id) || findCatalogProvider(id)) {
+    throw new Error(`Cannot update built-in provider: ${id}`);
+  }
+  const provider = upsertProvider({
+    id,
+    name: patch.name ?? existing.name,
+    status: patch.status ?? existing.status,
+    default_model: patch.default_model ?? existing.default_model,
+    base_url: patch.base_url ?? existing.base_url,
+    chat_completions_base_url: patch.chat_completions_base_url ?? existing.chat_completions_base_url,
+    responses_base_url: patch.responses_base_url ?? existing.responses_base_url,
+    anthropic_base_url: patch.anthropic_base_url ?? existing.anthropic_base_url,
+    voice_adapter: patch.voice_adapter ?? existing.voice_adapter,
+    tts_http_url: patch.tts_http_url ?? existing.tts_http_url,
+    tts_realtime_url: patch.tts_realtime_url ?? existing.tts_realtime_url,
+    asr_realtime_url: patch.asr_realtime_url ?? existing.asr_realtime_url,
+    asr_async_url: patch.asr_async_url ?? existing.asr_async_url,
+    supports_llm: patch.supports_llm ?? existing.supports_llm,
+    supports_asr: patch.supports_asr ?? existing.supports_asr,
+    supports_tts: patch.supports_tts ?? existing.supports_tts,
+    supports_audio_input: patch.supports_audio_input ?? existing.supports_audio_input,
+    supports_image_input: patch.supports_image_input ?? existing.supports_image_input,
+    supports_video_input: patch.supports_video_input ?? existing.supports_video_input,
+  });
+  const endpoint = _customEndpointForProvider(provider);
+  if (endpoint) {
+    const settings = _readSettings();
+    let changed = false;
+    const updatedAt = new Date().toISOString();
+    for (const setting of settings) {
+      if (setting.provider_id !== id) continue;
+      setting.base_url = endpoint.base_url;
+      setting.chat_completions_base_url = endpoint.chat_completions_base_url;
+      setting.responses_base_url = endpoint.responses_base_url;
+      setting.anthropic_base_url = endpoint.anthropic_base_url;
+      setting.voice_adapter = endpoint.voice_adapter;
+      setting.tts_http_url = endpoint.tts_http_url;
+      setting.tts_realtime_url = endpoint.tts_realtime_url;
+      setting.asr_realtime_url = endpoint.asr_realtime_url;
+      setting.asr_async_url = endpoint.asr_async_url;
+      setting.updated_at = updatedAt;
+      changed = true;
+    }
+    if (changed) _writeSettings(settings);
+  }
+  return provider;
+}
+
+export function deleteProvider(id: string, options: { cascade?: boolean } = {}): boolean {
   if (!id.trim()) return false;
   if (_isReadonlyProvider(id) || findCatalogProvider(id)) throw new Error(`Cannot delete built-in provider: ${id}`);
   const db = getDb();
   const existing = db.prepare("SELECT id FROM llm_providers WHERE id = ?").get(id);
   if (!existing) return false;
+  const reference = db.prepare("SELECT COUNT(*) AS count FROM llm_settings WHERE provider_id = ?").get(id) as {
+    count: number;
+  };
+  if (reference.count > 0 && !options.cascade) {
+    throw new Error(`Provider ${id} is referenced by ${reference.count} model setting(s)`);
+  }
   db.transaction(() => {
-    db.prepare("DELETE FROM llm_settings WHERE provider_id = ?").run(id);
+    if (options.cascade) {
+      db.prepare("DELETE FROM llm_settings WHERE provider_id = ?").run(id);
+    }
     db.prepare("DELETE FROM llm_provider_models WHERE provider_id = ?").run(id);
     db.prepare("DELETE FROM llm_provider_endpoints WHERE provider_id = ?").run(id);
     db.prepare("DELETE FROM llm_providers WHERE id = ?").run(id);
@@ -1337,6 +1430,9 @@ export function updateSetting(id: string, patch: Partial<Omit<LLMSetting, "id" |
   }
 
   const existing = settings[idx];
+  if (patch.provider_id !== undefined && patch.provider_id !== existing.provider_id) {
+    throw new Error("Changing provider_id is not supported; create a new model setting instead");
+  }
   const providerId = _canonicalProviderId(
     patch.provider_id ?? existing.provider_id,
     patch.endpoint_id ?? existing.endpoint_id,

--- a/homerail_manager/src/runtime/active-runs.ts
+++ b/homerail_manager/src/runtime/active-runs.ts
@@ -6,6 +6,7 @@ import {
   createDAGRun,
   edgeMatchesHandoff,
   failNode,
+  reconcileFailedDependencies,
   getNodeState,
   getReadyNodes,
   handoff,
@@ -569,14 +570,35 @@ function _applyOrphanedNodeDemotion(run: ActiveRun): string[] {
     });
   }
 
+  const skippedBlockedNodes = reconcileFailedDependencies(run.dagRun);
+  for (const nodeId of skippedBlockedNodes) {
+    _markNodeSessionStatus(run, nodeId, "cancelled");
+  }
+
+  // A failed prerequisite can leave downstream nodes permanently PENDING. If
+  // recovery has no READY/RUNNING work left, those nodes cannot make progress.
+  const hasFailedNodes = Array.from(run.dagRun.nodeStates.values()).some((state) => state === "FAILED");
+  const hasRunnableWork = Array.from(run.dagRun.nodeStates.values())
+    .some((state) => state === "READY" || state === "RUNNING");
+  if (hasFailedNodes && !hasRunnableWork) {
+    for (const [nodeId, state] of run.dagRun.nodeStates.entries()) {
+      if (state === "PENDING") {
+        run.dagRun.nodeStates.set(nodeId, "SKIPPED");
+        _markNodeSessionStatus(run, nodeId, "cancelled");
+      }
+    }
+  }
+
   // If demoting orphaned nodes made the run terminal, mark it failed.
-  if (demotedFromRunning.length > 0 && isRunTerminal(run.dagRun)) {
+  if (hasFailedNodes && isRunTerminal(run.dagRun)) {
     run.status = "failed";
     run.completedAt = Date.now();
     emit("dag:run_failed", {
       runId: run.runId,
       nodeId: demotedFromRunning[0],
-      reason: "run failed during cold recovery (orphaned running nodes)",
+      reason: demotedFromRunning.length > 0
+        ? "run failed during cold recovery (orphaned running nodes)"
+        : "run failed during cold recovery (blocked by failed dependency)",
     });
     deprovisionProvisionedForRun(run.runId);
   }

--- a/homerail_manager/src/server/llm-settings.ts
+++ b/homerail_manager/src/server/llm-settings.ts
@@ -3,6 +3,7 @@ import {
   getDefaultProviders,
   getProvider,
   upsertProvider,
+  updateProvider,
   deleteProvider,
   listSettings,
   getSetting,
@@ -14,6 +15,7 @@ import {
   type LLMPlanType,
   type LLMProtocol,
   type LLMAuthType,
+  type ProviderInput,
 } from "../persistence/llm-settings.js";
 
 interface BaseResponse {
@@ -34,6 +36,10 @@ function _badRequest(res: http.ServerResponse, message: string) {
 
 function _notFound(res: http.ServerResponse, message: string) {
   json(res, 404, { success: false, message, error: message });
+}
+
+function _conflict(res: http.ServerResponse, message: string) {
+  json(res, 409, { success: false, message, error: message });
 }
 
 function _ok(res: http.ServerResponse, message: string, data?: unknown) {
@@ -157,7 +163,15 @@ function _authType(value: unknown): LLMAuthType | undefined {
     : undefined;
 }
 
-function _providerBody(body: Record<string, unknown>, idOverride?: string) {
+function _voiceAdapter(value: unknown): ProviderInput["voice_adapter"] {
+  return value === "openai_audio" || value === "mimo_audio" ||
+      value === "volcengine_doubao_voice" || value === "volcengine_ark_voice" ||
+      value === "volcengine_openspeech" || value === "custom"
+    ? value
+    : undefined;
+}
+
+function _providerBody(body: Record<string, unknown>, idOverride?: string): ProviderInput {
   return {
     id: idOverride ?? _requiredString(body, "id") ?? "",
     name: typeof body.name === "string" ? body.name : undefined,
@@ -170,6 +184,11 @@ function _providerBody(body: Record<string, unknown>, idOverride?: string) {
       : undefined,
     responses_base_url: typeof body.responses_base_url === "string" ? body.responses_base_url : undefined,
     anthropic_base_url: typeof body.anthropic_base_url === "string" ? body.anthropic_base_url : undefined,
+    voice_adapter: _voiceAdapter(body.voice_adapter),
+    tts_http_url: typeof body.tts_http_url === "string" ? body.tts_http_url : undefined,
+    tts_realtime_url: typeof body.tts_realtime_url === "string" ? body.tts_realtime_url : undefined,
+    asr_realtime_url: typeof body.asr_realtime_url === "string" ? body.asr_realtime_url : undefined,
+    asr_async_url: typeof body.asr_async_url === "string" ? body.asr_async_url : undefined,
     supports_llm: typeof body.supports_llm === "boolean" ? body.supports_llm : undefined,
     supports_asr: typeof body.supports_asr === "boolean" ? body.supports_asr : undefined,
     supports_tts: typeof body.supports_tts === "boolean" ? body.supports_tts : undefined,
@@ -225,7 +244,8 @@ export function llmSettingsRoutesHandler(
   req: http.IncomingMessage,
   res: http.ServerResponse,
 ): boolean {
-  const pathname = new URL(req.url || "/", "http://localhost").pathname;
+  const requestUrl = new URL(req.url || "/", "http://localhost");
+  const pathname = requestUrl.pathname;
 
   // GET /api/providers or frontend-compatible GET /api/llm/providers
   if ((pathname === "/api/providers" || pathname === "/api/llm/providers") && req.method === "GET") {
@@ -356,10 +376,12 @@ export function llmSettingsRoutesHandler(
     _readJsonBody(req)
       .then((body) => {
         try {
-          const provider = upsertProvider(_providerBody(body as Record<string, unknown>, id));
-          _ok(res, "Provider upserted", provider);
+          const provider = updateProvider(id, _providerBody(body as Record<string, unknown>, id));
+          _ok(res, "Provider updated", provider);
         } catch (err) {
-          _badRequest(res, err instanceof Error ? err.message : String(err));
+          const message = err instanceof Error ? err.message : String(err);
+          if (message.includes("not found")) _notFound(res, message);
+          else _badRequest(res, message);
         }
       })
       .catch((err) => {
@@ -370,15 +392,18 @@ export function llmSettingsRoutesHandler(
 
   if (providerMatch && req.method === "DELETE") {
     const id = decodeURIComponent(providerMatch[1]);
+    const cascade = requestUrl.searchParams.get("cascade") === "true";
     try {
-      const removed = deleteProvider(id);
+      const removed = deleteProvider(id, { cascade });
       if (!removed) {
         _notFound(res, `Provider not found: ${id}`);
         return true;
       }
-      _ok(res, "Provider deleted", { id });
+      _ok(res, "Provider deleted", { id, cascade });
     } catch (err) {
-      _badRequest(res, err instanceof Error ? err.message : String(err));
+      const message = err instanceof Error ? err.message : String(err);
+      if (message.includes("is referenced by")) _conflict(res, message);
+      else _badRequest(res, message);
     }
     return true;
   }

--- a/homerail_manager/src/server/llm-settings.ts
+++ b/homerail_manager/src/server/llm-settings.ts
@@ -207,6 +207,7 @@ function _settingCreateBody(b: Record<string, unknown>) {
       ? b.models as string[]
       : undefined,
     api_key: _requiredString(b, "api_key"),
+    reuse_existing_api_key: b.reuse_existing_api_key === true,
     display_name: _requiredString(b, "display_name") ?? _requiredString(b, "alias"),
     alias: _requiredString(b, "alias"),
     endpoint_id: _requiredString(b, "endpoint_id"),
@@ -434,7 +435,15 @@ export function llmSettingsRoutesHandler(
           _badRequest(res, "Missing required field: model_name");
           return;
         }
-        if (!parsed.api_key) {
+        if (parsed.api_key === "__reuse_existing__") {
+          _badRequest(res, "Reserved API key value: __reuse_existing__; use reuse_existing_api_key instead");
+          return;
+        }
+        if (parsed.api_key && parsed.reuse_existing_api_key) {
+          _badRequest(res, "api_key and reuse_existing_api_key are mutually exclusive");
+          return;
+        }
+        if (!parsed.api_key && !parsed.reuse_existing_api_key) {
           _badRequest(res, "Missing required field: api_key");
           return;
         }
@@ -444,7 +453,7 @@ export function llmSettingsRoutesHandler(
             ...parsed,
             provider_id: parsed.provider_id,
             model_name: parsed.model_name,
-            api_key: parsed.api_key,
+            api_key: parsed.api_key ?? "",
           });
           _created(res, "Setting created", _maskSetting(setting));
         } catch (err) {

--- a/homerail_manager/src/server/voice.ts
+++ b/homerail_manager/src/server/voice.ts
@@ -498,6 +498,7 @@ async function _transcribeOpenAiCompatibleAsr(body: VoiceTranscribeBody): Promis
     throw new Error("Missing required field: audio_data_url");
   }
   const runtime = _resolveAsrRuntime(body);
+  const configuredTranscriptionUrl = _stringField(runtime.setting?.asr_async_url);
   if (isArkVoiceSetting(runtime.setting)) {
     const result = await transcribeArkAsr(arkVoiceRuntimeFromSetting(runtime.setting, "asr"), audioDataUrl);
     return { text: result.text, raw: result.raw };
@@ -509,7 +510,10 @@ async function _transcribeOpenAiCompatibleAsr(body: VoiceTranscribeBody): Promis
   const form = new FormData();
   form.set("model", runtime.model);
   form.set("file", new Blob([new Uint8Array(audio.buffer)], { type: audio.contentType }), audio.filename);
-  const response = await fetch(_joinApiUrl(runtime.baseUrl, "/v1/audio/transcriptions"), {
+  const transcriptionUrl = configuredTranscriptionUrl?.match(/^https?:\/\//)
+    ? configuredTranscriptionUrl
+    : _joinApiUrl(runtime.baseUrl, "/v1/audio/transcriptions");
+  const response = await fetch(transcriptionUrl, {
     method: "POST",
     headers: _authHeaders(runtime.apiKey, runtime.baseUrl),
     body: form,
@@ -795,6 +799,7 @@ export function voiceRoutesHandler(
     _readJsonBody(req)
       .then(async (body) => {
         const runtime = _resolveTtsRuntime(_loadVoiceSettings());
+        const configuredSpeechUrl = _stringField(runtime.setting?.tts_http_url);
         if (!runtime.apiKey) throw new Error("Missing TTS API key");
         if (isArkVoiceSetting(runtime.setting)) {
           const text = _stringField((body as VoiceSpeechBody).text);
@@ -819,7 +824,10 @@ export function voiceRoutesHandler(
           res.end(wav);
           return;
         }
-        const upstream = await fetch(_joinApiUrl(runtime.baseUrl, "/v1/audio/speech"), {
+        const speechUrl = configuredSpeechUrl?.match(/^https?:\/\//)
+          ? configuredSpeechUrl
+          : _joinApiUrl(runtime.baseUrl, "/v1/audio/speech");
+        const upstream = await fetch(speechUrl, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
@@ -945,7 +953,8 @@ function _resolveAsrRealtimeRuntime(): {
     MIMO_API_BASE_URL;
   const model = setting?.model_name ?? _stringField(settings.asr_model) ?? MIMO_API_ASR_MODEL;
   const apiKey = setting?.api_key ?? process.env.HOMERAIL_MIMO_API_KEY ?? "";
-  const explicitRealtimeUrl = _stringField(settings.asr_realtime_url);
+  const explicitRealtimeUrl = _stringField(setting?.asr_realtime_url) ??
+    _stringField(settings.asr_realtime_url);
   const strategy: AsrRealtimeStrategy = isArkVoiceSetting(setting)
     ? "ark_voice"
     : _isMimoApiAsr({ baseUrl, model })

--- a/homerail_manager/tests/cold-recovery.test.ts
+++ b/homerail_manager/tests/cold-recovery.test.ts
@@ -91,6 +91,31 @@ nodes:
 `);
 }
 
+function blockedDownstreamDag() {
+  return parseDAGYaml(`
+name: cold-recovery-blocked
+workflow_id: cold-recovery-blocked
+workspace:
+  project_id: project-a
+agents:
+  worker:
+    agent_type: deterministic
+    system: "HANDOFF port=done content=ok"
+nodes:
+  root:
+    agent: worker
+    outputs:
+      done:
+        to: ""
+  observer:
+    agent: worker
+    after: [root]
+    outputs:
+      done:
+        to: ""
+`);
+}
+
 describe("manager cold recovery", () => {
   let tmpHome: string;
   let oldHome: string | undefined;
@@ -185,6 +210,37 @@ describe("manager cold recovery", () => {
     expect(run.dagRun.nodeStates.get("work")).toBe("FAILED");
     expect(getDagSessionIndex("run-running", "work")?.status).toBe("failed");
     expect(events.some((e) => e.nodeId === "work")).toBe(true);
+  });
+
+  it("fails recovery when orphan demotion leaves only blocked pending nodes", () => {
+    createActiveRun("run-blocked-after-restart", blockedDownstreamDag());
+    dispatchReadyNodes("run-blocked-after-restart", new CaptureDispatcher());
+
+    _clearActiveRuns();
+    const summary = recoverAllActiveRuns();
+
+    const run = getActiveRun("run-blocked-after-restart")!;
+    expect(summary.failed).toContain("run-blocked-after-restart");
+    expect(run.status).toBe("failed");
+    expect(run.dagRun.nodeStates.get("root")).toBe("FAILED");
+    expect(run.dagRun.nodeStates.get("observer")).toBe("SKIPPED");
+    expect(loadRunMetadata("run-blocked-after-restart")?.status).toBe("failed");
+  });
+
+  it("settles persisted failed and ready states left by an older recovery", () => {
+    createActiveRun("run-legacy-recovery-state", blockedDownstreamDag());
+    const run = getActiveRun("run-legacy-recovery-state")!;
+    run.dagRun.nodeStates.set("root", "FAILED");
+    run.dagRun.nodeStates.set("observer", "READY");
+    writeRunMetadata("run-legacy-recovery-state", serializeRunMetadata(run));
+
+    _clearActiveRuns();
+    const summary = recoverAllActiveRuns();
+
+    const recovered = getActiveRun("run-legacy-recovery-state")!;
+    expect(summary.failed).toContain("run-legacy-recovery-state");
+    expect(recovered.status).toBe("failed");
+    expect(recovered.dagRun.nodeStates.get("observer")).toBe("SKIPPED");
   });
 
   it("skips runs that are already terminal in persisted metadata", () => {

--- a/homerail_manager/tests/llm-providers.test.ts
+++ b/homerail_manager/tests/llm-providers.test.ts
@@ -197,15 +197,28 @@ describe("custom LLM providers", () => {
     });
     expect(settingResponse.status).toBe(201);
 
+    const overrideResponse = await fetch(`http://127.0.0.1:${port}/api/llm/settings`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        provider_id: "editable-provider",
+        model_name: "model-v2",
+        base_url: "http://model-override.test/v1",
+        api_key: "local-no-key",
+        supports_llm: true,
+      }),
+    });
+    expect(overrideResponse.status).toBe(201);
+
     const updateResponse = await fetch(`http://127.0.0.1:${port}/api/llm/providers/editable-provider`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         name: "Renamed Provider",
-        base_url: "http://provider.test/v1",
+        base_url: "http://provider-new.test/v1",
         voice_adapter: "openai_audio",
-        asr_async_url: "http://provider.test/v1/audio/transcriptions",
-        asr_realtime_url: "ws://provider.test/v1/realtime",
+        asr_async_url: "http://provider-new.test/v1/audio/transcriptions",
+        asr_realtime_url: "ws://provider-new.test/v1/realtime",
       }),
     });
     expect(updateResponse.status).toBe(200);
@@ -224,16 +237,19 @@ describe("custom LLM providers", () => {
       id: "editable-provider",
       name: "Renamed Provider",
       default_model: "model-v1",
-      base_url: "http://provider.test/v1",
+      base_url: "http://provider-new.test/v1",
       supports_asr: true,
-      asr_async_url: "http://provider.test/v1/audio/transcriptions",
-      asr_realtime_url: "ws://provider.test/v1/realtime",
+      asr_async_url: "http://provider-new.test/v1/audio/transcriptions",
+      asr_realtime_url: "ws://provider-new.test/v1/realtime",
     });
     expect(findActiveSetting("editable-provider", "model-v1")).toMatchObject({
-      base_url: "http://provider.test/v1",
+      base_url: "http://provider-new.test/v1",
       voice_adapter: "openai_audio",
-      asr_async_url: "http://provider.test/v1/audio/transcriptions",
-      asr_realtime_url: "ws://provider.test/v1/realtime",
+      asr_async_url: "http://provider-new.test/v1/audio/transcriptions",
+      asr_realtime_url: "ws://provider-new.test/v1/realtime",
+    });
+    expect(findActiveSetting("editable-provider", "model-v2")).toMatchObject({
+      base_url: "http://model-override.test/v1",
     });
   });
 
@@ -421,7 +437,7 @@ describe("custom LLM providers", () => {
         provider_id: "xiaomi",
         endpoint_id: "xiaomi_mimo_api",
         model_name: "mimo-v2.5-tts",
-        api_key: "__reuse_existing__",
+        reuse_existing_api_key: true,
         is_active: true,
         supports_llm: false,
         supports_tts: true,
@@ -437,7 +453,7 @@ describe("custom LLM providers", () => {
         provider_id: "xiaomi",
         endpoint_id: "xiaomi_mimo_token_plan",
         model_name: "mimo-v2.5-pro",
-        api_key: "__reuse_existing__",
+        reuse_existing_api_key: true,
         is_active: true,
       }),
     });
@@ -445,6 +461,20 @@ describe("custom LLM providers", () => {
     expect(tokenPlanResponse.status).toBe(400);
     expect(tokenPlanBody.success).toBe(false);
     expect(tokenPlanBody.error).toContain("no existing key to reuse for this credential");
+
+    const reservedSentinelResponse = await fetch(`http://127.0.0.1:${port}/api/llm/settings`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        provider_id: "xiaomi",
+        endpoint_id: "xiaomi_mimo_api",
+        model_name: "mimo-reserved-key",
+        api_key: "__reuse_existing__",
+      }),
+    });
+    const reservedSentinelBody = await reservedSentinelResponse.json() as { error?: string };
+    expect(reservedSentinelResponse.status).toBe(400);
+    expect(reservedSentinelBody.error).toContain("Reserved API key value");
   });
 
   it("stores Doubao Speech API billing settings without returning plaintext API keys", async () => {

--- a/homerail_manager/tests/llm-providers.test.ts
+++ b/homerail_manager/tests/llm-providers.test.ts
@@ -168,6 +168,128 @@ describe("custom LLM providers", () => {
     expect(stored).toContain("manager_encrypted");
   });
 
+  it("updates custom providers without clearing omitted fields", async () => {
+    const port = await listen(server);
+    const createResponse = await fetch(`http://127.0.0.1:${port}/api/llm/providers`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: "editable-provider",
+        name: "Editable Provider",
+        default_model: "model-v1",
+        base_url: "http://provider.test/v1",
+        supports_llm: true,
+        supports_asr: true,
+      }),
+    });
+    expect(createResponse.status).toBe(201);
+
+    const settingResponse = await fetch(`http://127.0.0.1:${port}/api/llm/settings`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        provider_id: "editable-provider",
+        model_name: "model-v1",
+        api_key: "local-no-key",
+        supports_llm: false,
+        supports_asr: true,
+      }),
+    });
+    expect(settingResponse.status).toBe(201);
+
+    const updateResponse = await fetch(`http://127.0.0.1:${port}/api/llm/providers/editable-provider`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Renamed Provider",
+        base_url: "http://provider.test/v1",
+        voice_adapter: "openai_audio",
+        asr_async_url: "http://provider.test/v1/audio/transcriptions",
+        asr_realtime_url: "ws://provider.test/v1/realtime",
+      }),
+    });
+    expect(updateResponse.status).toBe(200);
+    const body = (await updateResponse.json()) as {
+      data: {
+        id: string;
+        name: string;
+        default_model: string;
+        base_url: string;
+        supports_asr: boolean;
+        asr_async_url: string;
+        asr_realtime_url: string;
+      };
+    };
+    expect(body.data).toMatchObject({
+      id: "editable-provider",
+      name: "Renamed Provider",
+      default_model: "model-v1",
+      base_url: "http://provider.test/v1",
+      supports_asr: true,
+      asr_async_url: "http://provider.test/v1/audio/transcriptions",
+      asr_realtime_url: "ws://provider.test/v1/realtime",
+    });
+    expect(findActiveSetting("editable-provider", "model-v1")).toMatchObject({
+      base_url: "http://provider.test/v1",
+      voice_adapter: "openai_audio",
+      asr_async_url: "http://provider.test/v1/audio/transcriptions",
+      asr_realtime_url: "ws://provider.test/v1/realtime",
+    });
+  });
+
+  it("rejects provider changes on model edits and protects referenced providers", async () => {
+    const port = await listen(server);
+    for (const id of ["provider-a", "provider-b"]) {
+      const response = await fetch(`http://127.0.0.1:${port}/api/llm/providers`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id,
+          name: id,
+          default_model: "model-v1",
+          base_url: `http://${id}.test/v1`,
+        }),
+      });
+      expect(response.status).toBe(201);
+    }
+
+    const settingResponse = await fetch(`http://127.0.0.1:${port}/api/llm/settings`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        provider_id: "provider-a",
+        model_name: "model-v1",
+        api_key: "secret-a",
+      }),
+    });
+    const setting = (await settingResponse.json()) as { data: { id: string } };
+    expect(settingResponse.status).toBe(201);
+
+    const moveResponse = await fetch(`http://127.0.0.1:${port}/api/llm/settings/${setting.data.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ provider_id: "provider-b" }),
+    });
+    expect(moveResponse.status).toBe(400);
+    expect(findActiveSetting("provider-a", "model-v1")).toBeTruthy();
+    expect(findActiveSetting("provider-b", "model-v1")).toBeUndefined();
+
+    const deleteResponse = await fetch(`http://127.0.0.1:${port}/api/llm/providers/provider-a`, {
+      method: "DELETE",
+    });
+    expect(deleteResponse.status).toBe(409);
+    expect(findActiveSetting("provider-a", "model-v1")).toBeTruthy();
+
+    const cascadeResponse = await fetch(`http://127.0.0.1:${port}/api/llm/providers/provider-a?cascade=true`, {
+      method: "DELETE",
+    });
+    expect(cascadeResponse.status).toBe(200);
+    expect(findActiveSetting("provider-a", "model-v1")).toBeUndefined();
+
+    const missingResponse = await fetch(`http://127.0.0.1:${port}/api/llm/providers/provider-a`);
+    expect(missingResponse.status).toBe(404);
+  });
+
   it("returns catalog models for openspeech provider probes", async () => {
     const port = await listen(server);
 

--- a/homerail_manager/tests/setup.ts
+++ b/homerail_manager/tests/setup.ts
@@ -1,0 +1,18 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterAll } from "vitest";
+
+const inheritedHome = process.env.HOMERAIL_HOME;
+const testHome = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-vitest-"));
+
+// Tests must never inherit the deployment database from the invoking shell.
+process.env.HOMERAIL_HOME = testHome;
+
+afterAll(async () => {
+  const { closeDb } = await import("../src/persistence/db.js");
+  closeDb();
+  if (inheritedHome === undefined) delete process.env.HOMERAIL_HOME;
+  else process.env.HOMERAIL_HOME = inheritedHome;
+  fs.rmSync(testHome, { recursive: true, force: true });
+});

--- a/homerail_manager/tests/voice-bootstrap.test.ts
+++ b/homerail_manager/tests/voice-bootstrap.test.ts
@@ -1016,6 +1016,85 @@ describe("voice bootstrap routes", () => {
     });
   });
 
+  it("uses explicit HTTP endpoints for custom OpenAI-compatible ASR and TTS settings", async () => {
+    const port = await listen(server);
+    const baseUrl = `http://127.0.0.1:${port}`;
+    upsertProvider({
+      id: "custom-audio-test",
+      name: "Custom Audio Test",
+      default_model: "local-audio",
+      base_url: "http://voice.test/v1",
+      supports_llm: false,
+      supports_asr: true,
+      supports_tts: true,
+    });
+    const setting = createSetting({
+      provider_id: "custom-audio-test",
+      model_name: "local-audio",
+      api_key: "local-no-key",
+      base_url: "http://voice.test/v1",
+      voice_adapter: "openai_audio",
+      tts_http_url: "http://voice.test/custom-speech",
+      asr_async_url: "http://voice.test/custom-transcriptions",
+      asr_realtime_url: "ws://voice.test/custom-realtime",
+      supports_llm: false,
+      supports_asr: true,
+      supports_tts: true,
+    });
+    await fetch(`${baseUrl}/api/voice`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        asr_llm_setting_id: setting.id,
+        tts_llm_setting_id: setting.id,
+      }),
+    });
+
+    const originalFetch = globalThis.fetch;
+    const upstreamUrls: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+      if (url.startsWith(baseUrl)) return originalFetch(input, init);
+      upstreamUrls.push(url);
+      if (url.endsWith("custom-transcriptions")) {
+        return new Response(JSON.stringify({ text: "custom transcript" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(Buffer.from("custom speech"), {
+        status: 200,
+        headers: { "Content-Type": "audio/wav" },
+      });
+    });
+
+    const speech = await fetch(`${baseUrl}/api/voice/speech`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: "hello" }),
+    });
+    expect(speech.status).toBe(200);
+
+    const transcribe = await fetch(`${baseUrl}/api/voice/transcribe`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        audio_data_url: `data:audio/wav;base64,${Buffer.from("audio").toString("base64")}`,
+      }),
+    });
+    const transcribeBody = await transcribe.json() as { data?: { text?: string } };
+    expect(transcribe.status).toBe(200);
+    expect(transcribeBody.data?.text).toBe("custom transcript");
+    expect(upstreamUrls).toEqual([
+      "http://voice.test/custom-speech",
+      "http://voice.test/custom-transcriptions",
+    ]);
+  });
+
   it("routes Doubao Speech TTS through the openspeech adapter instead of OpenAI audio speech", async () => {
     const port = await listen(server);
     const baseUrl = `http://127.0.0.1:${port}`;

--- a/homerail_manager/vitest.config.ts
+++ b/homerail_manager/vitest.config.ts
@@ -4,5 +4,6 @@ export default defineConfig({
   test: {
     include: ["tests/**/*.test.ts"],
     exclude: ["node_modules/**", "dist/**"],
+    setupFiles: ["./tests/setup.ts"],
   },
 });


### PR DESCRIPTION
## Summary

- reconcile stale DAG runs after Manager restarts so the dashboard does not keep showing abandoned work as active
- add purpose-specific LLM, ASR, and TTS model creation with separate, read-only provider binding when editing a model
- add custom provider management, purpose-aware HTTP/WebSocket voice endpoints, explicit cascading deletion, and inline confirmation controls
- reuse an existing credential for models on the same provider endpoint while keeping different billing plans isolated

## Root cause

Runtime recovery restored persisted active states without fully reconciling work that could no longer resume. In model settings, provider configuration, model configuration, and credentials were presented as one LLM-oriented form, which exposed irrelevant protocol fields and repeatedly requested credentials already stored for the same endpoint.

## User impact

The dashboard now clears stale run state after recovery. Model settings distinguish provider ownership from model capabilities, support LLM/ASR/TTS-specific configuration, avoid browser-native deletion prompts, and do not ask for the same API key again when adding another model under the same credential boundary.

## Validation

- rebased onto the latest `origin/main`
- `npm run ci`
- 1041 tests passed; 2 existing tests skipped
- production UI build and browser checks for custom TTS/ASR providers and GLM credential reuse
- HomeRail `doctor` passed against the local test deployment
