### PR TITLE
Authenticate control-plane WebSockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,9 @@ Worker containers connect back to the Manager through the URL Manager passes to
 Node. On Docker Desktop the default `host.docker.internal` mapping is usually
 enough; on Linux use Docker `host-gateway` support or set
 `HOMERAIL_MANAGER_WORKER_WS_BASE_URL`. Do not hardcode Docker bridge addresses.
+Remote Worker and Node connections require authenticated `wss://` endpoints;
+see [Control-Plane WebSocket Security](docs/control-plane-security.md) for token,
+reverse-proxy, certificate, and compatibility settings.
 
 Runtime helpers:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -211,6 +211,8 @@ hr start --ui --public \
 
 Worker 容器通过 Manager 传给 Node 的那个 URL，回连到 Manager。在 Docker Desktop 上，默认的 `host.docker.internal` 映射通常就够了；在 Linux 上，要么使用 Docker 的 `host-gateway` 支持，要么设置 `HOMERAIL_MANAGER_WORKER_WS_BASE_URL`。不要在模板或提交的配置中硬编码 Docker 网桥地址。
 
+远程 Worker 和 Node 必须使用经过身份认证的 `wss://` 端点。token、反向代理、证书和兼容设置见 [控制面 WebSocket 安全说明](docs/control-plane-security.md)。
+
 运行时辅助命令：
 
 ```bash

--- a/docs/control-plane-security.md
+++ b/docs/control-plane-security.md
@@ -1,0 +1,56 @@
+# Control-Plane WebSocket Security
+
+HomeRail has two privileged control-plane WebSocket paths:
+
+- `/ws/projects/<project>/workers/<worker>` carries model configuration, tasks, handoffs, and evidence.
+- `/ws/projects/<project>/nodes/<node>` carries Worker lifecycle requests for Docker-capable Nodes.
+
+These paths authenticate during the HTTP upgrade, before a socket can register.
+
+## Authentication defaults
+
+- A connection without a configured token is accepted only from a loopback address.
+- `HOMERAIL_WORKER_TOKEN` authenticates external Workers.
+- `HOMERAIL_NODE_TOKEN` authenticates external Nodes.
+- `HOMERAIL_CONTROL_PLANE_TOKEN` is a shared fallback when separate credentials are not required.
+- When a token is explicitly configured, every connection must send it, including loopback and reverse-proxy connections.
+
+Manager-created Docker Workers receive a generated token automatically. The token is stored at
+`${HOMERAIL_HOME}/manager/secrets/control-plane.token` with private file permissions so surviving Workers can reconnect after a Manager restart. It is not stored in the database, run evidence, or repository.
+
+For an external Worker, configure the same credential on Manager and Worker:
+
+```bash
+export HOMERAIL_WORKER_TOKEN="$(openssl rand -base64 32)"
+# Start Manager with this environment, then pass the same value to the Worker.
+```
+
+For an external Node, use `HOMERAIL_NODE_TOKEN` in both processes. Prefer separate Worker and Node tokens because a Node can create and destroy Worker containers.
+
+## Transport encryption
+
+Remote Worker and Node clients reject plaintext `ws://` URLs by default. Local loopback and `host.docker.internal` remain available for local development and Docker Desktop. Use `wss://` for multi-host deployments.
+
+Manager does not own production certificate renewal. Terminate TLS in a reverse proxy, keep Manager bound to loopback, and forward the upgrade and authorization headers:
+
+```nginx
+location /ws/ {
+    proxy_pass http://127.0.0.1:19191;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Authorization $http_authorization;
+}
+```
+
+Then configure clients with the external endpoint:
+
+```bash
+export HOMERAIL_MANAGER_WS_URL="wss://homerail.example.com"
+```
+
+For a private certificate authority, configure Node.js trust with `NODE_EXTRA_CA_CERTS`. Do not disable TLS verification.
+
+`HOMERAIL_ALLOW_INSECURE_REMOTE_WS=1` is an explicit compatibility escape hatch for an isolated trusted network. It affects only the client-side transport check; Manager authentication is still required. Do not use it on public, shared, or untrusted networks.
+
+This policy covers Worker and Node control-plane sockets. Browser events and voice WebSockets have separate trust boundaries and are not granted Worker or Node privileges.

--- a/docs/dag-patterns.md
+++ b/docs/dag-patterns.md
@@ -132,10 +132,12 @@ root or a protected file changed and restored before the final snapshot;
 OS-level containment remains the responsibility of the selected agent backend
 or container sandbox.
 
-Manager-to-Node and Manager-to-Worker WebSocket transport is trusted-network
-transport in this release. Multi-host deployments must provide network-layer
-isolation or a TLS-authenticated reverse proxy until native `wss` authentication
-is implemented.
+Manager-to-Node and Manager-to-Worker WebSocket upgrades are authenticated
+before registration. Connections without configured credentials are restricted
+to loopback; remote clients require a Bearer token and reject plaintext `ws://`
+unless the isolated-network compatibility override is explicit. Multi-host TLS
+termination and certificate renewal remain the reverse proxy's responsibility;
+see [Control-Plane WebSocket Security](control-plane-security.md).
 
 The self-hosted catalog validation uses an operator-configured Qwen 3.6 service
 through its Anthropic-compatible endpoint and the HomeRail `claude-sdk`

--- a/homerail_manager/src/node/websocket.ts
+++ b/homerail_manager/src/node/websocket.ts
@@ -27,33 +27,17 @@ import {
   recordAdvisorCall,
   requestNodeCorrection,
 } from "../runtime/active-runs.js";
+import {
+  isControlPlaneUpgradeAuthorized,
+  isLoopbackRemoteAddress,
+  rejectWebSocketUpgrade,
+} from "../server/control-plane-auth.js";
 
 const WS_URL_PATTERN = /^\/ws\/projects\/([^\/]+)\/nodes\/([^\/]+)$/;
 const DEFAULT_REGISTRATION_TIMEOUT_MS = 10_000;
 const DEFAULT_PING_INTERVAL_MS = 30_000;
 
