### PR TITLE
Add configurable workspace retention

### DIFF
--- a/agent-ui/src/api/agent/agent-settings-api.ts
+++ b/agent-ui/src/api/agent/agent-settings-api.ts
@@ -157,9 +157,25 @@ export interface AgentStorageRetentionInfo {
   cleanup_supported: boolean
   cleanup_tracked_gap: boolean
   cleanup_next_action: string
+  workspace_retention: WorkspaceRetentionSettings
   export_supported: boolean
   export_tracked_gap: boolean
   export_next_action: string
+}
+
+export interface WorkspaceRetentionSettings {
+  enabled: boolean
+  success_days: number
+  failure_days: number
+}
+
+export interface WorkspaceCleanupReport {
+  dry_run: boolean
+  scanned: number
+  eligible: number
+  removed: number
+  skipped: number
+  failed: number
 }
 
 export interface AgentRuntimeStatus {
@@ -631,6 +647,23 @@ export const agentSettingsApi = {
    */
   async getStorageInfo(): Promise<AgentStorageRetentionInfo> {
     const res = await http.get<AgentStorageRetentionInfo>('/api/settings/storage-info')
+    return res.data
+  },
+
+  async updateWorkspaceRetention(
+    settings: WorkspaceRetentionSettings,
+  ): Promise<WorkspaceRetentionSettings> {
+    const res = await http.post<WorkspaceRetentionSettings>(
+      '/api/settings/workspace-retention',
+      settings,
+    )
+    return res.data
+  },
+
+  async cleanupRunWorkspaces(dryRun = true): Promise<WorkspaceCleanupReport> {
+    const res = await http.post<WorkspaceCleanupReport>('/api/dag/workspaces/cleanup', {
+      dry_run: dryRun,
+    })
     return res.data
   },
 

--- a/agent-ui/src/api/agent/agent-settings-api.ts
+++ b/agent-ui/src/api/agent/agent-settings-api.ts
@@ -661,9 +661,11 @@ export const agentSettingsApi = {
   },
 
   async cleanupRunWorkspaces(dryRun = true): Promise<WorkspaceCleanupReport> {
-    const res = await http.post<WorkspaceCleanupReport>('/api/dag/workspaces/cleanup', {
-      dry_run: dryRun,
-    })
+    const res = await http.post<WorkspaceCleanupReport>(
+      '/api/dag/workspaces/cleanup',
+      { dry_run: dryRun },
+      { timeout: 0 },
+    )
     return res.data
   },
 

--- a/agent-ui/src/api/agent/index.ts
+++ b/agent-ui/src/api/agent/index.ts
@@ -30,6 +30,8 @@ export type {
   AgentRuntimeStatus,
   AgentWorkspaceSettings,
   AgentStorageRetentionInfo,
+  WorkspaceRetentionSettings,
+  WorkspaceCleanupReport,
   VoiceUiRulesAsset,
   VoiceSettings,
   VoiceTtsOutputChannel,

--- a/agent-ui/src/components/agent/AgentSettingsPage.test.ts
+++ b/agent-ui/src/components/agent/AgentSettingsPage.test.ts
@@ -28,6 +28,10 @@ vi.mock('./settings/ModelSettings.vue', () => ({
   default: { template: '<section data-testid="mock-model-settings" />' }
 }))
 
+vi.mock('./settings/StorageRetentionSettings.vue', () => ({
+  default: { template: '<section data-testid="mock-storage-retention-settings" />' }
+}))
+
 vi.mock('@/api/agent', () => ({
   listProjects: vi.fn(() => Promise.resolve({ data: { projects: [] } })),
   listProjectStorages: vi.fn(() => Promise.resolve({ data: { storages: [] } })),

--- a/agent-ui/src/components/agent/AgentSettingsPage.vue
+++ b/agent-ui/src/components/agent/AgentSettingsPage.vue
@@ -23,6 +23,7 @@ import {
 } from 'lucide-vue-next'
 import ModelSettings from './settings/ModelSettings.vue'
 import GeneralSettings from './settings/GeneralSettings.vue'
+import StorageRetentionSettings from './settings/StorageRetentionSettings.vue'
 import {
   listProjects,
   listProjectStorages,
@@ -30,7 +31,6 @@ import {
   agentSettingsApi,
   type AgentRuntimeStatus,
   type AgentWorkspaceSettings,
-  type AgentStorageRetentionInfo,
   type LLMSetting,
   type GitServer,
   type MCPServer,
@@ -155,7 +155,6 @@ const orchestrationTemplates = ref<OrchestrationTemplate[]>([])
 const orchestrationTemplatesError = ref<string | null>(null)
 const runtimeStatus = ref<AgentRuntimeStatus | null>(null)
 const workspaceSettings = ref<AgentWorkspaceSettings | null>(null)
-const storageInfo = ref<AgentStorageRetentionInfo | null>(null)
 const voiceSettings = ref<VoiceSettings | null>(null)
 const voiceAgentConfig = ref<VoiceAgentConfig | null>(null)
 const codexModels = ref<CodexModel[]>([])
@@ -773,7 +772,6 @@ async function refreshAll(): Promise<void> {
       orchestrationTemplateRes,
       runtimeStatusRes,
       workspaceSettingsRes,
-      storageInfoRes,
     ] = await Promise.all([
       listProjects({ limit: 200 }).catch(() => null),
       hiddenSettingsTabs.has('nodes') ? Promise.resolve(null) : listNodes().catch(() => null),
@@ -792,7 +790,6 @@ async function refreshAll(): Promise<void> {
       hiddenSettingsTabs.has('memory') ? Promise.resolve(null) : loadOrchestrationTemplates(),
       agentSettingsApi.getRuntimeStatus().catch(() => null),
       agentSettingsApi.getWorkspaceSettings().catch(() => null),
-      hiddenSettingsTabs.has('memory') ? Promise.resolve(null) : agentSettingsApi.getStorageInfo().catch(() => null),
     ])
 
     projects.value = projectRes?.data?.projects ?? []
@@ -811,7 +808,6 @@ async function refreshAll(): Promise<void> {
     codexModels.value = codexModelRes?.data?.models ?? []
     runtimeStatus.value = runtimeStatusRes ?? null
     workspaceSettings.value = workspaceSettingsRes ?? null
-    storageInfo.value = storageInfoRes ?? null
     if (voiceRes?.data) {
       voiceSettings.value = voiceRes.data
       voiceForm.value = {
@@ -1517,7 +1513,10 @@ onUnmounted(() => {
           </button>
         </div>
 
-        <GeneralSettings v-if="activeTab === 'general'" />
+        <template v-if="activeTab === 'general'">
+          <GeneralSettings />
+          <StorageRetentionSettings />
+        </template>
 
         <section v-if="activeTab === 'workspace'" data-testid="agent-settings-section-workspace" class="mt-10 space-y-6">
           <div class="grid gap-3 sm:grid-cols-3">
@@ -2203,37 +2202,6 @@ onUnmounted(() => {
                 <Network class="h-4 w-4" />
                 打开完整图谱
               </button>
-            </div>
-          </div>
-          <div class="rounded-lg border border-white/10 bg-[#252525] p-4" data-testid="agent-settings-storage-info">
-            <div class="flex items-center justify-between gap-3">
-              <div>
-                <h2 class="font-semibold">Storage & Retention</h2>
-                <p class="mt-1 text-xs text-gray-500">持久化运行数据、会话和证据的存储位置与保留状态。</p>
-              </div>
-              <span v-if="storageInfo" class="rounded-full bg-emerald-500/10 px-2 py-1 text-xs text-emerald-200">已连接</span>
-              <span v-else class="rounded-full bg-yellow-500/10 px-2 py-1 text-xs text-yellow-200">加载中...</span>
-            </div>
-            <div v-if="storageInfo" class="mt-4 space-y-3">
-              <div class="grid gap-3 sm:grid-cols-3">
-                <div class="rounded-md bg-[#1e1e1e] p-3">
-                  <div class="text-xs text-gray-500">Data Root</div>
-                  <div class="mt-1 break-all font-mono text-sm">{{ storageInfo.data_root }}</div>
-                </div>
-                <div class="rounded-md bg-[#1e1e1e] p-3">
-                  <div class="text-xs text-gray-500">Runs</div>
-                  <div class="mt-1 text-lg font-semibold">{{ storageInfo.runs_count }}</div>
-                </div>
-                <div class="rounded-md bg-[#1e1e1e] p-3">
-                  <div class="text-xs text-gray-500">Sessions Dir</div>
-                  <div class="mt-1 break-all font-mono text-sm">{{ storageInfo.sessions_dir }}</div>
-                </div>
-              </div>
-              <div class="flex flex-wrap gap-2 text-xs">
-                <span v-if="storageInfo.retention_supported" class="rounded-full bg-emerald-500/10 px-2 py-1 text-emerald-200">retention: supported</span>
-                <span v-if="storageInfo.cleanup_tracked_gap" class="rounded-full bg-yellow-500/10 px-2 py-1 text-yellow-200" data-testid="agent-settings-storage-tracked-gap-cleanup">{{ storageInfo.cleanup_next_action }}</span>
-                <span v-if="storageInfo.export_tracked_gap" class="rounded-full bg-yellow-500/10 px-2 py-1 text-yellow-200" data-testid="agent-settings-storage-tracked-gap-export">{{ storageInfo.export_next_action }}</span>
-              </div>
             </div>
           </div>
           <div class="grid gap-4 lg:grid-cols-[1fr_1fr]">

--- a/agent-ui/src/components/agent/settings/StorageRetentionSettings.test.ts
+++ b/agent-ui/src/components/agent/settings/StorageRetentionSettings.test.ts
@@ -121,4 +121,26 @@ describe('StorageRetentionSettings', () => {
     expect(cleanupRunWorkspaces).toHaveBeenCalledWith(false)
     app.unmount()
   })
+
+  it('clamps retention days to the supported range before saving', async () => {
+    const { app, root } = mount()
+    await flush()
+
+    const success = root.querySelector<HTMLInputElement>('[data-testid="agent-settings-workspace-retention-success-days"]')!
+    const failure = root.querySelector<HTMLInputElement>('[data-testid="agent-settings-workspace-retention-failure-days"]')!
+    success.value = '4000'
+    success.dispatchEvent(new Event('input', { bubbles: true }))
+    failure.value = '-3'
+    failure.dispatchEvent(new Event('input', { bubbles: true }))
+    root.querySelector<HTMLButtonElement>('[data-testid="agent-settings-workspace-retention-save"]')!
+      .dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flush()
+
+    expect(updateWorkspaceRetention).toHaveBeenCalledWith({
+      enabled: true,
+      success_days: 3650,
+      failure_days: 0,
+    })
+    app.unmount()
+  })
 })

--- a/agent-ui/src/components/agent/settings/StorageRetentionSettings.test.ts
+++ b/agent-ui/src/components/agent/settings/StorageRetentionSettings.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick } from 'vue'
+
+import StorageRetentionSettings from './StorageRetentionSettings.vue'
+
+const {
+  getStorageInfo,
+  updateWorkspaceRetention,
+  cleanupRunWorkspaces,
+  showToast,
+} = vi.hoisted(() => ({
+  getStorageInfo: vi.fn(),
+  updateWorkspaceRetention: vi.fn(),
+  cleanupRunWorkspaces: vi.fn(),
+  showToast: vi.fn(),
+}))
+
+vi.mock('@/api/agent', () => ({
+  agentSettingsApi: {
+    getStorageInfo,
+    updateWorkspaceRetention,
+    cleanupRunWorkspaces,
+  },
+}))
+
+vi.mock('@/components/controls/useToast', () => ({
+  useToast: () => ({ showToast }),
+}))
+
+async function flush(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+  await nextTick()
+}
+
+function mount() {
+  const root = document.createElement('div')
+  document.body.appendChild(root)
+  const app = createApp(StorageRetentionSettings)
+  app.mount(root)
+  return { app, root }
+}
+
+describe('StorageRetentionSettings', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    vi.clearAllMocks()
+    getStorageInfo.mockResolvedValue({
+      data_root: '/tmp/homerail/manager',
+      runs_count: 3,
+      sessions_dir: '/tmp/homerail/sessions',
+      retention_supported: true,
+      cleanup_supported: true,
+      cleanup_tracked_gap: false,
+      cleanup_next_action: '',
+      workspace_retention: { enabled: true, success_days: 7, failure_days: 7 },
+      export_supported: false,
+      export_tracked_gap: true,
+      export_next_action: 'not implemented',
+    })
+    updateWorkspaceRetention.mockImplementation(async (settings) => settings)
+    cleanupRunWorkspaces.mockResolvedValue({
+      dry_run: true,
+      scanned: 3,
+      eligible: 2,
+      removed: 0,
+      skipped: 1,
+      failed: 0,
+    })
+  })
+
+  it('shows seven-day defaults and persists edited success and failure policies', async () => {
+    const { app, root } = mount()
+    await flush()
+
+    const success = root.querySelector<HTMLInputElement>('[data-testid="agent-settings-workspace-retention-success-days"]')!
+    const failure = root.querySelector<HTMLInputElement>('[data-testid="agent-settings-workspace-retention-failure-days"]')!
+    expect(success.value).toBe('7')
+    expect(failure.value).toBe('7')
+
+    success.value = '10'
+    success.dispatchEvent(new Event('input', { bubbles: true }))
+    failure.value = '12'
+    failure.dispatchEvent(new Event('input', { bubbles: true }))
+    root.querySelector<HTMLButtonElement>('[data-testid="agent-settings-workspace-retention-save"]')!
+      .dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flush()
+
+    expect(updateWorkspaceRetention).toHaveBeenCalledWith({
+      enabled: true,
+      success_days: 10,
+      failure_days: 12,
+    })
+    app.unmount()
+  })
+
+  it('previews safely and requires confirmation before destructive cleanup', async () => {
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const { app, root } = mount()
+    await flush()
+
+    root.querySelector<HTMLButtonElement>('[data-testid="agent-settings-workspace-cleanup-preview"]')!
+      .dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flush()
+    expect(cleanupRunWorkspaces).toHaveBeenCalledWith(true)
+
+    root.querySelector<HTMLButtonElement>('[data-testid="agent-settings-workspace-cleanup-run"]')!
+      .dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flush()
+    expect(cleanupRunWorkspaces).not.toHaveBeenCalledWith(false)
+
+    confirm.mockReturnValue(true)
+    root.querySelector<HTMLButtonElement>('[data-testid="agent-settings-workspace-cleanup-run"]')!
+      .dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flush()
+    expect(cleanupRunWorkspaces).toHaveBeenCalledWith(false)
+    app.unmount()
+  })
+})

--- a/agent-ui/src/components/agent/settings/StorageRetentionSettings.test.ts
+++ b/agent-ui/src/components/agent/settings/StorageRetentionSettings.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, nextTick } from 'vue'
 
+import { i18n } from '@/plugins/i18n'
 import StorageRetentionSettings from './StorageRetentionSettings.vue'
 
 const {
@@ -37,6 +38,7 @@ function mount() {
   const root = document.createElement('div')
   document.body.appendChild(root)
   const app = createApp(StorageRetentionSettings)
+  app.use(i18n)
   app.mount(root)
   return { app, root }
 }
@@ -44,6 +46,7 @@ function mount() {
 describe('StorageRetentionSettings', () => {
   beforeEach(() => {
     document.body.innerHTML = ''
+    i18n.global.locale.value = 'zh-Hans'
     vi.clearAllMocks()
     getStorageInfo.mockResolvedValue({
       data_root: '/tmp/homerail/manager',
@@ -95,7 +98,7 @@ describe('StorageRetentionSettings', () => {
   })
 
   it('previews safely and requires confirmation before destructive cleanup', async () => {
-    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const nativeConfirm = vi.spyOn(window, 'confirm')
     const { app, root } = mount()
     await flush()
 
@@ -108,9 +111,11 @@ describe('StorageRetentionSettings', () => {
       .dispatchEvent(new MouseEvent('click', { bubbles: true }))
     await flush()
     expect(cleanupRunWorkspaces).not.toHaveBeenCalledWith(false)
+    expect(nativeConfirm).not.toHaveBeenCalled()
+    expect(root.querySelector('[data-testid="agent-settings-workspace-cleanup-confirm"]'))
+      .not.toBeNull()
 
-    confirm.mockReturnValue(true)
-    root.querySelector<HTMLButtonElement>('[data-testid="agent-settings-workspace-cleanup-run"]')!
+    root.querySelector<HTMLButtonElement>('[data-testid="agent-settings-workspace-cleanup-confirm-confirm"]')!
       .dispatchEvent(new MouseEvent('click', { bubbles: true }))
     await flush()
     expect(cleanupRunWorkspaces).toHaveBeenCalledWith(false)

--- a/agent-ui/src/components/agent/settings/StorageRetentionSettings.vue
+++ b/agent-ui/src/components/agent/settings/StorageRetentionSettings.vue
@@ -1,17 +1,21 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
-import { Loader2 } from 'lucide-vue-next'
+import { FileSearch, Loader2, Save, Trash2 } from 'lucide-vue-next'
+import { useI18n } from 'vue-i18n'
 
 import {
   agentSettingsApi,
   type AgentStorageRetentionInfo,
 } from '@/api/agent'
 import { useToast } from '@/components/controls/useToast'
+import InlineDeleteConfirm from './InlineDeleteConfirm.vue'
 
 const { showToast } = useToast()
+const { t } = useI18n()
 const storageInfo = ref<AgentStorageRetentionInfo | null>(null)
 const loading = ref(true)
 const saving = ref<string | null>(null)
+const cleanupConfirmOpen = ref(false)
 const form = ref({
   enabled: true,
   success_days: 7,
@@ -49,7 +53,7 @@ async function save(): Promise<void> {
     })
     form.value = { ...settings }
     if (storageInfo.value) storageInfo.value.workspace_retention = { ...settings }
-    showToast('工作区保留策略已保存', 'success', 2600)
+    showToast(t('settings.storage.saved'), 'success', 2600)
   } catch (error) {
     showToast(messageOf(error), 'error', 3600)
   } finally {
@@ -58,14 +62,20 @@ async function save(): Promise<void> {
 }
 
 async function cleanup(dryRun: boolean): Promise<void> {
-  if (!dryRun && !window.confirm('立即删除已超过保留期限且未固定的运行工作区？')) return
   saving.value = dryRun ? 'preview' : 'cleanup'
   try {
     const report = await agentSettingsApi.cleanupRunWorkspaces(dryRun)
-    if (!dryRun) await load()
-    const action = dryRun ? '预览' : '清理'
+    if (!dryRun) {
+      cleanupConfirmOpen.value = false
+      await load()
+    }
     showToast(
-      `${action}完成：符合条件 ${report.eligible}，已删除 ${report.removed}，失败 ${report.failed}`,
+      t('settings.storage.result', {
+        action: t(dryRun ? 'settings.storage.previewAction' : 'settings.storage.cleanupAction'),
+        eligible: report.eligible,
+        removed: report.removed,
+        failed: report.failed,
+      }),
       'success',
       2600,
     )
@@ -83,25 +93,25 @@ onMounted(load)
   <section class="mt-5 rounded-lg border border-white/10 bg-white/[0.045] p-4" data-testid="agent-settings-storage-info">
     <div class="flex items-center justify-between gap-3">
       <div>
-        <h2 class="font-semibold text-white/88">Storage & Retention</h2>
-        <p class="mt-1 text-sm text-white/42">配置已结束运行的工作区保留期限。</p>
+        <h2 class="font-semibold text-white/88">{{ t('settings.storage.title') }}</h2>
+        <p class="mt-1 text-sm text-white/42">{{ t('settings.storage.description') }}</p>
       </div>
-      <span v-if="storageInfo" class="rounded-full bg-emerald-500/10 px-2 py-1 text-xs text-emerald-200">已连接</span>
-      <span v-else class="rounded-full bg-yellow-500/10 px-2 py-1 text-xs text-yellow-200">{{ loading ? '加载中...' : '不可用' }}</span>
+      <span v-if="storageInfo" class="rounded-full bg-emerald-500/10 px-2 py-1 text-xs text-emerald-200">{{ t('settings.storage.connected') }}</span>
+      <span v-else class="rounded-full bg-yellow-500/10 px-2 py-1 text-xs text-yellow-200">{{ t(loading ? 'settings.storage.loading' : 'settings.storage.unavailable') }}</span>
     </div>
 
     <div v-if="storageInfo" class="mt-4 space-y-4">
       <div class="grid gap-3 sm:grid-cols-3">
         <div class="rounded-md bg-black/20 p-3">
-          <div class="text-xs text-white/42">Data Root</div>
+          <div class="text-xs text-white/42">{{ t('settings.storage.dataRoot') }}</div>
           <div class="mt-1 break-all font-mono text-sm text-white/75">{{ storageInfo.data_root }}</div>
         </div>
         <div class="rounded-md bg-black/20 p-3">
-          <div class="text-xs text-white/42">Runs</div>
+          <div class="text-xs text-white/42">{{ t('settings.storage.runs') }}</div>
           <div class="mt-1 text-lg font-semibold">{{ storageInfo.runs_count }}</div>
         </div>
         <div class="rounded-md bg-black/20 p-3">
-          <div class="text-xs text-white/42">Sessions Dir</div>
+          <div class="text-xs text-white/42">{{ t('settings.storage.sessionsDir') }}</div>
           <div class="mt-1 break-all font-mono text-sm text-white/75">{{ storageInfo.sessions_dir }}</div>
         </div>
       </div>
@@ -109,37 +119,49 @@ onMounted(load)
       <div class="border-t border-white/10 pt-4" data-testid="agent-settings-workspace-retention-form">
         <div class="flex items-center justify-between gap-4">
           <div>
-            <div class="text-sm font-medium">运行工作区自动清理</div>
-            <div class="mt-1 text-xs text-white/42">只清理已结束、未固定且超过保留期限的工作区。</div>
+            <div class="text-sm font-medium">{{ t('settings.storage.autoCleanup') }}</div>
+            <div class="mt-1 text-xs text-white/42">{{ t('settings.storage.autoCleanupDescription') }}</div>
           </div>
           <label class="flex shrink-0 items-center gap-2 whitespace-nowrap text-sm">
             <input v-model="form.enabled" type="checkbox" class="h-4 w-4 accent-cyan-400" data-testid="agent-settings-workspace-retention-enabled" />
-            启用
+            {{ t('settings.actions.enable') }}
           </label>
         </div>
         <div class="mt-4 grid gap-3 sm:grid-cols-2">
           <label class="text-sm">
-            <span class="text-white/55">成功运行保留天数</span>
+            <span class="text-white/55">{{ t('settings.storage.successDays') }}</span>
             <input v-model.number="form.success_days" type="number" min="0" max="3650" step="1" class="mt-1 h-10 w-full rounded-md border border-white/10 bg-black/20 px-3 outline-none focus:border-cyan-400/60" data-testid="agent-settings-workspace-retention-success-days" />
           </label>
           <label class="text-sm">
-            <span class="text-white/55">失败或取消运行保留天数</span>
+            <span class="text-white/55">{{ t('settings.storage.failureDays') }}</span>
             <input v-model.number="form.failure_days" type="number" min="0" max="3650" step="1" class="mt-1 h-10 w-full rounded-md border border-white/10 bg-black/20 px-3 outline-none focus:border-cyan-400/60" data-testid="agent-settings-workspace-retention-failure-days" />
           </label>
         </div>
         <div class="mt-4 flex flex-wrap justify-end gap-2">
           <button class="h-9 rounded-md border border-white/10 px-3 text-sm hover:bg-white/5 disabled:opacity-50" :disabled="saving !== null" data-testid="agent-settings-workspace-cleanup-preview" @click="cleanup(true)">
             <Loader2 v-if="saving === 'preview'" class="mr-2 inline h-4 w-4 animate-spin" />
-            预览清理
+            <FileSearch v-else class="mr-2 inline h-4 w-4" />
+            {{ t('settings.storage.preview') }}
           </button>
-          <button class="h-9 rounded-md border border-red-400/30 px-3 text-sm text-red-200 hover:bg-red-400/10 disabled:opacity-50" :disabled="saving !== null" data-testid="agent-settings-workspace-cleanup-run" @click="cleanup(false)">
+          <button class="h-9 rounded-md border border-red-400/30 px-3 text-sm text-red-200 hover:bg-red-400/10 disabled:opacity-50" :class="cleanupConfirmOpen ? 'bg-red-400/10' : ''" :disabled="saving !== null" data-testid="agent-settings-workspace-cleanup-run" @click="cleanupConfirmOpen = !cleanupConfirmOpen">
             <Loader2 v-if="saving === 'cleanup'" class="mr-2 inline h-4 w-4 animate-spin" />
-            立即清理
+            <Trash2 v-else class="mr-2 inline h-4 w-4" />
+            {{ t('settings.storage.cleanupNow') }}
           </button>
           <button class="h-9 rounded-md bg-cyan-500 px-4 text-sm font-medium text-black hover:bg-cyan-400 disabled:opacity-50" :disabled="saving !== null" data-testid="agent-settings-workspace-retention-save" @click="save">
             <Loader2 v-if="saving === 'save'" class="mr-2 inline h-4 w-4 animate-spin" />
-            保存策略
+            <Save v-else class="mr-2 inline h-4 w-4" />
+            {{ t('settings.storage.savePolicy') }}
           </button>
+        </div>
+        <div v-if="cleanupConfirmOpen" class="mt-3 ml-auto max-w-sm">
+          <InlineDeleteConfirm
+            test-id="agent-settings-workspace-cleanup-confirm"
+            :message="t('settings.storage.cleanupConfirm')"
+            :loading="saving === 'cleanup'"
+            @confirm="cleanup(false)"
+            @cancel="cleanupConfirmOpen = false"
+          />
         </div>
       </div>
     </div>

--- a/agent-ui/src/components/agent/settings/StorageRetentionSettings.vue
+++ b/agent-ui/src/components/agent/settings/StorageRetentionSettings.vue
@@ -1,0 +1,147 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { Loader2 } from 'lucide-vue-next'
+
+import {
+  agentSettingsApi,
+  type AgentStorageRetentionInfo,
+} from '@/api/agent'
+import { useToast } from '@/components/controls/useToast'
+
+const { showToast } = useToast()
+const storageInfo = ref<AgentStorageRetentionInfo | null>(null)
+const loading = ref(true)
+const saving = ref<string | null>(null)
+const form = ref({
+  enabled: true,
+  success_days: 7,
+  failure_days: 7,
+})
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String((error as { message?: string })?.message || error)
+}
+
+async function load(): Promise<void> {
+  loading.value = true
+  try {
+    storageInfo.value = await agentSettingsApi.getStorageInfo()
+    form.value = { ...storageInfo.value.workspace_retention }
+  } catch (error) {
+    showToast(messageOf(error), 'error', 3600)
+  } finally {
+    loading.value = false
+  }
+}
+
+function normalizedDays(value: number): number {
+  if (!Number.isFinite(value)) return 7
+  return Math.max(0, Math.min(3650, Math.round(value)))
+}
+
+async function save(): Promise<void> {
+  saving.value = 'save'
+  try {
+    const settings = await agentSettingsApi.updateWorkspaceRetention({
+      enabled: form.value.enabled,
+      success_days: normalizedDays(form.value.success_days),
+      failure_days: normalizedDays(form.value.failure_days),
+    })
+    form.value = { ...settings }
+    if (storageInfo.value) storageInfo.value.workspace_retention = { ...settings }
+    showToast('工作区保留策略已保存', 'success', 2600)
+  } catch (error) {
+    showToast(messageOf(error), 'error', 3600)
+  } finally {
+    saving.value = null
+  }
+}
+
+async function cleanup(dryRun: boolean): Promise<void> {
+  if (!dryRun && !window.confirm('立即删除已超过保留期限且未固定的运行工作区？')) return
+  saving.value = dryRun ? 'preview' : 'cleanup'
+  try {
+    const report = await agentSettingsApi.cleanupRunWorkspaces(dryRun)
+    if (!dryRun) await load()
+    const action = dryRun ? '预览' : '清理'
+    showToast(
+      `${action}完成：符合条件 ${report.eligible}，已删除 ${report.removed}，失败 ${report.failed}`,
+      'success',
+      2600,
+    )
+  } catch (error) {
+    showToast(messageOf(error), 'error', 3600)
+  } finally {
+    saving.value = null
+  }
+}
+
+onMounted(load)
+</script>
+
+<template>
+  <section class="mt-5 rounded-lg border border-white/10 bg-white/[0.045] p-4" data-testid="agent-settings-storage-info">
+    <div class="flex items-center justify-between gap-3">
+      <div>
+        <h2 class="font-semibold text-white/88">Storage & Retention</h2>
+        <p class="mt-1 text-sm text-white/42">配置已结束运行的工作区保留期限。</p>
+      </div>
+      <span v-if="storageInfo" class="rounded-full bg-emerald-500/10 px-2 py-1 text-xs text-emerald-200">已连接</span>
+      <span v-else class="rounded-full bg-yellow-500/10 px-2 py-1 text-xs text-yellow-200">{{ loading ? '加载中...' : '不可用' }}</span>
+    </div>
+
+    <div v-if="storageInfo" class="mt-4 space-y-4">
+      <div class="grid gap-3 sm:grid-cols-3">
+        <div class="rounded-md bg-black/20 p-3">
+          <div class="text-xs text-white/42">Data Root</div>
+          <div class="mt-1 break-all font-mono text-sm text-white/75">{{ storageInfo.data_root }}</div>
+        </div>
+        <div class="rounded-md bg-black/20 p-3">
+          <div class="text-xs text-white/42">Runs</div>
+          <div class="mt-1 text-lg font-semibold">{{ storageInfo.runs_count }}</div>
+        </div>
+        <div class="rounded-md bg-black/20 p-3">
+          <div class="text-xs text-white/42">Sessions Dir</div>
+          <div class="mt-1 break-all font-mono text-sm text-white/75">{{ storageInfo.sessions_dir }}</div>
+        </div>
+      </div>
+
+      <div class="border-t border-white/10 pt-4" data-testid="agent-settings-workspace-retention-form">
+        <div class="flex items-center justify-between gap-4">
+          <div>
+            <div class="text-sm font-medium">运行工作区自动清理</div>
+            <div class="mt-1 text-xs text-white/42">只清理已结束、未固定且超过保留期限的工作区。</div>
+          </div>
+          <label class="flex shrink-0 items-center gap-2 whitespace-nowrap text-sm">
+            <input v-model="form.enabled" type="checkbox" class="h-4 w-4 accent-cyan-400" data-testid="agent-settings-workspace-retention-enabled" />
+            启用
+          </label>
+        </div>
+        <div class="mt-4 grid gap-3 sm:grid-cols-2">
+          <label class="text-sm">
+            <span class="text-white/55">成功运行保留天数</span>
+            <input v-model.number="form.success_days" type="number" min="0" max="3650" step="1" class="mt-1 h-10 w-full rounded-md border border-white/10 bg-black/20 px-3 outline-none focus:border-cyan-400/60" data-testid="agent-settings-workspace-retention-success-days" />
+          </label>
+          <label class="text-sm">
+            <span class="text-white/55">失败或取消运行保留天数</span>
+            <input v-model.number="form.failure_days" type="number" min="0" max="3650" step="1" class="mt-1 h-10 w-full rounded-md border border-white/10 bg-black/20 px-3 outline-none focus:border-cyan-400/60" data-testid="agent-settings-workspace-retention-failure-days" />
+          </label>
+        </div>
+        <div class="mt-4 flex flex-wrap justify-end gap-2">
+          <button class="h-9 rounded-md border border-white/10 px-3 text-sm hover:bg-white/5 disabled:opacity-50" :disabled="saving !== null" data-testid="agent-settings-workspace-cleanup-preview" @click="cleanup(true)">
+            <Loader2 v-if="saving === 'preview'" class="mr-2 inline h-4 w-4 animate-spin" />
+            预览清理
+          </button>
+          <button class="h-9 rounded-md border border-red-400/30 px-3 text-sm text-red-200 hover:bg-red-400/10 disabled:opacity-50" :disabled="saving !== null" data-testid="agent-settings-workspace-cleanup-run" @click="cleanup(false)">
+            <Loader2 v-if="saving === 'cleanup'" class="mr-2 inline h-4 w-4 animate-spin" />
+            立即清理
+          </button>
+          <button class="h-9 rounded-md bg-cyan-500 px-4 text-sm font-medium text-black hover:bg-cyan-400 disabled:opacity-50" :disabled="saving !== null" data-testid="agent-settings-workspace-retention-save" @click="save">
+            <Loader2 v-if="saving === 'save'" class="mr-2 inline h-4 w-4 animate-spin" />
+            保存策略
+          </button>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>

--- a/agent-ui/src/locales/en-US/settings.json
+++ b/agent-ui/src/locales/en-US/settings.json
@@ -34,6 +34,28 @@
       }
     }
   },
+  "storage": {
+    "title": "Storage & Retention",
+    "description": "Configure how long completed run workspaces are retained.",
+    "connected": "Connected",
+    "loading": "Loading...",
+    "unavailable": "Unavailable",
+    "dataRoot": "Data root",
+    "runs": "Runs",
+    "sessionsDir": "Sessions directory",
+    "autoCleanup": "Automatic run workspace cleanup",
+    "autoCleanupDescription": "Automatically removes only terminal, unpinned workspaces past their retention period. Manual preview and cleanup remain available when disabled.",
+    "successDays": "Successful run retention (days)",
+    "failureDays": "Failed or cancelled run retention (days)",
+    "preview": "Preview cleanup",
+    "cleanupNow": "Clean up now",
+    "savePolicy": "Save policy",
+    "saved": "Workspace retention policy saved",
+    "cleanupConfirm": "Delete unpinned run workspaces past their retention period now? Run records and evidence will not be deleted.",
+    "previewAction": "Preview",
+    "cleanupAction": "Cleanup",
+    "result": "{action} complete: {eligible} eligible, {removed} removed, {failed} failed"
+  },
   "actions": {
     "refresh": "Refresh",
     "close": "Close",

--- a/agent-ui/src/locales/zh-Hans/settings.json
+++ b/agent-ui/src/locales/zh-Hans/settings.json
@@ -34,6 +34,28 @@
       }
     }
   },
+  "storage": {
+    "title": "存储与保留",
+    "description": "配置已结束运行的工作区保留期限。",
+    "connected": "已连接",
+    "loading": "加载中...",
+    "unavailable": "不可用",
+    "dataRoot": "数据目录",
+    "runs": "运行数",
+    "sessionsDir": "会话目录",
+    "autoCleanup": "运行工作区自动清理",
+    "autoCleanupDescription": "只自动清理已结束、未固定且超过保留期限的工作区。关闭后仍可手动预览和清理。",
+    "successDays": "成功运行保留天数",
+    "failureDays": "失败或取消运行保留天数",
+    "preview": "预览清理",
+    "cleanupNow": "立即清理",
+    "savePolicy": "保存策略",
+    "saved": "工作区保留策略已保存",
+    "cleanupConfirm": "立即删除已超过保留期限且未固定的运行工作区？运行记录和证据不会删除。",
+    "previewAction": "预览",
+    "cleanupAction": "清理",
+    "result": "{action}完成：符合条件 {eligible}，已删除 {removed}，失败 {failed}"
+  },
   "actions": {
     "refresh": "刷新",
     "close": "关闭",

--- a/agent-ui/src/locales/zh-Hant/settings.json
+++ b/agent-ui/src/locales/zh-Hant/settings.json
@@ -34,6 +34,28 @@
       }
     }
   },
+  "storage": {
+    "title": "儲存與保留",
+    "description": "設定已結束執行的工作區保留期限。",
+    "connected": "已連線",
+    "loading": "載入中...",
+    "unavailable": "無法使用",
+    "dataRoot": "資料目錄",
+    "runs": "執行數",
+    "sessionsDir": "工作階段目錄",
+    "autoCleanup": "執行工作區自動清理",
+    "autoCleanupDescription": "只自動清理已結束、未固定且超過保留期限的工作區。關閉後仍可手動預覽和清理。",
+    "successDays": "成功執行保留天數",
+    "failureDays": "失敗或取消執行保留天數",
+    "preview": "預覽清理",
+    "cleanupNow": "立即清理",
+    "savePolicy": "儲存策略",
+    "saved": "工作區保留策略已儲存",
+    "cleanupConfirm": "立即刪除已超過保留期限且未固定的執行工作區？執行記錄與證據不會刪除。",
+    "previewAction": "預覽",
+    "cleanupAction": "清理",
+    "result": "{action}完成：符合條件 {eligible}，已刪除 {removed}，失敗 {failed}"
+  },
   "actions": {
     "refresh": "刷新",
     "close": "關閉",

--- a/docs/workspace-retention.md
+++ b/docs/workspace-retention.md
@@ -1,0 +1,35 @@
+# Run Workspace Retention
+
+HomeRail keeps successful, failed, and cancelled run workspaces for seven days by default. The policy applies only to per-run directories under `$HOMERAIL_HOME/workspace`; run metadata, events, evidence, sessions, and the reserved `default` workspace are not deleted.
+
+## Why
+
+Run workspaces contain useful debugging artifacts, but retaining every checkout and generated file forever causes unbounded disk growth. A time-based policy keeps recent evidence available while making cleanup predictable. Successful and unsuccessful runs have separate values because operators may later choose to retain failed runs longer, although both defaults are seven days.
+
+## Configuration
+
+The Agent settings page exposes **Storage & Retention** under **General**. It can enable or disable automatic cleanup and set successful and failed/cancelled retention from 0 to 3650 days. Settings are written atomically to:
+
+```text
+$HOMERAIL_HOME/manager/workspace-retention.json
+```
+
+Before that file exists, deployments may seed the initial values with `HOMERAIL_WORKSPACE_CLEANUP_ENABLED`, `HOMERAIL_WORKSPACE_RETENTION_SUCCESS_DAYS`, and `HOMERAIL_WORKSPACE_RETENTION_FAILURE_DAYS`. Saving in the UI creates the persistent file. The scheduler interval defaults to six hours and can be set with `HOMERAIL_WORKSPACE_CLEANUP_INTERVAL_MS`.
+
+## Safety Rules
+
+- Automatic and manual cleanup consider only persisted terminal runs with `completedAt`.
+- Active in-memory runs, pinned runs, the reserved `default` workspace, and runs with pending worker cleanup are skipped.
+- Unknown orphan directories are not scanned or removed.
+- Symbolic links are removed without following their targets.
+- The cleanup API defaults to dry-run. The UI exposes a preview action and requires confirmation before actual deletion.
+- Policy updates, cleanup, and pin mutations use the Manager DAG mutation authorization boundary.
+
+## API
+
+- `GET /api/settings/storage-info` returns the effective policy.
+- `POST /api/settings/workspace-retention` persists `{ enabled, success_days, failure_days }`.
+- `POST /api/dag/workspaces/cleanup` accepts `{ dry_run: true | false }`; omitted means `true`.
+- `POST /api/runs/:run_id/workspace-retention` accepts `{ pinned: true | false }`.
+
+Mutation requests require a local connection or a valid `X-Homerail-Dag-Token` when `HOMERAIL_DAG_MUTATION_TOKEN` is configured.

--- a/docs/workspace-retention.md
+++ b/docs/workspace-retention.md
@@ -2,13 +2,15 @@
 
 HomeRail keeps successful, failed, and cancelled run workspaces for seven days by default. The policy applies only to per-run directories under `$HOMERAIL_HOME/workspace`; run metadata, events, evidence, sessions, and the reserved `default` workspace are not deleted.
 
+Cleanup runs on the Manager host. The current local Manager and Node topology shares the same `HOMERAIL_HOME`, so those run workspaces are covered. A remote Node that uses an independent data root requires its own node-side retention policy and is outside this cleaner's scope.
+
 ## Why
 
 Run workspaces contain useful debugging artifacts, but retaining every checkout and generated file forever causes unbounded disk growth. A time-based policy keeps recent evidence available while making cleanup predictable. Successful and unsuccessful runs have separate values because operators may later choose to retain failed runs longer, although both defaults are seven days.
 
 ## Configuration
 
-The Agent settings page exposes **Storage & Retention** under **General**. It can enable or disable automatic cleanup and set successful and failed/cancelled retention from 0 to 3650 days. Settings are written atomically to:
+The Agent settings page exposes **Storage & Retention** under **General**. It can enable or disable scheduled automatic cleanup and set successful and failed/cancelled retention from 0 to 3650 days. Manual preview and cleanup remain available while automatic cleanup is disabled. Settings are written atomically to:
 
 ```text
 $HOMERAIL_HOME/manager/workspace-retention.json
@@ -19,9 +21,9 @@ Before that file exists, deployments may seed the initial values with `HOMERAIL_
 ## Safety Rules
 
 - Automatic and manual cleanup consider only persisted terminal runs with `completedAt`.
-- Active in-memory runs, pinned runs, the reserved `default` workspace, and runs with pending worker cleanup are skipped.
+- Runs whose in-memory status is still active, pinned runs, the reserved `default` workspace, and runs with pending worker cleanup are skipped.
 - Unknown orphan directories are not scanned or removed.
-- Symbolic links are removed without following their targets.
+- A run workspace that is itself a symbolic link is unlinked without following its target. Resolved directories that escape through an intermediate symbolic link are rejected.
 - The cleanup API defaults to dry-run. The UI exposes a preview action and requires confirmation before actual deletion.
 - Policy updates, cleanup, and pin mutations use the Manager DAG mutation authorization boundary.
 

--- a/homerail_manager/src/events/bus.ts
+++ b/homerail_manager/src/events/bus.ts
@@ -38,6 +38,10 @@ export type DAGEventType =
   | "dag:cleanup_requested"
   | "dag:cleanup_completed"
   | "dag:cleanup_failed"
+  | "dag:workspace_retention_updated"
+  | "dag:workspace_cleanup_requested"
+  | "dag:workspace_cleanup_completed"
+  | "dag:workspace_cleanup_failed"
   | "dag:run_recovered"
   | "dag:deterministic_command"
   | "dag:state_updated"
@@ -91,6 +95,10 @@ export const DAG_EVENT_TYPES: DAGEventType[] = [
   "dag:cleanup_requested",
   "dag:cleanup_completed",
   "dag:cleanup_failed",
+  "dag:workspace_retention_updated",
+  "dag:workspace_cleanup_requested",
+  "dag:workspace_cleanup_completed",
+  "dag:workspace_cleanup_failed",
   "dag:run_recovered",
   "dag:deterministic_command",
   "dag:state_updated",

--- a/homerail_manager/src/persistence/store.ts
+++ b/homerail_manager/src/persistence/store.ts
@@ -7,6 +7,7 @@ import type {
   PersistedRunSnapshot,
   PersistedGraphData,
   NodeUsageRecord,
+  RunWorkspaceRetention,
 } from "./types.js";
 import type { DAGGraphData, DAGPatternInstanceMeta, ScorecardPolicyConfig } from "../orchestration/graph.js";
 import { DAG_EVENT_TYPES, subscribe, type DAGEventPayload } from "../events/bus.js";
@@ -31,6 +32,7 @@ interface SerializableRun {
   nodeCount?: number;
   agents?: Record<string, { agent_type?: string; model?: string; system?: string; description?: string; skills?: string[]; extra?: Record<string, unknown> }>;
   workspace?: Record<string, unknown>;
+  workspaceRetention?: RunWorkspaceRetention;
   scorecard?: ScorecardPolicyConfig;
   pattern?: DAGPatternInstanceMeta;
   createdAt: number;
@@ -203,6 +205,7 @@ export function serializeRunMetadata(run: SerializableRun): PersistedRunMetadata
     nodeCount: run.nodeCount,
     agents: run.agents,
     workspace: run.workspace,
+    workspaceRetention: run.workspaceRetention,
     scorecard: run.scorecard,
     pattern: run.pattern,
     createdAt: run.createdAt,

--- a/homerail_manager/src/persistence/types.ts
+++ b/homerail_manager/src/persistence/types.ts
@@ -39,6 +39,12 @@ export interface PersistedGraphData {
   edges: PersistedGraphEdge[];
 }
 
+export interface RunWorkspaceRetention {
+  pinned: boolean;
+  updatedAt: number;
+  cleanedAt?: number;
+}
+
 export interface PersistedRunMetadata {
   runId: string;
   workflowId?: string;
@@ -53,6 +59,7 @@ export interface PersistedRunMetadata {
   nodeCount?: number;
   agents?: Record<string, { agent_type?: string; model?: string; system?: string; description?: string; skills?: string[]; extra?: Record<string, unknown> }>;
   workspace?: Record<string, unknown>;
+  workspaceRetention?: RunWorkspaceRetention;
   scorecard?: ScorecardPolicyConfig;
   pattern?: DAGPatternInstanceMeta;
   createdAt: number;

--- a/homerail_manager/src/persistence/workspace-retention-settings.ts
+++ b/homerail_manager/src/persistence/workspace-retention-settings.ts
@@ -1,0 +1,95 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { getDataRoot } from "../config/env.js";
+
+export interface WorkspaceRetentionSettings {
+  enabled: boolean;
+  success_days: number;
+  failure_days: number;
+}
+
+export const DEFAULT_WORKSPACE_RETENTION_SETTINGS: WorkspaceRetentionSettings = {
+  enabled: true,
+  success_days: 7,
+  failure_days: 7,
+};
+
+const SETTINGS_FILE = "workspace-retention.json";
+const MAX_RETENTION_DAYS = 3_650;
+
+function settingsPath(): string {
+  return path.join(getDataRoot(), SETTINGS_FILE);
+}
+
+function normalizeDays(value: unknown, field: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0 || value > MAX_RETENTION_DAYS) {
+    throw new Error(`${field} must be an integer between 0 and ${MAX_RETENTION_DAYS}`);
+  }
+  return value;
+}
+
+export function normalizeWorkspaceRetentionSettings(
+  input: Record<string, unknown>,
+): WorkspaceRetentionSettings {
+  if (typeof input.enabled !== "boolean") {
+    throw new Error("enabled must be a boolean");
+  }
+  return {
+    enabled: input.enabled,
+    success_days: normalizeDays(input.success_days, "success_days"),
+    failure_days: normalizeDays(input.failure_days, "failure_days"),
+  };
+}
+
+function legacyEnvironmentDefaults(env: NodeJS.ProcessEnv): WorkspaceRetentionSettings {
+  const days = (raw: string | undefined, fallback: number): number => {
+    if (raw === undefined || raw.trim() === "") return fallback;
+    const parsed = Number(raw);
+    return Number.isInteger(parsed) && parsed >= 0 && parsed <= MAX_RETENTION_DAYS
+      ? parsed
+      : fallback;
+  };
+  return {
+    enabled: env.HOMERAIL_WORKSPACE_CLEANUP_ENABLED !== "0",
+    success_days: days(
+      env.HOMERAIL_WORKSPACE_RETENTION_SUCCESS_DAYS,
+      DEFAULT_WORKSPACE_RETENTION_SETTINGS.success_days,
+    ),
+    failure_days: days(
+      env.HOMERAIL_WORKSPACE_RETENTION_FAILURE_DAYS,
+      DEFAULT_WORKSPACE_RETENTION_SETTINGS.failure_days,
+    ),
+  };
+}
+
+export function loadWorkspaceRetentionSettings(
+  env: NodeJS.ProcessEnv = process.env,
+): WorkspaceRetentionSettings {
+  const file = settingsPath();
+  if (!fs.existsSync(file)) return legacyEnvironmentDefaults(env);
+  try {
+    const raw = JSON.parse(fs.readFileSync(file, "utf8")) as Record<string, unknown>;
+    return normalizeWorkspaceRetentionSettings(raw);
+  } catch (error) {
+    console.warn(
+      `[workspace-retention] Ignoring invalid settings file '${file}': ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return legacyEnvironmentDefaults(env);
+  }
+}
+
+export function saveWorkspaceRetentionSettings(
+  input: Record<string, unknown>,
+): WorkspaceRetentionSettings {
+  const settings = normalizeWorkspaceRetentionSettings(input);
+  const file = settingsPath();
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  const temp = `${file}.${process.pid}.${Date.now()}.tmp`;
+  fs.writeFileSync(temp, `${JSON.stringify(settings, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  fs.renameSync(temp, file);
+  return settings;
+}

--- a/homerail_manager/src/runtime/active-runs.ts
+++ b/homerail_manager/src/runtime/active-runs.ts
@@ -64,6 +64,7 @@ import {
   updateDagState,
   type DagApprovalRecord,
 } from "../persistence/dag-runtime-primitives.js";
+import type { RunWorkspaceRetention } from "../persistence/types.js";
 
 export interface InjectResult {
   runId: string;
@@ -91,6 +92,7 @@ export interface ActiveRun {
   nodeCount?: number;
   agents?: Record<string, DAGAgentConfig>;
   workspace?: Record<string, unknown>;
+  workspaceRetention?: RunWorkspaceRetention;
   scorecard?: ScorecardPolicyConfig;
   pattern?: DAGPatternInstanceMeta;
   dagRun: DAGRun;
@@ -671,6 +673,7 @@ export function restoreActiveRun(
       ? { ...metadata.agents }
       : undefined,
     workspace: metadata.workspace ? { ...metadata.workspace } : undefined,
+    workspaceRetention: metadata.workspaceRetention ? { ...metadata.workspaceRetention } : undefined,
     scorecard: metadata.scorecard ? { ...metadata.scorecard } : undefined,
     pattern: metadata.pattern
       ? { ...metadata.pattern, parameters: { ...(metadata.pattern.parameters ?? {}) } }

--- a/homerail_manager/src/runtime/workspace-retention.ts
+++ b/homerail_manager/src/runtime/workspace-retention.ts
@@ -1,0 +1,246 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { getDefaultWorkspacePath, getHomerailHome } from "../config/env.js";
+import { emit } from "../events/bus.js";
+import {
+  _isCleanupInflight,
+  listProvisionedForRun,
+} from "../orchestration/provisioned-cleanup.js";
+import {
+  listPersistedRunIds,
+  loadRunMetadata,
+  serializeRunMetadata,
+  writeRunMetadata,
+} from "../persistence/store.js";
+import type { DagRunStatus } from "../persistence/status.js";
+import type { RunWorkspaceRetention } from "../persistence/types.js";
+import { loadWorkspaceRetentionSettings } from "../persistence/workspace-retention-settings.js";
+import { getActiveRun } from "./active-runs.js";
+
+const DAY_MS = 24 * 60 * 60 * 1_000;
+
+export interface WorkspaceRetentionPolicy {
+  enabled: boolean;
+  successMs: number;
+  failureMs: number;
+  intervalMs: number;
+}
+
+export interface WorkspaceCleanupItem {
+  run_id: string;
+  status: DagRunStatus;
+  workspace_path: string;
+  eligible: boolean;
+  removed: boolean;
+  reason?: string;
+}
+
+export interface WorkspaceCleanupReport {
+  dry_run: boolean;
+  scanned: number;
+  eligible: number;
+  removed: number;
+  skipped: number;
+  failed: number;
+  items: WorkspaceCleanupItem[];
+}
+
+function nonNegativeNumber(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) return fallback;
+  return parsed;
+}
+
+export function resolveWorkspaceRetentionPolicy(
+  env: NodeJS.ProcessEnv = process.env,
+): WorkspaceRetentionPolicy {
+  const settings = loadWorkspaceRetentionSettings(env);
+  return {
+    enabled: settings.enabled,
+    successMs: settings.success_days * DAY_MS,
+    failureMs: settings.failure_days * DAY_MS,
+    intervalMs: Math.max(
+      60_000,
+      nonNegativeNumber(env.HOMERAIL_WORKSPACE_CLEANUP_INTERVAL_MS, 6 * 60 * 60 * 1_000),
+    ),
+  };
+}
+
+export function runWorkspacePath(runId: string): string {
+  const root = path.resolve(getHomerailHome(), "workspace");
+  const target = path.resolve(root, ...runId.split("/"));
+  if (target === root || !target.startsWith(`${root}${path.sep}`)) {
+    throw new Error(`Unsafe run workspace path for '${runId}'`);
+  }
+  return target;
+}
+
+export function setRunWorkspacePinned(runId: string, pinned: boolean): RunWorkspaceRetention {
+  const metadata = loadRunMetadata(runId);
+  if (!metadata) throw new Error(`Run not found: ${runId}`);
+  const retention: RunWorkspaceRetention = {
+    ...metadata.workspaceRetention,
+    pinned,
+    updatedAt: Date.now(),
+  };
+  const active = getActiveRun(runId);
+  if (active) {
+    active.workspaceRetention = retention;
+    writeRunMetadata(runId, serializeRunMetadata(active));
+  } else {
+    writeRunMetadata(runId, { ...metadata, workspaceRetention: retention });
+  }
+  emit("dag:workspace_retention_updated", { runId, pinned });
+  return retention;
+}
+
+function retentionForStatus(status: DagRunStatus, policy: WorkspaceRetentionPolicy): number | undefined {
+  if (status === "completed") return policy.successMs;
+  if (status === "failed" || status === "cancelled") return policy.failureMs;
+  return undefined;
+}
+
+function removeWorkspace(target: string): void {
+  const stat = fs.lstatSync(target);
+  fs.rmSync(target, {
+    recursive: stat.isDirectory() && !stat.isSymbolicLink(),
+    force: true,
+  });
+}
+
+function workspaceExists(target: string): boolean {
+  try {
+    fs.lstatSync(target);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+export function cleanupRunWorkspaces(options: {
+  dryRun?: boolean;
+  now?: number;
+  policy?: WorkspaceRetentionPolicy;
+} = {}): WorkspaceCleanupReport {
+  const dryRun = options.dryRun ?? true;
+  const now = options.now ?? Date.now();
+  const policy = options.policy ?? resolveWorkspaceRetentionPolicy();
+  const items: WorkspaceCleanupItem[] = [];
+  if (!policy.enabled) {
+    return { dry_run: dryRun, scanned: 0, eligible: 0, removed: 0, skipped: 0, failed: 0, items };
+  }
+
+  for (const runId of listPersistedRunIds()) {
+    const metadata = loadRunMetadata(runId);
+    if (!metadata) continue;
+    let workspacePath: string;
+    try {
+      workspacePath = runWorkspacePath(runId);
+    } catch (error) {
+      items.push({
+        run_id: runId,
+        status: metadata.status,
+        workspace_path: "",
+        eligible: false,
+        removed: false,
+        reason: error instanceof Error ? error.message : String(error),
+      });
+      continue;
+    }
+    const item: WorkspaceCleanupItem = {
+      run_id: runId,
+      status: metadata.status,
+      workspace_path: workspacePath,
+      eligible: false,
+      removed: false,
+    };
+    items.push(item);
+    if (workspacePath === path.resolve(getDefaultWorkspacePath())) {
+      item.reason = "reserved_default_workspace";
+      continue;
+    }
+    if (getActiveRun(runId)) {
+      item.reason = "run_active_in_memory";
+      continue;
+    }
+    const retentionMs = retentionForStatus(metadata.status, policy);
+    if (retentionMs === undefined) {
+      item.reason = "run_not_terminal";
+      continue;
+    }
+    if (metadata.workspaceRetention?.pinned) {
+      item.reason = "pinned";
+      continue;
+    }
+    if (metadata.completedAt === undefined) {
+      item.reason = "missing_completed_at";
+      continue;
+    }
+    if (now - metadata.completedAt < retentionMs) {
+      item.reason = "retention_not_expired";
+      continue;
+    }
+    if (_isCleanupInflight(runId) || listProvisionedForRun(runId).length > 0) {
+      item.reason = "worker_cleanup_pending";
+      continue;
+    }
+    if (!workspaceExists(workspacePath)) {
+      item.reason = "workspace_missing";
+      continue;
+    }
+    item.eligible = true;
+    if (dryRun) {
+      item.reason = "dry_run";
+      continue;
+    }
+    emit("dag:workspace_cleanup_requested", { runId, workspacePath });
+    try {
+      removeWorkspace(workspacePath);
+      item.removed = true;
+      const cleanedAt = Date.now();
+      const current = loadRunMetadata(runId);
+      if (current) {
+        writeRunMetadata(runId, {
+          ...current,
+          workspaceRetention: {
+            ...(current.workspaceRetention ?? { pinned: false, updatedAt: cleanedAt }),
+            cleanedAt,
+          },
+        });
+      }
+      emit("dag:workspace_cleanup_completed", { runId, workspacePath, cleanedAt });
+    } catch (error) {
+      item.reason = error instanceof Error ? error.message : String(error);
+      emit("dag:workspace_cleanup_failed", { runId, workspacePath, reason: item.reason });
+    }
+  }
+
+  return {
+    dry_run: dryRun,
+    scanned: items.length,
+    eligible: items.filter((item) => item.eligible).length,
+    removed: items.filter((item) => item.removed).length,
+    skipped: items.filter((item) => !item.eligible).length,
+    failed: items.filter((item) => item.eligible && item.reason !== undefined && item.reason !== "dry_run").length,
+    items,
+  };
+}
+
+export function startWorkspaceCleanupScheduler(
+  intervalMs = resolveWorkspaceRetentionPolicy().intervalMs,
+): () => void {
+  const timer = setInterval(() => {
+    try {
+      cleanupRunWorkspaces({ dryRun: false });
+    } catch (error) {
+      console.error(
+        `[workspace-retention] Scheduled cleanup failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }, intervalMs);
+  timer.unref();
+  return () => clearInterval(timer);
+}

--- a/homerail_manager/src/runtime/workspace-retention.ts
+++ b/homerail_manager/src/runtime/workspace-retention.ts
@@ -1,4 +1,4 @@
-import * as fs from "node:fs";
+import { promises as fs } from "node:fs";
 import * as path from "node:path";
 
 import { getDefaultWorkspacePath, getHomerailHome } from "../config/env.js";
@@ -19,6 +19,7 @@ import { loadWorkspaceRetentionSettings } from "../persistence/workspace-retenti
 import { getActiveRun } from "./active-runs.js";
 
 const DAY_MS = 24 * 60 * 60 * 1_000;
+const workspaceCleanupInflight = new Set<string>();
 
 export interface WorkspaceRetentionPolicy {
   enabled: boolean;
@@ -78,6 +79,9 @@ export function runWorkspacePath(runId: string): string {
 }
 
 export function setRunWorkspacePinned(runId: string, pinned: boolean): RunWorkspaceRetention {
+  if (workspaceCleanupInflight.has(runId)) {
+    throw new Error(`Run workspace cleanup is in progress: ${runId}`);
+  }
   const metadata = loadRunMetadata(runId);
   if (!metadata) throw new Error(`Run not found: ${runId}`);
   const retention: RunWorkspaceRetention = {
@@ -102,36 +106,69 @@ function retentionForStatus(status: DagRunStatus, policy: WorkspaceRetentionPoli
   return undefined;
 }
 
-function removeWorkspace(target: string): void {
-  const stat = fs.lstatSync(target);
-  fs.rmSync(target, {
-    recursive: stat.isDirectory() && !stat.isSymbolicLink(),
-    force: true,
-  });
+function isRunActiveInMemory(runId: string): boolean {
+  return getActiveRun(runId)?.status === "active";
 }
 
-function workspaceExists(target: string): boolean {
+interface WorkspaceEntry {
+  resolvedPath: string;
+  isSymbolicLink: boolean;
+  isDirectory: boolean;
+}
+
+function isInsideRoot(root: string, target: string): boolean {
+  const relative = path.relative(root, target);
+  return relative.length > 0 && !relative.startsWith("..") && !path.isAbsolute(relative);
+}
+
+async function realpathOrResolve(target: string): Promise<string> {
   try {
-    fs.lstatSync(target);
-    return true;
+    return await fs.realpath(target);
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return path.resolve(target);
     throw error;
   }
 }
 
-export function cleanupRunWorkspaces(options: {
+async function inspectWorkspace(target: string): Promise<WorkspaceEntry | undefined> {
+  let stat;
+  try {
+    stat = await fs.lstat(target);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw error;
+  }
+  if (stat.isSymbolicLink()) {
+    return { resolvedPath: target, isSymbolicLink: true, isDirectory: false };
+  }
+  const root = await fs.realpath(path.resolve(getHomerailHome(), "workspace"));
+  const resolvedPath = await fs.realpath(target);
+  if (!isInsideRoot(root, resolvedPath)) {
+    throw new Error(`Unsafe resolved run workspace path '${resolvedPath}'`);
+  }
+  return { resolvedPath, isSymbolicLink: false, isDirectory: stat.isDirectory() };
+}
+
+async function removeWorkspace(target: string, entry: WorkspaceEntry): Promise<void> {
+  await fs.rm(target, {
+    recursive: entry.isDirectory && !entry.isSymbolicLink,
+    force: true,
+  });
+}
+
+export async function cleanupRunWorkspaces(options: {
   dryRun?: boolean;
   now?: number;
   policy?: WorkspaceRetentionPolicy;
-} = {}): WorkspaceCleanupReport {
+  /** Test-only hook for holding the deletion boundary open. */
+  _removeWorkspace?: (target: string) => Promise<void>;
+} = {}): Promise<WorkspaceCleanupReport> {
   const dryRun = options.dryRun ?? true;
   const now = options.now ?? Date.now();
   const policy = options.policy ?? resolveWorkspaceRetentionPolicy();
   const items: WorkspaceCleanupItem[] = [];
-  if (!policy.enabled) {
-    return { dry_run: dryRun, scanned: 0, eligible: 0, removed: 0, skipped: 0, failed: 0, items };
-  }
+  const defaultWorkspace = path.resolve(getDefaultWorkspacePath());
+  const resolvedDefaultWorkspace = await realpathOrResolve(defaultWorkspace);
 
   for (const runId of listPersistedRunIds()) {
     const metadata = loadRunMetadata(runId);
@@ -158,11 +195,11 @@ export function cleanupRunWorkspaces(options: {
       removed: false,
     };
     items.push(item);
-    if (workspacePath === path.resolve(getDefaultWorkspacePath())) {
+    if (workspacePath === defaultWorkspace) {
       item.reason = "reserved_default_workspace";
       continue;
     }
-    if (getActiveRun(runId)) {
+    if (isRunActiveInMemory(runId)) {
       item.reason = "run_active_in_memory";
       continue;
     }
@@ -187,18 +224,66 @@ export function cleanupRunWorkspaces(options: {
       item.reason = "worker_cleanup_pending";
       continue;
     }
-    if (!workspaceExists(workspacePath)) {
-      item.reason = "workspace_missing";
-      continue;
-    }
-    item.eligible = true;
     if (dryRun) {
+      let entry: WorkspaceEntry | undefined;
+      try {
+        entry = await inspectWorkspace(workspacePath);
+      } catch (error) {
+        item.reason = error instanceof Error ? error.message : String(error);
+        continue;
+      }
+      if (!entry) {
+        item.reason = "workspace_missing";
+        continue;
+      }
+      if (!entry.isSymbolicLink && entry.resolvedPath === resolvedDefaultWorkspace) {
+        item.reason = "reserved_default_workspace";
+        continue;
+      }
+      item.eligible = true;
       item.reason = "dry_run";
       continue;
     }
-    emit("dag:workspace_cleanup_requested", { runId, workspacePath });
+    if (workspaceCleanupInflight.has(runId)) {
+      item.reason = "workspace_cleanup_inflight";
+      continue;
+    }
+    workspaceCleanupInflight.add(runId);
     try {
-      removeWorkspace(workspacePath);
+      const currentBeforeDelete = loadRunMetadata(runId);
+      if (!currentBeforeDelete) {
+        item.reason = "run_missing";
+        continue;
+      }
+      if (currentBeforeDelete.workspaceRetention?.pinned) {
+        item.reason = "pinned";
+        continue;
+      }
+      if (isRunActiveInMemory(runId)) {
+        item.reason = "run_active_in_memory";
+        continue;
+      }
+      if (_isCleanupInflight(runId) || listProvisionedForRun(runId).length > 0) {
+        item.reason = "worker_cleanup_pending";
+        continue;
+      }
+      const entry = await inspectWorkspace(workspacePath);
+      if (!entry) {
+        item.reason = "workspace_missing";
+        continue;
+      }
+      if (!entry.isSymbolicLink && entry.resolvedPath === resolvedDefaultWorkspace) {
+        item.reason = "reserved_default_workspace";
+        continue;
+      }
+      if (_isCleanupInflight(runId) || listProvisionedForRun(runId).length > 0) {
+        item.reason = "worker_cleanup_pending";
+        continue;
+      }
+      item.eligible = true;
+      emit("dag:workspace_cleanup_requested", { runId, workspacePath });
+      if (options._removeWorkspace) await options._removeWorkspace(workspacePath);
+      else await removeWorkspace(workspacePath, entry);
       item.removed = true;
       const cleanedAt = Date.now();
       const current = loadRunMetadata(runId);
@@ -215,6 +300,8 @@ export function cleanupRunWorkspaces(options: {
     } catch (error) {
       item.reason = error instanceof Error ? error.message : String(error);
       emit("dag:workspace_cleanup_failed", { runId, workspacePath, reason: item.reason });
+    } finally {
+      workspaceCleanupInflight.delete(runId);
     }
   }
 
@@ -232,14 +319,20 @@ export function cleanupRunWorkspaces(options: {
 export function startWorkspaceCleanupScheduler(
   intervalMs = resolveWorkspaceRetentionPolicy().intervalMs,
 ): () => void {
+  let cleanupRunning = false;
   const timer = setInterval(() => {
-    try {
-      cleanupRunWorkspaces({ dryRun: false });
-    } catch (error) {
-      console.error(
-        `[workspace-retention] Scheduled cleanup failed: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    }
+    const policy = resolveWorkspaceRetentionPolicy();
+    if (!policy.enabled || cleanupRunning) return;
+    cleanupRunning = true;
+    void cleanupRunWorkspaces({ dryRun: false, policy })
+      .catch((error) => {
+        console.error(
+          `[workspace-retention] Scheduled cleanup failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      })
+      .finally(() => {
+        cleanupRunning = false;
+      });
   }, intervalMs);
   timer.unref();
   return () => clearInterval(timer);

--- a/homerail_manager/src/server/http.ts
+++ b/homerail_manager/src/server/http.ts
@@ -35,6 +35,7 @@ import { emit } from "../events/bus.js";
 import { dispatchRecoveredRuns } from "../runtime/active-runs.js";
 import { startDagTriggerScheduler } from "../runtime/dag-triggers.js";
 import { readOrCreateControlPlaneToken } from "../persistence/control-plane-secret.js";
+import { startWorkspaceCleanupScheduler } from "../runtime/workspace-retention.js";
 
 function json(res: http.ServerResponse, status: number, body: unknown) {
   res.writeHead(status, { "Content-Type": "application/json" });
@@ -241,6 +242,7 @@ export function createServer(
   const graphExecutor = new GraphExecutor(actualDispatcher);
   const changeOrchestrator = new ChangeOrchestrator(graphExecutor);
   const stopTriggerScheduler = startDagTriggerScheduler(changeOrchestrator);
+  const stopWorkspaceCleanupScheduler = startWorkspaceCleanupScheduler();
 
   server = http.createServer((req, res) => {
     setCorsHeaders(res);
@@ -347,6 +349,7 @@ export function createServer(
     }
   });
   server.once("close", stopTriggerScheduler);
+  server.once("close", stopWorkspaceCleanupScheduler);
 
   const workerWebsocketOptions: WorkerWebSocketOptions = {
     ...wsOptions,

--- a/homerail_manager/src/server/mutations.ts
+++ b/homerail_manager/src/server/mutations.ts
@@ -472,12 +472,12 @@ export function mutationRoutesHandler(
   }
 
   if (pathname === "/api/dag/workspaces/cleanup" && req.method === "POST") {
-    void _readJsonBody(req).then((raw) => {
+    void _readJsonBody(req).then(async (raw) => {
       const body = raw as Record<string, unknown>;
       if (body.dry_run !== undefined && typeof body.dry_run !== "boolean") {
         throw new Error("dry_run must be a boolean");
       }
-      const report = cleanupRunWorkspaces({ dryRun: body.dry_run !== false });
+      const report = await cleanupRunWorkspaces({ dryRun: body.dry_run !== false });
       _ok(res, report.dry_run ? "Workspace cleanup preview completed" : "Workspace cleanup completed", report);
     }).catch((error) => _badRequest(res, error instanceof Error ? error.message : String(error)));
     return true;

--- a/homerail_manager/src/server/mutations.ts
+++ b/homerail_manager/src/server/mutations.ts
@@ -21,6 +21,10 @@ import { dagResourcesUnavailableForRun } from "./dag-resource-status.js";
 import { fireDagEventTrigger } from "../runtime/dag-triggers.js";
 import { updateDagState } from "../persistence/dag-runtime-primitives.js";
 import { WorkflowRunAdmissionError } from "../persistence/dag-run-admission.js";
+import {
+  cleanupRunWorkspaces,
+  setRunWorkspacePinned,
+} from "../runtime/workspace-retention.js";
 
 interface BaseResponse {
   success: boolean;
@@ -111,7 +115,9 @@ export function requiresDagMutationAuthorization(pathname: string, method?: stri
   return pathname === "/api/runs"
     || pathname.startsWith("/api/runs/")
     || pathname === "/api/dag/workflows/sync"
-    || pathname === "/api/dag/profiles/sync";
+    || pathname === "/api/dag/profiles/sync"
+    || pathname === "/api/dag/workspaces/cleanup"
+    || pathname === "/api/settings/workspace-retention";
 }
 
 async function _readJsonBody(req: http.IncomingMessage): Promise<unknown> {
@@ -446,6 +452,34 @@ export function mutationRoutesHandler(
         _badRequest(res, message);
       }
     }
+    return true;
+  }
+
+  const workspaceRetentionMatch = pathname.match(/^\/api\/runs\/([^/]+)\/workspace-retention$/);
+  if (workspaceRetentionMatch && req.method === "POST") {
+    const runId = decodeURIComponent(workspaceRetentionMatch[1]);
+    void _readJsonBody(req).then((raw) => {
+      const body = raw as Record<string, unknown>;
+      if (typeof body.pinned !== "boolean") throw new Error("pinned must be a boolean");
+      const retention = setRunWorkspacePinned(runId, body.pinned);
+      _ok(res, body.pinned ? "Run workspace pinned" : "Run workspace unpinned", retention);
+    }).catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      if (message.includes("not found")) _notFound(res, message);
+      else _badRequest(res, message);
+    });
+    return true;
+  }
+
+  if (pathname === "/api/dag/workspaces/cleanup" && req.method === "POST") {
+    void _readJsonBody(req).then((raw) => {
+      const body = raw as Record<string, unknown>;
+      if (body.dry_run !== undefined && typeof body.dry_run !== "boolean") {
+        throw new Error("dry_run must be a boolean");
+      }
+      const report = cleanupRunWorkspaces({ dryRun: body.dry_run !== false });
+      _ok(res, report.dry_run ? "Workspace cleanup preview completed" : "Workspace cleanup completed", report);
+    }).catch((error) => _badRequest(res, error instanceof Error ? error.message : String(error)));
     return true;
   }
 

--- a/homerail_manager/src/server/settings-storage-info.ts
+++ b/homerail_manager/src/server/settings-storage-info.ts
@@ -1,5 +1,5 @@
 /**
- * €” Settings Storage Info Route.
+ * - Settings Storage Info Route.
  *
  * Source Issue: #956
  *
@@ -13,6 +13,11 @@ import * as http from "node:http";
 import { getDataRoot, getDbPath, getSessionStoreRoot } from "../config/env.js";
 import { listPersistedRunIds } from "../persistence/store.js";
 import { sessionsDir } from "../persistence/agent-sessions.js";
+import {
+  loadWorkspaceRetentionSettings,
+  saveWorkspaceRetentionSettings,
+  type WorkspaceRetentionSettings,
+} from "../persistence/workspace-retention-settings.js";
 
 interface StorageInfoData {
   data_root: string;
@@ -24,6 +29,7 @@ interface StorageInfoData {
   cleanup_supported: boolean;
   cleanup_tracked_gap: boolean;
   cleanup_next_action: string;
+  workspace_retention: WorkspaceRetentionSettings;
   export_supported: boolean;
   export_tracked_gap: boolean;
   export_next_action: string;
@@ -34,14 +40,43 @@ function json(res: http.ServerResponse, status: number, body: unknown) {
   res.end(JSON.stringify(body));
 }
 
+async function readJsonBody(req: http.IncomingMessage): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    req.on("data", (chunk) => { data += chunk; });
+    req.on("end", () => {
+      try {
+        resolve(data ? JSON.parse(data) as Record<string, unknown> : {});
+      } catch (error) {
+        reject(error);
+      }
+    });
+    req.on("error", reject);
+  });
+}
+
 export function settingsStorageInfoHandler(
   req: http.IncomingMessage,
   res: http.ServerResponse,
 ): boolean {
-  if (req.method !== "GET") return false;
-
   const pathname = new URL(req.url || "/", "http://localhost").pathname;
-  if (pathname !== "/api/settings/storage-info") return false;
+  if (pathname === "/api/settings/workspace-retention" && req.method === "POST") {
+    void readJsonBody(req)
+      .then((body) => {
+        const settings = saveWorkspaceRetentionSettings(body);
+        json(res, 200, {
+          success: true,
+          message: "workspace retention settings updated",
+          data: settings,
+        });
+      })
+      .catch((error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        json(res, 400, { success: false, message, error: message });
+      });
+    return true;
+  }
+  if (pathname !== "/api/settings/storage-info" || req.method !== "GET") return false;
 
   const data: StorageInfoData = {
     data_root: getDataRoot(),
@@ -50,10 +85,10 @@ export function settingsStorageInfoHandler(
     sessions_dir: sessionsDir(),
     session_store_root: getSessionStoreRoot(),
     retention_supported: true,
-    cleanup_supported: false,
-    cleanup_tracked_gap: true,
-    cleanup_next_action:
-      "Implement run cleanup/retention API in TS Manager backend",
+    cleanup_supported: true,
+    cleanup_tracked_gap: false,
+    cleanup_next_action: "",
+    workspace_retention: loadWorkspaceRetentionSettings(),
     export_supported: false,
     export_tracked_gap: true,
     export_next_action:

--- a/homerail_manager/tests/workspace-retention.test.ts
+++ b/homerail_manager/tests/workspace-retention.test.ts
@@ -4,6 +4,10 @@ import * as os from "node:os";
 import * as path from "node:path";
 
 import { closeDb } from "../src/persistence/db.js";
+import {
+  _clearAllProvisionedWorkers,
+  registerProvisionedWorker,
+} from "../src/orchestration/provisioned-cleanup.js";
 import { loadRunMetadata, writeRunMetadata } from "../src/persistence/store.js";
 import {
   DEFAULT_WORKSPACE_RETENTION_SETTINGS,
@@ -39,11 +43,13 @@ describe("workspace retention", () => {
     process.env.HOMERAIL_HOME = tmpHome;
     closeDb();
     _clearActiveRuns();
+    _clearAllProvisionedWorkers();
   });
 
   afterEach(() => {
     closeDb();
     _clearActiveRuns();
+    _clearAllProvisionedWorkers();
     if (oldHome === undefined) delete process.env.HOMERAIL_HOME;
     else process.env.HOMERAIL_HOME = oldHome;
     if (oldMutationToken === undefined) delete process.env.HOMERAIL_DAG_MUTATION_TOKEN;
@@ -215,6 +221,60 @@ nodes:
     expect(fs.existsSync(workspace)).toBe(false);
   });
 
+  it("protects a truly active in-memory run even if persisted metadata appears terminal", async () => {
+    const now = Date.now();
+    const runId = "active-in-process";
+    createActiveRun(runId, parseDAGYaml(`
+name: retention-active-in-process
+agents:
+  worker:
+    agent_type: deterministic
+nodes:
+  work:
+    agent: worker
+    outputs:
+      done:
+        to: ""
+`));
+    const persisted = loadRunMetadata(runId);
+    if (!persisted) throw new Error("active run metadata was not persisted");
+    writeRunMetadata(runId, {
+      ...persisted,
+      status: "completed",
+      completedAt: now - 8 * DAY_MS,
+    });
+    const workspace = runWorkspacePath(runId);
+    fs.mkdirSync(workspace, { recursive: true });
+    fs.writeFileSync(path.join(workspace, "artifact.txt"), runId);
+
+    const report = await cleanupRunWorkspaces({ dryRun: false, now });
+
+    expect(report.removed).toBe(0);
+    expect(report.items.find((item) => item.run_id === runId)?.reason)
+      .toBe("run_active_in_memory");
+    expect(fs.existsSync(workspace)).toBe(true);
+  });
+
+  it("protects workspaces while provisioned worker cleanup is pending", async () => {
+    const now = Date.now();
+    const runId = "worker-cleanup-pending";
+    const workspace = addRun(runId, "completed", now - 8 * DAY_MS);
+    registerProvisionedWorker({
+      runId,
+      nodeId: "worker-node",
+      workerId: "worker-1",
+      containerId: "container-1",
+      dockerNodeId: "docker-node-1",
+    });
+
+    const report = await cleanupRunWorkspaces({ dryRun: false, now });
+
+    expect(report.removed).toBe(0);
+    expect(report.items.find((item) => item.run_id === runId)?.reason)
+      .toBe("worker_cleanup_pending");
+    expect(fs.existsSync(workspace)).toBe(true);
+  });
+
   it("serializes deletion against pinning and competing cleanup", async () => {
     const now = Date.now();
     const workspace = addRun("cleanup-race", "completed", now - 8 * DAY_MS);
@@ -256,6 +316,10 @@ nodes:
     expect(report.removed).toBe(0);
     expect(report.items.find((item) => item.run_id === "default")?.reason).toBe("reserved_default_workspace");
     expect(fs.existsSync(workspace)).toBe(true);
+  });
+
+  it("rejects run workspace paths that escape the managed root", () => {
+    expect(() => runWorkspacePath("../../outside")).toThrow("Unsafe run workspace path");
   });
 
   it("protects retention mutations with the control-plane authorization boundary", () => {

--- a/homerail_manager/tests/workspace-retention.test.ts
+++ b/homerail_manager/tests/workspace-retention.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import * as fs from "node:fs";
-import * as http from "node:http";
 import * as os from "node:os";
 import * as path from "node:path";
 
@@ -12,11 +11,17 @@ import {
   saveWorkspaceRetentionSettings,
 } from "../src/persistence/workspace-retention-settings.js";
 import {
+  _clearActiveRuns,
+  completeActiveRun,
+  createActiveRun,
+} from "../src/runtime/active-runs.js";
+import {
   cleanupRunWorkspaces,
   resolveWorkspaceRetentionPolicy,
   runWorkspacePath,
   setRunWorkspacePinned,
 } from "../src/runtime/workspace-retention.js";
+import { parseDAGYaml } from "../src/orchestration/yaml-loader.js";
 import { requiresDagMutationAuthorization } from "../src/server/mutations.js";
 import { createServer } from "../src/server/http.js";
 
@@ -33,10 +38,12 @@ describe("workspace retention", () => {
     tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-workspace-retention-"));
     process.env.HOMERAIL_HOME = tmpHome;
     closeDb();
+    _clearActiveRuns();
   });
 
   afterEach(() => {
     closeDb();
+    _clearActiveRuns();
     if (oldHome === undefined) delete process.env.HOMERAIL_HOME;
     else process.env.HOMERAIL_HOME = oldHome;
     if (oldMutationToken === undefined) delete process.env.HOMERAIL_DAG_MUTATION_TOKEN;
@@ -82,7 +89,7 @@ describe("workspace retention", () => {
     }
   });
 
-  it("previews and then removes only expired, terminal, unpinned workspaces", () => {
+  it("previews and then removes only expired, terminal, unpinned workspaces", async () => {
     const now = Date.now();
     const expiredSuccess = addRun("success-old", "completed", now - 8 * DAY_MS);
     const expiredFailure = addRun("failure-old", "failed", now - 8 * DAY_MS);
@@ -91,13 +98,13 @@ describe("workspace retention", () => {
     const pinned = addRun("failed-pinned", "failed", now - 20 * DAY_MS);
     setRunWorkspacePinned("failed-pinned", true);
 
-    const preview = cleanupRunWorkspaces({ dryRun: true, now });
+    const preview = await cleanupRunWorkspaces({ dryRun: true, now });
     expect(preview.eligible).toBe(2);
     expect(preview.removed).toBe(0);
     expect(fs.existsSync(expiredSuccess)).toBe(true);
     expect(fs.existsSync(expiredFailure)).toBe(true);
 
-    const report = cleanupRunWorkspaces({ dryRun: false, now });
+    const report = await cleanupRunWorkspaces({ dryRun: false, now });
     expect(report.removed).toBe(2);
     expect(report.failed).toBe(0);
     expect(fs.existsSync(expiredSuccess)).toBe(false);
@@ -108,7 +115,7 @@ describe("workspace retention", () => {
     expect(loadRunMetadata("success-old")?.workspaceRetention?.cleanedAt).toEqual(expect.any(Number));
   });
 
-  it("unlinks an expired workspace symlink without touching its target", () => {
+  it("unlinks an expired workspace symlink without touching its target", async () => {
     const now = Date.now();
     writeRunMetadata("linked-run", {
       runId: "linked-run",
@@ -126,7 +133,7 @@ describe("workspace retention", () => {
     fs.symlinkSync(outside, link, process.platform === "win32" ? "junction" : "dir");
 
     try {
-      const report = cleanupRunWorkspaces({ dryRun: false, now });
+      const report = await cleanupRunWorkspaces({ dryRun: false, now });
       expect(report.removed).toBe(1);
       expect(fs.existsSync(link)).toBe(false);
       expect(fs.readFileSync(outsideFile, "utf8")).toBe("keep");
@@ -135,11 +142,116 @@ describe("workspace retention", () => {
     }
   });
 
-  it("never removes the reserved default workspace", () => {
+  it("rejects workspace paths that escape through an intermediate symlink", async () => {
+    const now = Date.now();
+    writeRunMetadata("linked-parent/run", {
+      runId: "linked-parent/run",
+      createdAt: now - 10 * DAY_MS,
+      completedAt: now - 8 * DAY_MS,
+      status: "completed",
+      nodeStates: {},
+      handoffedNodes: [],
+    });
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-retention-parent-outside-"));
+    const outsideRun = path.join(outside, "run");
+    fs.mkdirSync(outsideRun);
+    const outsideFile = path.join(outsideRun, "keep.txt");
+    fs.writeFileSync(outsideFile, "keep");
+    const link = path.dirname(runWorkspacePath("linked-parent/run"));
+    fs.mkdirSync(path.dirname(link), { recursive: true });
+    fs.symlinkSync(outside, link, process.platform === "win32" ? "junction" : "dir");
+
+    try {
+      const report = await cleanupRunWorkspaces({ dryRun: false, now });
+      expect(report.removed).toBe(0);
+      expect(report.items.find((item) => item.run_id === "linked-parent/run")?.reason)
+        .toContain("Unsafe resolved run workspace path");
+      expect(fs.readFileSync(outsideFile, "utf8")).toBe("keep");
+    } finally {
+      fs.unlinkSync(link);
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it("allows manual cleanup while automatic cleanup is disabled", async () => {
+    const now = Date.now();
+    const workspace = addRun("manual-cleanup", "completed", now - 8 * DAY_MS);
+    const policy = {
+      ...resolveWorkspaceRetentionPolicy({}),
+      enabled: false,
+    };
+
+    const report = await cleanupRunWorkspaces({ dryRun: false, now, policy });
+
+    expect(report.removed).toBe(1);
+    expect(fs.existsSync(workspace)).toBe(false);
+  });
+
+  it("cleans terminal runs that remain in the in-memory run store", async () => {
+    const runId = "completed-in-process";
+    const run = createActiveRun(runId, parseDAGYaml(`
+name: retention-completed-in-process
+agents:
+  worker:
+    agent_type: deterministic
+nodes:
+  work:
+    agent: worker
+    outputs:
+      done:
+        to: ""
+`));
+    completeActiveRun(runId);
+    const workspace = runWorkspacePath(runId);
+    fs.mkdirSync(workspace, { recursive: true });
+    fs.writeFileSync(path.join(workspace, "artifact.txt"), runId);
+
+    const report = await cleanupRunWorkspaces({
+      dryRun: false,
+      now: (run.completedAt ?? Date.now()) + 8 * DAY_MS,
+    });
+
+    expect(report.removed).toBe(1);
+    expect(fs.existsSync(workspace)).toBe(false);
+  });
+
+  it("serializes deletion against pinning and competing cleanup", async () => {
+    const now = Date.now();
+    const workspace = addRun("cleanup-race", "completed", now - 8 * DAY_MS);
+    let releaseRemoval!: () => void;
+    const removalReleased = new Promise<void>((resolve) => { releaseRemoval = resolve; });
+    let removalStarted!: () => void;
+    const started = new Promise<void>((resolve) => { removalStarted = resolve; });
+
+    const firstCleanup = cleanupRunWorkspaces({
+      dryRun: false,
+      now,
+      _removeWorkspace: async (target) => {
+        removalStarted();
+        await removalReleased;
+        await fs.promises.rm(target, { recursive: true, force: true });
+      },
+    });
+    await started;
+
+    try {
+      expect(() => setRunWorkspacePinned("cleanup-race", true)).toThrow("cleanup is in progress");
+      const competing = await cleanupRunWorkspaces({ dryRun: false, now });
+      expect(competing.items.find((item) => item.run_id === "cleanup-race")?.reason)
+        .toBe("workspace_cleanup_inflight");
+    } finally {
+      releaseRemoval();
+    }
+    const completed = await firstCleanup;
+    expect(completed.removed).toBe(1);
+    expect(fs.existsSync(workspace)).toBe(false);
+  });
+
+  it("never removes the reserved default workspace", async () => {
     const now = Date.now();
     const workspace = addRun("default", "completed", now - 30 * DAY_MS);
 
-    const report = cleanupRunWorkspaces({ dryRun: false, now });
+    const report = await cleanupRunWorkspaces({ dryRun: false, now });
 
     expect(report.removed).toBe(0);
     expect(report.items.find((item) => item.run_id === "default")?.reason).toBe("reserved_default_workspace");

--- a/homerail_manager/tests/workspace-retention.test.ts
+++ b/homerail_manager/tests/workspace-retention.test.ts
@@ -1,0 +1,212 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as http from "node:http";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { closeDb } from "../src/persistence/db.js";
+import { loadRunMetadata, writeRunMetadata } from "../src/persistence/store.js";
+import {
+  DEFAULT_WORKSPACE_RETENTION_SETTINGS,
+  loadWorkspaceRetentionSettings,
+  saveWorkspaceRetentionSettings,
+} from "../src/persistence/workspace-retention-settings.js";
+import {
+  cleanupRunWorkspaces,
+  resolveWorkspaceRetentionPolicy,
+  runWorkspacePath,
+  setRunWorkspacePinned,
+} from "../src/runtime/workspace-retention.js";
+import { requiresDagMutationAuthorization } from "../src/server/mutations.js";
+import { createServer } from "../src/server/http.js";
+
+const DAY_MS = 24 * 60 * 60 * 1_000;
+
+describe("workspace retention", () => {
+  let oldHome: string | undefined;
+  let oldMutationToken: string | undefined;
+  let tmpHome: string;
+
+  beforeEach(() => {
+    oldHome = process.env.HOMERAIL_HOME;
+    oldMutationToken = process.env.HOMERAIL_DAG_MUTATION_TOKEN;
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-workspace-retention-"));
+    process.env.HOMERAIL_HOME = tmpHome;
+    closeDb();
+  });
+
+  afterEach(() => {
+    closeDb();
+    if (oldHome === undefined) delete process.env.HOMERAIL_HOME;
+    else process.env.HOMERAIL_HOME = oldHome;
+    if (oldMutationToken === undefined) delete process.env.HOMERAIL_DAG_MUTATION_TOKEN;
+    else process.env.HOMERAIL_DAG_MUTATION_TOKEN = oldMutationToken;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  function addRun(
+    runId: string,
+    status: "active" | "completed" | "failed" | "cancelled",
+    completedAt?: number,
+  ): string {
+    writeRunMetadata(runId, {
+      runId,
+      createdAt: completedAt ? completedAt - DAY_MS : Date.now(),
+      completedAt,
+      status,
+      nodeStates: {},
+      handoffedNodes: [],
+    });
+    const workspace = runWorkspacePath(runId);
+    fs.mkdirSync(workspace, { recursive: true });
+    fs.writeFileSync(path.join(workspace, "artifact.txt"), runId);
+    return workspace;
+  }
+
+  it("defaults successful and failed runs to seven days and persists UI settings", () => {
+    expect(loadWorkspaceRetentionSettings({})).toEqual(DEFAULT_WORKSPACE_RETENTION_SETTINGS);
+    expect(resolveWorkspaceRetentionPolicy({})).toMatchObject({
+      enabled: true,
+      successMs: 7 * DAY_MS,
+      failureMs: 7 * DAY_MS,
+    });
+
+    saveWorkspaceRetentionSettings({ enabled: false, success_days: 14, failure_days: 21 });
+    expect(loadWorkspaceRetentionSettings({})).toEqual({
+      enabled: false,
+      success_days: 14,
+      failure_days: 21,
+    });
+    if (process.platform !== "win32") {
+      expect(fs.statSync(path.join(tmpHome, "manager", "workspace-retention.json")).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it("previews and then removes only expired, terminal, unpinned workspaces", () => {
+    const now = Date.now();
+    const expiredSuccess = addRun("success-old", "completed", now - 8 * DAY_MS);
+    const expiredFailure = addRun("failure-old", "failed", now - 8 * DAY_MS);
+    const recent = addRun("success-recent", "completed", now - 6 * DAY_MS);
+    const active = addRun("active-run", "active");
+    const pinned = addRun("failed-pinned", "failed", now - 20 * DAY_MS);
+    setRunWorkspacePinned("failed-pinned", true);
+
+    const preview = cleanupRunWorkspaces({ dryRun: true, now });
+    expect(preview.eligible).toBe(2);
+    expect(preview.removed).toBe(0);
+    expect(fs.existsSync(expiredSuccess)).toBe(true);
+    expect(fs.existsSync(expiredFailure)).toBe(true);
+
+    const report = cleanupRunWorkspaces({ dryRun: false, now });
+    expect(report.removed).toBe(2);
+    expect(report.failed).toBe(0);
+    expect(fs.existsSync(expiredSuccess)).toBe(false);
+    expect(fs.existsSync(expiredFailure)).toBe(false);
+    expect(fs.existsSync(recent)).toBe(true);
+    expect(fs.existsSync(active)).toBe(true);
+    expect(fs.existsSync(pinned)).toBe(true);
+    expect(loadRunMetadata("success-old")?.workspaceRetention?.cleanedAt).toEqual(expect.any(Number));
+  });
+
+  it("unlinks an expired workspace symlink without touching its target", () => {
+    const now = Date.now();
+    writeRunMetadata("linked-run", {
+      runId: "linked-run",
+      createdAt: now - 10 * DAY_MS,
+      completedAt: now - 8 * DAY_MS,
+      status: "cancelled",
+      nodeStates: {},
+      handoffedNodes: [],
+    });
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-retention-outside-"));
+    const outsideFile = path.join(outside, "keep.txt");
+    fs.writeFileSync(outsideFile, "keep");
+    const link = runWorkspacePath("linked-run");
+    fs.mkdirSync(path.dirname(link), { recursive: true });
+    fs.symlinkSync(outside, link, process.platform === "win32" ? "junction" : "dir");
+
+    try {
+      const report = cleanupRunWorkspaces({ dryRun: false, now });
+      expect(report.removed).toBe(1);
+      expect(fs.existsSync(link)).toBe(false);
+      expect(fs.readFileSync(outsideFile, "utf8")).toBe("keep");
+    } finally {
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it("never removes the reserved default workspace", () => {
+    const now = Date.now();
+    const workspace = addRun("default", "completed", now - 30 * DAY_MS);
+
+    const report = cleanupRunWorkspaces({ dryRun: false, now });
+
+    expect(report.removed).toBe(0);
+    expect(report.items.find((item) => item.run_id === "default")?.reason).toBe("reserved_default_workspace");
+    expect(fs.existsSync(workspace)).toBe(true);
+  });
+
+  it("protects retention mutations with the control-plane authorization boundary", () => {
+    expect(requiresDagMutationAuthorization("/api/settings/workspace-retention", "POST")).toBe(true);
+    expect(requiresDagMutationAuthorization("/api/dag/workspaces/cleanup", "POST")).toBe(true);
+    expect(requiresDagMutationAuthorization("/api/runs/run-1/workspace-retention", "POST")).toBe(true);
+  });
+
+  it("rejects non-numeric retention values at the persisted API boundary", () => {
+    expect(() => saveWorkspaceRetentionSettings({
+      enabled: true,
+      success_days: "7",
+      failure_days: 7,
+    })).toThrow("success_days must be an integer");
+  });
+
+  it("persists settings and defaults cleanup to dry-run through the HTTP API", async () => {
+    process.env.HOMERAIL_DAG_MUTATION_TOKEN = "retention-secret";
+    const server = createServer(0, undefined, undefined, false);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address !== "object") throw new Error("server did not bind");
+    const baseUrl = `http://127.0.0.1:${address.port}`;
+    const headers = {
+      "Content-Type": "application/json",
+      "x-homerail-dag-token": "retention-secret",
+    };
+
+    try {
+      const unauthorized = await fetch(`${baseUrl}/api/settings/workspace-retention`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled: true, success_days: 9, failure_days: 11 }),
+      });
+      expect(unauthorized.status).toBe(403);
+
+      const update = await fetch(`${baseUrl}/api/settings/workspace-retention`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ enabled: true, success_days: 9, failure_days: 11 }),
+      });
+      expect(update.status).toBe(200);
+
+      const info = await fetch(`${baseUrl}/api/settings/storage-info`);
+      expect(await info.json()).toMatchObject({
+        success: true,
+        data: {
+          cleanup_supported: true,
+          workspace_retention: { enabled: true, success_days: 9, failure_days: 11 },
+        },
+      });
+
+      const cleanup = await fetch(`${baseUrl}/api/dag/workspaces/cleanup`, {
+        method: "POST",
+        headers,
+        body: "{}",
+      });
+      expect(await cleanup.json()).toMatchObject({
+        success: true,
+        data: { dry_run: true, removed: 0 },
+      });
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- retain successful and failed/cancelled run workspaces for seven days by default
- persist configurable retention settings under HOMERAIL_HOME
- add scheduled cleanup, dry-run preview, immediate cleanup, and per-run pinning APIs
- expose Storage & Retention controls on the visible General settings page
- protect active, pinned, default, pending-cleanup, and symlink-target workspaces

## Why

PR #21 creates durable runtime workspaces but does not bound their disk usage. This follow-up adds an operator-controlled lifecycle without deleting run metadata, evidence, or unknown directories.

## Validation

- repository-wide npm run ci passed
- Protocol 95, Manager 342, Node 160, Worker 180, CLI 183, Agent UI 126, live validator 6
- real HTTP authorization, persistence, and dry-run behavior passed
- desktop and narrow-screen browser rendering passed

## Dependency

- stacked on PR #21; keep as Draft until #21 is merged and this branch is rebased onto main