### PR TITLE
preserve full Manager responses in Voice Cockpit details

### DIFF
--- a/agent-ui/src/api/agent/agent-voice-api.ts
+++ b/agent-ui/src/api/agent/agent-voice-api.ts
@@ -32,6 +32,7 @@ export type {
   UpdateVoiceAgentConfigRequest,
   VoiceTtsOutputChannel,
   VoiceSpeechEvent,
+  VoiceManagerResult,
   VoiceTurnResponse,
   VoiceConfirmResponse,
   VoiceStreamEvent,

--- a/agent-ui/src/api/services/voice-agent-api.ts
+++ b/agent-ui/src/api/services/voice-agent-api.ts
@@ -52,6 +52,7 @@ export interface VoiceConversationMessage {
   id: string
   role: 'user' | 'assistant' | 'system'
   text: string
+  spoken_text?: string
   created_at: string
   channel?: 'final' | 'commentary'
   kind?: 'message' | 'error'
@@ -162,24 +163,30 @@ export interface VoiceSpeechEvent {
   text: string
 }
 
+export interface VoiceManagerResult {
+  [key: string]: unknown
+  text?: string
+  run_id?: string | null
+  run_ids?: string[]
+  session_id?: string | null
+  issue?: Record<string, unknown>
+  orchestrator?: Record<string, unknown>
+  manager_provider_name?: string
+  manager_model_name?: string
+}
+
 export interface VoiceTurnResponse {
   workspace: VoiceWorkspace
   spoken_text: string
   voice_events?: VoiceSpeechEvent[]
   suggested_action?: 'confirm' | null
+  manager?: VoiceManagerResult
+  manager_status?: VoiceManagerStatus
 }
 
 export interface VoiceConfirmResponse {
   workspace: VoiceWorkspace
-  manager: {
-    text?: string
-    run_id?: string | null
-    session_id?: string | null
-    issue?: Record<string, unknown>
-    orchestrator?: Record<string, unknown>
-    manager_provider_name?: string
-    manager_model_name?: string
-  }
+  manager: VoiceManagerResult
   manager_status?: VoiceManagerStatus
   spoken_text: string
   voice_events?: VoiceSpeechEvent[]
@@ -188,7 +195,7 @@ export interface VoiceConfirmResponse {
 export type VoiceStreamEvent =
   | { type: 'workspace'; workspace: VoiceWorkspace }
   | { type: 'speech'; event: VoiceSpeechEvent; workspace?: VoiceWorkspace }
-  | { type: 'done'; workspace: VoiceWorkspace; spoken_text?: string; voice_events?: VoiceSpeechEvent[]; suggested_action?: 'confirm' | null; manager_status?: VoiceManagerStatus }
+  | { type: 'done'; workspace: VoiceWorkspace; spoken_text?: string; voice_events?: VoiceSpeechEvent[]; suggested_action?: 'confirm' | null; manager?: VoiceManagerResult; manager_status?: VoiceManagerStatus }
   | { type: 'error'; message: string; workspace?: VoiceWorkspace }
   | { type: string; [key: string]: unknown }
 

--- a/agent-ui/src/components/agent/AgentVoiceCockpit.vue
+++ b/agent-ui/src/components/agent/AgentVoiceCockpit.vue
@@ -82,7 +82,8 @@ import {
   createVoiceSpeechEventKey,
   hasRecentVoiceSpeechEvent,
   isVoiceConversationMessageSpeakable,
-  rememberVoiceSpeechEvent
+  rememberVoiceSpeechEvent,
+  voiceConversationMessageSpeechText
 } from '@/utils/voice-speech-queue'
 import {
   isAndroidTvCompactViewport,
@@ -3076,18 +3077,19 @@ function queueNewAssistantSpeech(nextWorkspace: VoiceWorkspace | null | undefine
     item =>
       isVoiceConversationMessageSpeakable(item) &&
       !spokenAssistantMessageIds.value.has(item.id) &&
-      item.text.trim()
+      voiceConversationMessageSpeechText(item)
   )
   if (!candidates.length) return
   const next = new Set(spokenAssistantMessageIds.value)
   for (const item of candidates) next.add(item.id)
   spokenAssistantMessageIds.value = next
   const messages = candidates.filter(item => {
-    const event = { channel: item.channel || 'final', text: item.text }
+    const speechText = voiceConversationMessageSpeechText(item)
+    const event = { channel: item.channel || 'final', text: speechText }
     if (!hasRecentVoiceSpeechEvent(speechEventKeySeenAt, event)) return true
     recordTtsDebug(
       'tts_workspace_fallback_deduped',
-      `id=${item.id} key=${createVoiceSpeechEventKey(event)} text="${previewSpeechText(item.text)}"`
+      `id=${item.id} key=${createVoiceSpeechEventKey(event)} text="${previewSpeechText(speechText)}"`
     )
     return false
   })
@@ -3095,7 +3097,14 @@ function queueNewAssistantSpeech(nextWorkspace: VoiceWorkspace | null | undefine
   backgroundSpeechQueue = backgroundSpeechQueue
     .then(async () => {
       for (const item of messages) {
-        enqueueSpeechEvent({ id: item.id, channel: item.channel || 'final', text: item.text }, 'workspace')
+        enqueueSpeechEvent(
+          {
+            id: item.id,
+            channel: item.channel || 'final',
+            text: voiceConversationMessageSpeechText(item)
+          },
+          'workspace'
+        )
       }
     })
     .catch((err: any) => {

--- a/agent-ui/src/utils/voice-speech-queue.test.ts
+++ b/agent-ui/src/utils/voice-speech-queue.test.ts
@@ -6,6 +6,7 @@ import {
   normalizeVoiceSpeechTextForKey,
   pruneVoiceSpeechEventKeys,
   rememberVoiceSpeechEvent,
+  voiceConversationMessageSpeechText,
 } from './voice-speech-queue'
 
 describe('voice speech queue helpers', () => {
@@ -18,12 +19,31 @@ describe('voice speech queue helpers', () => {
 
   it('dedupes explicit speech events and workspace fallback by spoken text', () => {
     const seen = new Map<string, number>()
-    const explicit = { id: 'speech-1', channel: 'final', text: '队列复测会播放 TTS。' }
-    const fallback = { id: 'assistant-1', channel: 'final', text: '队列复测会播放 TTS。' }
+    const explicit = { id: 'speech-1', channel: 'final', text: '精简的 TTS。' }
+    const conversation = {
+      id: 'assistant-1',
+      channel: 'final',
+      text: '这是详情面板需要完整展示、但绝不能在流式事件结束后再次朗读的 Manager 回答。',
+      spoken_text: '精简的 TTS。',
+    }
+    const fallback = {
+      channel: conversation.channel,
+      text: voiceConversationMessageSpeechText(conversation),
+    }
 
     expect(hasRecentVoiceSpeechEvent(seen, fallback, 1_000)).toBe(false)
     rememberVoiceSpeechEvent(seen, explicit, 1_000)
     expect(hasRecentVoiceSpeechEvent(seen, fallback, 1_001)).toBe(true)
+  })
+
+  it('prefers persisted spoken text and falls back for legacy conversation messages', () => {
+    expect(voiceConversationMessageSpeechText({
+      text: '完整显示文本',
+      spoken_text: '精简朗读文本',
+    })).toBe('精简朗读文本')
+    expect(voiceConversationMessageSpeechText({ text: '旧会话文本' })).toBe('旧会话文本')
+    expect(voiceConversationMessageSpeechText({ text: '不要朗读', spoken_text: '' })).toBe('')
+    expect(voiceConversationMessageSpeechText({ text: '   ', spoken_text: '   ' })).toBe('')
   })
 
   it('keeps commentary and final channels separate', () => {
@@ -53,6 +73,12 @@ describe('voice speech queue helpers', () => {
       role: 'assistant',
       kind: 'message',
       text: '任务已经完成。',
+    })).toBe(true)
+    expect(isVoiceConversationMessageSpeakable({
+      role: 'assistant',
+      kind: 'message',
+      text: '',
+      spoken_text: '任务已经完成。',
     })).toBe(true)
   })
 })

--- a/agent-ui/src/utils/voice-speech-queue.ts
+++ b/agent-ui/src/utils/voice-speech-queue.ts
@@ -9,6 +9,7 @@ export interface VoiceConversationSpeechCandidate {
   role?: string | null
   kind?: string | null
   text?: string | null
+  spoken_text?: string | null
 }
 
 export const VOICE_SPEECH_EVENT_KEY_TTL_MS = 60_000
@@ -20,7 +21,20 @@ export function normalizeVoiceSpeechTextForKey(text: string | null | undefined):
 export function isVoiceConversationMessageSpeakable(
   message: VoiceConversationSpeechCandidate,
 ): boolean {
-  return message.role === 'assistant' && message.kind !== 'error' && Boolean(message.text?.trim())
+  return (
+    message.role === 'assistant' &&
+    message.kind !== 'error' &&
+    Boolean(voiceConversationMessageSpeechText(message))
+  )
+}
+
+export function voiceConversationMessageSpeechText(
+  message: VoiceConversationSpeechCandidate,
+): string {
+  if (message.spoken_text !== undefined && message.spoken_text !== null) {
+    return message.spoken_text.trim()
+  }
+  return message.text?.trim() || ''
 }
 
 export function createVoiceSpeechEventKey(event: VoiceSpeechFingerprintInput): string {

--- a/homerail_manager/src/server/voice-agent-bootstrap.ts
+++ b/homerail_manager/src/server/voice-agent-bootstrap.ts
@@ -117,6 +117,7 @@ interface VoiceWorkspace {
     id: string;
     role: "user" | "assistant" | "system";
     text: string;
+    spoken_text?: string;
     created_at: string;
     channel?: "final" | "commentary";
     kind?: "message" | "error";
@@ -742,8 +743,17 @@ function appendConversation(
   text: string,
   channel: "final" | "commentary" = "final",
   kind: "message" | "error" = "message",
+  spokenText?: string,
 ) {
-  workspace.conversation.push({ id: generateId("msg-"), role, text, channel, kind, created_at: now() });
+  workspace.conversation.push({
+    id: generateId("msg-"),
+    role,
+    text,
+    ...(spokenText !== undefined ? { spoken_text: spokenText } : {}),
+    channel,
+    kind,
+    created_at: now(),
+  });
   workspace.conversation = workspace.conversation.slice(-80);
 }
 
@@ -1049,11 +1059,12 @@ async function submitVoiceWorkspaceToManagerAgent(
       let streamResult: Awaited<ReturnType<typeof runManagerAgentTurn>> | undefined;
       for await (const event of runManagerAgentTurnStream(turnInput, options)) {
         if (event.type === "commentary") {
-          const text = shortText(String(event.text || "").trim(), 120);
+          const text = String(event.text || "").trim();
           if (!text) continue;
-          appendConversation(workspace, "assistant", text, "commentary");
+          const spokenText = shortText(text, 120);
+          appendConversation(workspace, "assistant", text, "commentary", "message", spokenText);
           realtimeHooks.streamedCommentaryTexts?.add(text);
-          realtimeHooks.onSpeech({ id: generateId("speech-"), channel: "commentary", text });
+          realtimeHooks.onSpeech({ id: generateId("speech-"), channel: "commentary", text: spokenText });
         } else if (event.type === "result") {
           streamResult = event.result;
         }
@@ -1087,13 +1098,14 @@ async function submitVoiceWorkspaceToManagerAgent(
   const surface = objectValue(result.voice_surface);
   const surfaceCommentary = Array.isArray(surface?.commentary_texts) ? surface.commentary_texts : [];
   const alreadyStreamed = realtimeHooks?.streamedCommentaryTexts ?? new Set<string>();
-  const commentaryTexts = [
+  const commentaryMessages = [
     ...(Array.isArray(result.commentary_texts) ? result.commentary_texts : []),
     ...surfaceCommentary,
   ]
-    .map((item) => shortText(String(item || "").trim(), 120))
+    .map((item) => String(item || "").trim())
     .filter((item) => item && !alreadyStreamed.has(item))
-    .slice(0, 6);
+    .slice(0, 6)
+    .map((text) => ({ text, spokenText: shortText(text, 120) }));
   const agentErrors = Array.isArray(result.agent_errors)
     ? result.agent_errors.map((item) => shortText(String(item || "").trim(), 500)).filter(Boolean).slice(0, 10)
     : [];
@@ -1131,14 +1143,21 @@ async function submitVoiceWorkspaceToManagerAgent(
   // Manager 执行状态只写 progress_brief/manager_run_id，不在这里程序化插入 status widget。
   removeWidget(workspace, "manager-run");
   removeWidget(workspace, "manager-agent-blocker");
-  for (const commentary of commentaryTexts) {
-    appendConversation(workspace, "assistant", commentary, "commentary");
+  for (const commentary of commentaryMessages) {
+    appendConversation(
+      workspace,
+      "assistant",
+      commentary.text,
+      "commentary",
+      "message",
+      commentary.spokenText,
+    );
   }
-  appendConversation(workspace, "assistant", spoken);
+  appendConversation(workspace, "assistant", reply, "final", "message", spoken);
   return {
     spoken_text: spoken,
     suggested_action: null,
-    commentary_texts: commentaryTexts,
+    commentary_texts: commentaryMessages.map((item) => item.spokenText),
     manager: {
       text: reply,
       session_id: workspace.manager_session_id ?? null,
@@ -1646,7 +1665,14 @@ export function voiceAgentBootstrapHandler(
         const priority = body.priority === "high" || body.priority === "low" ? body.priority : "normal";
         const spoken = typeof body.spoken_text === "string" && body.spoken_text.trim() ? body.spoken_text.trim() : title;
         workspace.progress_brief = { status: priority === "high" ? "blocked" : "running", short_text: spoken, updated_at: now() };
-        appendConversation(workspace, "assistant", msg ? `${spoken}\n${msg}` : spoken);
+        appendConversation(
+          workspace,
+          "assistant",
+          msg ? `${spoken}\n${msg}` : spoken,
+          "final",
+          "message",
+          spoken,
+        );
         ok(res, "Voice notification queued", { workspace: saveWorkspace(workspace), spoken_text: spoken, voice_events: voiceEvents(spoken) });
       })
       .catch((err) => badRequest(res, err instanceof Error ? err.message : "Invalid JSON body"));

--- a/homerail_manager/tests/voice-bootstrap.test.ts
+++ b/homerail_manager/tests/voice-bootstrap.test.ts
@@ -850,14 +850,15 @@ describe("voice bootstrap routes", () => {
   });
 
   it("streams Manager Agent commentary before the final done event", async () => {
+    const fullCommentary = `正在检查项目：${"逐项核对完整的依赖、配置与运行日志。".repeat(8)}`;
     _setHostCodexManagerAgentStreamRunnerForTest(async function* (input) {
-      yield { type: "commentary", text: "正在检查项目。", source: "tool" };
+      yield { type: "commentary", text: fullCommentary, source: "tool" };
       yield {
         type: "result",
         result: {
           text: `handled ${input.message}`,
           spoken_text: "处理完成。",
-          commentary_texts: ["正在检查项目。"],
+          commentary_texts: [fullCommentary],
           session_id: input.session_id || "host-session-stream",
           run_id: null,
           run_ids: [],
@@ -891,16 +892,30 @@ describe("voice bootstrap routes", () => {
     const lines = (await stream.text())
       .trim()
       .split("\n")
-      .map((line) => JSON.parse(line) as { type: string; event?: { channel?: string; text?: string } });
+      .map((line) => JSON.parse(line) as {
+        type: string;
+        event?: { channel?: string; text?: string };
+        workspace?: {
+          conversation: Array<{ role: string; text: string; spoken_text?: string; channel?: string }>;
+        };
+      });
     const commentaryIndex = lines.findIndex((line) => line.type === "speech" && line.event?.channel === "commentary");
     const doneIndex = lines.findIndex((line) => line.type === "done");
     const commentaryEvents = lines.filter((line) => line.type === "speech" && line.event?.channel === "commentary");
+    const doneWorkspace = lines[doneIndex]?.workspace;
 
     expect(stream.status).toBe(200);
     expect(commentaryIndex).toBeGreaterThan(-1);
     expect(doneIndex).toBeGreaterThan(commentaryIndex);
     expect(commentaryEvents).toHaveLength(1);
-    expect(commentaryEvents[0]?.event?.text).toBe("正在检查项目。");
+    expect(commentaryEvents[0]?.event?.text?.length).toBeLessThanOrEqual(120);
+    expect(commentaryEvents[0]?.event?.text).not.toBe(fullCommentary);
+    expect(doneWorkspace?.conversation).toContainEqual(expect.objectContaining({
+      role: "assistant",
+      text: fullCommentary,
+      spoken_text: commentaryEvents[0]?.event?.text,
+      channel: "commentary",
+    }));
   });
 
   it("persists manager-agent voice errors as failed sessions instead of throwing status errors", async () => {
@@ -1525,7 +1540,7 @@ describe("voice bootstrap routes", () => {
           task_draft: unknown;
           pending_confirmations: unknown[];
           widgets: Array<{ id: string }>;
-          conversation: Array<{ role: string; text: string; channel?: string }>;
+          conversation: Array<{ role: string; text: string; spoken_text?: string; channel?: string }>;
           debug_events: Array<{ code: string }>;
           progress_brief: { status: string };
         };
@@ -1544,7 +1559,14 @@ describe("voice bootstrap routes", () => {
     expect(body.data.workspace.conversation).toContainEqual(expect.objectContaining({
       role: "assistant",
       text: "正在调用 Manager tools。",
+      spoken_text: "正在调用 Manager tools。",
       channel: "commentary",
+    }));
+    expect(body.data.workspace.conversation).toContainEqual(expect.objectContaining({
+      role: "assistant",
+      text: "host codex handled: HomeRail 语音测试，请创建一个一句话任务摘要，不要执行真实操作。",
+      spoken_text: "已启动执行，我会继续跟进。",
+      channel: "final",
     }));
     expect(body.data.workspace.progress_brief.status).toBe("done");
     expect(body.data.workspace.debug_events).toContainEqual(expect.objectContaining({ code: "manager_agent_warning" }));
@@ -1849,7 +1871,7 @@ describe("voice bootstrap routes", () => {
         spoken_text: string;
         workspace: {
           widgets: Array<{ id: string; type: string; body: string }>;
-          conversation: Array<{ role: string; text: string; channel?: string }>;
+          conversation: Array<{ role: string; text: string; spoken_text?: string; channel?: string }>;
         };
       };
     };
@@ -1861,9 +1883,115 @@ describe("voice bootstrap routes", () => {
     expect(body.data.workspace.widgets).not.toContainEqual(expect.objectContaining({ id: "manager-summary" }));
     expect(body.data.workspace.conversation.at(-1)).toMatchObject({
       role: "assistant",
-      text: body.data.spoken_text,
+      text: verbose,
+      spoken_text: body.data.spoken_text,
       channel: "final",
     });
+    const reloaded = await fetch(`${baseUrl}/api/voice-agent/sessions/${createdBody.data.session_id}`);
+    const reloadedBody = await reloaded.json() as {
+      data: {
+        conversation: Array<{ role: string; text: string; spoken_text?: string; channel?: string }>;
+      };
+    };
+    expect(reloaded.status).toBe(200);
+    expect(reloadedBody.data.conversation.at(-1)).toMatchObject({
+      role: "assistant",
+      text: verbose,
+      spoken_text: body.data.spoken_text,
+      channel: "final",
+    });
+  });
+
+  it("persists full blocked and failed explanations while speaking concise status text", async () => {
+    const fullCommentary = `正在核对失败原因：${"检查运行记录和依赖状态。".repeat(12)}`;
+    const explanations = {
+      blocked: `任务暂时被阻塞：${"缺少继续执行所需的外部输入和确认。".repeat(10)}`,
+      failed: `任务执行失败：${"下游服务返回了不可恢复的错误，需要人工处理。".repeat(10)}`,
+    };
+    _setHostCodexManagerAgentRunnerForTest(async (input) => {
+      const status = input.message === "simulate failed" ? "failed" : "blocked";
+      return {
+        text: explanations[status],
+        spoken_text: explanations[status],
+        session_id: input.session_id || "host-session-status",
+        run_id: null,
+        run_ids: [],
+        objective: { required: true, satisfied: false, tool_calls: [] },
+        tool_calls: [],
+        tool_results: [],
+        commentary_texts: [fullCommentary],
+        voice_surface: {
+          progress: { status, short_text: explanations[status] },
+          task_draft: null,
+          widgets: [],
+          remove_widget_ids: [],
+        },
+        worker_id: "host-codex",
+        container_name: null,
+      };
+    });
+    const port = await listen(server);
+    const baseUrl = `http://127.0.0.1:${port}`;
+
+    await fetch(`${baseUrl}/api/voice-agent/config`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ harness: "codex_appserver", model_name: "gpt-5.5", reasoning_effort: "low" }),
+    });
+    const created = await fetch(`${baseUrl}/api/voice-agent/sessions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+    const createdBody = await created.json() as { data: { session_id: string } };
+
+    for (const status of ["blocked", "failed"] as const) {
+      const turn = await fetch(`${baseUrl}/api/voice-agent/sessions/${createdBody.data.session_id}/turn`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: `simulate ${status}` }),
+      });
+      const body = await turn.json() as {
+        data: {
+          spoken_text: string;
+          voice_events: Array<{ channel: string; text: string }>;
+          manager: { text?: string };
+          workspace: {
+            progress_brief: { status: string };
+            conversation: Array<{
+              role: string;
+              text: string;
+              spoken_text?: string;
+              channel?: string;
+            }>;
+          };
+        };
+      };
+      const finalMessage = body.data.workspace.conversation.at(-1);
+      const commentaryMessage = body.data.workspace.conversation.findLast(
+        (item) => item.channel === "commentary" && item.text === fullCommentary,
+      );
+      const commentarySpeech = body.data.voice_events.find((event) => event.channel === "commentary");
+
+      expect(turn.status).toBe(200);
+      expect(body.data.workspace.progress_brief.status).toBe(status);
+      expect(body.data.manager.text).toBe(explanations[status]);
+      expect(body.data.spoken_text).toBe("处理被阻塞，原因已放到屏幕上。");
+      expect(finalMessage).toMatchObject({
+        role: "assistant",
+        text: explanations[status],
+        spoken_text: body.data.spoken_text,
+        channel: "final",
+      });
+      expect(commentarySpeech?.text.length).toBeLessThanOrEqual(120);
+      expect(commentarySpeech?.text).not.toBe(fullCommentary);
+      expect(commentaryMessage).toMatchObject({
+        role: "assistant",
+        text: fullCommentary,
+        spoken_text: commentarySpeech?.text,
+        channel: "commentary",
+      });
+    }
   });
 
   it("applies structured voice surface without creating the default Manager Agent status card", async () => {


### PR DESCRIPTION
## Summary

- persist complete Manager final responses and commentary in the voice workspace
- store concise TTS narration separately as optional `spoken_text`
- make Agent UI fallback playback and deduplication use the spoken representation
- keep legacy sessions compatible when `spoken_text` is absent

## Validation

- `npm run ci` — 1233 passed, 2 skipped, 0 failed
- focused Manager voice bootstrap tests — 37 passed
- focused Agent UI speech queue tests — 6 passed

Fixes #27