-export function isLoopbackNodeRemoteAddress(address: string | null | undefined): boolean {
-  if (!address) return false;
-  const normalized = address.trim().toLowerCase();
-  if (normalized === "::1" || normalized === "localhost") return true;
-  if (normalized.startsWith("127.")) return true;
-  if (normalized.startsWith("::ffff:")) {
-    return isLoopbackNodeRemoteAddress(normalized.slice("::ffff:".length));
-  }
-  return normalized === "0:0:0:0:0:ffff:7f00:1";
-}
-
-function rejectUpgrade(
-  socket: { write(chunk: string): unknown; destroy(): void },
-  statusCode: number,
-  reason: string,
-): void {
-  try {
-    socket.write(`HTTP/1.1 ${statusCode} ${reason}\r\nConnection: close\r\n\r\n`);
-  } finally {
-    socket.destroy();
-  }
-}
+export const isLoopbackNodeRemoteAddress = isLoopbackRemoteAddress;
 
 function hasRegisteredNode(): boolean {
   return getAllNodes().some((node) => node.socket.readyState === WebSocket.OPEN);
@@ -145,6 +129,8 @@ function mirrorSessionTranscript(
 export interface NodeWebSocketOptions {
   registrationTimeoutMs?: number;
   pingIntervalMs?: number;
+  authToken?: string;
+  allowLoopbackWithoutToken?: boolean;
   onHandoffApplied?: (runId: string) => void;
 }
 
@@ -155,6 +141,11 @@ export function setupNodeWebSocket(
   const registrationTimeoutMs =
     options.registrationTimeoutMs ?? DEFAULT_REGISTRATION_TIMEOUT_MS;
   const pingIntervalMs = options.pingIntervalMs ?? DEFAULT_PING_INTERVAL_MS;
+  const authToken = options.authToken
+    ?? process.env.HOMERAIL_NODE_TOKEN
+    ?? process.env.HOMERAIL_CONTROL_PLANE_TOKEN;
+  const allowLoopbackWithoutToken = options.allowLoopbackWithoutToken
+    ?? !authToken?.trim();
 
   const wss = new WebSocketServer({ noServer: true });
 
@@ -167,8 +158,13 @@ export function setupNodeWebSocket(
     const project_id = match[1];
     const node_id = match[2];
 
-    if (!isLoopbackNodeRemoteAddress(req.socket.remoteAddress)) {
-      rejectUpgrade(socket, 403, "Forbidden");
+    if (!isControlPlaneUpgradeAuthorized({
+      remoteAddress: req.socket.remoteAddress,
+      authorization: req.headers.authorization,
+      configuredToken: authToken,
+      allowLoopbackWithoutToken,
+    })) {
+      rejectWebSocketUpgrade(socket, 401, "Unauthorized");
       return;
     }
 

--- a/homerail_manager/src/persistence/control-plane-secret.ts
+++ b/homerail_manager/src/persistence/control-plane-secret.ts
@@ -1,0 +1,44 @@
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { getDataRoot } from "../config/env.js";
+
+function secretDirectory(): string {
+  return path.join(getDataRoot(), "secrets");
+}
+
+export function controlPlaneTokenPath(): string {
+  return path.join(secretDirectory(), "control-plane.token");
+}
+
+function enforcePrivateMode(filePath: string, mode: number): void {
+  try {
+    fs.chmodSync(filePath, mode);
+  } catch {
+    // Best effort on platforms that do not support POSIX modes.
+  }
+}
+
+export function readOrCreateControlPlaneToken(
+  generate: () => string = () => crypto.randomBytes(32).toString("base64url"),
+): string {
+  const dir = secretDirectory();
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  enforcePrivateMode(dir, 0o700);
+  const filePath = controlPlaneTokenPath();
+  if (fs.existsSync(filePath)) {
+    const existing = fs.readFileSync(filePath, "utf8").trim();
+    if (!existing) throw new Error(`Invalid empty control-plane token at ${filePath}`);
+    enforcePrivateMode(filePath, 0o600);
+    return existing;
+  }
+
+  const token = generate().trim();
+  if (!token) throw new Error("Generated control-plane token must not be empty");
+  const tmpPath = `${filePath}.${process.pid}.tmp`;
+  fs.writeFileSync(tmpPath, `${token}\n`, { encoding: "utf8", mode: 0o600 });
+  fs.renameSync(tmpPath, filePath);
+  enforcePrivateMode(filePath, 0o600);
+  return token;
+}

--- a/homerail_manager/src/server/control-plane-auth.ts
+++ b/homerail_manager/src/server/control-plane-auth.ts
@@ -1,0 +1,59 @@
+import { timingSafeEqual } from "node:crypto";
+
+export function isLoopbackRemoteAddress(address: string | null | undefined): boolean {
+  if (!address) return false;
+  const normalized = address.trim().toLowerCase();
+  if (normalized === "::1" || normalized === "localhost") return true;
+  if (normalized.startsWith("127.")) return true;
+  if (normalized.startsWith("::ffff:")) {
+    return isLoopbackRemoteAddress(normalized.slice("::ffff:".length));
+  }
+  return normalized === "0:0:0:0:0:ffff:7f00:1";
+}
+
+function bearerToken(header: string | string[] | undefined): string | undefined {
+  const value = Array.isArray(header) ? header[0] : header;
+  if (!value) return undefined;
+  const match = /^Bearer\s+(.+)$/i.exec(value.trim());
+  const token = match?.[1]?.trim();
+  return token || undefined;
+}
+
+function tokensEqual(actual: string, expected: string): boolean {
+  const actualBytes = Buffer.from(actual);
+  const expectedBytes = Buffer.from(expected);
+  return actualBytes.length === expectedBytes.length
+    && timingSafeEqual(actualBytes, expectedBytes);
+}
+
+export function isControlPlaneUpgradeAuthorized(input: {
+  remoteAddress: string | null | undefined;
+  authorization: string | string[] | undefined;
+  configuredToken?: string;
+  allowLoopbackWithoutToken?: boolean;
+}): boolean {
+  const expected = input.configuredToken?.trim();
+  const actual = bearerToken(input.authorization);
+  if (expected && actual && tokensEqual(actual, expected)) return true;
+  if (expected) {
+    return input.allowLoopbackWithoutToken === true
+      && isLoopbackRemoteAddress(input.remoteAddress);
+  }
+  return isLoopbackRemoteAddress(input.remoteAddress);
+}
+
+export function rejectWebSocketUpgrade(
+  socket: { write(chunk: string): unknown; destroy(): void },
+  statusCode: number,
+  reason: string,
+): void {
+  try {
+    socket.write(
+      `HTTP/1.1 ${statusCode} ${reason}\r\n`
+        + `${statusCode === 401 ? "WWW-Authenticate: Bearer\r\n" : ""}`
+        + "Connection: close\r\nContent-Length: 0\r\n\r\n",
+    );
+  } finally {
+    socket.destroy();
+  }
+}

--- a/homerail_manager/src/server/http.ts
+++ b/homerail_manager/src/server/http.ts
@@ -34,6 +34,7 @@ import type { DAGDispatcher } from "../orchestration/dag-dispatcher.js";
 import { emit } from "../events/bus.js";
 import { dispatchRecoveredRuns } from "../runtime/active-runs.js";
 import { startDagTriggerScheduler } from "../runtime/dag-triggers.js";
+import { readOrCreateControlPlaneToken } from "../persistence/control-plane-secret.js";
 
 function json(res: http.ServerResponse, status: number, body: unknown) {
   res.writeHead(status, { "Content-Type": "application/json" });
@@ -80,7 +81,24 @@ const WORKER_ENV_PASSTHROUGH = [
   "CLAUDE_MAX_TURNS",
   "CLAUDE_SDK_QUERY_TIMEOUT_MS",
   "CLAUDE_THINKING_BUDGET",
+  "HOMERAIL_ALLOW_INSECURE_REMOTE_WS",
 ] as const;
+
+export interface WorkerControlPlaneAuth {
+  token: string;
+  explicitlyConfigured: boolean;
+}
+
+export function resolveWorkerControlPlaneAuth(
+  env: NodeJS.ProcessEnv = process.env,
+  generateToken: () => string = readOrCreateControlPlaneToken,
+): WorkerControlPlaneAuth {
+  const configured = env.HOMERAIL_WORKER_TOKEN?.trim()
+    || env.HOMERAIL_CONTROL_PLANE_TOKEN?.trim();
+  return configured
+    ? { token: configured, explicitlyConfigured: true }
+    : { token: generateToken(), explicitlyConfigured: false };
+}
 
 const MANAGER_AGENT_ENV_PASSTHROUGH = [
   "HOMERAIL_MANAGER_AGENT_BACKEND",
@@ -93,9 +111,23 @@ const MANAGER_AGENT_ENV_PASSTHROUGH = [
 ] as const;
 
 export function resolveWorkerRuntimeEnv(): Record<string, string> | undefined {
+  return resolveWorkerRuntimeEnvFrom(process.env);
+}
+
+export function resolveProvisionedWorkerRuntimeEnv(
+  auth: WorkerControlPlaneAuth,
+  env: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
+  return {
+    ...(resolveWorkerRuntimeEnvFrom(env) ?? {}),
+    HOMERAIL_WORKER_TOKEN: auth.token,
+  };
+}
+
+function resolveWorkerRuntimeEnvFrom(envSource: NodeJS.ProcessEnv): Record<string, string> | undefined {
   const env: Record<string, string> = {};
   for (const key of WORKER_ENV_PASSTHROUGH) {
-    const value = process.env[key];
+    const value = envSource[key];
     if (value !== undefined && value.trim().length > 0) {
       env[key] = value;
     }
@@ -126,12 +158,23 @@ export function createServer(
   managerAgentConfigOptions: ManagerAgentConfigRoutesOptions = {},
 ) {
   let server: http.Server;
+  const workerControlPlaneAuth = resolveWorkerControlPlaneAuth();
+  const effectiveWorkerToken = wsOptions?.authToken?.trim()
+    || workerControlPlaneAuth.token;
+  const effectiveWorkerTokenIsExplicit = Boolean(wsOptions?.authToken?.trim())
+    || workerControlPlaneAuth.explicitlyConfigured;
+  const configuredNodeToken = process.env.HOMERAIL_NODE_TOKEN?.trim()
+    || process.env.HOMERAIL_CONTROL_PLANE_TOKEN?.trim();
   const workerImage = process.env.HOMERAIL_WORKER_IMAGE || "homerail-worker:latest";
+  const workerRuntimeEnv = resolveProvisionedWorkerRuntimeEnv({
+    token: effectiveWorkerToken,
+    explicitlyConfigured: effectiveWorkerTokenIsExplicit,
+  });
   const defaultProvisionerOptions: WsDispatchAdapterOptions = {
     provisioner: {
       image: workerImage,
       extraHosts: resolveManagerWorkerExtraHosts(),
-      env: resolveWorkerRuntimeEnv(),
+      env: workerRuntimeEnv,
     },
     managerBaseUrl: () => {
       const addr = server?.address();
@@ -276,8 +319,11 @@ export function createServer(
   });
   server.once("close", stopTriggerScheduler);
 
-  const websocketOptions = {
+  const workerWebsocketOptions: WorkerWebSocketOptions = {
     ...wsOptions,
+    authToken: effectiveWorkerToken,
+    allowLoopbackWithoutToken: wsOptions?.allowLoopbackWithoutToken
+      ?? !effectiveWorkerTokenIsExplicit,
     onHandoffApplied: (runId: string) => {
       graphExecutor.tick(runId);
     },
@@ -340,8 +386,15 @@ export function createServer(
       dispatchRecoveredRuns(actualDispatcher);
     },
   };
-  setupWorkerWebSocket(server, websocketOptions);
-  setupNodeWebSocket(server, websocketOptions);
+  const nodeWebsocketOptions: NodeWebSocketOptions = {
+    ...wsOptions,
+    authToken: wsOptions?.authToken ?? configuredNodeToken,
+    allowLoopbackWithoutToken: wsOptions?.allowLoopbackWithoutToken
+      ?? !configuredNodeToken,
+    onHandoffApplied: workerWebsocketOptions.onHandoffApplied,
+  };
+  setupWorkerWebSocket(server, workerWebsocketOptions);
+  setupNodeWebSocket(server, nodeWebsocketOptions);
   setupEventWebSocket(server);
   setupVoiceRealtimeWebSocket(server);
 

--- a/homerail_manager/src/server/http.ts
+++ b/homerail_manager/src/server/http.ts
@@ -150,6 +150,36 @@ export function resolveManagerAgentRuntimeEnv(): Record<string, string> | undefi
   return Object.keys(env).length > 0 ? env : undefined;
 }
 
+export function mergeProvisionerOptions(
+  defaults: WsDispatchAdapterOptions,
+  overrides: WsDispatchAdapterOptions | false | undefined,
+  workerToken: string,
+): WsDispatchAdapterOptions {
+  if (overrides === undefined) return defaults;
+  if (overrides === false) return { provisioner: false };
+  if (overrides.provisioner === false) {
+    return { ...defaults, ...overrides, provisioner: false };
+  }
+
+  const defaultProvisioner = defaults.provisioner === false
+    ? undefined
+    : defaults.provisioner;
+  const overrideProvisioner = overrides.provisioner;
+  return {
+    ...defaults,
+    ...overrides,
+    provisioner: {
+      ...defaultProvisioner,
+      ...overrideProvisioner,
+      env: {
+        ...(defaultProvisioner?.env ?? {}),
+        ...(overrideProvisioner?.env ?? {}),
+        HOMERAIL_WORKER_TOKEN: workerToken,
+      },
+    },
+  };
+}
+
 export function createServer(
   port: number,
   wsOptions?: WorkerWebSocketOptions & NodeWebSocketOptions,
@@ -188,12 +218,11 @@ export function createServer(
     },
     projectId: process.env.HOMERAIL_PROJECT_ID ?? "p1",
   };
-  const adapterOptions =
-    provisionerOptions === undefined
-      ? defaultProvisionerOptions
-      : provisionerOptions === false
-        ? { provisioner: false as false }
-        : provisionerOptions;
+  const adapterOptions = mergeProvisionerOptions(
+    defaultProvisionerOptions,
+    provisionerOptions,
+    effectiveWorkerToken,
+  );
   const managerAgentContainerOptions =
     provisionerOptions === false
       ? undefined

--- a/homerail_manager/src/worker/websocket.ts
+++ b/homerail_manager/src/worker/websocket.ts
@@ -24,6 +24,10 @@ import {
   recordAdvisorCall,
   requestNodeCorrection,
 } from "../runtime/active-runs.js";
+import {
+  isControlPlaneUpgradeAuthorized,
+  rejectWebSocketUpgrade,
+} from "../server/control-plane-auth.js";
 
 const WS_URL_PATTERN = /^\/ws\/projects\/([^\/]+)\/workers\/([^\/]+)$/;
 const DEFAULT_REGISTRATION_TIMEOUT_MS = 10_000;
@@ -115,6 +119,8 @@ function mirrorSessionTranscript(
 export interface WorkerWebSocketOptions {
   registrationTimeoutMs?: number;
   pingIntervalMs?: number;
+  authToken?: string;
+  allowLoopbackWithoutToken?: boolean;
   onHandoffApplied?: (runId: string) => void;
   onManagerCommand?: (
     workerId: string,
@@ -133,6 +139,11 @@ export function setupWorkerWebSocket(
   const registrationTimeoutMs =
     options.registrationTimeoutMs ?? DEFAULT_REGISTRATION_TIMEOUT_MS;
   const pingIntervalMs = options.pingIntervalMs ?? DEFAULT_PING_INTERVAL_MS;
+  const authToken = options.authToken
+    ?? process.env.HOMERAIL_WORKER_TOKEN
+    ?? process.env.HOMERAIL_CONTROL_PLANE_TOKEN;
+  const allowLoopbackWithoutToken = options.allowLoopbackWithoutToken
+    ?? !authToken?.trim();
 
   let firstWorkerFired = false;
 
@@ -146,6 +157,16 @@ export function setupWorkerWebSocket(
 
     const project_id = match[1];
     const worker_id = match[2];
+
+    if (!isControlPlaneUpgradeAuthorized({
+      remoteAddress: req.socket.remoteAddress,
+      authorization: req.headers.authorization,
+      configuredToken: authToken,
+      allowLoopbackWithoutToken,
+    })) {
+      rejectWebSocketUpgrade(socket, 401, "Unauthorized");
+      return;
+    }
 
     wss.handleUpgrade(req, socket, head, (ws) => {
       wss.emit("connection", ws, req, project_id, worker_id);

--- a/homerail_manager/tests/control-plane-auth.test.ts
+++ b/homerail_manager/tests/control-plane-auth.test.ts
@@ -1,0 +1,175 @@
+import * as http from "node:http";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import WebSocket from "ws";
+
+import {
+  isControlPlaneUpgradeAuthorized,
+  isLoopbackRemoteAddress,
+} from "../src/server/control-plane-auth.js";
+import {
+  resolveProvisionedWorkerRuntimeEnv,
+  resolveWorkerControlPlaneAuth,
+} from "../src/server/http.js";
+import { setupNodeWebSocket } from "../src/node/websocket.js";
+import { _clearNodes } from "../src/node/registry.js";
+import { setupWorkerWebSocket } from "../src/worker/websocket.js";
+import { _clearWorkers } from "../src/worker/registry.js";
+import {
+  controlPlaneTokenPath,
+  readOrCreateControlPlaneToken,
+} from "../src/persistence/control-plane-secret.js";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { closeDb } from "../src/persistence/db.js";
+
+async function listen(server: http.Server): Promise<number> {
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address !== "object") throw new Error("server did not bind");
+  return address.port;
+}
+
+async function closeServer(server: http.Server): Promise<void> {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+function upgradeStatus(url: string, token?: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url, token
+      ? { headers: { Authorization: `Bearer ${token}` } }
+      : undefined);
+    const timer = setTimeout(() => {
+      ws.terminate();
+      reject(new Error("timed out waiting for websocket upgrade"));
+    }, 1_000);
+    ws.once("open", () => {
+      clearTimeout(timer);
+      ws.close();
+      resolve(101);
+    });
+    ws.once("unexpected-response", (_request, response) => {
+      clearTimeout(timer);
+      response.resume();
+      resolve(response.statusCode ?? 0);
+    });
+    ws.once("error", (error) => {
+      if ((error as NodeJS.ErrnoException).code !== "ECONNRESET") {
+        clearTimeout(timer);
+        reject(error);
+      }
+    });
+  });
+}
+
+describe("control-plane websocket authentication", () => {
+  let oldHome: string | undefined;
+  let tmpHome: string;
+
+  beforeEach(() => {
+    oldHome = process.env.HOMERAIL_HOME;
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-control-plane-auth-"));
+    process.env.HOMERAIL_HOME = tmpHome;
+    closeDb();
+  });
+
+  afterEach(() => {
+    _clearNodes();
+    _clearWorkers();
+    closeDb();
+    if (oldHome === undefined) delete process.env.HOMERAIL_HOME;
+    else process.env.HOMERAIL_HOME = oldHome;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("allows loopback without a configured token and requires bearer auth remotely", () => {
+    expect(isLoopbackRemoteAddress("::ffff:127.0.0.1")).toBe(true);
+    expect(isControlPlaneUpgradeAuthorized({
+      remoteAddress: "127.0.0.1",
+      authorization: undefined,
+    })).toBe(true);
+    expect(isControlPlaneUpgradeAuthorized({
+      remoteAddress: "192.0.2.20",
+      authorization: undefined,
+    })).toBe(false);
+    expect(isControlPlaneUpgradeAuthorized({
+      remoteAddress: "192.0.2.20",
+      authorization: "Bearer wrong",
+      configuredToken: "secret",
+    })).toBe(false);
+    expect(isControlPlaneUpgradeAuthorized({
+      remoteAddress: "192.0.2.20",
+      authorization: "Bearer secret",
+      configuredToken: "secret",
+    })).toBe(true);
+  });
+
+  it("requires configured credentials even on loopback unless explicitly exempted", () => {
+    expect(isControlPlaneUpgradeAuthorized({
+      remoteAddress: "127.0.0.1",
+      authorization: undefined,
+      configuredToken: "secret",
+    })).toBe(false);
+    expect(isControlPlaneUpgradeAuthorized({
+      remoteAddress: "127.0.0.1",
+      authorization: undefined,
+      configuredToken: "secret",
+      allowLoopbackWithoutToken: true,
+    })).toBe(true);
+  });
+
+  it("enforces worker and node tokens before accepting the websocket upgrade", async () => {
+    const server = http.createServer();
+    setupWorkerWebSocket(server, {
+      authToken: "worker-secret",
+      allowLoopbackWithoutToken: false,
+    });
+    setupNodeWebSocket(server, {
+      authToken: "node-secret",
+      allowLoopbackWithoutToken: false,
+    });
+    const port = await listen(server);
+
+    try {
+      const workerUrl = `ws://127.0.0.1:${port}/ws/projects/p1/workers/w1`;
+      const nodeUrl = `ws://127.0.0.1:${port}/ws/projects/p1/nodes/n1`;
+      await expect(upgradeStatus(workerUrl)).resolves.toBe(401);
+      await expect(upgradeStatus(workerUrl, "wrong")).resolves.toBe(401);
+      await expect(upgradeStatus(workerUrl, "worker-secret")).resolves.toBe(101);
+      await expect(upgradeStatus(nodeUrl)).resolves.toBe(401);
+      await expect(upgradeStatus(nodeUrl, "node-secret")).resolves.toBe(101);
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it("uses configured tokens or generates a provision token", () => {
+    expect(resolveWorkerControlPlaneAuth({
+      HOMERAIL_WORKER_TOKEN: " configured-token ",
+    }, () => "unused")).toEqual({
+      token: "configured-token",
+      explicitlyConfigured: true,
+    });
+    const generated = resolveWorkerControlPlaneAuth({}, () => "generated-token");
+    expect(generated).toEqual({
+      token: "generated-token",
+      explicitlyConfigured: false,
+    });
+    expect(resolveProvisionedWorkerRuntimeEnv(generated, {
+      CLAUDE_MAX_TURNS: "8",
+      ANTHROPIC_API_KEY: "must-not-propagate",
+    })).toEqual({
+      CLAUDE_MAX_TURNS: "8",
+      HOMERAIL_WORKER_TOKEN: "generated-token",
+    });
+  });
+
+  it("persists the generated provision token across Manager restarts", () => {
+    expect(readOrCreateControlPlaneToken(() => "persisted-token")).toBe("persisted-token");
+    expect(readOrCreateControlPlaneToken(() => "must-not-rotate")).toBe("persisted-token");
+    expect(fs.readFileSync(controlPlaneTokenPath(), "utf8").trim()).toBe("persisted-token");
+    if (process.platform !== "win32") {
+      expect(fs.statSync(controlPlaneTokenPath()).mode & 0o777).toBe(0o600);
+    }
+  });
+});

--- a/homerail_manager/tests/control-plane-auth.test.ts
+++ b/homerail_manager/tests/control-plane-auth.test.ts
@@ -7,13 +7,15 @@ import {
   isLoopbackRemoteAddress,
 } from "../src/server/control-plane-auth.js";
 import {
+  createServer,
+  mergeProvisionerOptions,
   resolveProvisionedWorkerRuntimeEnv,
   resolveWorkerControlPlaneAuth,
 } from "../src/server/http.js";
 import { setupNodeWebSocket } from "../src/node/websocket.js";
 import { _clearNodes } from "../src/node/registry.js";
 import { setupWorkerWebSocket } from "../src/worker/websocket.js";
-import { _clearWorkers } from "../src/worker/registry.js";
+import { _clearWorkers, getWorker } from "../src/worker/registry.js";
 import {
   controlPlaneTokenPath,
   readOrCreateControlPlaneToken,
@@ -22,12 +24,22 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { closeDb } from "../src/persistence/db.js";
+import { WsClient } from "../../homerail_worker/src/ws-client.js";
 
-async function listen(server: http.Server): Promise<number> {
-  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+async function listen(server: http.Server, port = 0): Promise<number> {
+  await new Promise<void>((resolve) => server.listen(port, "127.0.0.1", resolve));
   const address = server.address();
   if (!address || typeof address !== "object") throw new Error("server did not bind");
   return address.port;
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error("timed out waiting for condition");
 }
 
 async function closeServer(server: http.Server): Promise<void> {
@@ -137,6 +149,7 @@ describe("control-plane websocket authentication", () => {
       await expect(upgradeStatus(workerUrl, "wrong")).resolves.toBe(401);
       await expect(upgradeStatus(workerUrl, "worker-secret")).resolves.toBe(101);
       await expect(upgradeStatus(nodeUrl)).resolves.toBe(401);
+      await expect(upgradeStatus(nodeUrl, "wrong")).resolves.toBe(401);
       await expect(upgradeStatus(nodeUrl, "node-secret")).resolves.toBe(101);
     } finally {
       await closeServer(server);
@@ -170,6 +183,70 @@ describe("control-plane websocket authentication", () => {
     expect(fs.readFileSync(controlPlaneTokenPath(), "utf8").trim()).toBe("persisted-token");
     if (process.platform !== "win32") {
       expect(fs.statSync(controlPlaneTokenPath()).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it("preserves control-plane defaults when provisioner options are customized", () => {
+    const managerWorkerWsBaseUrl = () => "ws://host.docker.internal:23456";
+    const merged = mergeProvisionerOptions({
+      provisioner: {
+        image: "default-worker",
+        extraHosts: ["host.docker.internal:host-gateway"],
+        env: { CLAUDE_MAX_TURNS: "8", HOMERAIL_WORKER_TOKEN: "default-token" },
+      },
+      managerBaseUrl: "http://127.0.0.1:23456",
+      managerWorkerWsBaseUrl,
+      projectId: "p1",
+    }, {
+      provisioner: {
+        image: "custom-worker",
+        env: { CUSTOM_RUNTIME_FLAG: "1", HOMERAIL_WORKER_TOKEN: "stale-token" },
+      },
+    }, "effective-token");
+
+    expect(merged.managerWorkerWsBaseUrl).toBe(managerWorkerWsBaseUrl);
+    expect(merged.projectId).toBe("p1");
+    expect(merged.provisioner).toMatchObject({
+      image: "custom-worker",
+      extraHosts: ["host.docker.internal:host-gateway"],
+      env: {
+        CLAUDE_MAX_TURNS: "8",
+        CUSTOM_RUNTIME_FLAG: "1",
+        HOMERAIL_WORKER_TOKEN: "effective-token",
+      },
+    });
+  });
+
+  it("reuses the persisted token when a worker reconnects after Manager restart", async () => {
+    let server = createServer(0, undefined, undefined, false);
+    const port = await listen(server);
+    const token = fs.readFileSync(controlPlaneTokenPath(), "utf8").trim();
+    const workerId = "restart-auth-worker";
+    const client = new WsClient({
+      url: `ws://127.0.0.1:${port}/ws/projects/p1/workers/${workerId}`,
+      workerId,
+      token,
+      reconnectBaseMs: 25,
+      reconnectMaxMs: 50,
+    });
+    client.on("error", () => undefined);
+
+    try {
+      client.connect();
+      await waitFor(() => getWorker(workerId)?.socket.readyState === WebSocket.OPEN);
+
+      getWorker(workerId)?.socket.terminate();
+      await waitFor(() => getWorker(workerId) === undefined);
+      await closeServer(server);
+
+      server = createServer(port, undefined, undefined, false);
+      await listen(server, port);
+      await waitFor(() => getWorker(workerId)?.socket.readyState === WebSocket.OPEN);
+      expect(fs.readFileSync(controlPlaneTokenPath(), "utf8").trim()).toBe(token);
+    } finally {
+      client.close();
+      getWorker(workerId)?.socket.terminate();
+      await closeServer(server);
     }
   });
 });

--- a/homerail_manager/tests/server-http.test.ts
+++ b/homerail_manager/tests/server-http.test.ts
@@ -6,6 +6,7 @@ const ENV_KEYS = [
   "CLAUDE_MAX_TURNS",
   "CLAUDE_SDK_QUERY_TIMEOUT_MS",
   "CLAUDE_THINKING_BUDGET",
+  "HOMERAIL_ALLOW_INSECURE_REMOTE_WS",
   "GITEA_TOKEN",
   "ANTHROPIC_API_KEY",
 ] as const;
@@ -30,11 +31,12 @@ describe("manager HTTP server worker runtime env", () => {
     restoreEnv();
   });
 
-  it("passes only explicit Claude SDK runtime controls to provisioned workers", () => {
+  it("passes only explicit safe runtime controls to provisioned workers", () => {
     saveEnv();
     process.env.CLAUDE_MAX_TURNS = "8";
     process.env.CLAUDE_SDK_QUERY_TIMEOUT_MS = "120000";
     process.env.CLAUDE_THINKING_BUDGET = "2048";
+    process.env.HOMERAIL_ALLOW_INSECURE_REMOTE_WS = "1";
     process.env.GITEA_TOKEN = "<redacted-gitea-token>";
     process.env.ANTHROPIC_API_KEY = "should-not-propagate";
 
@@ -42,6 +44,7 @@ describe("manager HTTP server worker runtime env", () => {
       CLAUDE_MAX_TURNS: "8",
       CLAUDE_SDK_QUERY_TIMEOUT_MS: "120000",
       CLAUDE_THINKING_BUDGET: "2048",
+      HOMERAIL_ALLOW_INSECURE_REMOTE_WS: "1",
     });
   });
 
@@ -50,6 +53,7 @@ describe("manager HTTP server worker runtime env", () => {
     delete process.env.CLAUDE_MAX_TURNS;
     process.env.CLAUDE_SDK_QUERY_TIMEOUT_MS = " ";
     delete process.env.CLAUDE_THINKING_BUDGET;
+    delete process.env.HOMERAIL_ALLOW_INSECURE_REMOTE_WS;
 
     expect(resolveWorkerRuntimeEnv()).toBeUndefined();
   });

--- a/homerail_node/src/cli.test.ts
+++ b/homerail_node/src/cli.test.ts
@@ -57,6 +57,8 @@ describe("cli arg parsing logic", () => {
     expect(args.nodeId).toBe("");
     expect(args.provider).toBe("docker-cli");
     expect(args.capabilities).toEqual(["docker-cli"]);
+    expect(args.token).toBe("");
+    expect(args.allowInsecureRemoteWs).toBe(false);
   });
 
   it("derives default manager URL from HOMERAIL_MANAGER_PORT", () => {
@@ -94,12 +96,16 @@ describe("cli arg parsing logic", () => {
       HOMERAIL_NODE_ID: "env-node",
       HOMERAIL_NODE_PROVIDER: "docker-api",
       HOMERAIL_NODE_CAPABILITIES: "cap1,cap2",
+      HOMERAIL_NODE_TOKEN: " node-token ",
+      HOMERAIL_ALLOW_INSECURE_REMOTE_WS: "1",
     });
     expect(args.managerUrl).toBe("ws://env-host:5555");
     expect(args.projectId).toBe("env-proj");
     expect(args.nodeId).toBe("env-node");
     expect(args.provider).toBe("docker-api");
     expect(args.capabilities).toEqual(["cap1", "cap2", "docker-api"]);
+    expect(args.token).toBe("node-token");
+    expect(args.allowInsecureRemoteWs).toBe(true);
   });
 
   it("args override env vars", () => {
@@ -135,7 +141,9 @@ describe("node control-plane WebSocket client", () => {
     const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
     const port = await listenWebSocket(server);
     const messages: unknown[] = [];
-    server.on("connection", (socket) => {
+    const authorizationHeaders: Array<string | undefined> = [];
+    server.on("connection", (socket, request) => {
+      authorizationHeaders.push(request.headers.authorization);
       socket.on("message", (raw) => {
         messages.push(JSON.parse(raw.toString()));
       });
@@ -147,6 +155,7 @@ describe("node control-plane WebSocket client", () => {
       nodeId: "local-docker-node",
       provider: new MockProvider(),
       capabilities: ["docker-cli"],
+      token: " node-secret ",
       reconnectInitialDelayMs: 50,
       reconnectMaxDelayMs: 50,
     });
@@ -159,6 +168,7 @@ describe("node control-plane WebSocket client", () => {
 
       expect(messages.filter((msg) => (msg as { type?: string }).type === "register")).toHaveLength(2);
       expect(messages.filter((msg) => (msg as { type?: string }).type === "capabilities")).toHaveLength(2);
+      expect(authorizationHeaders).toEqual(["Bearer node-secret", "Bearer node-secret"]);
     } finally {
       client.close();
       await closeWebSocket(server);

--- a/homerail_node/src/cli.ts
+++ b/homerail_node/src/cli.ts
@@ -16,6 +16,8 @@ export interface CliArgs {
   nodeId: string;
   provider: string;
   capabilities: string[];
+  token: string;
+  allowInsecureRemoteWs: boolean;
 }
 
 type CliEnv = Partial<Record<
@@ -24,7 +26,10 @@ type CliEnv = Partial<Record<
   | "HOMERAIL_PROJECT_ID"
   | "HOMERAIL_NODE_ID"
   | "HOMERAIL_NODE_PROVIDER"
-  | "HOMERAIL_NODE_CAPABILITIES",
+  | "HOMERAIL_NODE_CAPABILITIES"
+  | "HOMERAIL_NODE_TOKEN"
+  | "HOMERAIL_CONTROL_PLANE_TOKEN"
+  | "HOMERAIL_ALLOW_INSECURE_REMOTE_WS",
   string
 >>;
 
@@ -63,6 +68,8 @@ export function parseArgs(argv: string[], env: CliEnv = process.env): CliArgs {
   let projectId = env.HOMERAIL_PROJECT_ID ?? "";
   let nodeId = env.HOMERAIL_NODE_ID ?? "";
   let provider = env.HOMERAIL_NODE_PROVIDER ?? "docker-cli";
+  const token = (env.HOMERAIL_NODE_TOKEN ?? env.HOMERAIL_CONTROL_PLANE_TOKEN ?? "").trim();
+  const allowInsecureRemoteWs = env.HOMERAIL_ALLOW_INSECURE_REMOTE_WS === "1";
   const caps: string[] = [];
 
   const envCaps = env.HOMERAIL_NODE_CAPABILITIES;
@@ -94,7 +101,15 @@ export function parseArgs(argv: string[], env: CliEnv = process.env): CliArgs {
 
   appendProviderCapabilities(caps, provider);
 
-  return { managerUrl, projectId, nodeId, provider, capabilities: caps };
+  return {
+    managerUrl,
+    projectId,
+    nodeId,
+    provider,
+    capabilities: caps,
+    token,
+    allowInsecureRemoteWs,
+  };
 }
 
 export function resolveProvider(name: string): ExecutionProvider {
@@ -136,6 +151,8 @@ async function main(): Promise<void> {
     nodeId: args.nodeId,
     provider,
     capabilities: args.capabilities,
+    token: args.token,
+    allowInsecureRemote: args.allowInsecureRemoteWs,
   });
 
   await client.connect();

--- a/homerail_node/src/control-plane/__tests__/security.test.ts
+++ b/homerail_node/src/control-plane/__tests__/security.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { assertSecureControlPlaneUrl } from "../security.js";
+
+describe("node control-plane transport policy", () => {
+  it("allows wss and local websocket URLs", () => {
+    expect(() => assertSecureControlPlaneUrl("wss://manager.example.test/ws")).not.toThrow();
+    expect(() => assertSecureControlPlaneUrl("ws://localhost:19191/ws")).not.toThrow();
+    expect(() => assertSecureControlPlaneUrl("ws://[::1]:19191/ws")).not.toThrow();
+  });
+
+  it("fails closed for remote plaintext websocket URLs", () => {
+    expect(() => assertSecureControlPlaneUrl("ws://manager.example.test/ws"))
+      .toThrow("Remote Manager WebSocket connections require wss://");
+    expect(() => assertSecureControlPlaneUrl("ws://manager.example.test/ws", true)).not.toThrow();
+  });
+});

--- a/homerail_node/src/control-plane/security.ts
+++ b/homerail_node/src/control-plane/security.ts
@@ -1,0 +1,26 @@
+const LOCAL_WEBSOCKET_HOSTS = new Set([
+  "localhost",
+  "::1",
+  "host.docker.internal",
+]);
+
+function isLocalWebSocketHost(hostname: string): boolean {
+  const normalized = hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  return LOCAL_WEBSOCKET_HOSTS.has(normalized) || normalized.startsWith("127.");
+}
+
+export function assertSecureControlPlaneUrl(
+  rawUrl: string,
+  allowInsecureRemote = false,
+): void {
+  const url = new URL(rawUrl);
+  if (url.protocol !== "ws:" && url.protocol !== "wss:") {
+    throw new Error(`Manager WebSocket URL must use ws:// or wss://: ${rawUrl}`);
+  }
+  if (url.protocol === "wss:" || isLocalWebSocketHost(url.hostname)) return;
+  if (allowInsecureRemote) return;
+  throw new Error(
+    "Remote Manager WebSocket connections require wss://. "
+      + "Set HOMERAIL_ALLOW_INSECURE_REMOTE_WS=1 only for an isolated trusted network.",
+  );
+}

--- a/homerail_node/src/control-plane/ws-client.ts
+++ b/homerail_node/src/control-plane/ws-client.ts
@@ -1,6 +1,7 @@
 import WebSocket from "ws";
 import type { ExecutionProvider } from "../providers/types.js";
 import { handleLifecycleRequest, type LifecycleRequest, type LifecycleResponse } from "./lifecycle-handler.js";
+import { assertSecureControlPlaneUrl } from "./security.js";
 
 export interface NodeClientOptions {
   managerUrl: string;
@@ -8,6 +9,8 @@ export interface NodeClientOptions {
   nodeId: string;
   provider: ExecutionProvider;
   capabilities?: string[];
+  token?: string;
+  allowInsecureRemote?: boolean;
   reconnectInitialDelayMs?: number;
   reconnectMaxDelayMs?: number;
 }
@@ -28,6 +31,8 @@ export function createNodeClient(options: NodeClientOptions): NodeClient {
   let reconnectAttempt = 0;
 
   const url = `${managerUrl}/ws/projects/${projectId}/nodes/${nodeId}`;
+  assertSecureControlPlaneUrl(url, options.allowInsecureRemote ?? false);
+  const token = options.token?.trim();
   const initialDelay = Math.max(50, options.reconnectInitialDelayMs ?? 1_000);
   const maxDelay = Math.max(initialDelay, options.reconnectMaxDelayMs ?? 30_000);
 
@@ -57,7 +62,10 @@ export function createNodeClient(options: NodeClientOptions): NodeClient {
   function openSocket(initial: boolean): Promise<void> {
     if (ws?.readyState === WebSocket.OPEN && registered) return Promise.resolve();
     return new Promise((resolve, reject) => {
-      const socket = new WebSocket(url);
+      const headers = token
+        ? { Authorization: `Bearer ${token}` }
+        : undefined;
+      const socket = new WebSocket(url, { headers });
       let settled = false;
 
       const settleError = (err: Error) => {

--- a/homerail_protocol/src/telemetry-redaction.ts
+++ b/homerail_protocol/src/telemetry-redaction.ts
@@ -6,7 +6,7 @@
 const REDACTED = "***REDACTED***";
 
 const SECRET_TEXT_PATTERNS: Array<[RegExp, string]> = [
-  [/("(?:api[_-]?key|token|secret|password|credential|authorization|auth)"\s*:\s*")[^"]+(")/gi, `$1${REDACTED}$2`],
+  [/("[^"]*(?:api[_-]?key|token|secret|password|credential|authorization|auth)"\s*:\s*")[^"]+(")/gi, `$1${REDACTED}$2`],
   [/(api[_-]?key|token|secret|password)=([^&\s'"]+)/gi, "$1=***REDACTED***"],
   [/(Authorization:\s*(?:Bearer|token)\s+)[^\s'"]+/gi, "$1***REDACTED***"],
   [/(Bearer\s+)[A-Za-z0-9._~+/-]{8,}/gi, "$1***REDACTED***"],
@@ -18,10 +18,7 @@ function isSecretKey(key: string): boolean {
   const normalized = key.replace(/[^a-z0-9]/gi, "").toLowerCase();
   return normalized === "apikey"
     || normalized.endsWith("apikey")
-    || normalized === "token"
-    || normalized.endsWith("accesstoken")
-    || normalized.endsWith("refreshtoken")
-    || normalized.endsWith("approvaltoken")
+    || normalized.endsWith("token")
     || normalized === "secret"
     || normalized.endsWith("clientsecret")
     || normalized === "password"

--- a/homerail_protocol/tests/telemetry-redaction.test.ts
+++ b/homerail_protocol/tests/telemetry-redaction.test.ts
@@ -6,6 +6,8 @@ describe("telemetry redaction", () => {
     const redacted = redactTelemetry({
       api_key: "secret-field-value",
       nested: {
+        HOMERAIL_WORKER_TOKEN: "worker-control-plane-secret",
+        HOMERAIL_NODE_TOKEN: "node-control-plane-secret",
         message: "Authorization: Bearer bearer-secret-123456 token=query-secret-value",
         url: "https://user:password-value@example.test/path",
       },
@@ -14,10 +16,22 @@ describe("telemetry redaction", () => {
     const text = JSON.stringify(redacted);
 
     expect(text).not.toContain("secret-field-value");
+    expect(text).not.toContain("worker-control-plane-secret");
+    expect(text).not.toContain("node-control-plane-secret");
     expect(text).not.toContain("bearer-secret-123456");
     expect(text).not.toContain("query-secret-value");
     expect(text).not.toContain("password-value");
     expect(text).not.toContain("sk-outputsecret12345");
     expect(text).toContain("***REDACTED***");
+  });
+
+  it("redacts control-plane token keys in serialized JSON text", () => {
+    const redacted = redactTelemetry(
+      '{"env":{"HOMERAIL_WORKER_TOKEN":"worker-secret","HOMERAIL_NODE_TOKEN":"node-secret"}}',
+    );
+
+    expect(redacted).not.toContain("worker-secret");
+    expect(redacted).not.toContain("node-secret");
+    expect(redacted).toContain("***REDACTED***");
   });
 });

--- a/homerail_worker/src/__tests__/control-plane-security.test.ts
+++ b/homerail_worker/src/__tests__/control-plane-security.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { assertSecureControlPlaneUrl } from "../control-plane-security.js";
+
+describe("worker control-plane transport policy", () => {
+  it("allows encrypted remote and local development websocket URLs", () => {
+    expect(() => assertSecureControlPlaneUrl("wss://manager.example.test/ws")).not.toThrow();
+    expect(() => assertSecureControlPlaneUrl("ws://127.0.0.1:19191/ws")).not.toThrow();
+    expect(() => assertSecureControlPlaneUrl("ws://host.docker.internal:19191/ws")).not.toThrow();
+  });
+
+  it("rejects insecure remote websocket URLs unless explicitly allowed", () => {
+    expect(() => assertSecureControlPlaneUrl("ws://192.0.2.20:19191/ws"))
+      .toThrow("Remote Manager WebSocket connections require wss://");
+    expect(() => assertSecureControlPlaneUrl("ws://192.0.2.20:19191/ws", true)).not.toThrow();
+    expect(() => assertSecureControlPlaneUrl("https://manager.example.test/ws"))
+      .toThrow("must use ws:// or wss://");
+  });
+});

--- a/homerail_worker/src/__tests__/ws-client.test.ts
+++ b/homerail_worker/src/__tests__/ws-client.test.ts
@@ -3,12 +3,39 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { WebSocketServer } from "ws";
 import { WsClient } from "../ws-client.js";
 
 // We test the WsClient's event emission and message handling logic
 // without a real WebSocket server by mocking the ws module.
 
 describe("WsClient", () => {
+  it("sends the worker bearer token during the websocket upgrade", async () => {
+    const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    await new Promise<void>((resolve) => server.once("listening", resolve));
+    const address = server.address();
+    if (!address || typeof address !== "object") throw new Error("server did not bind");
+    const authorization = new Promise<string | undefined>((resolve) => {
+      server.once("connection", (_socket, request) => resolve(request.headers.authorization));
+    });
+    const client = new WsClient({
+      url: `ws://127.0.0.1:${address.port}`,
+      workerId: "authenticated-worker",
+      token: " worker-secret ",
+    });
+    const connected = new Promise<void>((resolve) => client.once("connected", resolve));
+
+    try {
+      client.connect();
+      await expect(authorization).resolves.toBe("Bearer worker-secret");
+      await connected;
+    } finally {
+      client.close();
+      for (const socket of server.clients) socket.terminate();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
   it("emits connected on open", () => {
     const client = new WsClient({
       url: "ws://localhost:9999",

--- a/homerail_worker/src/control-plane-security.ts
+++ b/homerail_worker/src/control-plane-security.ts
@@ -1,0 +1,26 @@
+const LOCAL_WEBSOCKET_HOSTS = new Set([
+  "localhost",
+  "::1",
+  "host.docker.internal",
+]);
+
+function isLocalWebSocketHost(hostname: string): boolean {
+  const normalized = hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  return LOCAL_WEBSOCKET_HOSTS.has(normalized) || normalized.startsWith("127.");
+}
+
+export function assertSecureControlPlaneUrl(
+  rawUrl: string,
+  allowInsecureRemote = false,
+): void {
+  const url = new URL(rawUrl);
+  if (url.protocol !== "ws:" && url.protocol !== "wss:") {
+    throw new Error(`Manager WebSocket URL must use ws:// or wss://: ${rawUrl}`);
+  }
+  if (url.protocol === "wss:" || isLocalWebSocketHost(url.hostname)) return;
+  if (allowInsecureRemote) return;
+  throw new Error(
+    "Remote Manager WebSocket connections require wss://. "
+      + "Set HOMERAIL_ALLOW_INSECURE_REMOTE_WS=1 only for an isolated trusted network.",
+  );
+}

--- a/homerail_worker/src/index.ts
+++ b/homerail_worker/src/index.ts
@@ -23,6 +23,7 @@ const MANAGER_WS_URL =
   process.env.MANAGER_WORKER_WS_URL ??
   `${DEFAULT_MANAGER_WS_BASE}/ws/projects/default/workers/${encodeURIComponent(WORKER_ID)}`;
 const TOKEN = process.env.HOMERAIL_WORKER_TOKEN ?? "";
+const ALLOW_INSECURE_REMOTE_WS = process.env.HOMERAIL_ALLOW_INSECURE_REMOTE_WS === "1";
 const CAPABILITIES = (process.env.HOMERAIL_WORKER_CAPABILITIES ?? "")
   .split(",")
   .map((capability) => capability.trim())
@@ -38,6 +39,7 @@ const client = new WsClient({
   workerId: WORKER_ID,
   capabilities: CAPABILITIES,
   token: TOKEN,
+  allowInsecureRemote: ALLOW_INSECURE_REMOTE_WS,
 });
 
 let activePrompt:

--- a/homerail_worker/src/ws-client.ts
+++ b/homerail_worker/src/ws-client.ts
@@ -6,12 +6,14 @@
 
 import WebSocket from "ws";
 import { EventEmitter } from "node:events";
+import { assertSecureControlPlaneUrl } from "./control-plane-security.js";
 
 export interface WsClientOptions {
   url: string;
   workerId: string;
   capabilities?: string[];
   token?: string;
+  allowInsecureRemote?: boolean;
   heartbeatIntervalMs?: number;
   heartbeatTimeoutMs?: number;
   reconnectBaseMs?: number;
@@ -39,12 +41,14 @@ export class WsClient extends EventEmitter {
       url: opts.url,
       workerId: opts.workerId,
       capabilities: opts.capabilities ?? [],
-      token: opts.token ?? "",
+      token: opts.token?.trim() ?? "",
+      allowInsecureRemote: opts.allowInsecureRemote ?? false,
       heartbeatIntervalMs: opts.heartbeatIntervalMs ?? 30_000,
       heartbeatTimeoutMs: opts.heartbeatTimeoutMs ?? 10_000,
       reconnectBaseMs: opts.reconnectBaseMs ?? 1_000,
       reconnectMaxMs: opts.reconnectMaxMs ?? 60_000,
     };
+    assertSecureControlPlaneUrl(this.opts.url, this.opts.allowInsecureRemote);
     this.reconnectDelay = this.opts.reconnectBaseMs;
   }
 


### PR DESCRIPTION
## Summary

- require Bearer authentication on Manager worker and node WebSocket control-plane connections
- generate and persist a private default control-plane token under HOMERAIL_HOME
- require secure WebSocket transport for remote clients while preserving local and Docker host connectivity
- cover authentication rejection, token reuse, and reconnect behavior

## Why

PR #21 expands the runtime control plane. Without transport authentication, a process that can reach the Manager WebSocket endpoints could register as a worker or node. This follow-up makes registration an authenticated boundary.

## Validation

- repository-wide local CI passed
- real Docker worker registration passed
- Manager restart and authenticated worker reconnect passed

## Dependency

- stacked on PR #21; keep as Draft until #21 is merged and this branch is rebased onto main