### PR TITLE
Run live validation and PR review in parallel

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,3 +1,4 @@
 self-hosted-runner:
   labels:
     - homerail-live
+    - homerail-pr-review

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,8 @@ jobs:
         run: npm run build:packages
 
       - name: Run isolated live DAG pattern validation
+        env:
+          HOMERAIL_LIVE_SLOT: ${{ runner.name }}
         run: npm run validate:dag-patterns-runner
 
       - name: Upload validation evidence

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -37,7 +37,7 @@ jobs:
       (github.event.pull_request.draft == false &&
        github.event.pull_request.head.repo.full_name == github.repository &&
        github.actor == 'xiaotianfotos')
-    runs-on: [self-hosted, Linux, X64, homerail-live]
+    runs-on: [self-hosted, Linux, X64, homerail-pr-review]
     timeout-minutes: 90
     env:
       HOMERAIL_GITHUB_API_BASE_URL: ${{ github.api_url }}
@@ -103,6 +103,7 @@ jobs:
       - name: Run HomeRail PR Review DAG
         id: review
         env:
+          HOMERAIL_LIVE_SLOT: ${{ runner.name }}
           HOMERAIL_PR_REVIEW_INPUT: ${{ steps.input.outputs.json }}
           HOMERAIL_PR_REVIEW_ARTIFACT_DIR: ${{ github.workspace }}/artifacts/pr-review
         run: bash scripts/run-pr-review-live-runner.sh

--- a/assets/orchestrations/pr-review.yaml.template
+++ b/assets/orchestrations/pr-review.yaml.template
@@ -19,7 +19,7 @@ spec:
 
   pattern:
     id: pr-review-scenario
-    version: 1.3.1
+    version: 1.3.2
     source: HomeRail concrete scenario composed from budget-gate, orchestrator-workers, and quorum
     parameters:
       reviewer_count: 4
@@ -199,6 +199,16 @@ spec:
               line: { type: integer, minimum: 1 }
               verdict: { type: string, enum: [confirmed, rejected] }
               reason: { type: string, minLength: 1, maxLength: 4000 }
+
+    CoverageVote:
+      type: object
+      additionalProperties: false
+      required: [voter, vote, confidence, evidence]
+      properties:
+        voter: { type: string, const: coverage }
+        vote: { type: string, enum: [accept, reject] }
+        confidence: { type: string, enum: [high, medium, low] }
+        evidence: { type: string, minLength: 1, maxLength: 12000 }
 
     FinalReview:
       type: object
@@ -574,11 +584,13 @@ spec:
         Verify that runtime, security, tests, and frontend scopes all produced
         explicit ReviewerResult records and that the synthesis did not silently
         discard stronger evidence. Vote accept only when coverage is complete.
-        Do not end with prose. Your final action MUST call handoff on voted with
-        exactly:
-        {"voter":"coverage","vote":"accept|reject","confidence":"high|medium|low","evidence":"text","finding_verdicts":[]}
+        Coverage does not adjudicate individual findings. Never include
+        finding_verdicts or any other extra field. Do not end with prose. Your
+        final action MUST call handoff on voted with exactly:
+        {"voter":"coverage","vote":"accept|reject","confidence":"high|medium|low","evidence":"text"}
         If input:correction exists, do not re-analyze or call any tool except
-        handoff; immediately resubmit the existing vote in the exact shape.
+        handoff; discard any previous finding-level output and immediately
+        resubmit the existing vote in the exact four-field shape.
 
     publisher:
       system: |
@@ -698,14 +710,14 @@ spec:
       agent: coverage_voter
       workspace_access: { writable_paths: [], readonly_paths: [repository] }
       inputs: { report: { contract: DraftReviewReport } }
-      outputs: { voted: { contract: VerificationVote }, failed: {} }
+      outputs: { voted: { contract: CoverageVote }, failed: {} }
 
     verification_quorum:
       kind: join
       inputs:
         evidence: { contract: VerificationVote }
         false_positive: { contract: VerificationVote }
-        coverage: { contract: VerificationVote }
+        coverage: { contract: CoverageVote }
       outputs: { accepted: {}, rejected: {} }
       config:
         mode: n_of_m

--- a/assets/orchestrations/pr-review.yaml.template
+++ b/assets/orchestrations/pr-review.yaml.template
@@ -19,7 +19,7 @@ spec:
 
   pattern:
     id: pr-review-scenario
-    version: 1.3.0
+    version: 1.3.1
     source: HomeRail concrete scenario composed from budget-gate, orchestrator-workers, and quorum
     parameters:
       reviewer_count: 4
@@ -353,17 +353,24 @@ spec:
         You prepare a read-only pull request checkout. The input is the output
         of a Manager budget gate; the RunEnvelope is at input.input and the
         original PRReviewInput is at input.input.payload.
-        Validate repo, PR, base, head, base_clone_url, and head_clone_url. The
-        two clone URLs were resolved in code from trusted GitHub PR metadata and
-        are constrained to credential-free HTTPS URLs by the input contract.
-        Treat only those two fields as repository locations; never derive a URL
-        from repo, substitute another host, or add credentials. Clone the exact
-        base_clone_url into /workspace/repository, fetch the exact base commit
+        Manager contract validation already guarantees repo, PR, base, head,
+        base_clone_url, and head_clone_url are present there. Use those nested
+        values directly; never claim a required field is missing after using it
+        in a command. Treat only those two URL fields as repository locations;
+        never derive a URL from repo, substitute another host, or add
+        credentials. Use exactly one checkout path: /workspace/repository.
+        Never create /workspace/repository.git, a bare or mirror clone, or any
+        intermediate repository path. Clone the exact base_clone_url directly
+        into /workspace/repository without --depth, fetch the exact base commit
         from that origin, then fetch the exact head commit from head_clone_url
         (using a separate read-only remote when the URLs differ). Checkout head
-        in detached mode. Never modify tracked
-        files. Collect changed_files from git diff --name-only base...head and
-        diff_stat from git diff --stat base...head. Do not end with prose.
+        in detached mode. Do not use git verify-commit; exact rev-parse equality
+        is the required revision check. Never modify tracked files after the
+        detached checkout. Collect changed_files from git diff --name-only
+        base...head and diff_stat from git diff --stat base...head. Call failed
+        only when a required nested value is truly absent before any command,
+        an exact fetch or checkout command fails, or HEAD does not equal head.
+        Do not end with prose.
         Your final action MUST call the handoff tool on port ready with exactly
         this object and no extra keys:
         {"repo":"owner/name","pr":1,"base":"sha","head":"sha","repository_path":"/workspace/repository","changed_files":["path"],"diff_stat":"text","title":"text","author":"login"}
@@ -875,5 +882,5 @@ spec:
     max_parallelism: 4
     max_dispatches: 32
     max_handoffs: 64
-    max_corrections_per_node: 3
+    max_corrections_per_node: 5
     max_tool_calls_per_node: 40

--- a/docs/scenarios/pr-review.md
+++ b/docs/scenarios/pr-review.md
@@ -90,6 +90,14 @@ created by the trusted maintainer. This avoids running untrusted fork content on
 the `.112` runner. Maintainers can use `workflow_dispatch` for an explicit
 review after evaluating that boundary.
 
