### PR TITLE
Fix Kimi provider endpoints and runtime failures

### DIFF
--- a/agent-ui/src/api/services/voice-agent-api.ts
+++ b/agent-ui/src/api/services/voice-agent-api.ts
@@ -54,6 +54,7 @@ export interface VoiceConversationMessage {
   text: string
   created_at: string
   channel?: 'final' | 'commentary'
+  kind?: 'message' | 'error'
 }
 
 export interface VoiceDebugEvent {

--- a/agent-ui/src/components/agent/AgentVoiceCockpit.vue
+++ b/agent-ui/src/components/agent/AgentVoiceCockpit.vue
@@ -71,6 +71,7 @@ import {
   type VoiceKeyboardButtonBinding
 } from '@/utils/voice-hid-control'
 import type { LLMSetting } from '@/api/services/llm-settings-api'
+import { isKimiProviderId } from '@/lib/model-runtime'
 import {
   cleanVoiceTranscript,
   isRecentDuplicateVoiceTranscript,
@@ -954,7 +955,7 @@ function isCustomModelSetting(setting: LLMSetting): boolean {
 }
 
 function isKimiCodeCompatibleSetting(setting: LLMSetting): boolean {
-  return setting.provider_id === 'kimi' || isCustomModelSetting(setting)
+  return isKimiProviderId(setting.provider_id) || isCustomModelSetting(setting)
 }
 
 function toggleModelMenu(): void {

--- a/agent-ui/src/components/agent/AgentVoiceCockpit.vue
+++ b/agent-ui/src/components/agent/AgentVoiceCockpit.vue
@@ -71,7 +71,8 @@ import {
   type VoiceKeyboardButtonBinding
 } from '@/utils/voice-hid-control'
 import type { LLMSetting } from '@/api/services/llm-settings-api'
-import { isKimiProviderId } from '@/lib/model-runtime'
+import { formatRuntimeModelSettingLabel, isKimiProviderId } from '@/lib/model-runtime'
+import { createProtocolLabels } from '@/lib/protocol-labels'
 import {
   cleanVoiceTranscript,
   isRecentDuplicateVoiceTranscript,
@@ -80,6 +81,7 @@ import {
 import {
   createVoiceSpeechEventKey,
   hasRecentVoiceSpeechEvent,
+  isVoiceConversationMessageSpeakable,
   rememberVoiceSpeechEvent
 } from '@/utils/voice-speech-queue'
 import {
@@ -125,6 +127,7 @@ import {
 
 const store = useAgentStore()
 const { t, te } = useI18n()
+const { planLabel } = createProtocolLabels(t)
 // 新手引导配置状态检测（用于"模型配置"按钮的缺配提示）
 const { status: onboardingStatus, refresh: refreshOnboarding } = useOnboardingStatus()
 const needsOnboardingHint = computed(() => onboardingStatus.value.needsOnboarding)
@@ -532,11 +535,11 @@ const voiceModelFallback = computed(() =>
 )
 const asrModelLabel = computed(() => {
   const setting = asrModelOptions.value.find(item => item.id === selectedAsrModelId.value)
-  return modelSettingLabel(setting) || voiceSettings.value?.asr_model || t('voice.model.asrUnconfigured')
+  return modelSettingLabel(setting, asrModelOptions.value) || voiceSettings.value?.asr_model || t('voice.model.asrUnconfigured')
 })
 const ttsModelLabel = computed(() => {
   const setting = ttsModelOptions.value.find(item => item.id === selectedTtsModelId.value)
-  return modelSettingLabel(setting) || voiceSettings.value?.tts_model || t('voice.model.ttsUnconfigured')
+  return modelSettingLabel(setting, ttsModelOptions.value) || voiceSettings.value?.tts_model || t('voice.model.ttsUnconfigured')
 })
 const selectedTtsSetting = computed(
   () => ttsModelOptions.value.find(item => item.id === selectedTtsModelId.value) ?? null
@@ -935,12 +938,8 @@ const fullscreenGateAction = computed(() =>
   canRequestElementFullscreen.value ? t('voice.fullscreen.enter') : t('voice.fullscreen.continue')
 )
 
-function modelSettingLabel(
-  setting?: { provider_name?: string; display_name?: string | null; model_name?: string } | null
-): string {
-  if (!setting) return ''
-  const model = setting.display_name || setting.model_name || ''
-  return setting.provider_name ? `${setting.provider_name} / ${model}` : model
+function modelSettingLabel(setting: LLMSetting | null | undefined, siblings: LLMSetting[]): string {
+  return formatRuntimeModelSettingLabel(setting, siblings, planLabel)
 }
 
 function isCustomModelSetting(setting: LLMSetting): boolean {
@@ -3075,7 +3074,9 @@ function rememberSpeechEvents(events: VoiceSpeechEvent[]): void {
 function queueNewAssistantSpeech(nextWorkspace: VoiceWorkspace | null | undefined): void {
   const candidates = (nextWorkspace?.conversation ?? []).filter(
     item =>
-      item.role === 'assistant' && !spokenAssistantMessageIds.value.has(item.id) && item.text.trim()
+      isVoiceConversationMessageSpeakable(item) &&
+      !spokenAssistantMessageIds.value.has(item.id) &&
+      item.text.trim()
   )
   if (!candidates.length) return
   const next = new Set(spokenAssistantMessageIds.value)
@@ -4527,7 +4528,7 @@ function summarizeTask(value: string): string {
                     :value="setting.id"
                     class="bg-[#111315] text-white"
                   >
-                    {{ modelSettingLabel(setting) }}
+                    {{ modelSettingLabel(setting, managerAgentModelOptions) }}
                   </option>
                 </select>
               </div>
@@ -4605,7 +4606,7 @@ function summarizeTask(value: string): string {
                   :value="setting.id"
                   class="bg-[#111315] text-white"
                 >
-                  {{ modelSettingLabel(setting) }}
+                  {{ modelSettingLabel(setting, asrModelOptions) }}
                 </option>
               </select>
             </label>
@@ -4630,7 +4631,7 @@ function summarizeTask(value: string): string {
                   :value="setting.id"
                   class="bg-[#111315] text-white"
                 >
-                  {{ modelSettingLabel(setting) }}
+                  {{ modelSettingLabel(setting, ttsModelOptions) }}
                 </option>
               </select>
             </label>
@@ -5201,10 +5202,15 @@ function summarizeTask(value: string): string {
                 class="voice-thread-item"
                 :class="[
                   item.role === 'user' ? 'voice-thread-item--user' : 'voice-thread-item--assistant',
-                  item.channel === 'commentary' ? 'voice-thread-item--commentary' : ''
+                  item.channel === 'commentary' ? 'voice-thread-item--commentary' : '',
+                  item.kind === 'error' ? 'voice-thread-item--error' : ''
                 ]"
                 :title="item.text"
               >
+                <span v-if="item.kind === 'error'" class="voice-thread-item__error-label">
+                  <AlertTriangle class="h-3.5 w-3.5" />
+                  {{ t('voice.sidebar.executionError') }}
+                </span>
                 <span v-if="item.channel === 'commentary'" class="voice-thread-item__channel"
                   >commentary</span
                 >
@@ -7828,6 +7834,23 @@ function summarizeTask(value: string): string {
   align-self: flex-start;
   background: rgba(20, 184, 166, 0.16);
   color: rgba(236, 253, 245, 0.86);
+}
+
+.voice-thread-item--error {
+  max-width: 100%;
+  border: 1px solid rgba(248, 113, 113, 0.34);
+  background: rgba(127, 29, 29, 0.22);
+  color: rgba(254, 226, 226, 0.92);
+}
+
+.voice-thread-item__error-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 6px;
+  color: rgba(252, 165, 165, 0.95);
+  font-size: 11px;
+  font-weight: 700;
 }
 
 .voice-thread-item--commentary {

--- a/agent-ui/src/components/agent/onboarding/OnboardingWizard.vue
+++ b/agent-ui/src/components/agent/onboarding/OnboardingWizard.vue
@@ -19,6 +19,7 @@ import { useOnboardingStatus } from '@/composables/useOnboardingStatus'
 import { listProviders, agentSettingsApi } from '@/api/agent'
 import { probeDockerWorkspaceMount, type DockerWorkspaceProbeResult } from '@/api/services/voice-agent-api'
 import { cn } from '@/lib/utils'
+import { isKimiProviderId } from '@/lib/model-runtime'
 import type { Provider } from '@/api/types/orchestration-v2.types'
 import type { LLMSetting } from '@/api/services/llm-settings-api'
 import OnboardingStepForm from './OnboardingStepForm.vue'
@@ -210,7 +211,7 @@ function isDedicatedManagerAgentSetting(setting: LLMSetting | undefined): settin
 const existingManagerAgentSettings = computed(() => existingSettings.value.filter(isDedicatedManagerAgentSetting))
 
 function harnessForManagerAgentSetting(setting: LLMSetting): 'kimi_code' | 'claude_agent_sdk' {
-  return setting.provider_id === 'kimi' ? 'kimi_code' : 'claude_agent_sdk'
+  return isKimiProviderId(setting.provider_id) ? 'kimi_code' : 'claude_agent_sdk'
 }
 
 async function applyCreatedManagerAgentSetting(setting: LLMSetting | undefined): Promise<void> {

--- a/agent-ui/src/lib/model-runtime.test.ts
+++ b/agent-ui/src/lib/model-runtime.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest'
+import { isKimiProviderId } from './model-runtime'
+
+describe('model runtime provider helpers', () => {
+  it('recognizes both CN and international Kimi providers', () => {
+    expect(isKimiProviderId('kimi_cn')).toBe(true)
+    expect(isKimiProviderId('kimi')).toBe(true)
+    expect(isKimiProviderId('glm')).toBe(false)
+  })
+})

--- a/agent-ui/src/lib/model-runtime.test.ts
+++ b/agent-ui/src/lib/model-runtime.test.ts
@@ -1,10 +1,36 @@
 import { describe, expect, it } from 'vitest'
-import { isKimiProviderId } from './model-runtime'
+import { formatRuntimeModelSettingLabel, isKimiProviderId } from './model-runtime'
 
 describe('model runtime provider helpers', () => {
   it('recognizes both CN and international Kimi providers', () => {
     expect(isKimiProviderId('kimi_cn')).toBe(true)
     expect(isKimiProviderId('kimi')).toBe(true)
     expect(isKimiProviderId('glm')).toBe(false)
+  })
+
+  it('adds plan labels only when a provider has multiple billing plans', () => {
+    const apiSetting = {
+      provider_id: 'kimi_cn',
+      provider_name: 'Kimi / Moonshot CN',
+      display_name: 'kimi-k2.7-code',
+      model_name: 'kimi-k2.7-code',
+      plan_type: 'api_billing',
+    }
+    const codingSetting = {
+      ...apiSetting,
+      model_name: 'kimi-for-coding',
+      plan_type: 'coding_plan',
+    }
+    const planLabel = (plan?: string) => (plan === 'coding_plan' ? 'Coding Plan' : 'API 计费')
+
+    expect(formatRuntimeModelSettingLabel(apiSetting, [apiSetting], planLabel)).toBe(
+      'Kimi / Moonshot CN / kimi-k2.7-code',
+    )
+    expect(formatRuntimeModelSettingLabel(apiSetting, [apiSetting, codingSetting], planLabel)).toBe(
+      'Kimi / Moonshot CN / kimi-k2.7-code · API 计费',
+    )
+    expect(formatRuntimeModelSettingLabel(codingSetting, [apiSetting, codingSetting], planLabel)).toBe(
+      'Kimi / Moonshot CN / kimi-k2.7-code · Coding Plan',
+    )
   })
 })

--- a/agent-ui/src/lib/model-runtime.ts
+++ b/agent-ui/src/lib/model-runtime.ts
@@ -1,5 +1,31 @@
 const KIMI_PROVIDER_IDS = new Set(['kimi_cn', 'kimi'])
 
+export interface RuntimeModelLabelSetting {
+  provider_id?: string | null
+  provider_name?: string | null
+  display_name?: string | null
+  model_name?: string | null
+  plan_type?: string | null
+}
+
 export function isKimiProviderId(providerId?: string | null): boolean {
   return Boolean(providerId && KIMI_PROVIDER_IDS.has(providerId))
+}
+
+export function formatRuntimeModelSettingLabel(
+  setting: RuntimeModelLabelSetting | null | undefined,
+  siblingSettings: RuntimeModelLabelSetting[],
+  planLabel: (plan?: string) => string,
+): string {
+  if (!setting) return ''
+  const model = setting.display_name || setting.model_name || ''
+  const base = setting.provider_name ? `${setting.provider_name} / ${model}` : model
+  if (!setting.provider_id) return base
+
+  const providerPlans = new Set(
+    siblingSettings
+      .filter(item => item.provider_id === setting.provider_id)
+      .map(item => item.plan_type || 'custom'),
+  )
+  return providerPlans.size > 1 ? `${base} · ${planLabel(setting.plan_type || 'custom')}` : base
 }

--- a/agent-ui/src/lib/model-runtime.ts
+++ b/agent-ui/src/lib/model-runtime.ts
@@ -1,0 +1,5 @@
+const KIMI_PROVIDER_IDS = new Set(['kimi_cn', 'kimi'])
+
+export function isKimiProviderId(providerId?: string | null): boolean {
+  return Boolean(providerId && KIMI_PROVIDER_IDS.has(providerId))
+}

--- a/agent-ui/src/locales/en-US/voice.json
+++ b/agent-ui/src/locales/en-US/voice.json
@@ -142,7 +142,8 @@
     "newSession": "New session",
     "records": "History",
     "hideDetails": "Hide details",
-    "emptyRecords": "No history yet."
+    "emptyRecords": "No history yet.",
+    "executionError": "Execution failed"
   },
   "project": {
     "configuration": "Directory settings",

--- a/agent-ui/src/locales/zh-Hans/voice.json
+++ b/agent-ui/src/locales/zh-Hans/voice.json
@@ -142,7 +142,8 @@
     "newSession": "新会话",
     "records": "记录",
     "hideDetails": "隐藏详情",
-    "emptyRecords": "暂无记录。"
+    "emptyRecords": "暂无记录。",
+    "executionError": "执行失败"
   },
   "project": {
     "configuration": "目录配置",

--- a/agent-ui/src/locales/zh-Hant/voice.json
+++ b/agent-ui/src/locales/zh-Hant/voice.json
@@ -142,7 +142,8 @@
     "newSession": "新會話",
     "records": "記錄",
     "hideDetails": "隱藏詳情",
-    "emptyRecords": "暫無記錄。"
+    "emptyRecords": "暫無記錄。",
+    "executionError": "執行失敗"
   },
   "project": {
     "configuration": "目錄配置",

--- a/agent-ui/src/stores/agent-store.ts
+++ b/agent-ui/src/stores/agent-store.ts
@@ -6,6 +6,7 @@ import { mapManagerSessionMessages } from './agent/message-mapper'
 import { clearAgentSession, loadAgentSession, saveAgentSession } from './agent/persistence'
 import type { AgentChatMessage, AgentInspectorTab, ManagerSessionItem } from './agent/types'
 import type { LLMSetting } from '@/api/services/llm-settings-api'
+import { isKimiProviderId } from '@/lib/model-runtime'
 import {
   deleteManagerSession,
   getManagerAgentConfig,
@@ -183,10 +184,12 @@ export const useAgentStore = defineStore('agent', () => {
     const current = active.find(
       setting => setting.provider_id === managerProviderName.value && setting.model_name === managerModelName.value,
     )
-    const legacyDefault = managerProviderName.value === 'kimi' && managerModelName.value === 'K2.6'
+    const legacyDefault = isKimiProviderId(managerProviderName.value) && managerModelName.value === 'K2.6'
     if (current && !legacyDefault) return
     const preferred = active.find(setting => setting.is_default)
+      ?? active.find(setting => setting.provider_id === 'kimi_cn' && setting.model_name === 'kimi-k2.7-code')
       ?? active.find(setting => setting.provider_id === 'kimi' && setting.model_name === 'kimi-k2.7-code')
+      ?? active.find(setting => setting.provider_id === 'kimi_cn' && setting.model_name === 'K2.6')
       ?? active.find(setting => setting.provider_id === 'kimi' && setting.model_name === 'K2.6')
       ?? active[0]
     managerProviderName.value = preferred.provider_id

--- a/agent-ui/src/utils/voice-speech-queue.test.ts
+++ b/agent-ui/src/utils/voice-speech-queue.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   createVoiceSpeechEventKey,
   hasRecentVoiceSpeechEvent,
+  isVoiceConversationMessageSpeakable,
   normalizeVoiceSpeechTextForKey,
   pruneVoiceSpeechEventKeys,
   rememberVoiceSpeechEvent,
@@ -40,5 +41,18 @@ describe('voice speech queue helpers', () => {
     expect(hasRecentVoiceSpeechEvent(seen, { channel: 'final', text: '旧消息' }, 10_050, 100)).toBe(true)
     pruneVoiceSpeechEventKeys(seen, 10_101, 100)
     expect(hasRecentVoiceSpeechEvent(seen, { channel: 'final', text: '旧消息' }, 10_101, 100)).toBe(false)
+  })
+
+  it('never sends structured execution errors to TTS', () => {
+    expect(isVoiceConversationMessageSpeakable({
+      role: 'assistant',
+      kind: 'error',
+      text: '主 Agent 执行失败：provider rejected the credential',
+    })).toBe(false)
+    expect(isVoiceConversationMessageSpeakable({
+      role: 'assistant',
+      kind: 'message',
+      text: '任务已经完成。',
+    })).toBe(true)
   })
 })

--- a/agent-ui/src/utils/voice-speech-queue.ts
+++ b/agent-ui/src/utils/voice-speech-queue.ts
@@ -5,10 +5,22 @@ export interface VoiceSpeechFingerprintInput {
   text?: string | null
 }
 
+export interface VoiceConversationSpeechCandidate {
+  role?: string | null
+  kind?: string | null
+  text?: string | null
+}
+
 export const VOICE_SPEECH_EVENT_KEY_TTL_MS = 60_000
 
 export function normalizeVoiceSpeechTextForKey(text: string | null | undefined): string {
   return (text || '').replace(/\s+/g, ' ').trim()
+}
+
+export function isVoiceConversationMessageSpeakable(
+  message: VoiceConversationSpeechCandidate,
+): boolean {
+  return message.role === 'assistant' && message.kind !== 'error' && Boolean(message.text?.trim())
 }
 
 export function createVoiceSpeechEventKey(event: VoiceSpeechFingerprintInput): string {

--- a/homerail_cli/src/commands/doctor.ts
+++ b/homerail_cli/src/commands/doctor.ts
@@ -74,10 +74,12 @@ const CLAUDE_SDK_COMPATIBLE_PROVIDER_IDS = new Set([
   "xiaomi",
   "deepseek",
   "kimi",
+  "kimi_cn",
   "minimax",
   "minimax_cn",
   "aliyun",
 ]);
+const KIMI_PROVIDER_IDS = new Set(["kimi", "kimi_cn"]);
 
 function stringValue(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
@@ -244,7 +246,7 @@ export function managerAgentReadiness(
       (!configModel || modelName(setting) === configModel),
     );
   } else if (harness === "kimi_code") {
-    const compatible = settings.filter((setting) => providerId(setting) === "kimi");
+    const compatible = settings.filter((setting) => KIMI_PROVIDER_IDS.has(providerId(setting)));
     selected = compatible.find(isDefaultSetting) ?? compatible[0];
   } else {
     const compatible = settings.filter((setting) => Boolean(anthropicCompatibleBaseUrl(setting)));
@@ -261,7 +263,7 @@ export function managerAgentReadiness(
     };
   }
   if (harness === "kimi_code") {
-    if (providerId(selected) !== "kimi") {
+    if (!KIMI_PROVIDER_IDS.has(providerId(selected))) {
       return {
         name: "manager-agent",
         ok: false,

--- a/homerail_cli/tests/doctor.test.ts
+++ b/homerail_cli/tests/doctor.test.ts
@@ -120,6 +120,28 @@ describe("doctor readiness helpers", () => {
     });
   });
 
+  it("accepts a Kimi CN setting for the Kimi Code manager agent", () => {
+    const resp = settings([
+      {
+        id: "kimi-cn-coding",
+        provider_id: "kimi_cn",
+        model_name: "kimi-for-coding",
+        is_active: true,
+        is_default: true,
+        supports_llm: true,
+        protocol: "openai_compatible",
+        base_url: "https://api.kimi.com/coding/v1",
+      },
+    ]);
+
+    const check = managerAgentReadiness({ harness: "kimi_code" }, resp);
+    expect(check).toMatchObject({
+      name: "manager-agent",
+      ok: true,
+      detail: "kimi_cn/kimi-for-coding via kimi_code",
+    });
+  });
+
   it("reports Docker CLI absence for Docker-backed DAG readiness", () => {
     const checks = dockerReadiness(runnerFor([
       { status: null, error: Object.assign(new Error("spawn docker ENOENT"), { code: "ENOENT" }) },

--- a/homerail_manager/src/index.ts
+++ b/homerail_manager/src/index.ts
@@ -4,6 +4,7 @@ import { initEventLogging } from "./persistence/store.js";
 import { recoverAllActiveRuns } from "./runtime/active-runs.js";
 import { recoverStaleVoiceSessions } from "./server/voice-session-registry.js";
 import { markRecoveryComplete } from "./health/index.js";
+import { shutdownHostShellManagerAgents } from "./server/host-shell-manager-agent.js";
 
 initEventLogging();
 
@@ -28,3 +29,17 @@ server.listen(port, host, () => {
     console.error(`voice recovery: reset ${voiceRecovery.recovered.length} stale session(s)`);
   }
 });
+
+let shuttingDown = false;
+function shutdown(): void {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  const forcedExit = setTimeout(() => process.exit(1), 5_000);
+  forcedExit.unref();
+  void shutdownHostShellManagerAgents().finally(() => {
+    server.close(() => process.exit(0));
+  });
+}
+
+process.once("SIGINT", shutdown);
+process.once("SIGTERM", shutdown);

--- a/homerail_manager/src/persistence/llm-settings.ts
+++ b/homerail_manager/src/persistence/llm-settings.ts
@@ -10,6 +10,7 @@ import { normalizeStatus, type ProviderStatus } from "./status.js";
 import { nowIso } from "./time.js";
 import {
   baseUrlForProtocol,
+  canonicalModelNameForEndpoint,
   canonicalProviderIdForEndpoint,
   findCatalogProvider,
   findCatalogEndpoint,
@@ -148,6 +149,7 @@ const LEGACY_CLAUDE_SDK_COMPATIBLE_PROVIDER_IDS = [
   "xiaomi",
   "deepseek",
   "kimi",
+  "kimi_cn",
   "minimax",
   "minimax_cn",
   "aliyun",
@@ -672,7 +674,8 @@ function _normalizeStoredSetting(raw: unknown): { setting?: LLMSetting; needsMig
     storedEndpointId,
     storedBaseUrl ?? provider?.base_url,
   );
-  const modelPreset = findEndpointModel(endpoint, rec.model_name);
+  const modelName = canonicalModelNameForEndpoint(providerId, storedEndpointId, rec.model_name);
+  const modelPreset = findEndpointModel(endpoint, modelName);
   const lockedEndpoint = _isLockedCatalogEndpoint(providerId, endpoint);
   const endpointId = lockedEndpoint
     ? endpoint?.id ?? storedEndpointId ?? "custom"
@@ -696,7 +699,7 @@ function _normalizeStoredSetting(raw: unknown): { setting?: LLMSetting; needsMig
   const inferredAnthropicBaseUrl = lockedEndpoint
     ? endpoint?.anthropic_base_url ?? storedAnthropicBaseUrl ?? provider?.anthropic_base_url
     : storedAnthropicBaseUrl ?? endpoint?.anthropic_base_url ?? provider?.anthropic_base_url;
-  needsMigration = needsMigration || rec.provider_id !== providerId || rec.endpoint_id !== endpointId || typeof rec.plan_type !== "string" ||
+  needsMigration = needsMigration || rec.provider_id !== providerId || rec.endpoint_id !== endpointId || rec.model_name !== modelName || typeof rec.plan_type !== "string" ||
     typeof rec.protocol !== "string" || typeof rec.display_name !== "string" ||
     (typeof rec.base_url === "string" && officialBaseUrl !== undefined && rec.base_url !== officialBaseUrl) ||
     (lockedEndpoint && endpoint?.plan_type !== undefined && rec.plan_type !== endpoint.plan_type) ||
@@ -704,13 +707,13 @@ function _normalizeStoredSetting(raw: unknown): { setting?: LLMSetting; needsMig
 
   // models 向后兼容：旧 setting 无 models 字段时，从 model_name 派生 [model_name]
   const models = Array.isArray(rec.models) && rec.models.every((m) => typeof m === "string")
-    ? rec.models as string[]
-    : [rec.model_name];
+    ? (rec.models as string[]).map((item) => canonicalModelNameForEndpoint(providerId, storedEndpointId, item))
+    : [modelName];
 
   const setting: LLMSetting = {
     id: rec.id,
     provider_id: providerId,
-    model_name: rec.model_name,
+    model_name: modelName,
     models,
     api_key: apiKey,
     display_name: _stringField(rec, "display_name") ?? _stringField(rec, "alias") ?? rec.model_name,
@@ -1390,9 +1393,11 @@ function _buildSetting(
 }
 
 export function createSetting(input: LLMSettingInput): LLMSetting {
+  const providerId = _canonicalProviderId(input.provider_id, input.endpoint_id, input.base_url, input.model_name);
   input = {
     ...input,
-    provider_id: _canonicalProviderId(input.provider_id, input.endpoint_id, input.base_url, input.model_name),
+    provider_id: providerId,
+    model_name: canonicalModelNameForEndpoint(providerId, input.endpoint_id, input.model_name),
   };
   const provider = getProvider(input.provider_id);
   if (!provider) {
@@ -1481,7 +1486,11 @@ export function updateSetting(id: string, patch: Partial<Omit<LLMSetting, "id" |
     throw new Error(`Unknown provider_id: ${providerId}`);
   }
 
-  const modelName = patch.model_name ?? existing.model_name;
+  const modelName = canonicalModelNameForEndpoint(
+    providerId,
+    patch.endpoint_id ?? existing.endpoint_id,
+    patch.model_name ?? existing.model_name,
+  );
   const modelChanged = modelName !== existing.model_name;
   const mergedInput: LLMSettingInput = {
     ...existing,

--- a/homerail_manager/src/persistence/provider-catalog.ts
+++ b/homerail_manager/src/persistence/provider-catalog.ts
@@ -67,6 +67,13 @@ const VOLCENGINE_PROVIDER_ID = "volcengine";
 const LEGACY_DOUBAO_SPEECH_PROVIDER_ID = "doubao-speech";
 export const DOUBAO_SPEECH_PROVIDER_ID = VOLCENGINE_PROVIDER_ID;
 export const DOUBAO_SPEECH_ENDPOINT_ID = "volcengine_openspeech_api";
+export const KIMI_PROVIDER_ID = "kimi";
+export const KIMI_CN_PROVIDER_ID = "kimi_cn";
+export const KIMI_CODING_PLAN_ENDPOINT_ID = "kimi_coding_plan";
+
+export function isKimiProviderId(providerId?: string): boolean {
+  return providerId === KIMI_PROVIDER_ID || providerId === KIMI_CN_PROVIDER_ID;
+}
 
 const LEGACY_DOUBAO_SPEECH_ENDPOINT_IDS = new Set([
   "volcengine_ark_agent_plan_voice",
@@ -98,6 +105,17 @@ export function canonicalProviderIdForEndpoint(
   baseUrl?: string,
   modelName?: string,
 ): string {
+  if (
+    providerId === KIMI_PROVIDER_ID &&
+    (
+      endpointId === KIMI_CODING_PLAN_ENDPOINT_ID ||
+      normalizeBaseUrl(baseUrl).startsWith("https://api.kimi.com/coding") ||
+      modelName === "kimi-for-coding" ||
+      modelName === "kimi-for-coding-highspeed"
+    )
+  ) {
+    return KIMI_CN_PROVIDER_ID;
+  }
   if (providerId === LEGACY_DOUBAO_SPEECH_PROVIDER_ID) {
     return VOLCENGINE_PROVIDER_ID;
   }
@@ -112,6 +130,22 @@ export function canonicalProviderIdForEndpoint(
     return VOLCENGINE_PROVIDER_ID;
   }
   return providerId;
+}
+
+export function canonicalModelNameForEndpoint(
+  providerId: string,
+  endpointId: string | undefined,
+  modelName: string,
+): string {
+  const canonicalProviderId = canonicalProviderIdForEndpoint(providerId, endpointId, undefined, modelName);
+  if (
+    canonicalProviderId === KIMI_CN_PROVIDER_ID &&
+    endpointId === KIMI_CODING_PLAN_ENDPOINT_ID &&
+    modelName === "kimi-k2.7-code"
+  ) {
+    return "kimi-for-coding";
+  }
+  return modelName;
 }
 
 function model(id: string, capabilities: ModelCapabilities = {}, extra: Partial<ProviderModelPreset> = {}): ProviderModelPreset {
@@ -167,7 +201,53 @@ function endpointBaseUrls(endpoint: ProviderEndpointPreset): string[] {
 
 export const DEFAULT_PROVIDER_CATALOG: CatalogProviderInfo[] = [
   {
-    id: "kimi",
+    id: KIMI_CN_PROVIDER_ID,
+    name: "Kimi / Moonshot CN",
+    status: "active",
+    default_model: "kimi-k2.7-code",
+    base_url: "https://api.moonshot.cn/v1",
+    docs_url: "https://platform.moonshot.cn/docs/api/overview",
+    endpoints: [
+      endpoint({
+        id: "kimi_cn_api",
+        provider_id: KIMI_CN_PROVIDER_ID,
+        name: "Kimi CN API 计费",
+        plan_type: "api_billing",
+        protocol: "openai_compatible",
+        base_url: "https://api.moonshot.cn/v1",
+        chat_completions_base_url: "https://api.moonshot.cn/v1",
+        anthropic_base_url: "https://api.moonshot.cn/anthropic",
+        auth_type: "bearer",
+        key_hint: "Moonshot CN API Key (sk-*)",
+        default_model: "kimi-k2.7-code",
+        docs_url: "https://platform.moonshot.cn/docs/api/overview",
+        models: [
+          model("kimi-k2.7-code", {}, { recommended: true }),
+          model("kimi-k2.6", { supports_image_input: true, supports_video_input: true }),
+        ],
+      }),
+      endpoint({
+        id: KIMI_CODING_PLAN_ENDPOINT_ID,
+        provider_id: KIMI_CN_PROVIDER_ID,
+        name: "Kimi Coding Plan",
+        plan_type: "coding_plan",
+        protocol: "openai_compatible",
+        base_url: "https://api.kimi.com/coding/v1",
+        chat_completions_base_url: "https://api.kimi.com/coding/v1",
+        anthropic_base_url: "https://api.kimi.com/coding",
+        auth_type: "bearer",
+        key_hint: "Kimi Coding Plan Key",
+        default_model: "kimi-for-coding",
+        docs_url: "https://www.kimi.com/code/docs/",
+        models: [
+          model("kimi-for-coding", {}, { recommended: true }),
+          model("kimi-for-coding-highspeed"),
+        ],
+      }),
+    ],
+  },
+  {
+    id: KIMI_PROVIDER_ID,
     name: "Kimi / Moonshot",
     status: "active",
     default_model: "kimi-k2.7-code",
@@ -176,7 +256,7 @@ export const DEFAULT_PROVIDER_CATALOG: CatalogProviderInfo[] = [
     endpoints: [
       endpoint({
         id: "kimi_api",
-        provider_id: "kimi",
+        provider_id: KIMI_PROVIDER_ID,
         name: "Kimi API 计费",
         plan_type: "api_billing",
         protocol: "openai_compatible",
@@ -191,21 +271,6 @@ export const DEFAULT_PROVIDER_CATALOG: CatalogProviderInfo[] = [
           model("kimi-k2.7-code", {}, { recommended: true }),
           model("kimi-k2.6", { supports_image_input: true, supports_video_input: true }),
         ],
-      }),
-      endpoint({
-        id: "kimi_coding_plan",
-        provider_id: "kimi",
-        name: "Kimi Coding Plan",
-        plan_type: "coding_plan",
-        protocol: "openai_compatible",
-        base_url: "https://api.kimi.com/coding/v1",
-        chat_completions_base_url: "https://api.kimi.com/coding/v1",
-        anthropic_base_url: "https://api.kimi.com/coding",
-        auth_type: "bearer",
-        key_hint: "Kimi Coding Plan Key",
-        default_model: "kimi-k2.7-code",
-        docs_url: "https://platform.kimi.ai/docs/guide/agent-support",
-        models: [model("kimi-k2.7-code", {}, { recommended: true })],
       }),
     ],
   },

--- a/homerail_manager/src/runtime/agent-runtime-resolver.ts
+++ b/homerail_manager/src/runtime/agent-runtime-resolver.ts
@@ -9,6 +9,12 @@ import {
   type LLMSetting,
 } from "../persistence/llm-settings.js";
 import {
+  canonicalModelNameForEndpoint,
+  isKimiProviderId,
+  KIMI_CN_PROVIDER_ID,
+  KIMI_PROVIDER_ID,
+} from "../persistence/provider-catalog.js";
+import {
   DEFAULT_MANAGER_AGENT_RUNTIME_AGENT_TYPE,
   ManagerAgentRuntimePlacement,
   isDisabledDirectLlmAgentType,
@@ -88,18 +94,29 @@ function isCustomModelSetting(setting: LLMSetting): boolean {
 }
 
 function isKimiCodeCompatibleSetting(setting: LLMSetting): boolean {
-  return setting.provider_id === "kimi" || isCustomModelSetting(setting);
+  return isKimiProviderId(setting.provider_id) || isCustomModelSetting(setting);
+}
+
+function findActiveKimiSetting(modelName?: string): LLMSetting | undefined {
+  return findActiveSetting(KIMI_CN_PROVIDER_ID, modelName) ??
+    findActiveSetting(KIMI_PROVIDER_ID, modelName) ??
+    (modelName === "kimi-k2.7-code"
+      ? findActiveSetting(KIMI_CN_PROVIDER_ID, "kimi-for-coding")
+      : undefined);
 }
 
 function settingForInput(input: AgentRuntimeResolutionInput): LLMSetting {
   const label = input.surface === "manager_agent" ? "Manager" : "DAG";
   const requested = requestedAgentType(input);
+  const directlyRequestedSetting = input.providerName
+    ? findActiveSetting(input.providerName, input.modelName)
+    : undefined;
   const setting = input.settingId
     ? getSetting(input.settingId)
     : input.providerName
-    ? findActiveSetting(input.providerName, input.modelName)
+    ? directlyRequestedSetting ?? (isKimiProviderId(input.providerName) ? findActiveKimiSetting(input.modelName) : undefined)
     : requested === "kimi_code"
-    ? findActiveSetting("kimi", input.modelName)
+    ? findActiveKimiSetting(input.modelName)
     : input.surface === "manager_agent" || requested === "claude-sdk"
     ? findActiveClaudeSdkCompatibleSetting()
     : input.surface === "dag"
@@ -124,7 +141,7 @@ function settingForInput(input: AgentRuntimeResolutionInput): LLMSetting {
 function agentTypeForSetting(setting: LLMSetting, input: AgentRuntimeResolutionInput): string {
   const explicit = requestedAgentType(input);
   const requested = explicit ?? DEFAULT_MANAGER_AGENT_RUNTIME_AGENT_TYPE;
-  if (setting.provider_id === "kimi" && explicit !== managerAgentHarnessDefinition("claude_agent_sdk").agent_type) {
+  if (isKimiProviderId(setting.provider_id) && explicit !== managerAgentHarnessDefinition("claude_agent_sdk").agent_type) {
     return managerAgentHarnessDefinition("kimi_code").agent_type;
   }
   if (requested === "kimi_code") {
@@ -161,6 +178,9 @@ export function resolveAgentRuntimeConfig(input: AgentRuntimeResolutionInput): A
   const setting = settingForInput(input);
   const agentType = agentTypeForSetting(setting, input);
   const baseUrl = baseUrlForSetting(setting, agentType);
+  const requestedModel = input.modelName
+    ? canonicalModelNameForEndpoint(setting.provider_id, setting.endpoint_id, input.modelName)
+    : undefined;
   if (!baseUrl) {
     if (agentType === "claude-sdk") {
       throw new Error(`Claude SDK requires an Anthropic-compatible endpoint for ${setting.provider_id}/${setting.model_name}; Chat Completions endpoints are not supported for harness execution. Configure an Anthropic base URL or use the Kimi Code harness for Kimi.`);
@@ -169,7 +189,7 @@ export function resolveAgentRuntimeConfig(input: AgentRuntimeResolutionInput): A
   }
   return {
     provider_name: setting.provider_id,
-    model: input.settingId ? setting.model_name : input.modelName || setting.model_name,
+    model: input.settingId ? setting.model_name : requestedModel || setting.model_name,
     api_key: setting.api_key,
     base_url: baseUrl,
     protocol: agentType === "claude-sdk" ? "anthropic_compatible" : setting.protocol,

--- a/homerail_manager/src/server/host-codex-manager-agent.ts
+++ b/homerail_manager/src/server/host-codex-manager-agent.ts
@@ -141,8 +141,26 @@ export type HostCodexManagerAgentStreamRunner = (
   input: HostCodexManagerAgentInput,
 ) => AsyncIterable<HostCodexManagerAgentStreamEvent>;
 
+export class HostCodexManagerAgentExecutionError extends Error {
+  readonly data: Record<string, unknown>;
+
+  constructor(errors: string[], data: Record<string, unknown>) {
+    super(errors.at(-1) || "Host Codex Manager Agent execution failed");
+    this.name = "HostCodexManagerAgentExecutionError";
+    this.data = { code: "agent_execution_failed", errors, ...data };
+    Object.setPrototypeOf(this, HostCodexManagerAgentExecutionError.prototype);
+  }
+}
+
+type HostCodexAgentEventRunner = (
+  prompt: string,
+  tools: ToolDefinition[],
+  context: AgentRunContext,
+) => AsyncIterable<AgentEvent>;
+
 let hostRunnerOverride: HostCodexManagerAgentRunner | undefined;
 let hostStreamRunnerOverride: HostCodexManagerAgentStreamRunner | undefined;
+let hostAgentEventRunnerOverride: HostCodexAgentEventRunner | undefined;
 
 export function _setHostCodexManagerAgentRunnerForTest(runner?: HostCodexManagerAgentRunner): void {
   hostRunnerOverride = runner;
@@ -150,6 +168,10 @@ export function _setHostCodexManagerAgentRunnerForTest(runner?: HostCodexManager
 
 export function _setHostCodexManagerAgentStreamRunnerForTest(runner?: HostCodexManagerAgentStreamRunner): void {
   hostStreamRunnerOverride = runner;
+}
+
+export function _setHostCodexAgentEventRunnerForTest(runner?: HostCodexAgentEventRunner): void {
+  hostAgentEventRunnerOverride = runner;
 }
 
 export function _buildCodexAppServerArgsForTest(): string[] {
@@ -1275,6 +1297,7 @@ function buildHostCodexManagerAgentResult(
   toolCommentaryTexts: string[],
   toolCalls: Array<{ id: string; name: string; input: Record<string, unknown> }>,
   toolResults: Array<{ tool_use_id: string; content: string; is_error?: boolean }>,
+  agentErrors: string[],
 ): Record<string, unknown> {
   const config = input.agent_config;
   const finalText = state.finalNotes.at(-1) || compactDeltas(texts) || "Manager Agent turn completed.";
@@ -1323,6 +1346,7 @@ function buildHostCodexManagerAgentResult(
     },
     tool_calls: toolCalls,
     tool_results: toolResults,
+    ...(agentErrors.length ? { agent_errors: agentErrors } : {}),
     commentary_texts: commentary,
     project_id: input.project_id ?? config.project_id ?? null,
     worker_id: "host-codex",
@@ -1356,28 +1380,30 @@ async function* runHostCodexManagerAgentTurnEvents(
   const texts: string[] = [];
   const commentaryTexts: string[] = [];
   const toolCommentaryTexts: string[] = [];
+  const agentErrors: string[] = [];
   let emittedVoiceSurfaceCommentaryCount = 0;
   const abortController = new AbortController();
   const turnTimeoutMs = managerAgentTurnTimeoutMs();
   const timeout = turnTimeoutMs > 0 ? setTimeout(() => abortController.abort(), turnTimeoutMs) : undefined;
   timeout?.unref?.();
-  const adapter = new HostCodexAppServerAdapter();
+  const prompt = buildPrompt(input.history, message, input.continue_chat !== false);
+  const tools = createManagerTools(state, responseMode);
+  const context: AgentRunContext = {
+    systemPrompt: systemPrompt(config, responseMode, voiceUiRules, voiceSystemContract, input.manager_skills),
+    provider: config.provider_name || undefined,
+    model: config.model || "codex",
+    apiKey: config.api_key || "",
+    baseUrl: config.base_url || "",
+    workspace,
+    abortSignal: abortController.signal,
+    reasoning_effort: config.reasoning_effort,
+    service_tier: config.service_tier,
+  };
+  const eventStream = hostAgentEventRunnerOverride
+    ? hostAgentEventRunnerOverride(prompt, tools, context)
+    : new HostCodexAppServerAdapter().run(prompt, tools, context);
   try {
-    for await (const event of adapter.run(
-      buildPrompt(input.history, message, input.continue_chat !== false),
-      createManagerTools(state, responseMode),
-      {
-        systemPrompt: systemPrompt(config, responseMode, voiceUiRules, voiceSystemContract, input.manager_skills),
-        provider: config.provider_name || undefined,
-        model: config.model || "codex",
-        apiKey: config.api_key || "",
-        baseUrl: config.base_url || "",
-        workspace,
-        abortSignal: abortController.signal,
-        reasoning_effort: config.reasoning_effort,
-        service_tier: config.service_tier,
-      },
-    )) {
+    for await (const event of eventStream) {
       if (event.type === "text") {
         texts.push(event.text);
       } else if (event.type === "thinking") {
@@ -1397,11 +1423,18 @@ async function* runHostCodexManagerAgentTurnEvents(
           yield { type: "commentary", text, source: "voice_surface" };
         }
       } else if (event.type === "error") {
-        texts.push(`[ERROR] ${event.message}`);
+        agentErrors.push(event.message);
       }
     }
   } finally {
     if (timeout) clearTimeout(timeout);
+  }
+  if (agentErrors.length > 0 && !state.objectiveToolCalls.some((item) => item.success)) {
+    throw new HostCodexManagerAgentExecutionError(agentErrors, {
+      observed_tool_calls: toolCalls.map((item) => item.name),
+      objective_tool_calls: state.objectiveToolCalls,
+      run_ids: state.createdRunIds,
+    });
   }
   const remainingSurfaceCommentary = state.voiceSurface.commentaryTexts.slice(emittedVoiceSurfaceCommentaryCount);
   for (const text of remainingSurfaceCommentary) {
@@ -1420,6 +1453,7 @@ async function* runHostCodexManagerAgentTurnEvents(
       toolCommentaryTexts,
       toolCalls,
       toolResults,
+      agentErrors,
     ),
   };
 }

--- a/homerail_manager/src/server/host-shell-manager-agent.ts
+++ b/homerail_manager/src/server/host-shell-manager-agent.ts
@@ -21,10 +21,36 @@ export interface HostShellManagerAgent {
   processName: string;
 }
 
+interface HostShellHealth {
+  fingerprint: string;
+  processId: number | null;
+  projectId: string | null;
+  workerId: string;
+}
+
+interface PersistedHostShellProcess {
+  version: 1;
+  pid: number;
+  port: number;
+  fingerprint: string;
+  processName: string;
+  workerId: string;
+  projectId: string | null;
+}
+
+interface RunningHostShellProcess {
+  process?: ChildProcess;
+  processId: number;
+  fingerprint: string;
+  projectId?: string;
+  url: string;
+}
+
 const HOST_AGENT_PORT_BASE = 59000;
 const HOST_AGENT_PORT_SPAN = 5000;
 
-const running = new Map<string, { process: ChildProcess; fingerprint: string }>();
+const running = new Map<string, RunningHostShellProcess>();
+const starting = new Map<string, Promise<HostShellManagerAgent>>();
 
 function canonicalProjectId(projectId?: string): string {
   const trimmed = (projectId ?? "").trim();
@@ -49,6 +75,52 @@ function hostPort(projectId?: string): number {
 
 function baseUrl(projectId?: string): string {
   return `http://127.0.0.1:${hostPort(projectId)}`;
+}
+
+function runtimeStatePath(projectId?: string): string {
+  const dir = path.join(getDataRoot(), "manager-agents-host", canonicalProjectId(projectId));
+  fs.mkdirSync(dir, { recursive: true });
+  return path.join(dir, "runtime.json");
+}
+
+function readRuntimeState(projectId?: string): PersistedHostShellProcess | undefined {
+  try {
+    const raw = JSON.parse(fs.readFileSync(runtimeStatePath(projectId), "utf-8")) as Partial<PersistedHostShellProcess>;
+    if (
+      raw.version !== 1 ||
+      !Number.isSafeInteger(raw.pid) || Number(raw.pid) <= 0 ||
+      !Number.isSafeInteger(raw.port) || Number(raw.port) <= 0 ||
+      typeof raw.fingerprint !== "string" || !raw.fingerprint ||
+      typeof raw.processName !== "string" || !raw.processName ||
+      typeof raw.workerId !== "string" || !raw.workerId ||
+      !(typeof raw.projectId === "string" || raw.projectId === null)
+    ) {
+      return undefined;
+    }
+    return raw as PersistedHostShellProcess;
+  } catch {
+    return undefined;
+  }
+}
+
+function writeRuntimeState(projectId: string | undefined, state: PersistedHostShellProcess): void {
+  const file = runtimeStatePath(projectId);
+  const temp = `${file}.${process.pid}.${Date.now()}.tmp`;
+  fs.writeFileSync(temp, `${JSON.stringify(state, null, 2)}\n`, { encoding: "utf-8", mode: 0o600 });
+  fs.renameSync(temp, file);
+}
+
+function removeRuntimeState(projectId: string | undefined, expected?: Pick<PersistedHostShellProcess, "pid" | "fingerprint">): void {
+  const file = runtimeStatePath(projectId);
+  if (expected) {
+    const current = readRuntimeState(projectId);
+    if (!current || current.pid !== expected.pid || current.fingerprint !== expected.fingerprint) return;
+  }
+  try {
+    fs.rmSync(file, { force: true });
+  } catch {
+    // Best-effort cleanup; a later ensure can reconcile the stale record.
+  }
 }
 
 function runtimeRoot(): string {
@@ -177,16 +249,35 @@ function hostFingerprint(input: {
 
 export const _hostShellWorkerEntryFingerprintForTest = workerEntryFingerprint;
 
-async function health(url: string, fingerprint?: string): Promise<boolean> {
+async function healthDetails(url: string): Promise<HostShellHealth | undefined> {
   try {
     const res = await fetch(`${url}/health`, { signal: AbortSignal.timeout(3_000) });
-    if (!res.ok) return false;
+    if (!res.ok) return undefined;
     const data = await res.json() as Record<string, unknown>;
-    if (data.status !== "running" || data.service !== "manager-agent") return false;
-    return fingerprint ? data.fingerprint === fingerprint : true;
+    if (
+      data.status !== "running" ||
+      data.service !== "manager-agent" ||
+      typeof data.fingerprint !== "string" ||
+      typeof data.worker_id !== "string"
+    ) {
+      return undefined;
+    }
+    return {
+      fingerprint: data.fingerprint,
+      processId: typeof data.process_id === "number" && Number.isSafeInteger(data.process_id)
+        ? data.process_id
+        : null,
+      projectId: typeof data.project_id === "string" ? data.project_id : null,
+      workerId: data.worker_id,
+    };
   } catch {
-    return false;
+    return undefined;
   }
+}
+
+async function health(url: string, fingerprint?: string): Promise<boolean> {
+  const details = await healthDetails(url);
+  return Boolean(details && (!fingerprint || details.fingerprint === fingerprint));
 }
 
 async function waitForHealth(url: string, fingerprint: string, timeoutMs: number): Promise<boolean> {
@@ -206,16 +297,89 @@ function enrichPathForGitBash(shellPath: string, env: NodeJS.ProcessEnv): string
   return [binDir, usrBin, env.PATH ?? ""].filter(Boolean).join(path.delimiter);
 }
 
-function stopProcess(record?: { process: ChildProcess }): void {
-  if (!record?.process || record.process.killed) return;
+function processIsRunning(pid: number): boolean {
   try {
-    record.process.kill();
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function stopProcess(record?: RunningHostShellProcess): void {
+  if (!record) return;
+  if (record.process && !record.process.killed) {
+    try {
+      record.process.kill("SIGTERM");
+      return;
+    } catch {
+      // Fall through to the persisted PID.
+    }
+  }
+  if (!processIsRunning(record.processId)) return;
+  try {
+    process.kill(record.processId, "SIGTERM");
   } catch {
     // Best-effort.
   }
 }
 
-export async function ensureHostShellManagerAgent(
+async function waitForFingerprintToStop(url: string, fingerprint: string, timeoutMs = 5_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() <= deadline) {
+    const current = await healthDetails(url);
+    if (!current || current.fingerprint !== fingerprint) return true;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  return false;
+}
+
+async function waitForProcessToStop(pid: number, timeoutMs = 5_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() <= deadline) {
+    if (!processIsRunning(pid)) return true;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return false;
+}
+
+function stateMatchesHealth(
+  state: PersistedHostShellProcess,
+  observed: HostShellHealth,
+  projectId: string | undefined,
+): boolean {
+  return state.port === hostPort(projectId) &&
+    state.processName === processName(projectId) &&
+    state.workerId === workerId(projectId) &&
+    state.projectId === (projectId ?? null) &&
+    state.fingerprint === observed.fingerprint &&
+    observed.workerId === state.workerId &&
+    observed.projectId === state.projectId &&
+    (observed.processId === null || observed.processId === state.pid);
+}
+
+function healthMatchesProject(observed: HostShellHealth, projectId: string | undefined): boolean {
+  return observed.workerId === workerId(projectId) && observed.projectId === (projectId ?? null);
+}
+
+async function stopPersistedProcess(
+  projectId: string | undefined,
+  url: string,
+  state: PersistedHostShellProcess,
+  observed: HostShellHealth,
+): Promise<boolean> {
+  if (!stateMatchesHealth(state, observed, projectId)) return false;
+  stopProcess({ processId: state.pid, fingerprint: state.fingerprint, projectId, url });
+  const [healthStopped, processStopped] = await Promise.all([
+    waitForFingerprintToStop(url, state.fingerprint),
+    waitForProcessToStop(state.pid),
+  ]);
+  const stopped = healthStopped && processStopped;
+  if (stopped) removeRuntimeState(projectId, state);
+  return stopped;
+}
+
+async function ensureHostShellManagerAgentInternal(
   projectId: string | undefined,
   options: HostShellManagerAgentOptions,
 ): Promise<HostShellManagerAgent> {
@@ -253,15 +417,50 @@ export async function ensureHostShellManagerAgent(
   env.HOMERAIL_MANAGER_AGENT_FINGERPRINT = fingerprint;
 
   const existing = running.get(name);
-  if (existing && existing.fingerprint === fingerprint && !existing.process.killed && await health(url, fingerprint)) {
-    return { processId: existing.process.pid ?? null, baseUrl: url, workerId: workerId(projectId), processName: name };
+  if (
+    existing &&
+    existing.fingerprint === fingerprint &&
+    (!existing.process || !existing.process.killed) &&
+    await health(url, fingerprint)
+  ) {
+    return { processId: existing.processId, baseUrl: url, workerId: workerId(projectId), processName: name };
   }
-  if (!existing && await health(url, fingerprint)) {
-    return { processId: null, baseUrl: url, workerId: workerId(projectId), processName: name };
+  const observed = await healthDetails(url);
+  const persisted = readRuntimeState(projectId);
+  if (!existing && observed?.fingerprint === fingerprint && healthMatchesProject(observed, projectId)) {
+    const processId = persisted && stateMatchesHealth(persisted, observed, projectId) ? persisted.pid : observed.processId;
+    if (processId) {
+      const adoptedState: PersistedHostShellProcess = {
+        version: 1,
+        pid: processId,
+        port: hostPort(projectId),
+        fingerprint,
+        processName: name,
+        workerId: workerId(projectId),
+        projectId: projectId ?? null,
+      };
+      writeRuntimeState(projectId, adoptedState);
+      running.set(name, { processId, fingerprint, projectId, url });
+    }
+    return { processId: processId ?? null, baseUrl: url, workerId: workerId(projectId), processName: name };
   }
   if (existing) {
     stopProcess(existing);
     running.delete(name);
+    const [healthStopped, processStopped] = await Promise.all([
+      waitForFingerprintToStop(url, existing.fingerprint),
+      waitForProcessToStop(existing.processId),
+    ]);
+    if (!healthStopped || !processStopped) {
+      throw new Error(`Host-shell Manager Agent process ${existing.processId} did not stop`);
+    }
+    removeRuntimeState(projectId, { pid: existing.processId, fingerprint: existing.fingerprint });
+  } else if (observed) {
+    if (!persisted || !await stopPersistedProcess(projectId, url, persisted, observed)) {
+      throw new Error(
+        `Host-shell Manager Agent port ${hostPort(projectId)} is occupied by an unmanaged or stale process`,
+      );
+    }
   }
 
   const logDir = path.join(getDataRoot(), "logs");
@@ -283,16 +482,81 @@ export async function ensureHostShellManagerAgent(
   fs.closeSync(out);
   fs.closeSync(err);
   child.unref();
-  running.set(name, { process: child, fingerprint });
+  if (!child.pid) {
+    try {
+      child.kill("SIGTERM");
+    } catch {
+      // Best-effort.
+    }
+    throw new Error("Host-shell Manager Agent process did not expose a PID");
+  }
+  const state: PersistedHostShellProcess = {
+    version: 1,
+    pid: child.pid,
+    port: hostPort(projectId),
+    fingerprint,
+    processName: name,
+    workerId: workerId(projectId),
+    projectId: projectId ?? null,
+  };
+  running.set(name, { process: child, processId: child.pid, fingerprint, projectId, url });
+  try {
+    writeRuntimeState(projectId, state);
+  } catch (err) {
+    stopProcess(running.get(name));
+    running.delete(name);
+    throw err;
+  }
+  child.once("exit", () => {
+    if (running.get(name)?.process === child) running.delete(name);
+    removeRuntimeState(projectId, state);
+  });
 
   const healthy = await waitForHealth(url, fingerprint, options.healthTimeoutMs ?? options.startTimeoutMs ?? 15_000);
   if (!healthy) {
-    stopProcess({ process: child });
+    stopProcess({ process: child, processId: child.pid, fingerprint, projectId, url });
     running.delete(name);
+    removeRuntimeState(projectId, state);
     throw new Error("Host-shell Manager Agent did not become healthy");
   }
 
   return { processId: child.pid ?? null, baseUrl: url, workerId: workerId(projectId), processName: name };
+}
+
+export async function ensureHostShellManagerAgent(
+  projectId: string | undefined,
+  options: HostShellManagerAgentOptions,
+): Promise<HostShellManagerAgent> {
+  const name = processName(projectId);
+  const inflight = starting.get(name);
+  if (inflight) return inflight;
+  const promise = ensureHostShellManagerAgentInternal(projectId, options);
+  starting.set(name, promise);
+  try {
+    return await promise;
+  } finally {
+    if (starting.get(name) === promise) starting.delete(name);
+  }
+}
+
+export async function shutdownHostShellManagerAgents(): Promise<void> {
+  const entries = [...running.values()];
+  running.clear();
+  await Promise.all(entries.map(async (record) => {
+    stopProcess(record);
+    const [healthStopped, processStopped] = await Promise.all([
+      waitForFingerprintToStop(record.url, record.fingerprint, 2_000),
+      waitForProcessToStop(record.processId, 2_000),
+    ]);
+    if (healthStopped && processStopped) {
+      removeRuntimeState(record.projectId, { pid: record.processId, fingerprint: record.fingerprint });
+    }
+  }));
+}
+
+export function _forgetHostShellManagerAgentsForTest(): void {
+  running.clear();
+  starting.clear();
 }
 
 export async function forwardChatToHostShellManagerAgent(

--- a/homerail_manager/src/server/host-shell-manager-agent.ts
+++ b/homerail_manager/src/server/host-shell-manager-agent.ts
@@ -43,6 +43,7 @@ interface RunningHostShellProcess {
   processId: number;
   fingerprint: string;
   projectId?: string;
+  stateFile: string;
   url: string;
 }
 
@@ -83,9 +84,9 @@ function runtimeStatePath(projectId?: string): string {
   return path.join(dir, "runtime.json");
 }
 
-function readRuntimeState(projectId?: string): PersistedHostShellProcess | undefined {
+function readRuntimeStateFile(file: string): PersistedHostShellProcess | undefined {
   try {
-    const raw = JSON.parse(fs.readFileSync(runtimeStatePath(projectId), "utf-8")) as Partial<PersistedHostShellProcess>;
+    const raw = JSON.parse(fs.readFileSync(file, "utf-8")) as Partial<PersistedHostShellProcess>;
     if (
       raw.version !== 1 ||
       !Number.isSafeInteger(raw.pid) || Number(raw.pid) <= 0 ||
@@ -103,17 +104,15 @@ function readRuntimeState(projectId?: string): PersistedHostShellProcess | undef
   }
 }
 
-function writeRuntimeState(projectId: string | undefined, state: PersistedHostShellProcess): void {
-  const file = runtimeStatePath(projectId);
+function writeRuntimeState(file: string, state: PersistedHostShellProcess): void {
   const temp = `${file}.${process.pid}.${Date.now()}.tmp`;
   fs.writeFileSync(temp, `${JSON.stringify(state, null, 2)}\n`, { encoding: "utf-8", mode: 0o600 });
   fs.renameSync(temp, file);
 }
 
-function removeRuntimeState(projectId: string | undefined, expected?: Pick<PersistedHostShellProcess, "pid" | "fingerprint">): void {
-  const file = runtimeStatePath(projectId);
+function removeRuntimeState(file: string, expected?: Pick<PersistedHostShellProcess, "pid" | "fingerprint">): void {
   if (expected) {
-    const current = readRuntimeState(projectId);
+    const current = readRuntimeStateFile(file);
     if (!current || current.pid !== expected.pid || current.fingerprint !== expected.fingerprint) return;
   }
   try {
@@ -365,17 +364,18 @@ function healthMatchesProject(observed: HostShellHealth, projectId: string | und
 async function stopPersistedProcess(
   projectId: string | undefined,
   url: string,
+  stateFile: string,
   state: PersistedHostShellProcess,
   observed: HostShellHealth,
 ): Promise<boolean> {
   if (!stateMatchesHealth(state, observed, projectId)) return false;
-  stopProcess({ processId: state.pid, fingerprint: state.fingerprint, projectId, url });
+  stopProcess({ processId: state.pid, fingerprint: state.fingerprint, projectId, stateFile, url });
   const [healthStopped, processStopped] = await Promise.all([
     waitForFingerprintToStop(url, state.fingerprint),
     waitForProcessToStop(state.pid),
   ]);
   const stopped = healthStopped && processStopped;
-  if (stopped) removeRuntimeState(projectId, state);
+  if (stopped) removeRuntimeState(stateFile, state);
   return stopped;
 }
 
@@ -393,6 +393,7 @@ async function ensureHostShellManagerAgentInternal(
   const processCwd = projectWorkspace ?? prepareHostWorkspace(projectId);
   const resolvedManagerRestUrl = managerRestUrl(options);
   const url = baseUrl(projectId);
+  const stateFile = runtimeStatePath(projectId);
   const env: Record<string, string> = {
     MANAGER_AGENT_MODE: "1",
     MANAGER_AGENT_PORT: String(hostPort(projectId)),
@@ -426,7 +427,7 @@ async function ensureHostShellManagerAgentInternal(
     return { processId: existing.processId, baseUrl: url, workerId: workerId(projectId), processName: name };
   }
   const observed = await healthDetails(url);
-  const persisted = readRuntimeState(projectId);
+  const persisted = readRuntimeStateFile(stateFile);
   if (!existing && observed?.fingerprint === fingerprint && healthMatchesProject(observed, projectId)) {
     const processId = persisted && stateMatchesHealth(persisted, observed, projectId) ? persisted.pid : observed.processId;
     if (processId) {
@@ -439,8 +440,8 @@ async function ensureHostShellManagerAgentInternal(
         workerId: workerId(projectId),
         projectId: projectId ?? null,
       };
-      writeRuntimeState(projectId, adoptedState);
-      running.set(name, { processId, fingerprint, projectId, url });
+      writeRuntimeState(stateFile, adoptedState);
+      running.set(name, { processId, fingerprint, projectId, stateFile, url });
     }
     return { processId: processId ?? null, baseUrl: url, workerId: workerId(projectId), processName: name };
   }
@@ -454,9 +455,9 @@ async function ensureHostShellManagerAgentInternal(
     if (!healthStopped || !processStopped) {
       throw new Error(`Host-shell Manager Agent process ${existing.processId} did not stop`);
     }
-    removeRuntimeState(projectId, { pid: existing.processId, fingerprint: existing.fingerprint });
+    removeRuntimeState(stateFile, { pid: existing.processId, fingerprint: existing.fingerprint });
   } else if (observed) {
-    if (!persisted || !await stopPersistedProcess(projectId, url, persisted, observed)) {
+    if (!persisted || !await stopPersistedProcess(projectId, url, stateFile, persisted, observed)) {
       throw new Error(
         `Host-shell Manager Agent port ${hostPort(projectId)} is occupied by an unmanaged or stale process`,
       );
@@ -499,9 +500,9 @@ async function ensureHostShellManagerAgentInternal(
     workerId: workerId(projectId),
     projectId: projectId ?? null,
   };
-  running.set(name, { process: child, processId: child.pid, fingerprint, projectId, url });
+  running.set(name, { process: child, processId: child.pid, fingerprint, projectId, stateFile, url });
   try {
-    writeRuntimeState(projectId, state);
+    writeRuntimeState(stateFile, state);
   } catch (err) {
     stopProcess(running.get(name));
     running.delete(name);
@@ -509,14 +510,14 @@ async function ensureHostShellManagerAgentInternal(
   }
   child.once("exit", () => {
     if (running.get(name)?.process === child) running.delete(name);
-    removeRuntimeState(projectId, state);
+    removeRuntimeState(stateFile, state);
   });
 
   const healthy = await waitForHealth(url, fingerprint, options.healthTimeoutMs ?? options.startTimeoutMs ?? 15_000);
   if (!healthy) {
-    stopProcess({ process: child, processId: child.pid, fingerprint, projectId, url });
+    stopProcess({ process: child, processId: child.pid, fingerprint, projectId, stateFile, url });
     running.delete(name);
-    removeRuntimeState(projectId, state);
+    removeRuntimeState(stateFile, state);
     throw new Error("Host-shell Manager Agent did not become healthy");
   }
 
@@ -549,7 +550,7 @@ export async function shutdownHostShellManagerAgents(): Promise<void> {
       waitForProcessToStop(record.processId, 2_000),
     ]);
     if (healthStopped && processStopped) {
-      removeRuntimeState(record.projectId, { pid: record.processId, fingerprint: record.fingerprint });
+      removeRuntimeState(record.stateFile, { pid: record.processId, fingerprint: record.fingerprint });
     }
   }));
 }

--- a/homerail_manager/src/server/manager-agent-runtime.ts
+++ b/homerail_manager/src/server/manager-agent-runtime.ts
@@ -9,6 +9,7 @@ import {
   forwardChatToHostShellManagerAgent,
 } from "./host-shell-manager-agent.js";
 import {
+  HostCodexManagerAgentExecutionError,
   loadVoiceSystemContract,
   runHostCodexManagerAgentTurn,
   runHostCodexManagerAgentTurnStream,
@@ -108,7 +109,11 @@ export async function runManagerAgentTurn(
         "manager_chat_error",
         err instanceof Error ? err.message : String(err),
         runtimePlacement,
-        { worker_id: "host-codex", project_id: input.project_id ?? null },
+        {
+          worker_id: "host-codex",
+          project_id: input.project_id ?? null,
+          ...(err instanceof HostCodexManagerAgentExecutionError ? err.data : {}),
+        },
       );
     }
   }
@@ -256,7 +261,11 @@ export async function* runManagerAgentTurnStream(
       "manager_chat_error",
       err instanceof Error ? err.message : String(err),
       runtimePlacement,
-      { worker_id: "host-codex", project_id: input.project_id ?? null },
+      {
+        worker_id: "host-codex",
+        project_id: input.project_id ?? null,
+        ...(err instanceof HostCodexManagerAgentExecutionError ? err.data : {}),
+      },
     );
   }
 }

--- a/homerail_manager/src/server/mutations.ts
+++ b/homerail_manager/src/server/mutations.ts
@@ -299,6 +299,7 @@ export function mutationRoutesHandler(
           text: reply,
           tool_calls: Array.isArray(result.tool_calls) ? result.tool_calls : [],
           tool_results: Array.isArray(result.tool_results) ? result.tool_results : [],
+          agent_errors: Array.isArray(result.agent_errors) ? result.agent_errors : [],
           run_id: runId,
           run_ids: Array.isArray(result.run_ids) ? result.run_ids : runId ? [runId] : [],
           session_id: sessionId,

--- a/homerail_manager/src/server/voice-agent-bootstrap.ts
+++ b/homerail_manager/src/server/voice-agent-bootstrap.ts
@@ -1094,6 +1094,12 @@ async function submitVoiceWorkspaceToManagerAgent(
     .map((item) => shortText(String(item || "").trim(), 120))
     .filter((item) => item && !alreadyStreamed.has(item))
     .slice(0, 6);
+  const agentErrors = Array.isArray(result.agent_errors)
+    ? result.agent_errors.map((item) => shortText(String(item || "").trim(), 500)).filter(Boolean).slice(0, 10)
+    : [];
+  for (const error of agentErrors) {
+    appendDebugEvent(workspace, "manager_agent_warning", error, "warning");
+  }
   const runId = typeof result.run_id === "string" && result.run_id.trim() ? result.run_id.trim() : undefined;
   const runIds = Array.isArray(result.run_ids)
     ? result.run_ids.map((item) => String(item || "").trim()).filter(Boolean)
@@ -1143,6 +1149,7 @@ async function submitVoiceWorkspaceToManagerAgent(
       effective_config: objectValue(result.effective_config) ?? null,
       tool_calls: Array.isArray(result.tool_calls) ? result.tool_calls : [],
       tool_results: Array.isArray(result.tool_results) ? result.tool_results : [],
+      agent_errors: agentErrors,
     },
     manager_status: managerStatus(workspace),
   };

--- a/homerail_manager/src/server/voice-agent-bootstrap.ts
+++ b/homerail_manager/src/server/voice-agent-bootstrap.ts
@@ -113,7 +113,14 @@ interface VoiceWorkspace {
   } | null;
   pending_confirmations: Array<{ id: string; kind: "submit_task" | "memory_write"; summary: string }>;
   memory_refs: Array<{ id: string; title: string; summary: string; source: string }>;
-  conversation: Array<{ id: string; role: "user" | "assistant" | "system"; text: string; created_at: string; channel?: "final" | "commentary" }>;
+  conversation: Array<{
+    id: string;
+    role: "user" | "assistant" | "system";
+    text: string;
+    created_at: string;
+    channel?: "final" | "commentary";
+    kind?: "message" | "error";
+  }>;
   debug_events: Array<{ id: string; level: "debug" | "info" | "warning" | "error"; code: string; message: string; created_at: string }>;
   progress_brief: { status: string; short_text: string; updated_at: string };
   widgets: VoiceWidget[];
@@ -729,8 +736,14 @@ function sessionItem(workspace: VoiceWorkspace): Record<string, unknown> {
   };
 }
 
-function appendConversation(workspace: VoiceWorkspace, role: "user" | "assistant" | "system", text: string, channel: "final" | "commentary" = "final") {
-  workspace.conversation.push({ id: generateId("msg-"), role, text, channel, created_at: now() });
+function appendConversation(
+  workspace: VoiceWorkspace,
+  role: "user" | "assistant" | "system",
+  text: string,
+  channel: "final" | "commentary" = "final",
+  kind: "message" | "error" = "message",
+) {
+  workspace.conversation.push({ id: generateId("msg-"), role, text, channel, kind, created_at: now() });
   workspace.conversation = workspace.conversation.slice(-80);
 }
 
@@ -979,14 +992,14 @@ function managerAgentHistory(workspace: VoiceWorkspace): Array<{ role: string; c
 
 function markManagerAgentBlocker(workspace: VoiceWorkspace, code: string, message: string): ManagerAgentHandoffResult {
   appendDebugEvent(workspace, code, message, "error");
-  const spoken = code === "manager_agent_unavailable"
+  const displayText = code === "manager_agent_unavailable"
     ? `主 Agent 执行入口不可用：${message}`
     : `主 Agent 执行失败：${message}`;
-  workspace.progress_brief = { status: "error", short_text: shortText(spoken, 80), updated_at: now() };
+  workspace.progress_brief = { status: "error", short_text: shortText(displayText, 80), updated_at: now() };
   removeWidget(workspace, "manager-agent-blocker");
   removeWidget(workspace, "manager-run");
-  appendConversation(workspace, "assistant", spoken);
-  return { spoken_text: spoken, suggested_action: null, manager: { error: message, code }, manager_status: managerStatus(workspace) };
+  appendConversation(workspace, "assistant", displayText, "final", "error");
+  return { spoken_text: "", suggested_action: null, manager: { error: message, code }, manager_status: managerStatus(workspace) };
 }
 
 async function submitVoiceWorkspaceToManagerAgent(

--- a/homerail_manager/tests/agent-runtime-resolver.test.ts
+++ b/homerail_manager/tests/agent-runtime-resolver.test.ts
@@ -86,8 +86,8 @@ describe("agent runtime resolver", () => {
 
     for (const resolved of [manager, dag]) {
       expect(resolved).toMatchObject({
-        provider_name: "kimi",
-        model: "kimi-k2.7-code",
+        provider_name: "kimi_cn",
+        model: "kimi-for-coding",
         api_key: "pk-test-kimi",
         base_url: "https://api.kimi.com/coding/v1",
         protocol: "openai_compatible",
@@ -113,8 +113,8 @@ describe("agent runtime resolver", () => {
     const resolved = resolveAgentRuntimeConfig({ surface: "dag" });
 
     expect(resolved).toMatchObject({
-      provider_name: "kimi",
-      model: "kimi-k2.7-code",
+      provider_name: "kimi_cn",
+      model: "kimi-for-coding",
       api_key: "pk-test-kimi",
       base_url: "https://api.kimi.com/coding/v1",
       protocol: "openai_compatible",
@@ -143,8 +143,8 @@ describe("agent runtime resolver", () => {
     });
 
     expect(resolved).toMatchObject({
-      provider_name: "kimi",
-      model: "kimi-k2.7-code",
+      provider_name: "kimi_cn",
+      model: "kimi-for-coding",
       api_key: "pk-test-kimi",
       base_url: "https://api.kimi.com/coding",
       protocol: "anthropic_compatible",

--- a/homerail_manager/tests/dispatch-capabilities.test.ts
+++ b/homerail_manager/tests/dispatch-capabilities.test.ts
@@ -616,8 +616,8 @@ nodes:
     expect(envelope.agentConfig).toMatchObject({
       agent_type: "kimi_code",
       llm: {
-        provider: "kimi",
-        model: "kimi-k2.7-code",
+        provider: "kimi_cn",
+        model: "kimi-for-coding",
         api_key: "test-kimi-key",
         base_url: "https://api.kimi.com/coding/v1",
         protocol: "openai_compatible",

--- a/homerail_manager/tests/host-shell-manager-agent.test.ts
+++ b/homerail_manager/tests/host-shell-manager-agent.test.ts
@@ -1,16 +1,101 @@
 import * as fs from "node:fs";
+import * as net from "node:net";
 import * as os from "node:os";
 import * as path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { _hostShellWorkerEntryFingerprintForTest } from "../src/server/host-shell-manager-agent.js";
+import {
+  _forgetHostShellManagerAgentsForTest,
+  _hostShellWorkerEntryFingerprintForTest,
+  ensureHostShellManagerAgent,
+  shutdownHostShellManagerAgents,
+} from "../src/server/host-shell-manager-agent.js";
+
+async function availablePort(): Promise<number> {
+  const server = net.createServer();
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("failed to allocate test port");
+  await new Promise<void>((resolve, reject) => server.close((err) => err ? reject(err) : resolve()));
+  return address.port;
+}
+
+function writeFakeWorker(entry: string, marker: string): void {
+  fs.writeFileSync(entry, `
+    // ${marker}
+    const http = require('node:http');
+    const port = Number(process.env.MANAGER_AGENT_PORT || '0');
+    const server = http.createServer((req, res) => {
+      if (req.method === 'GET' && req.url === '/health') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          status: 'running',
+          service: 'manager-agent',
+          fingerprint: process.env.HOMERAIL_MANAGER_AGENT_FINGERPRINT,
+          process_id: process.pid,
+          project_id: process.env.PROJECT_ID || null,
+          worker_id: process.env.HOMERAIL_WORKER_ID,
+        }));
+        return;
+      }
+      res.writeHead(404).end();
+    });
+    setTimeout(() => server.listen(port, '127.0.0.1'), 100);
+  `, "utf-8");
+}
+
+function processIsRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForProcessToStop(pid: number): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() <= deadline && processIsRunning(pid)) {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}
 
 describe("host-shell Manager Agent worker fingerprint", () => {
   let tmpDir: string | undefined;
+  let oldHome: string | undefined;
+  let oldPort: string | undefined;
+  let oldEntry: string | undefined;
+  let oldShell: string | undefined;
+  let oldWorkspace: string | undefined;
 
-  afterEach(() => {
+  beforeEach(async () => {
+    oldHome = process.env.HOMERAIL_HOME;
+    oldPort = process.env.HOMERAIL_MANAGER_AGENT_HOST_PORT;
+    oldEntry = process.env.HOMERAIL_MANAGER_AGENT_HOST_ENTRY;
+    oldShell = process.env.HOMERAIL_MANAGER_AGENT_SHELL;
+    oldWorkspace = process.env.HOMERAIL_PROJECT_WORKSPACE;
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-host-shell-"));
+    process.env.HOMERAIL_HOME = tmpDir;
+    process.env.HOMERAIL_MANAGER_AGENT_HOST_PORT = String(await availablePort());
+    process.env.HOMERAIL_MANAGER_AGENT_SHELL = process.platform === "win32" ? process.execPath : "/bin/sh";
+    process.env.HOMERAIL_PROJECT_WORKSPACE = tmpDir;
+  });
+
+  afterEach(async () => {
+    await shutdownHostShellManagerAgents();
+    _forgetHostShellManagerAgentsForTest();
     if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
     tmpDir = undefined;
+    if (oldHome === undefined) delete process.env.HOMERAIL_HOME;
+    else process.env.HOMERAIL_HOME = oldHome;
+    if (oldPort === undefined) delete process.env.HOMERAIL_MANAGER_AGENT_HOST_PORT;
+    else process.env.HOMERAIL_MANAGER_AGENT_HOST_PORT = oldPort;
+    if (oldEntry === undefined) delete process.env.HOMERAIL_MANAGER_AGENT_HOST_ENTRY;
+    else process.env.HOMERAIL_MANAGER_AGENT_HOST_ENTRY = oldEntry;
+    if (oldShell === undefined) delete process.env.HOMERAIL_MANAGER_AGENT_SHELL;
+    else process.env.HOMERAIL_MANAGER_AGENT_SHELL = oldShell;
+    if (oldWorkspace === undefined) delete process.env.HOMERAIL_PROJECT_WORKSPACE;
+    else process.env.HOMERAIL_PROJECT_WORKSPACE = oldWorkspace;
   });
 
   it("changes when the worker entry build artifact changes", () => {
@@ -25,5 +110,45 @@ describe("host-shell Manager Agent worker fingerprint", () => {
     expect(first.path).toBe(path.resolve(entry));
     expect(second.path).toBe(path.resolve(entry));
     expect(second).not.toEqual(first);
+  });
+
+  it("coalesces concurrent starts for the same project", async () => {
+    const entry = path.join(tmpDir!, "fake-worker.cjs");
+    writeFakeWorker(entry, "concurrent start");
+    process.env.HOMERAIL_MANAGER_AGENT_HOST_ENTRY = entry;
+    const options = { managerRestUrl: "http://127.0.0.1:19191", healthTimeoutMs: 5_000 };
+
+    const [first, second] = await Promise.all([
+      ensureHostShellManagerAgent(undefined, options),
+      ensureHostShellManagerAgent(undefined, options),
+    ]);
+
+    expect(first.processId).toBeTypeOf("number");
+    expect(second.processId).toBe(first.processId);
+  });
+
+  it("reclaims a persisted process when the Manager restarts with a new worker build", async () => {
+    const entry = path.join(tmpDir!, "fake-worker.cjs");
+    writeFakeWorker(entry, "first worker build");
+    process.env.HOMERAIL_MANAGER_AGENT_HOST_ENTRY = entry;
+    const options = { managerRestUrl: "http://127.0.0.1:19191", healthTimeoutMs: 5_000 };
+
+    const first = await ensureHostShellManagerAgent(undefined, options);
+    expect(first.processId).toBeTypeOf("number");
+    _forgetHostShellManagerAgentsForTest();
+    writeFakeWorker(entry, "second worker build with a different artifact size");
+
+    const second = await ensureHostShellManagerAgent(undefined, options);
+
+    expect(second.processId).toBeTypeOf("number");
+    expect(second.processId).not.toBe(first.processId);
+    await waitForProcessToStop(first.processId!);
+    expect(processIsRunning(first.processId!)).toBe(false);
+    const state = JSON.parse(fs.readFileSync(
+      path.join(tmpDir!, "manager", "manager-agents-host", "__default__", "runtime.json"),
+      "utf-8",
+    )) as { pid: number; fingerprint: string };
+    expect(state.pid).toBe(second.processId);
+    expect(state.fingerprint).toMatch(/^[a-f0-9]{16}$/);
   });
 });

--- a/homerail_manager/tests/llm-providers.test.ts
+++ b/homerail_manager/tests/llm-providers.test.ts
@@ -6,8 +6,10 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   _clearAllSettings,
+  createSetting,
   findActiveClaudeSdkCompatibleSetting,
   findActiveSetting,
+  listProviders,
   listSettings,
   resolveClaudeSdkBaseUrlForSetting,
   updateSetting,
@@ -41,6 +43,47 @@ describe("custom LLM providers", () => {
     process.env.HOMERAIL_HOME = tmpHome;
     _clearAllSettings();
     server = createServer(0, undefined, undefined, false);
+  });
+
+  it("separates Kimi CN and international credentials and migrates the legacy Coding Plan", () => {
+    const providers = listProviders();
+    const kimiCn = providers.find((provider) => provider.id === "kimi_cn");
+    const kimiInternational = providers.find((provider) => provider.id === "kimi");
+
+    expect(kimiCn).toMatchObject({
+      name: "Kimi / Moonshot CN",
+      base_url: "https://api.moonshot.cn/v1",
+    });
+    expect(kimiCn?.endpoints).toContainEqual(expect.objectContaining({
+      id: "kimi_cn_api",
+      base_url: "https://api.moonshot.cn/v1",
+      default_model: "kimi-k2.7-code",
+    }));
+    expect(kimiCn?.endpoints).toContainEqual(expect.objectContaining({
+      id: "kimi_coding_plan",
+      base_url: "https://api.kimi.com/coding/v1",
+      default_model: "kimi-for-coding",
+    }));
+    expect(kimiInternational).toMatchObject({
+      name: "Kimi / Moonshot",
+      base_url: "https://api.moonshot.ai/v1",
+    });
+    expect(kimiInternational?.endpoints).toHaveLength(1);
+
+    const migrated = createSetting({
+      provider_id: "kimi",
+      endpoint_id: "kimi_coding_plan",
+      model_name: "kimi-k2.7-code",
+      api_key: "pk-legacy-kimi-coding-plan",
+      is_active: true,
+      is_default: true,
+    });
+    expect(migrated).toMatchObject({
+      provider_id: "kimi_cn",
+      endpoint_id: "kimi_coding_plan",
+      model_name: "kimi-for-coding",
+      base_url: "https://api.kimi.com/coding/v1",
+    });
   });
 
   afterEach(async () => {

--- a/homerail_manager/tests/manager-chat.test.ts
+++ b/homerail_manager/tests/manager-chat.test.ts
@@ -22,6 +22,7 @@ import {
   _loadVoiceUiRulesForTest,
   _managerRestUrlForTest,
   _renderVoiceMemoForTest,
+  _setHostCodexAgentEventRunnerForTest,
   _setHostCodexManagerAgentRunnerForTest,
   _systemPromptForTest,
   _voiceMemoPathForTest,
@@ -97,6 +98,7 @@ describe("/api/manager/chat", () => {
     _clearAllSessions();
     _clearNodes();
     clearLlmSettings();
+    _setHostCodexAgentEventRunnerForTest();
     _setHostCodexManagerAgentRunnerForTest();
     await close(server);
     if (oldHome === undefined) delete process.env.HOMERAIL_HOME;
@@ -1001,6 +1003,7 @@ describe("/api/manager/chat", () => {
         objective: { required: false, satisfied: true, tool_calls: [] },
         tool_calls: [],
         tool_results: [],
+        agent_errors: ["harness stream ended after completing the response"],
         worker_id: "host-codex",
         container_name: null,
       };
@@ -1025,6 +1028,7 @@ describe("/api/manager/chat", () => {
         text: string;
         worker_id: string;
         container_name: string | null;
+        agent_errors: string[];
         runtime_placement: string;
         manager_agent_config: { agent_type: string; runtime_placement: string };
       };
@@ -1035,6 +1039,7 @@ describe("/api/manager/chat", () => {
     expect(body.data.text).toBe("host codex handled");
     expect(body.data.worker_id).toBe("host-codex");
     expect(body.data.container_name).toBeNull();
+    expect(body.data.agent_errors).toEqual(["harness stream ended after completing the response"]);
     expect(body.data.runtime_placement).toBe("host");
     expect(body.data.manager_agent_config.agent_type).toBe("codex_appserver");
     expect(body.data.manager_agent_config.runtime_placement).toBe("host");
@@ -1044,6 +1049,45 @@ describe("/api/manager/chat", () => {
       id: "homerail-dag-patterns",
       source: "home",
     }));
+  });
+
+  it("returns host Codex harness failures as structured errors instead of assistant text", async () => {
+    _setHostCodexAgentEventRunnerForTest(async function* () {
+      yield { type: "error", message: "provider rejected the configured credential" };
+      yield { type: "done" };
+    });
+    const port = await listen(server);
+    const baseUrl = `http://127.0.0.1:${port}`;
+    const saved = await fetch(`${baseUrl}/api/manager-agent/config`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ harness: "codex_appserver", model_name: "gpt-5.5" }),
+    });
+    expect(saved.status).toBe(200);
+
+    const response = await fetch(`${baseUrl}/api/manager/chat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "hello", project_id: "p-host-codex-error" }),
+    });
+    const body = await response.json() as {
+      success: boolean;
+      error?: string;
+      data?: Record<string, unknown>;
+    };
+
+    expect(response.status).toBe(503);
+    expect(body.success).toBe(false);
+    expect(body.error).toContain("Host Codex Manager Agent 响应错误");
+    expect(body.data).toMatchObject({
+      code: "agent_execution_failed",
+      errors: ["provider rejected the configured credential"],
+      observed_tool_calls: [],
+      run_ids: [],
+      worker_id: "host-codex",
+      project_id: "p-host-codex-error",
+    });
+    expect(JSON.stringify(body)).not.toContain("[ERROR]");
   });
 
   it("normalizes container-only manager URLs for host Codex tools", () => {

--- a/homerail_manager/tests/manager-chat.test.ts
+++ b/homerail_manager/tests/manager-chat.test.ts
@@ -614,6 +614,8 @@ describe("/api/manager/chat", () => {
     expect(config.agent_type).toBe("kimi_code");
     expect(config.runtime_placement).toBe("container");
     expect(config.base_url).toBe("https://api.kimi.com/coding/v1");
+    expect(config.provider_name).toBe("kimi_cn");
+    expect(config.model).toBe("kimi-for-coding");
   });
 
   it("resolves explicit kimi_code harness against the active Kimi setting", () => {
@@ -631,8 +633,8 @@ describe("/api/manager/chat", () => {
     const config = resolveManagerAgentConfig(undefined, undefined, undefined, undefined, "kimi_code");
 
     expect(config).toMatchObject({
-      provider_name: "kimi",
-      model: "kimi-k2.7-code",
+      provider_name: "kimi_cn",
+      model: "kimi-for-coding",
       agent_type: "kimi_code",
       runtime_placement: "container",
       base_url: "https://api.kimi.com/coding/v1",
@@ -948,8 +950,8 @@ describe("/api/manager/chat", () => {
     expect(body.data).toMatchObject({
       harness: "kimi_code",
       llm_setting_id: setting.id,
-      provider_name: "kimi",
-      model_name: "kimi-k2.7-code",
+      provider_name: "kimi_cn",
+      model_name: "kimi-for-coding",
     });
   });
 
@@ -979,7 +981,7 @@ describe("/api/manager/chat", () => {
     expect(saved.status).toBe(200);
     expect(body.data).toMatchObject({
       harness: "claude_agent_sdk",
-      provider_name: "kimi",
+      provider_name: "kimi_cn",
     });
   });
 

--- a/homerail_manager/tests/voice-bootstrap.test.ts
+++ b/homerail_manager/tests/voice-bootstrap.test.ts
@@ -17,6 +17,7 @@ import {
   parseArkVoicePacket,
 } from "../src/server/ark-voice.js";
 import {
+  _setHostCodexAgentEventRunnerForTest,
   _setHostCodexManagerAgentRunnerForTest,
   _setHostCodexManagerAgentStreamRunnerForTest,
 } from "../src/server/host-codex-manager-agent.js";
@@ -110,6 +111,7 @@ describe("voice bootstrap routes", () => {
     _clearStoredVoiceSettings();
     _clearAllSettings();
     _clearNodes();
+    _setHostCodexAgentEventRunnerForTest();
     _setHostCodexManagerAgentRunnerForTest();
     _setHostCodexManagerAgentStreamRunnerForTest();
     await close(server);
@@ -1491,6 +1493,7 @@ describe("voice bootstrap routes", () => {
       objective: { required: false, satisfied: true, tool_calls: [{ name: "create_and_run", success: true }] },
       tool_calls: [{ id: "tool-1", name: "create_and_run", input: { yamlPath: "assets/orchestrations/test.yaml" } }],
       tool_results: [{ tool_use_id: "tool-1", content: "ok" }],
+      agent_errors: ["harness stream ended after the run was created"],
       commentary_texts: ["正在调用 Manager tools。"],
       worker_id: "host-codex",
       container_name: null,
@@ -1526,7 +1529,7 @@ describe("voice bootstrap routes", () => {
           debug_events: Array<{ code: string }>;
           progress_brief: { status: string };
         };
-        manager: { code?: string; run_ids?: string[]; text?: string };
+        manager: { code?: string; run_ids?: string[]; text?: string; agent_errors?: string[] };
       };
     };
 
@@ -1535,6 +1538,7 @@ describe("voice bootstrap routes", () => {
     expect(body.data.suggested_action).toBeNull();
     expect(body.data.manager.code).toBeUndefined();
     expect(body.data.manager.run_ids).toEqual(["run-host-codex"]);
+    expect(body.data.manager.agent_errors).toEqual(["harness stream ended after the run was created"]);
     expect(body.data.workspace.task_draft).toBeNull();
     expect(body.data.workspace.pending_confirmations).toHaveLength(0);
     expect(body.data.workspace.conversation).toContainEqual(expect.objectContaining({
@@ -1543,8 +1547,58 @@ describe("voice bootstrap routes", () => {
       channel: "commentary",
     }));
     expect(body.data.workspace.progress_brief.status).toBe("done");
+    expect(body.data.workspace.debug_events).toContainEqual(expect.objectContaining({ code: "manager_agent_warning" }));
     expect(body.data.workspace.widgets).not.toContainEqual(expect.objectContaining({ id: "manager-run" }));
     expect(body.data.workspace.widgets).not.toContainEqual(expect.objectContaining({ id: "manager-agent-blocker" }));
+  });
+
+  it("renders host Codex harness failures as silent error messages", async () => {
+    _setHostCodexAgentEventRunnerForTest(async function* () {
+      yield { type: "error", message: "provider rejected the configured credential" };
+      yield { type: "done" };
+    });
+    const port = await listen(server);
+    const baseUrl = `http://127.0.0.1:${port}`;
+
+    await fetch(`${baseUrl}/api/voice-agent/config`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ harness: "codex_appserver", model_name: "gpt-5.5", reasoning_effort: "low" }),
+    });
+    const created = await fetch(`${baseUrl}/api/voice-agent/sessions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+    const createdBody = await created.json() as { data: { session_id: string } };
+    const turn = await fetch(`${baseUrl}/api/voice-agent/sessions/${createdBody.data.session_id}/turn`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: "hello" }),
+    });
+    const body = await turn.json() as {
+      data: {
+        spoken_text: string;
+        voice_events: Array<{ channel: string; text: string }>;
+        manager: { code?: string; error?: string };
+        workspace: {
+          progress_brief: { status: string };
+          conversation: Array<{ role: string; kind?: string; text: string }>;
+        };
+      };
+    };
+
+    expect(turn.status).toBe(200);
+    expect(body.data.spoken_text).toBe("");
+    expect(body.data.voice_events).toEqual([]);
+    expect(body.data.manager.code).toBe("manager_chat_error");
+    expect(body.data.workspace.progress_brief.status).toBe("error");
+    expect(body.data.workspace.conversation).toContainEqual(expect.objectContaining({
+      role: "assistant",
+      kind: "error",
+      text: expect.stringContaining("主 Agent 执行失败"),
+    }));
+    expect(JSON.stringify(body)).not.toContain("[ERROR]");
   });
 
   it("routes non-Codex voice turns through the same Manager Agent container path", async () => {

--- a/homerail_manager/tests/voice-bootstrap.test.ts
+++ b/homerail_manager/tests/voice-bootstrap.test.ts
@@ -438,19 +438,27 @@ describe("voice bootstrap routes", () => {
           progress_brief: { status: string };
           debug_events: Array<{ code: string }>;
           widgets: Array<{ id: string }>;
+          conversation: Array<{ role: string; text: string; kind?: string }>;
         };
+        voice_events: Array<{ channel: string; text: string }>;
       };
     };
 
     expect(turn.status).toBe(200);
     expect(turnBody.success).toBe(true);
     expect(turnBody.data.suggested_action).toBeNull();
-    expect(turnBody.data.spoken_text).toContain("主 Agent 执行入口不可用");
+    expect(turnBody.data.spoken_text).toBe("");
+    expect(turnBody.data.voice_events).toEqual([]);
     expect(turnBody.data.workspace.pending_confirmations).toHaveLength(0);
     expect(turnBody.data.workspace.progress_brief.status).toBe("error");
     expect(turnBody.data.workspace.debug_events).toContainEqual(expect.objectContaining({ code: "manager_agent_unavailable" }));
     expect(turnBody.data.workspace.widgets).not.toContainEqual(expect.objectContaining({ id: "manager-agent-blocker" }));
     expect(turnBody.data.workspace.widgets).not.toContainEqual(expect.objectContaining({ id: "manager-run" }));
+    expect(turnBody.data.workspace.conversation).toContainEqual(expect.objectContaining({
+      role: "assistant",
+      kind: "error",
+      text: expect.stringContaining("主 Agent 执行入口不可用"),
+    }));
 
     const titledList = await fetch(`http://127.0.0.1:${port}/api/voice-agent/sessions?project_id=p1&limit=5`);
     const titledListBody = await titledList.json() as { data: { sessions: Array<{ session_id: string; title?: string | null }> } };
@@ -477,7 +485,7 @@ describe("voice bootstrap routes", () => {
     const confirmBody = await confirm.json() as { success: boolean; data: { spoken_text: string; manager: { code?: string } } };
     expect(confirm.status).toBe(200);
     expect(confirmBody.success).toBe(true);
-    expect(confirmBody.data.spoken_text).toContain("主 Agent 执行入口不可用");
+    expect(confirmBody.data.spoken_text).toBe("");
     expect(confirmBody.data.manager.code).toBe("manager_agent_unavailable");
   });
 
@@ -920,12 +928,23 @@ describe("voice bootstrap routes", () => {
       body: JSON.stringify({ text: "请回复收到，别执行任何操作。" }),
     });
     const streamText = await stream.text();
+    const streamEvents = streamText.trim().split("\n").map((line) => JSON.parse(line) as Record<string, unknown>);
     const row = getDb()
       .prepare("SELECT status, message_count FROM sessions WHERE session_id = ?")
       .get(createdBody.data.session_id) as { status: string; message_count: number };
 
     expect(stream.status).toBe(200);
     expect(streamText).toContain("主 Agent 执行失败");
+    expect(streamEvents).not.toContainEqual(expect.objectContaining({ type: "speech" }));
+    expect(streamEvents).toContainEqual(expect.objectContaining({ type: "done", spoken_text: "" }));
+    expect(streamEvents).toContainEqual(expect.objectContaining({
+      type: "workspace",
+      workspace: expect.objectContaining({
+        conversation: expect.arrayContaining([
+          expect.objectContaining({ kind: "error", text: expect.stringContaining("主 Agent 执行失败") }),
+        ]),
+      }),
+    }));
     expect(streamText).not.toContain("Invalid session status: error");
     expect(row.status).toBe("failed");
     expect(row.message_count).toBe(2);

--- a/homerail_worker/src/__tests__/kimi-code.test.ts
+++ b/homerail_worker/src/__tests__/kimi-code.test.ts
@@ -282,6 +282,7 @@ describe("KimiCodeAdapter", () => {
       });
 
       expect(config).toContain('default_model = "kimi-for-coding"');
+      expect(config).toContain('default_thinking = true');
       expect(config).toContain('default_provider = "kimi-fast"');
       expect(config).toContain('[providers."kimi-fast"]');
       expect(config).toContain('type = "kimi"');
@@ -290,6 +291,20 @@ describe("KimiCodeAdapter", () => {
       expect(config).toContain('[models."kimi-for-coding"]');
       expect(config).toContain('provider = "kimi-fast"');
       expect(config).toContain('max_context_size = 128000');
+      expect(config).toContain('capabilities = [ "thinking", "always_thinking", "image_in", "video_in", "tool_use" ]');
+    });
+
+    it("does not force always-thinking capabilities for unrelated custom models", () => {
+      const config = adapter.buildKimiConfig({
+        ...ctx,
+        provider: "custom-openai",
+        model: "custom-chat-model",
+        apiKey: "pk-test-secret",
+        baseUrl: "https://example.com/v1",
+      });
+
+      expect(config).not.toContain("default_thinking");
+      expect(config).not.toContain("always_thinking");
     });
   });
 

--- a/homerail_worker/src/__tests__/manager-agent-server.test.ts
+++ b/homerail_worker/src/__tests__/manager-agent-server.test.ts
@@ -168,6 +168,29 @@ class ErrorAgent implements AgentClient {
   }
 }
 
+class ObjectiveSuccessWithErrorAgent implements AgentClient {
+  async *run(
+    _prompt: string,
+    tools: DagToolDefinition[],
+    _context: AgentRunContext,
+  ): AsyncIterable<AgentEvent> {
+    const tool = tools.find((item) => item.name === "create_and_run");
+    if (!tool) throw new Error("create_and_run tool missing");
+    const input = { workflow_id: "public-two-node-template", profile: "offline-deterministic" };
+    yield { type: "tool_use", id: "tool-1", name: "create_and_run", input };
+    const result = await tool.handler(input);
+    yield {
+      type: "tool_result",
+      tool_use_id: "tool-1",
+      content: result.content.map((item) => item.text).join(""),
+      is_error: result.is_error,
+    };
+    yield { type: "text", text: "started" };
+    yield { type: "error", message: "harness stream ended after the run was created" };
+    yield { type: "done" };
+  }
+}
+
 class ListOrchestrationsAgent implements AgentClient {
   observed = "";
 
@@ -459,6 +482,50 @@ describe("manager-agent server", () => {
       expect(JSON.stringify(body)).not.toContain("[ERROR]");
     } finally {
       await close(server);
+    }
+  });
+
+  it("preserves harness errors as non-spoken diagnostics after an objective succeeds", async () => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-manager-agent-workspace-"));
+    tmpDirs.push(workspace);
+    registerAgentBackend("manager-agent-partial-error-test", () => new ObjectiveSuccessWithErrorAgent());
+    vi.stubEnv("PROJECT_WORKSPACE", workspace);
+
+    const managerApi = makeManagerApiServer();
+    const managerPort = await listen(managerApi);
+    vi.stubEnv("MANAGER_REST_URL", `http://127.0.0.1:${managerPort}/api`);
+
+    const server = startManagerAgentServer(0);
+    await new Promise<void>((resolve) => server.once("listening", () => resolve()));
+    const addr = server.address();
+    const port = typeof addr === "object" && addr ? addr.port : 0;
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/chat`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          message: "start a DAG",
+          response_mode: "voice",
+          agent_config: { agent_type: "manager-agent-partial-error-test", model: "test-model" },
+        }),
+      });
+      const body = await response.json() as {
+        text?: string;
+        spoken_text?: string;
+        agent_errors?: string[];
+        run_ids?: string[];
+      };
+
+      expect(response.status).toBe(200);
+      expect(body.text).toBe("started");
+      expect(body.spoken_text).toBe("started");
+      expect(body.run_ids).toEqual(["run-test-123"]);
+      expect(body.agent_errors).toEqual(["harness stream ended after the run was created"]);
+      expect(JSON.stringify(body)).not.toContain("[ERROR]");
+    } finally {
+      await close(server);
+      await close(managerApi);
     }
   });
 

--- a/homerail_worker/src/__tests__/manager-agent-server.test.ts
+++ b/homerail_worker/src/__tests__/manager-agent-server.test.ts
@@ -289,6 +289,31 @@ describe("manager-agent server", () => {
     for (const dir of tmpDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("reports the host process identity used for lifecycle recovery", async () => {
+    vi.stubEnv("HOMERAIL_MANAGER_AGENT_FINGERPRINT", "fingerprint-test");
+    vi.stubEnv("HOMERAIL_WORKER_ID", "manager-agent-host-project-test");
+    vi.stubEnv("PROJECT_ID", "project-test");
+    const server = startManagerAgentServer(0);
+    await new Promise<void>((resolve) => server.once("listening", resolve));
+    const address = server.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/health`);
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        status: "running",
+        service: "manager-agent",
+        fingerprint: "fingerprint-test",
+        process_id: process.pid,
+        project_id: "project-test",
+        worker_id: "manager-agent-host-project-test",
+      });
+    } finally {
+      await close(server);
+    }
+  });
+
   it("does not use regex guards to force objective tools for action-oriented DAG requests", async () => {
     const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-manager-agent-workspace-"));
     tmpDirs.push(workspace);

--- a/homerail_worker/src/__tests__/manager-agent-server.test.ts
+++ b/homerail_worker/src/__tests__/manager-agent-server.test.ts
@@ -161,6 +161,13 @@ class DeltaTextAgent implements AgentClient {
   }
 }
 
+class ErrorAgent implements AgentClient {
+  async *run(): AsyncIterable<AgentEvent> {
+    yield { type: "error", message: "provider rejected the configured credential" };
+    yield { type: "done" };
+  }
+}
+
 class ListOrchestrationsAgent implements AgentClient {
   observed = "";
 
@@ -391,6 +398,42 @@ describe("manager-agent server", () => {
     } finally {
       await close(server);
       await close(managerApi);
+    }
+  });
+
+  it("returns harness failures as structured errors instead of assistant text", async () => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-manager-agent-workspace-"));
+    tmpDirs.push(workspace);
+    registerAgentBackend("manager-agent-error-test", () => new ErrorAgent());
+    vi.stubEnv("PROJECT_WORKSPACE", workspace);
+
+    const server = startManagerAgentServer(0);
+    await new Promise<void>((resolve) => server.once("listening", () => resolve()));
+    const addr = server.address();
+    const port = typeof addr === "object" && addr ? addr.port : 0;
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/chat`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          message: "hello",
+          agent_config: { agent_type: "manager-agent-error-test", model: "test-model" },
+        }),
+      });
+      const body = await response.json() as { error?: string; data?: Record<string, unknown> };
+
+      expect(response.status).toBe(502);
+      expect(body.error).toBe("provider rejected the configured credential");
+      expect(body.data).toMatchObject({
+        code: "agent_execution_failed",
+        errors: ["provider rejected the configured credential"],
+        observed_tool_calls: [],
+        run_ids: [],
+      });
+      expect(JSON.stringify(body)).not.toContain("[ERROR]");
+    } finally {
+      await close(server);
     }
   });
 

--- a/homerail_worker/src/agent/kimi-code.ts
+++ b/homerail_worker/src/agent/kimi-code.ts
@@ -182,6 +182,11 @@ function resolveKimiAgentTransport(options?: KimiCodeAdapterOptions): KimiAgentT
   return "cli";
 }
 
+function requiresAlwaysThinking(model: string): boolean {
+  const normalized = model.trim().toLowerCase();
+  return normalized === "kimi-k2.7-code" || normalized.startsWith("kimi-for-coding");
+}
+
 /** Parsed line from kimi CLI stream-json output. */
 interface StreamJsonLine {
   type?: string;
@@ -760,9 +765,11 @@ export class KimiCodeAdapter implements AgentClient {
     const safeMaxContextSize = Number.isFinite(maxContextSize) && maxContextSize > 0
       ? maxContextSize
       : 128000;
+    const alwaysThinking = requiresAlwaysThinking(model);
 
     return [
       `default_model = ${tomlString(model)}`,
+      ...(alwaysThinking ? ["default_thinking = true"] : []),
       `default_provider = ${tomlString(providerId)}`,
       "",
       `[providers.${tomlString(providerId)}]`,
@@ -775,6 +782,9 @@ export class KimiCodeAdapter implements AgentClient {
       `provider = ${tomlString(providerId)}`,
       `model = ${tomlString(model)}`,
       `max_context_size = ${safeMaxContextSize}`,
+      ...(alwaysThinking
+        ? ['capabilities = [ "thinking", "always_thinking", "image_in", "video_in", "tool_use" ]']
+        : []),
       "",
     ].join("\n");
   }

--- a/homerail_worker/src/manager-agent/server.ts
+++ b/homerail_worker/src/manager-agent/server.ts
@@ -960,6 +960,7 @@ async function handleChat(body: ChatRequest): Promise<Record<string, unknown>> {
     },
     tool_calls: toolCalls,
     tool_results: toolResults,
+    ...(agentErrors.length ? { agent_errors: agentErrors } : {}),
     commentary_texts: state.voiceSurface.commentaryTexts,
     project_id: body.project_id ?? process.env.PROJECT_ID ?? null,
   };

--- a/homerail_worker/src/manager-agent/server.ts
+++ b/homerail_worker/src/manager-agent/server.ts
@@ -975,6 +975,7 @@ export function startManagerAgentServer(port = Number(process.env.MANAGER_AGENT_
         worker_id: process.env.WORKER_ID || process.env.HOMERAIL_WORKER_ID || null,
         project_id: process.env.PROJECT_ID || null,
         fingerprint: process.env.HOMERAIL_MANAGER_AGENT_FINGERPRINT || null,
+        process_id: process.pid,
       });
       return;
     }

--- a/homerail_worker/src/manager-agent/server.ts
+++ b/homerail_worker/src/manager-agent/server.ts
@@ -95,6 +95,18 @@ class ManagerAgentObjectiveUnsatisfiedError extends Error {
   }
 }
 
+class ManagerAgentExecutionError extends Error {
+  readonly statusCode = 502;
+  readonly data: Record<string, unknown>;
+
+  constructor(errors: string[], data: Record<string, unknown>) {
+    super(errors.at(-1) || "Manager Agent harness execution failed");
+    this.name = "ManagerAgentExecutionError";
+    this.data = { code: "agent_execution_failed", errors, ...data };
+    Object.setPrototypeOf(this, ManagerAgentExecutionError.prototype);
+  }
+}
+
 function json(res: http.ServerResponse, status: number, body: unknown): void {
   res.writeHead(status, { "Content-Type": "application/json" });
   res.end(JSON.stringify(body));
@@ -835,6 +847,7 @@ async function handleChat(body: ChatRequest): Promise<Record<string, unknown>> {
   const toolCalls: ToolTrace[] = [];
   const toolResults: ToolResultTrace[] = [];
   const texts: string[] = [];
+  const agentErrors: string[] = [];
   const responseMode = body.response_mode === "voice" ? "voice" : "chat";
   const requiredToolCalls = normalizeRequiredToolCalls(body.required_tool_calls);
   const tools = createManagerTools(state, responseMode);
@@ -874,7 +887,7 @@ async function handleChat(body: ChatRequest): Promise<Record<string, unknown>> {
           is_error: event.is_error,
         });
       } else if (event.type === "error") {
-        texts.push(`[ERROR] ${event.message}`);
+        agentErrors.push(event.message);
       }
     }
   } finally {
@@ -884,6 +897,13 @@ async function handleChat(body: ChatRequest): Promise<Record<string, unknown>> {
   }
   if (timedOut && !state.objectiveToolCalls.some((item) => item.success)) {
     throw new ManagerAgentTurnTimeoutError(turnTimeoutMs, {
+      observed_tool_calls: toolCalls.map((item) => item.name),
+      objective_tool_calls: state.objectiveToolCalls,
+      run_ids: state.createdRunIds,
+    });
+  }
+  if (agentErrors.length > 0 && !state.objectiveToolCalls.some((item) => item.success)) {
+    throw new ManagerAgentExecutionError(agentErrors, {
       observed_tool_calls: toolCalls.map((item) => item.name),
       objective_tool_calls: state.objectiveToolCalls,
       run_ids: state.createdRunIds,
@@ -968,6 +988,10 @@ export function startManagerAgentServer(port = Number(process.env.MANAGER_AGENT_
             return;
           }
           if (err instanceof ManagerAgentObjectiveUnsatisfiedError) {
+            json(res, err.statusCode, { error: err.message, data: err.data });
+            return;
+          }
+          if (err instanceof ManagerAgentExecutionError) {
             json(res, err.statusCode, { error: err.message, data: err.data });
             return;
           }


### PR DESCRIPTION
## Summary

- add an explicit `Kimi / Moonshot CN` provider backed by `api.moonshot.cn`
- keep `Kimi / Moonshot` as the international provider backed by `api.moonshot.ai`
- expose Coding Plan only on the CN provider and use the current `kimi-for-coding` model IDs
- migrate legacy Kimi Coding Plan settings without rewriting ordinary international API settings
- enable required always-thinking capabilities for K2.7 Code in isolated Kimi CLI configs
- return Kimi, container, and host Codex harness failures as structured errors instead of ordinary `[ERROR]` assistant text
- render Voice errors with a dedicated error state and exclude them from all TTS fallback paths
- preserve post-success harness errors as non-spoken diagnostics without retrying completed side effects
- append plan labels only when one provider exposes multiple billing plans
- persist host-shell process ownership, reclaim stale instances after Manager restarts, and coalesce concurrent starts

## Validation

- `npm run ci`
- protocol: 96 passed
- manager: 375 passed
- node: 162 passed, 1 skipped
- worker: 187 passed, 1 skipped
- CLI: 184 passed
- Agent UI: 139 passed
- live validator: 6 passed
- live host-shell prompt passed with both Kimi CN API billing and Kimi Coding Plan settings
- controlled Voice failures emitted zero speech events and persisted one structured error message
- host Codex app-server failures return structured diagnostics and never enter `spoken_text`
- partial-success harness failures remain successful and expose `agent_errors` without `[ERROR]` text
- Playwright verified distinct API billing/Coding Plan labels and the error presentation
- host-shell restart recovery and concurrent-start regression tests passed with real child processes

Fixes #29