+PR Review jobs require a dedicated self-hosted runner with the
+`homerail-pr-review` label. Live catalog validation continues to use the
+`homerail-live` label. When both runners share one host, the bootstrap derives a
+separate state, artifact, and cleanup slot from `runner.name`; Manager port
+selection is serialized only until each isolated Manager is healthy. Do not put
+both custom labels on one runner, because that would allow the two jobs to queue
+on the same worker instead of running concurrently.
+
 Runner repository configuration:
 
 - `HOMERAIL_PATTERN_MODEL_BASE_URL`: the Qwen3.6 Anthropic-compatible endpoint;

--- a/homerail_manager/src/runtime/active-runs.ts
+++ b/homerail_manager/src/runtime/active-runs.ts
@@ -613,19 +613,9 @@ function _applyOrphanedNodeDemotion(run: ActiveRun): string[] {
     _markNodeSessionStatus(run, nodeId, "cancelled");
   }
 
-  // A failed prerequisite can leave downstream nodes permanently PENDING. If
-  // recovery has no READY/RUNNING work left, those nodes cannot make progress.
+  _skipPendingNodesWhenFailureStalls(run);
+
   const hasFailedNodes = Array.from(run.dagRun.nodeStates.values()).some((state) => state === "FAILED");
-  const hasRunnableWork = Array.from(run.dagRun.nodeStates.values())
-    .some((state) => state === "READY" || state === "RUNNING");
-  if (hasFailedNodes && !hasRunnableWork) {
-    for (const [nodeId, state] of run.dagRun.nodeStates.entries()) {
-      if (state === "PENDING") {
-        run.dagRun.nodeStates.set(nodeId, "SKIPPED");
-        _markNodeSessionStatus(run, nodeId, "cancelled");
-      }
-    }
-  }
 
   // If demoting orphaned nodes made the run terminal, mark it failed.
   if (hasFailedNodes && isRunTerminal(run.dagRun)) {
@@ -642,6 +632,23 @@ function _applyOrphanedNodeDemotion(run: ActiveRun): string[] {
   }
 
   return demotedFromRunning;
+}
+
+function _skipPendingNodesWhenFailureStalls(run: ActiveRun): string[] {
+  const states = Array.from(run.dagRun.nodeStates.values());
+  if (!states.some((state) => state === "FAILED")) return [];
+  if (states.some((state) =>
+    state === "READY" || state === "RUNNING" || state === "WAITING_FOR_APPROVAL"
+  )) return [];
+
+  const skipped: string[] = [];
+  for (const [nodeId, state] of run.dagRun.nodeStates.entries()) {
+    if (state !== "PENDING") continue;
+    run.dagRun.nodeStates.set(nodeId, "SKIPPED");
+    _markNodeSessionStatus(run, nodeId, "cancelled");
+    skipped.push(nodeId);
+  }
+  return skipped.sort();
 }
 
 export type RestoreActiveRunResult =
@@ -868,6 +875,7 @@ export function failActiveRun(runId: string, nodeId: string, reason: string): Ac
   const readyBefore = new Set(getReadyNodes(run.dagRun));
   failNode(run.dagRun, nodeId, { error: reason });
   _markNodeSessionStatus(run, nodeId, "failed");
+  _skipPendingNodesWhenFailureStalls(run);
   writeRunMetadata(runId, serializeRunMetadata(run));
   _emitNodeStateChanges(run, before);
   emit("dag:node_failed", { runId, nodeId, reason });

--- a/homerail_manager/tests/dag-correction-retry.test.ts
+++ b/homerail_manager/tests/dag-correction-retry.test.ts
@@ -207,6 +207,73 @@ spec:
     expect(getActiveRun("run-auto-handoff-contract")?.dagRun.nodeStates.get("start")).toBe("FAILED");
   });
 
+  it("settles pending descendants when a contracted auto-handoff failure leaves no runnable work", () => {
+    const parsed = parseWorkflowSource(`
+api_version: homerail.ai/v1
+kind: Workflow
+metadata: { id: correction-stalled-descendant, name: Correction Stalled Descendant }
+spec:
+  contracts:
+    Text: { type: string }
+  agents:
+    worker: { system: Return text. }
+  nodes:
+    seed:
+      kind: agent
+      agent: worker
+      outputs:
+        report: { contract: Text }
+    voter:
+      kind: agent
+      agent: worker
+      inputs:
+        report: { contract: Text }
+      outputs:
+        voted: { contract: Text }
+    finalize:
+      kind: agent
+      agent: worker
+      inputs:
+        report: { contract: Text }
+        vote: { contract: Text }
+      outputs:
+        done: { contract: Text }
+    terminal:
+      kind: terminal
+      outcome: success
+      inputs:
+        result: { contract: Text }
+  edges:
+    - { from: seed.report, to: voter.report }
+    - { from: seed.report, to: finalize.report }
+    - { from: voter.voted, to: finalize.vote }
+    - { from: finalize.done, to: terminal.result }
+  policies:
+    max_corrections_per_node: 0
+`);
+    parsed.meta.agents!.worker!.agent_type = "deterministic";
+    createActiveRun("run-auto-handoff-stalled-descendant", parsed);
+    const dispatcher = new FlakyDispatcher({ status: "dispatched", targetType: "fake", targetId: "worker" });
+
+    expect(dispatchReadyNodes("run-auto-handoff-stalled-descendant", dispatcher)).toBe(1);
+    handoffActiveRun("run-auto-handoff-stalled-descendant", "seed", "report", "context");
+    expect(dispatchReadyNodes("run-auto-handoff-stalled-descendant", dispatcher)).toBe(1);
+    expect(requestNodeCorrection(
+      "run-auto-handoff-stalled-descendant",
+      "voter",
+      "invalid vote",
+    ).status).toBe("exhausted");
+
+    const run = autoHandoffAfterCorrectionExhausted(
+      "run-auto-handoff-stalled-descendant",
+      "voter",
+      "invalid vote",
+    );
+    expect(run?.status).toBe("failed");
+    expect(run?.dagRun.nodeStates.get("voter")).toBe("FAILED");
+    expect(run?.dagRun.nodeStates.get("finalize")).toBe("SKIPPED");
+  });
+
   it("retries retryable dispatch failures once before marking the node running", () => {
     const parsed = parseDAGYaml(correctionYaml());
     createActiveRun("run-dispatch-retry", parsed);

--- a/homerail_manager/tests/pr-review-scenario.test.ts
+++ b/homerail_manager/tests/pr-review-scenario.test.ts
@@ -105,6 +105,9 @@ describe("PR Review scenario assets", () => {
       threshold: 2,
       field: "vote",
     });
+    expect(nodes.find((node) => node.id === "coverage_vote")?.outputs).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: "voted", contract: "CoverageVote" }),
+    ]));
     expect(nodes.find((node) => node.id === "quorum_result")?.config).toMatchObject({
       mode: "any",
       field: "passed",
@@ -394,7 +397,7 @@ describe("PR Review scenario assets", () => {
       voter: "false_positive", vote: "reject", confidence: "medium", evidence: "one concern", finding_verdicts: [],
     });
     handoffActiveRun("pr-review-runtime", "coverage_vote", "voted", {
-      voter: "coverage", vote: "accept", confidence: "high", evidence: "all scopes present", finding_verdicts: [],
+      voter: "coverage", vote: "accept", confidence: "high", evidence: "all scopes present",
     });
     expect(executor.tick("pr-review-runtime")).toBeGreaterThan(0);
     expect(dispatcher.dispatched.at(-1)?.nodeId).toBe("refine");

--- a/homerail_manager/tests/pr-review-scenario.test.ts
+++ b/homerail_manager/tests/pr-review-scenario.test.ts
@@ -139,8 +139,13 @@ describe("PR Review scenario assets", () => {
     expect(agents.preparer?.system).toContain('"repository_path":"/workspace/repository"');
     expect(agents.preparer?.system).toContain("base_clone_url");
     expect(agents.preparer?.system).toContain("head_clone_url");
+    expect(agents.preparer?.system).toContain("Manager contract validation already guarantees");
+    expect(agents.preparer?.system).toContain("Never create /workspace/repository.git");
+    expect(agents.preparer?.system).toContain("never claim a required field is missing after using it");
+    expect(agents.preparer?.system).toContain("Do not use git verify-commit");
     expect(agents.preparer?.system).not.toContain("https://github.com/<repo>.git");
     expect(agents.preparer?.system).not.toContain('"status":"ready"');
+    expect(result.canonical?.policies?.max_corrections_per_node).toBe(5);
     expect(nodes.find((node) => node.id === "synthesize")?.inputs).toEqual(expect.arrayContaining([
       expect.objectContaining({ name: "context" }),
     ]));

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "install:all": "npm --prefix homerail_protocol ci && npm --prefix homerail_manager ci && npm --prefix homerail_node ci && npm --prefix homerail_worker ci && npm --prefix homerail_cli ci && npm --prefix agent-ui ci",
     "build:packages": "npm --prefix homerail_protocol run build && npm --prefix homerail_manager run build && npm --prefix homerail_node run build && npm --prefix homerail_worker run build && npm --prefix homerail_cli run build && npm --prefix agent-ui run build",
     "build": "npm run build:packages",
-    "test:live-validator": "node --test scripts/dag-pattern-live-contracts.test.mjs",
+    "test:live-validator": "node --test scripts/dag-pattern-live-contracts.test.mjs scripts/live-runner-isolation.test.mjs",
     "test:packages": "npm --prefix homerail_protocol test && npm --prefix homerail_manager test && npm --prefix homerail_node test && npm --prefix homerail_worker test && npm --prefix homerail_cli test && npm --prefix agent-ui test && npm run test:live-validator",
     "test": "npm run build:packages && npm run test:packages",
     "typecheck": "npm --prefix homerail_protocol run typecheck && npm --prefix homerail_manager run typecheck && npm --prefix homerail_node run typecheck && npm --prefix homerail_worker run typecheck && npm --prefix homerail_cli run typecheck && npm --prefix agent-ui run typecheck",

--- a/scripts/cleanup-dag-patterns-live-runner.sh
+++ b/scripts/cleanup-dag-patterns-live-runner.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 RUNNER_BASE="${HOMERAIL_RUNNER_BASE:-$HOME/.homerail-runners}"
 HOME_ROOT="${HOMERAIL_LIVE_HOME_BASE:-$RUNNER_BASE/homerail_home}"
 
+if [ -n "${HOMERAIL_LIVE_HOME_BASE:-}" ] && [ -z "${HOMERAIL_RUNNER_BASE:-}" ]; then
+  echo "HOMERAIL_RUNNER_BASE is required when HOMERAIL_LIVE_HOME_BASE is configured." >&2
+  exit 1
+fi
+
 sanitize_slot() {
   printf '%s' "$1" | tr -c 'A-Za-z0-9_.-' '-'
 }

--- a/scripts/cleanup-dag-patterns-live-runner.sh
+++ b/scripts/cleanup-dag-patterns-live-runner.sh
@@ -2,23 +2,93 @@
 set -euo pipefail
 
 RUNNER_BASE="${HOMERAIL_RUNNER_BASE:-$HOME/.homerail-runners}"
-HOME_BASE="${HOMERAIL_LIVE_HOME_BASE:-$RUNNER_BASE/homerail_home}"
-LOCK_FILE="$RUNNER_BASE/dag-patterns-live.lock"
+HOME_ROOT="${HOMERAIL_LIVE_HOME_BASE:-$RUNNER_BASE/homerail_home}"
 
-mkdir -p "$RUNNER_BASE" "$HOME_BASE"
-if [ "${HOMERAIL_CLEANUP_LOCK_HELD:-0}" != "1" ]; then
-  exec 9>"$LOCK_FILE"
+sanitize_slot() {
+  printf '%s' "$1" | tr -c 'A-Za-z0-9_.-' '-'
+}
+
+container_ids_for_scope() {
+  local slot="$1" id label
+  if [ "$slot" != "__legacy_unscoped__" ]; then
+    docker ps -aq --filter "label=org.homerail.live_slot=$slot"
+    return
+  fi
+  while IFS= read -r id; do
+    [ -n "$id" ] || continue
+    label="$(docker container inspect --format '{{ index .Config.Labels "org.homerail.live_slot" }}' "$id" 2>/dev/null || true)"
+    { [ -z "$label" ] || [ "$label" = "<no value>" ]; } && printf '%s\n' "$id"
+  done < <(docker ps -aq --filter "label=org.homerail.live_run")
+}
+
+image_ids_for_scope() {
+  local slot="$1" id label
+  if [ "$slot" != "__legacy_unscoped__" ]; then
+    docker images --filter "label=org.homerail.live_slot=$slot" --format "{{.ID}}" | sort -u
+    return
+  fi
+  while IFS= read -r id; do
+    [ -n "$id" ] || continue
+    label="$(docker image inspect --format '{{ index .Config.Labels "org.homerail.live_slot" }}' "$id" 2>/dev/null || true)"
+    { [ -z "$label" ] || [ "$label" = "<no value>" ]; } && printf '%s\n' "$id"
+  done < <(docker images --filter "label=org.homerail.live_run" --format "{{.ID}}" | sort -u)
+}
+
+cleanup_scope() {
+  local slot="$1" home_base="$2"
+  local -a containers images
+
+  mkdir -p "$home_base"
+  mapfile -t containers < <(container_ids_for_scope "$slot")
+  if [ "${#containers[@]}" -gt 0 ]; then
+    docker rm -f "${containers[@]}" >/dev/null
+  fi
+
+  mapfile -t images < <(image_ids_for_scope "$slot")
+  if [ "${#images[@]}" -gt 0 ]; then
+    docker image rm -f "${images[@]}" >/dev/null
+  fi
+
+  find "$home_base" -mindepth 1 -maxdepth 1 -type d -name 'run-*' -exec rm -rf -- {} +
+}
+
+cleanup_scope_with_lock() (
+  local slot="$1" home_base="$2" lock_file="$3"
+  mkdir -p "$(dirname "$lock_file")" "$home_base"
+  exec 9>"$lock_file"
   flock -n 9 || exit 0
+  cleanup_scope "$slot" "$home_base"
+)
+
+mkdir -p "$RUNNER_BASE" "$HOME_ROOT"
+
+if [ -n "${HOMERAIL_LIVE_SLOT:-}" ]; then
+  LIVE_SLOT="$(sanitize_slot "$HOMERAIL_LIVE_SLOT")"
+  case "$LIVE_SLOT" in
+    ""|.|..) exit 1 ;;
+  esac
+  HOME_BASE="$HOME_ROOT/slots/$LIVE_SLOT"
+  LOCK_FILE="$RUNNER_BASE/slots/$LIVE_SLOT/dag-patterns-live.lock"
+  if [ "${HOMERAIL_CLEANUP_LOCK_HELD:-0}" = "1" ]; then
+    cleanup_scope "$LIVE_SLOT" "$HOME_BASE"
+  else
+    cleanup_scope_with_lock "$LIVE_SLOT" "$HOME_BASE" "$LOCK_FILE"
+  fi
+  exit 0
 fi
 
-mapfile -t containers < <(docker ps -aq --filter "label=org.homerail.live_run")
-if [ "${#containers[@]}" -gt 0 ]; then
-  docker rm -f "${containers[@]}" >/dev/null
+# Legacy runs used one global lock and did not label resources with a runner slot.
+LEGACY_LOCK_FILE="$RUNNER_BASE/dag-patterns-live.lock"
+if [ "${HOMERAIL_CLEANUP_LOCK_HELD:-0}" = "1" ]; then
+  cleanup_scope "__legacy_unscoped__" "$HOME_ROOT"
+  exit 0
 fi
+cleanup_scope_with_lock "__legacy_unscoped__" "$HOME_ROOT" "$LEGACY_LOCK_FILE"
 
-mapfile -t images < <(docker images --filter "label=org.homerail.live_run" --format "{{.ID}}" | sort -u)
-if [ "${#images[@]}" -gt 0 ]; then
-  docker image rm -f "${images[@]}" >/dev/null
-fi
-
-find "$HOME_BASE" -mindepth 1 -maxdepth 1 -type d -name 'run-*' -exec rm -rf -- {} +
+shopt -s nullglob
+for slot_dir in "$RUNNER_BASE"/slots/*; do
+  [ -d "$slot_dir" ] || continue
+  LIVE_SLOT="$(basename "$slot_dir")"
+  HOME_BASE="$HOME_ROOT/slots/$LIVE_SLOT"
+  cleanup_scope_with_lock "$LIVE_SLOT" "$HOME_BASE" "$slot_dir/dag-patterns-live.lock"
+done

--- a/scripts/cleanup-dag-patterns-live-runner.sh
+++ b/scripts/cleanup-dag-patterns-live-runner.sh
@@ -49,30 +49,39 @@ image_ids_for_scope() {
 cleanup_scope() {
   local slot="$1" home_base="$2"
   local -a containers images
+  local failed=0
 
-  mkdir -p "$home_base"
+  mkdir -p "$home_base" || return 1
   mapfile -t containers < <(container_ids_for_scope "$slot")
   if [ "${#containers[@]}" -gt 0 ]; then
-    docker rm -f "${containers[@]}" >/dev/null
+    if ! docker rm -f "${containers[@]}" >/dev/null; then
+      failed=1
+    fi
   fi
 
   mapfile -t images < <(image_ids_for_scope "$slot")
   if [ "${#images[@]}" -gt 0 ]; then
-    docker image rm -f "${images[@]}" >/dev/null
+    if ! docker image rm -f "${images[@]}" >/dev/null; then
+      failed=1
+    fi
   fi
 
-  find "$home_base" -mindepth 1 -maxdepth 1 -type d -name 'run-*' -exec rm -rf -- {} +
+  if ! find "$home_base" -mindepth 1 -maxdepth 1 -type d -name 'run-*' -exec rm -rf -- {} +; then
+    failed=1
+  fi
+  return "$failed"
 }
 
 cleanup_scope_with_lock() (
   local slot="$1" home_base="$2" lock_file="$3"
-  mkdir -p "$(dirname "$lock_file")" "$home_base"
-  exec 9>"$lock_file"
+  mkdir -p "$(dirname "$lock_file")" "$home_base" || exit 1
+  exec 9>"$lock_file" || exit 1
   flock -n 9 || exit 0
   cleanup_scope "$slot" "$home_base"
 )
 
 mkdir -p "$RUNNER_BASE" "$HOME_ROOT"
+cleanup_failed=0
 
 if [ -n "${HOMERAIL_LIVE_SLOT:-}" ]; then
   LIVE_SLOT="$(sanitize_slot "$HOMERAIL_LIVE_SLOT")"
@@ -82,25 +91,37 @@ if [ -n "${HOMERAIL_LIVE_SLOT:-}" ]; then
   HOME_BASE="$HOME_ROOT/slots/$LIVE_SLOT"
   LOCK_FILE="$RUNNER_BASE/slots/$LIVE_SLOT/dag-patterns-live.lock"
   if [ "${HOMERAIL_CLEANUP_LOCK_HELD:-0}" = "1" ]; then
-    cleanup_scope "$LIVE_SLOT" "$HOME_BASE"
+    if ! cleanup_scope "$LIVE_SLOT" "$HOME_BASE"; then
+      cleanup_failed=1
+    fi
   else
-    cleanup_scope_with_lock "$LIVE_SLOT" "$HOME_BASE" "$LOCK_FILE"
+    if ! cleanup_scope_with_lock "$LIVE_SLOT" "$HOME_BASE" "$LOCK_FILE"; then
+      cleanup_failed=1
+    fi
   fi
-  exit 0
+  exit "$cleanup_failed"
 fi
 
 # Legacy runs used one global lock and did not label resources with a runner slot.
 LEGACY_LOCK_FILE="$RUNNER_BASE/dag-patterns-live.lock"
 if [ "${HOMERAIL_CLEANUP_LOCK_HELD:-0}" = "1" ]; then
-  cleanup_scope "__legacy_unscoped__" "$HOME_ROOT"
-  exit 0
+  if ! cleanup_scope "__legacy_unscoped__" "$HOME_ROOT"; then
+    cleanup_failed=1
+  fi
+else
+  if ! cleanup_scope_with_lock "__legacy_unscoped__" "$HOME_ROOT" "$LEGACY_LOCK_FILE"; then
+    cleanup_failed=1
+  fi
 fi
-cleanup_scope_with_lock "__legacy_unscoped__" "$HOME_ROOT" "$LEGACY_LOCK_FILE"
 
 shopt -s nullglob
 for slot_dir in "$RUNNER_BASE"/slots/*; do
   [ -d "$slot_dir" ] || continue
   LIVE_SLOT="$(basename "$slot_dir")"
   HOME_BASE="$HOME_ROOT/slots/$LIVE_SLOT"
-  cleanup_scope_with_lock "$LIVE_SLOT" "$HOME_BASE" "$slot_dir/dag-patterns-live.lock"
+  if ! cleanup_scope_with_lock "$LIVE_SLOT" "$HOME_BASE" "$slot_dir/dag-patterns-live.lock"; then
+    echo "Cleanup failed for live runner slot $LIVE_SLOT; continuing with remaining slots." >&2
+    cleanup_failed=1
+  fi
 done
+exit "$cleanup_failed"

--- a/scripts/cleanup-dag-patterns-live-runner.sh
+++ b/scripts/cleanup-dag-patterns-live-runner.sh
@@ -16,8 +16,14 @@ container_ids_for_scope() {
   fi
   while IFS= read -r id; do
     [ -n "$id" ] || continue
-    label="$(docker container inspect --format '{{ index .Config.Labels "org.homerail.live_slot" }}' "$id" 2>/dev/null || true)"
-    { [ -z "$label" ] || [ "$label" = "<no value>" ]; } && printf '%s\n' "$id"
+    if ! label="$(
+      docker container inspect \
+        --format '{{with index .Config.Labels "org.homerail.live_slot"}}{{.}}{{end}}' \
+        "$id" 2>/dev/null
+    )"; then
+      continue
+    fi
+    [ -z "$label" ] && printf '%s\n' "$id"
   done < <(docker ps -aq --filter "label=org.homerail.live_run")
 }
 
@@ -29,8 +35,14 @@ image_ids_for_scope() {
   fi
   while IFS= read -r id; do
     [ -n "$id" ] || continue
-    label="$(docker image inspect --format '{{ index .Config.Labels "org.homerail.live_slot" }}' "$id" 2>/dev/null || true)"
-    { [ -z "$label" ] || [ "$label" = "<no value>" ]; } && printf '%s\n' "$id"
+    if ! label="$(
+      docker image inspect \
+        --format '{{with index .Config.Labels "org.homerail.live_slot"}}{{.}}{{end}}' \
+        "$id" 2>/dev/null
+    )"; then
+      continue
+    fi
+    [ -z "$label" ] && printf '%s\n' "$id"
   done < <(docker images --filter "label=org.homerail.live_run" --format "{{.ID}}" | sort -u)
 }
 

--- a/scripts/live-runner-isolation.test.mjs
+++ b/scripts/live-runner-isolation.test.mjs
@@ -32,6 +32,31 @@ test("routes live jobs to isolated runner slots and serializes only Manager port
   assert.ok(release > start, "port lock must be released after Manager binds its port");
 });
 
+test("cleanup fails closed when a custom home omits the matching runner root", { skip: process.platform !== "linux" }, (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-live-runner-config-test-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const customHome = path.join(root, "custom-home");
+  const sentinel = path.join(customHome, "slots", "slot-a", "run-active", "sentinel");
+  fs.mkdirSync(path.dirname(sentinel), { recursive: true });
+  fs.writeFileSync(sentinel, "active");
+
+  const result = spawnSync("bash", [cleanupScript], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      HOME: path.join(root, "default-home"),
+      HOMERAIL_RUNNER_BASE: "",
+      HOMERAIL_LIVE_HOME_BASE: customHome,
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /HOMERAIL_RUNNER_BASE is required/);
+  assert.equal(fs.readFileSync(sentinel, "utf8"), "active");
+});
+
 test("cleanup removes only one unlocked live runner slot", { skip: process.platform !== "linux" }, async (t) => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-live-runner-test-"));
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));

--- a/scripts/live-runner-isolation.test.mjs
+++ b/scripts/live-runner-isolation.test.mjs
@@ -53,14 +53,14 @@ case "\${1:-}" in
     case "$*" in
       *live_slot=slot-a*) echo container-a ;;
       *live_slot=slot-b*) echo container-b ;;
-      *live_run*) printf '%s\\n' container-legacy container-a container-b ;;
+      *live_run*) printf '%s\\n' container-legacy container-a container-b container-inspect-error ;;
     esac
     ;;
   images)
     case "$*" in
       *live_slot=slot-a*) echo image-a ;;
       *live_slot=slot-b*) echo image-b ;;
-      *live_run*) printf '%s\\n' image-legacy image-a image-b ;;
+      *live_run*) printf '%s\\n' image-legacy image-a image-b image-inspect-error ;;
     esac
     ;;
   container)
@@ -68,7 +68,8 @@ case "\${1:-}" in
     case "$id" in
       container-a) echo slot-a ;;
       container-b) echo slot-b ;;
-      container-legacy) echo '<no value>' ;;
+      container-legacy) ;;
+      container-inspect-error) exit 42 ;;
     esac
     ;;
   image)
@@ -77,7 +78,8 @@ case "\${1:-}" in
       case "$id" in
         image-a) echo slot-a ;;
         image-b) echo slot-b ;;
-        image-legacy) echo '<no value>' ;;
+        image-legacy) ;;
+        image-inspect-error) exit 42 ;;
       esac
     fi
     ;;
@@ -127,7 +129,15 @@ esac
   removals = fs.readFileSync(dockerLog, "utf8").split("\n").filter((line) => /^(rm -f|image rm -f)/.test(line));
   assert.ok(removals.includes("rm -f container-legacy"));
   assert.ok(removals.includes("image rm -f image-legacy"));
-  assert.ok(removals.every((line) => !line.includes("container-b") && !line.includes("image-b")));
+  assert.ok(
+    removals.every(
+      (line) =>
+        !line.includes("container-b") &&
+        !line.includes("image-b") &&
+        !line.includes("container-inspect-error") &&
+        !line.includes("image-inspect-error"),
+    ),
+  );
 
   if (lockHolder.exitCode === null) {
     lockHolder.kill("SIGTERM");

--- a/scripts/live-runner-isolation.test.mjs
+++ b/scripts/live-runner-isolation.test.mjs
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const cleanupScript = path.join(repoRoot, "scripts", "cleanup-dag-patterns-live-runner.sh");
+
+test("routes live jobs to isolated runner slots and serializes only Manager port allocation", () => {
+  const ci = fs.readFileSync(path.join(repoRoot, ".github", "workflows", "ci.yml"), "utf8");
+  const review = fs.readFileSync(path.join(repoRoot, ".github", "workflows", "pr-review.yml"), "utf8");
+  const actionlint = fs.readFileSync(path.join(repoRoot, ".github", "actionlint.yaml"), "utf8");
+  const runner = fs.readFileSync(path.join(repoRoot, "scripts", "run-dag-patterns-live-runner.sh"), "utf8");
+
+  assert.match(ci, /HOMERAIL_LIVE_SLOT: \$\{\{ runner\.name \}\}/);
+  assert.match(review, /runs-on: \[self-hosted, Linux, X64, homerail-pr-review\]/);
+  assert.match(review, /HOMERAIL_LIVE_SLOT: \$\{\{ runner\.name \}\}/);
+  assert.match(actionlint, /- homerail-pr-review/);
+  assert.match(runner, /org\.homerail\.live_slot=\$LIVE_SLOT/);
+  assert.match(runner, /manager-port-allocation\.lock/);
+
+  const acquire = runner.indexOf('flock -w 60 8');
+  const start = runner.indexOf('cli.js" start --host');
+  const release = runner.indexOf('flock -u 8');
+  assert.ok(acquire >= 0 && acquire < start, "port lock must be held before Manager starts");
+  assert.ok(release > start, "port lock must be released after Manager binds its port");
+});
+
+test("cleanup removes only one unlocked live runner slot", { skip: process.platform !== "linux" }, async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-live-runner-test-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const runnerBase = path.join(root, "runner");
+  const homeRoot = path.join(root, "home");
+  const fakeBin = path.join(root, "bin");
+  const dockerLog = path.join(root, "docker.log");
+  const runA = path.join(homeRoot, "slots", "slot-a", "run-a");
+  const runB = path.join(homeRoot, "slots", "slot-b", "run-b");
+  const legacyRun = path.join(homeRoot, "run-legacy");
+  fs.mkdirSync(fakeBin, { recursive: true });
+  fs.mkdirSync(runA, { recursive: true });
+  fs.mkdirSync(runB, { recursive: true });
+  fs.mkdirSync(legacyRun, { recursive: true });
+
+  const fakeDocker = `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$DOCKER_LOG"
+case "\${1:-}" in
+  ps)
+    case "$*" in
+      *live_slot=slot-a*) echo container-a ;;
+      *live_slot=slot-b*) echo container-b ;;
+      *live_run*) printf '%s\\n' container-legacy container-a container-b ;;
+    esac
+    ;;
+  images)
+    case "$*" in
+      *live_slot=slot-a*) echo image-a ;;
+      *live_slot=slot-b*) echo image-b ;;
+      *live_run*) printf '%s\\n' image-legacy image-a image-b ;;
+    esac
+    ;;
+  container)
+    id="\${!#}"
+    case "$id" in
+      container-a) echo slot-a ;;
+      container-b) echo slot-b ;;
+      container-legacy) echo '<no value>' ;;
+    esac
+    ;;
+  image)
+    if [ "\${2:-}" = "inspect" ]; then
+      id="\${!#}"
+      case "$id" in
+        image-a) echo slot-a ;;
+        image-b) echo slot-b ;;
+        image-legacy) echo '<no value>' ;;
+      esac
+    fi
+    ;;
+esac
+`;
+  const dockerPath = path.join(fakeBin, "docker");
+  fs.writeFileSync(dockerPath, fakeDocker, { mode: 0o755 });
+
+  const baseEnv = {
+    ...process.env,
+    PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+    DOCKER_LOG: dockerLog,
+    HOMERAIL_RUNNER_BASE: runnerBase,
+    HOMERAIL_LIVE_HOME_BASE: homeRoot,
+    HOMERAIL_CLEANUP_LOCK_HELD: "0",
+  };
+  const runCleanup = (extraEnv = {}) => {
+    const result = spawnSync("bash", [cleanupScript], {
+      cwd: repoRoot,
+      env: { ...baseEnv, HOMERAIL_LIVE_SLOT: "", ...extraEnv },
+      encoding: "utf8",
+    });
+    assert.equal(result.status, 0, result.stderr);
+  };
+
+  runCleanup({ HOMERAIL_LIVE_SLOT: "slot-a" });
+  assert.equal(fs.existsSync(runA), false);
+  assert.equal(fs.existsSync(runB), true);
+  assert.equal(fs.existsSync(legacyRun), true);
+  let removals = fs.readFileSync(dockerLog, "utf8").split("\n").filter((line) => /^(rm -f|image rm -f)/.test(line));
+  assert.deepEqual(removals, ["rm -f container-a", "image rm -f image-a"]);
+
+  fs.writeFileSync(dockerLog, "");
+  const slotBLock = path.join(runnerBase, "slots", "slot-b", "dag-patterns-live.lock");
+  const lockReady = path.join(root, "lock-ready");
+  fs.mkdirSync(path.dirname(slotBLock), { recursive: true });
+  const lockHolder = spawn("bash", ["-c", 'exec 9>"$1"; flock 9; : >"$2"; sleep 30', "bash", slotBLock, lockReady]);
+  t.after(() => lockHolder.kill("SIGTERM"));
+  for (let attempt = 0; attempt < 100 && !fs.existsSync(lockReady); attempt += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  assert.equal(fs.existsSync(lockReady), true, "slot lock holder did not start");
+
+  runCleanup();
+  assert.equal(fs.existsSync(legacyRun), false);
+  assert.equal(fs.existsSync(runB), true, "timer cleanup must skip a locked slot");
+  removals = fs.readFileSync(dockerLog, "utf8").split("\n").filter((line) => /^(rm -f|image rm -f)/.test(line));
+  assert.ok(removals.includes("rm -f container-legacy"));
+  assert.ok(removals.includes("image rm -f image-legacy"));
+  assert.ok(removals.every((line) => !line.includes("container-b") && !line.includes("image-b")));
+
+  if (lockHolder.exitCode === null) {
+    lockHolder.kill("SIGTERM");
+    await new Promise((resolve) => lockHolder.once("exit", resolve));
+  }
+  runCleanup();
+  assert.equal(fs.existsSync(runB), false);
+  removals = fs.readFileSync(dockerLog, "utf8").split("\n").filter((line) => /^(rm -f|image rm -f)/.test(line));
+  assert.ok(removals.includes("rm -f container-b"));
+  assert.ok(removals.includes("image rm -f image-b"));
+});

--- a/scripts/live-runner-isolation.test.mjs
+++ b/scripts/live-runner-isolation.test.mjs
@@ -23,6 +23,7 @@ test("routes live jobs to isolated runner slots and serializes only Manager port
   assert.match(runner, /LIVE_RUN_LABEL="org\.homerail\.live_run_v2"/);
   assert.match(runner, /--label "\$LIVE_RUN_LABEL=\$RUN_KEY"/);
   assert.match(runner, /manager-port-allocation\.lock/);
+  assert.match(runner, /dag chats "\$REVIEW_RUN_ID" --tools 20 --raw-tools/);
 
   const acquire = runner.indexOf('flock -w 60 8');
   const start = runner.indexOf('cli.js" start --host');
@@ -112,6 +113,13 @@ esac
   assert.equal(fs.existsSync(runB), true);
   assert.equal(fs.existsSync(legacyRun), true);
   let removals = fs.readFileSync(dockerLog, "utf8").split("\n").filter((line) => /^(rm -f|image rm -f)/.test(line));
+  assert.deepEqual(removals, ["rm -f container-a", "image rm -f image-a"]);
+
+  fs.mkdirSync(runA, { recursive: true });
+  fs.writeFileSync(dockerLog, "");
+  runCleanup({ HOMERAIL_LIVE_SLOT: "slot-a", HOMERAIL_CLEANUP_LOCK_HELD: "1" });
+  assert.equal(fs.existsSync(runA), false);
+  removals = fs.readFileSync(dockerLog, "utf8").split("\n").filter((line) => /^(rm -f|image rm -f)/.test(line));
   assert.deepEqual(removals, ["rm -f container-a", "image rm -f image-a"]);
 
   fs.writeFileSync(dockerLog, "");

--- a/scripts/live-runner-isolation.test.mjs
+++ b/scripts/live-runner-isolation.test.mjs
@@ -20,6 +20,8 @@ test("routes live jobs to isolated runner slots and serializes only Manager port
   assert.match(review, /HOMERAIL_LIVE_SLOT: \$\{\{ runner\.name \}\}/);
   assert.match(actionlint, /- homerail-pr-review/);
   assert.match(runner, /org\.homerail\.live_slot=\$LIVE_SLOT/);
+  assert.match(runner, /LIVE_RUN_LABEL="org\.homerail\.live_run_v2"/);
+  assert.match(runner, /--label "\$LIVE_RUN_LABEL=\$RUN_KEY"/);
   assert.match(runner, /manager-port-allocation\.lock/);
 
   const acquire = runner.indexOf('flock -w 60 8');

--- a/scripts/live-runner-isolation.test.mjs
+++ b/scripts/live-runner-isolation.test.mjs
@@ -86,6 +86,11 @@ case "\${1:-}" in
       esac
     fi
     ;;
+  rm)
+    if [ "\${FAIL_SLOT_A:-0}" = "1" ] && [[ "$*" == *container-a* ]]; then
+      exit 42
+    fi
+    ;;
 esac
 `;
   const dockerPath = path.join(fakeBin, "docker");
@@ -99,13 +104,14 @@ esac
     HOMERAIL_LIVE_HOME_BASE: homeRoot,
     HOMERAIL_CLEANUP_LOCK_HELD: "0",
   };
-  const runCleanup = (extraEnv = {}) => {
+  const runCleanup = (extraEnv = {}, expectedStatus = 0) => {
     const result = spawnSync("bash", [cleanupScript], {
       cwd: repoRoot,
       env: { ...baseEnv, HOMERAIL_LIVE_SLOT: "", ...extraEnv },
       encoding: "utf8",
     });
-    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.status, expectedStatus, result.stderr);
+    return result;
   };
 
   runCleanup({ HOMERAIL_LIVE_SLOT: "slot-a" });
@@ -155,6 +161,17 @@ esac
   }
   runCleanup();
   assert.equal(fs.existsSync(runB), false);
+  removals = fs.readFileSync(dockerLog, "utf8").split("\n").filter((line) => /^(rm -f|image rm -f)/.test(line));
+  assert.ok(removals.includes("rm -f container-b"));
+  assert.ok(removals.includes("image rm -f image-b"));
+
+  fs.mkdirSync(runA, { recursive: true });
+  fs.mkdirSync(runB, { recursive: true });
+  fs.writeFileSync(dockerLog, "");
+  const failedCleanup = runCleanup({ FAIL_SLOT_A: "1" }, 1);
+  assert.match(failedCleanup.stderr, /Cleanup failed for live runner slot slot-a/);
+  assert.equal(fs.existsSync(runA), false);
+  assert.equal(fs.existsSync(runB), false, "a failed slot must not prevent later slot cleanup");
   removals = fs.readFileSync(dockerLog, "utf8").split("\n").filter((line) => /^(rm -f|image rm -f)/.test(line));
   assert.ok(removals.includes("rm -f container-b"));
   assert.ok(removals.includes("image rm -f image-b"));

--- a/scripts/live-runner-isolation.test.mjs
+++ b/scripts/live-runner-isolation.test.mjs
@@ -27,9 +27,16 @@ test("routes live jobs to isolated runner slots and serializes only Manager port
 
   const acquire = runner.indexOf('flock -w 60 8');
   const start = runner.indexOf('cli.js" start --host');
-  const release = runner.indexOf('flock -u 8');
+  const cleanupStart = runner.indexOf("cleanup() {");
+  const cleanupRelease = runner.indexOf('flock -u 8', cleanupStart);
+  const cleanupRuntimeStop = runner.indexOf('cli.js" runtime stop', cleanupStart);
+  const releaseAfterStart = runner.indexOf('flock -u 8', start);
   assert.ok(acquire >= 0 && acquire < start, "port lock must be held before Manager starts");
-  assert.ok(release > start, "port lock must be released after Manager binds its port");
+  assert.ok(releaseAfterStart > start, "port lock must be released after Manager binds its port");
+  assert.ok(
+    cleanupRelease > cleanupStart && cleanupRelease < cleanupRuntimeStop,
+    "failure cleanup must release the port lock before stopping runtime resources",
+  );
 });
 
 test("cleanup fails closed when a custom home omits the matching runner root", { skip: process.platform !== "linux" }, (t) => {

--- a/scripts/run-dag-patterns-live-runner.sh
+++ b/scripts/run-dag-patterns-live-runner.sh
@@ -83,6 +83,8 @@ mkdir -p "$HOMERAIL_HOME"
 cleanup() {
   local exit_code=$?
   set +e
+  flock -u 8 2>/dev/null || true
+  exec 8>&-
   if [ -x "$REPO_ROOT/homerail_cli/dist/cli.js" ] || [ -f "$REPO_ROOT/homerail_cli/dist/cli.js" ]; then
     node "$REPO_ROOT/homerail_cli/dist/cli.js" runtime stop >/dev/null 2>&1
   fi

--- a/scripts/run-dag-patterns-live-runner.sh
+++ b/scripts/run-dag-patterns-live-runner.sh
@@ -15,7 +15,14 @@ MODEL_PROTOCOL="${HOMERAIL_PATTERN_MODEL_PROTOCOL:-anthropic_compatible}"
 AGENT_TYPE="${HOMERAIL_PATTERN_AGENT_TYPE:-claude-sdk}"
 RUN_KEY="${HOMERAIL_LIVE_RUN_KEY:-${GITHUB_RUN_ID:-manual}-${GITHUB_RUN_ATTEMPT:-1}}"
 RUN_KEY="$(printf '%s' "$RUN_KEY" | tr -c 'A-Za-z0-9_.-' '-')"
-LIVE_SLOT="$(printf '%s' "${HOMERAIL_LIVE_SLOT:-legacy}" | tr -c 'A-Za-z0-9_.-' '-')"
+LIVE_SLOT_INPUT="${HOMERAIL_LIVE_SLOT:-}"
+LIVE_SLOT="$(printf '%s' "${LIVE_SLOT_INPUT:-legacy}" | tr -c 'A-Za-z0-9_.-' '-')"
+LIVE_RUN_LABEL="org.homerail.live_run"
+if [ -n "$LIVE_SLOT_INPUT" ]; then
+  # Old checkout scripts globally delete the legacy label, so explicit slots use
+  # a versioned label that remains safe during the migration.
+  LIVE_RUN_LABEL="org.homerail.live_run_v2"
+fi
 
 case "$LIVE_SLOT" in
   ""|.|..)
@@ -79,11 +86,11 @@ cleanup() {
   if [ -x "$REPO_ROOT/homerail_cli/dist/cli.js" ] || [ -f "$REPO_ROOT/homerail_cli/dist/cli.js" ]; then
     node "$REPO_ROOT/homerail_cli/dist/cli.js" runtime stop >/dev/null 2>&1
   fi
-  mapfile -t containers < <(docker ps -aq --filter "label=org.homerail.live_run=$RUN_KEY" 2>/dev/null)
+  mapfile -t containers < <(docker ps -aq --filter "label=$LIVE_RUN_LABEL=$RUN_KEY" 2>/dev/null)
   if [ "${#containers[@]}" -gt 0 ]; then
     docker rm -f "${containers[@]}" >/dev/null 2>&1
   fi
-  mapfile -t images < <(docker images --filter "label=org.homerail.live_run=$RUN_KEY" --format "{{.ID}}" | sort -u)
+  mapfile -t images < <(docker images --filter "label=$LIVE_RUN_LABEL=$RUN_KEY" --format "{{.ID}}" | sort -u)
   if [ "${#images[@]}" -gt 0 ]; then
     docker image rm -f "${images[@]}" >/dev/null 2>&1
   fi
@@ -217,7 +224,7 @@ fi
 
 echo "Building isolated worker image $HOMERAIL_WORKER_IMAGE"
 docker build \
-  --label "org.homerail.live_run=$RUN_KEY" \
+  --label "$LIVE_RUN_LABEL=$RUN_KEY" \
   --label "org.homerail.live_slot=$LIVE_SLOT" \
   -t "$HOMERAIL_WORKER_IMAGE" \
   -f "$REPO_ROOT/homerail_worker/Dockerfile" \

--- a/scripts/run-dag-patterns-live-runner.sh
+++ b/scripts/run-dag-patterns-live-runner.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 LIVE_TASK="${HOMERAIL_LIVE_TASK:-patterns}"
 RUNNER_BASE="${HOMERAIL_RUNNER_BASE:-$HOME/.homerail-runners}"
-HOME_BASE="${HOMERAIL_LIVE_HOME_BASE:-$RUNNER_BASE/homerail_home}"
-ARTIFACT_BASE="${HOMERAIL_LIVE_ARTIFACTS:-$RUNNER_BASE/artifacts}"
+HOME_ROOT="${HOMERAIL_LIVE_HOME_BASE:-$RUNNER_BASE/homerail_home}"
+ARTIFACT_ROOT="${HOMERAIL_LIVE_ARTIFACTS:-$RUNNER_BASE/artifacts}"
 PREFERRED_MANAGER_PORT="${HOMERAIL_MANAGER_PORT:-}"
 MODEL_BASE_URL="${HOMERAIL_PATTERN_MODEL_BASE_URL:-}"
 MODEL_NAME="${HOMERAIL_PATTERN_MODEL:-qwen3.6}"
@@ -15,6 +15,19 @@ MODEL_PROTOCOL="${HOMERAIL_PATTERN_MODEL_PROTOCOL:-anthropic_compatible}"
 AGENT_TYPE="${HOMERAIL_PATTERN_AGENT_TYPE:-claude-sdk}"
 RUN_KEY="${HOMERAIL_LIVE_RUN_KEY:-${GITHUB_RUN_ID:-manual}-${GITHUB_RUN_ATTEMPT:-1}}"
 RUN_KEY="$(printf '%s' "$RUN_KEY" | tr -c 'A-Za-z0-9_.-' '-')"
+LIVE_SLOT="$(printf '%s' "${HOMERAIL_LIVE_SLOT:-legacy}" | tr -c 'A-Za-z0-9_.-' '-')"
+
+case "$LIVE_SLOT" in
+  ""|.|..)
+    echo "HOMERAIL_LIVE_SLOT must contain a safe runner slot name." >&2
+    exit 1
+    ;;
+esac
+
+export HOMERAIL_LIVE_SLOT="$LIVE_SLOT"
+HOME_BASE="$HOME_ROOT/slots/$LIVE_SLOT"
+ARTIFACT_BASE="$ARTIFACT_ROOT/slots/$LIVE_SLOT"
+SLOT_BASE="$RUNNER_BASE/slots/$LIVE_SLOT"
 
 case "$LIVE_TASK" in
   patterns|pr-review) ;;
@@ -49,9 +62,9 @@ fi
 PERSISTENT_ARTIFACT_DIR="$ARTIFACT_BASE/$RUN_KEY"
 REPORT_PATH="$PERSISTENT_ARTIFACT_DIR/dag-patterns-live.json"
 UPLOAD_REPORT_PATH="${HOMERAIL_LIVE_REPORT_PATH:-$REPO_ROOT/artifacts/dag-patterns-live.json}"
-LOCK_FILE="$RUNNER_BASE/dag-patterns-live.lock"
+LOCK_FILE="$SLOT_BASE/dag-patterns-live.lock"
 
-mkdir -p "$RUNNER_BASE" "$HOME_BASE" "$PERSISTENT_ARTIFACT_DIR" "$(dirname "$UPLOAD_REPORT_PATH")"
+mkdir -p "$RUNNER_BASE" "$SLOT_BASE" "$HOME_BASE" "$PERSISTENT_ARTIFACT_DIR" "$(dirname "$UPLOAD_REPORT_PATH")"
 exec 9>"$LOCK_FILE"
 if ! flock -w 60 9; then
   echo "Another HomeRail live validation is already running on this runner." >&2
@@ -205,10 +218,17 @@ fi
 echo "Building isolated worker image $HOMERAIL_WORKER_IMAGE"
 docker build \
   --label "org.homerail.live_run=$RUN_KEY" \
+  --label "org.homerail.live_slot=$LIVE_SLOT" \
   -t "$HOMERAIL_WORKER_IMAGE" \
   -f "$REPO_ROOT/homerail_worker/Dockerfile" \
   "$REPO_ROOT"
 
+PORT_LOCK_FILE="$RUNNER_BASE/manager-port-allocation.lock"
+exec 8>"$PORT_LOCK_FILE"
+if ! flock -w 60 8; then
+  echo "Could not acquire the Manager port allocation lock." >&2
+  exit 1
+fi
 if ! MANAGER_PORT="$(select_manager_port "$PREFERRED_MANAGER_PORT")"; then
   echo "No free Runner Manager port is available in the 20000-29999 range." >&2
   exit 1
@@ -222,6 +242,8 @@ else
 fi
 
 node "$REPO_ROOT/homerail_cli/dist/cli.js" start --host 0.0.0.0 --no-build-worker-image
+flock -u 8
+exec 8>&-
 SETTING_ID="$(node "$REPO_ROOT/scripts/configure-live-pattern-model.mjs")"
 
 if [ "$LIVE_TASK" = "pr-review" ]; then

--- a/scripts/run-dag-patterns-live-runner.sh
+++ b/scripts/run-dag-patterns-live-runner.sh
@@ -284,6 +284,18 @@ if [ "$LIVE_TASK" = "pr-review" ]; then
     node -e 'const fs=require("fs"); const value=JSON.parse(fs.readFileSync(process.argv[1], "utf8")); if (!value.run_id) process.exit(1); process.stdout.write(String(value.run_id))' \
       "$command_path"
   )"
+  REVIEW_STATUS="$(
+    node -e 'const fs=require("fs"); const value=JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(String(value.status ?? "unknown"))' \
+      "$command_path"
+  )"
+  if [ "$REVIEW_STATUS" != "completed" ]; then
+    node "$REPO_ROOT/homerail_cli/dist/cli.js" dag quick "$REVIEW_RUN_ID" --events 50 \
+      >"$REVIEW_ARTIFACT_DIR/dag-quick.txt" 2>&1 || true
+    node "$REPO_ROOT/homerail_cli/dist/cli.js" dag chats "$REVIEW_RUN_ID" --tools 20 --raw-tools \
+      >"$REVIEW_ARTIFACT_DIR/dag-chats.txt" 2>&1 || true
+    node "$REPO_ROOT/homerail_cli/dist/cli.js" dag handoffs "$REVIEW_RUN_ID" --content-limit 2000 \
+      >"$REVIEW_ARTIFACT_DIR/dag-handoffs.txt" 2>&1 || true
+  fi
   node "$REPO_ROOT/homerail_cli/dist/cli.js" dag artifact "$REVIEW_RUN_ID" pr-review.json \
     --output "$REVIEW_ARTIFACT_DIR/pr-review.json"
   node "$REPO_ROOT/homerail_cli/dist/cli.js" dag artifact "$REVIEW_RUN_ID" pr-review.md \


### PR DESCRIPTION
## Summary

- route model-backed PR Review to a dedicated `homerail-pr-review` runner
- isolate live Runner state, artifacts, Docker resources, and cleanup locks by Runner name
- serialize only Manager port allocation while each isolated runtime starts
- retain cleanup compatibility for legacy unscoped resources
- add actionlint configuration, operator documentation, and regression coverage

## Validation

- `npm run ci`
- `actionlint`
- `shellcheck scripts/run-dag-patterns-live-runner.sh scripts/cleanup-dag-patterns-live-runner.sh`
- `npm run test:live-validator`

## Host setup

A second self-hosted runner named `homerail-pr-review-112` is registered with only the `homerail-pr-review` custom label. The existing `homerail-live-112` runner remains dedicated to live DAG pattern validation.
