### PR TITLE
Add durable DAG activity plane

### DIFF
--- a/docs/architecture/durable-dag-actors.md
+++ b/docs/architecture/durable-dag-actors.md
@@ -1,0 +1,66 @@
+# Durable DAG Actors
+
+This document defines the durable activity boundary introduced by Epic #36. It is intentionally narrower than actor retention, command routing, UI projection, or supervision.
+
+## Activity Plane
+
+The Activity Plane is the append-only record of what a DAG actor did. The Worker emits events, the Manager validates and persists them, and consumers replay them. Activity events never mutate A2UI directly.
+
+The V1 envelope is `dag-activity-event-v1`:
+
+| Field | Meaning |
+| --- | --- |
+| `schema_version` | Contract version. V1 is the integer `1`. |
+| `event_id` | Globally unique idempotency key. Replaying the same event is a no-op; reusing the ID for different content is rejected. |
+| `run_id` | Durable DAG run identity. |
+| `round_id` | Command/response round that produced the event. Until multi-round actors land, the node session is used. |
+| `node_id` | DAG node that owns the execution slot. It must match the authenticated Worker stream context. |
+| `actor_id` | Logical actor identity. It defaults to `node_id` until logical actors are introduced. |
+| `generation` | Actor process generation, starting at 1. A replacement process increments it; older generations remain auditable. |
+| `surface_id` | Optional logical UI surface association. It is routing metadata, not a request to update A2UI. |
+| `sequence` | Strictly increasing sequence inside one `(run_id, actor_id, generation)`. |
+| `timestamp` | Producer time in Unix milliseconds. Journal receive order is stored separately. |
+| `type` | `started`, `progress`, `finding`, `tool_used`, `blocked`, `completed`, or `failed`. |
+| `payload` | Structured, redacted event-specific data. |
+
+Ordering is guaranteed only for one actor generation. Journal sequence provides deterministic replay order for events the Manager received, but it is not a causal total order across actors. Consumers must use actor identity, generation, and activity sequence when deciding whether an event is current.
+
+Workers receive `activity_sequence_start` with dispatch metadata and continue from the last sequence already persisted for that actor generation. A first dispatch starts at zero; corrections and later dispatches resume after the durable cursor.
+
+## Production Rules
+
+Lifecycle events are runtime-owned:
+
+- `started` is emitted when a Worker begins a node invocation.
+- `tool_used` is emitted for tool start and completion, including a redacted result preview.
+- `completed` is emitted immediately before a contract-valid handoff. It closes the Worker round; the Manager run state remains authoritative for whether the DAG node was accepted.
+- `failed` is emitted before a terminal node error.
+
+Agents may explicitly report only `progress`, `finding`, and `blocked` through `report_activity`. These events must represent useful state changes or evidence. Fixed, tool-name-derived status prose is not activity.
+
+## Persistence And Replay
+
+The Manager persists Activity Plane events in `dag_activity_events`; the existing `dag_events` table and `/api/runs/:run_id/events` endpoint remain unchanged for backward compatibility.
+
+Journal writes enforce:
+
+1. protocol validation before persistence;
+2. transport `run_id`, `node_id`, and `round_id` identity matching;
+3. credential redaction again at the Manager trust boundary;
+4. idempotency by `event_id`;
+5. uniqueness of sequence within one actor generation;
+6. append-only rows with no update API.
+
+Replay uses `GET /api/runs/:run_id/activities`, with optional `actor_id`, `after_seq`, and bounded `limit` query parameters. The cursor is the Manager journal sequence, so replay resumes without relying on producer clocks.
+
+## Follow-up Boundaries
+
+- **Logical actors and inbox (#38):** assign stable `actor_id`, durable inbox records, and sequence starts.
+- **Multi-round execution (#39):** create new `round_id` values while continuing the actor-generation sequence.
+- **Lease and cold recovery (#40):** increment `generation` when ownership changes and reject stale writes for live projection while retaining them for audit.
+- **Projector (#41):** consume journal events and produce A2UI transactions. It must not edit journal rows.
+- **Live UI (#42):** subscribe to projected state, not raw Worker output.
+- **Supervisor and intervention (#43-#44):** read the same journal and issue commands through the control plane, never by rewriting activity history.
+- **End-to-end proof (#45):** verify multiple actors, live projection, recovery, and release as one scenario.
+
+Keeping these boundaries separate lets the journal remain the stable fact source while actor lifecycle and presentation evolve independently.

--- a/homerail_manager/src/node/websocket.ts
+++ b/homerail_manager/src/node/websocket.ts
@@ -16,7 +16,7 @@ import {
 import { resolveLifecycleResponse, rejectAllPendingRequests } from "./lifecycle-request.js";
 import { applyResponseHandoff } from "../orchestration/response-bridge.js";
 import { handleDagMessageResponse } from "../orchestration/dag-message-router.js";
-import { clearByTargetId } from "../orchestration/dispatch-tracker.js";
+import { clearByTargetId, isCurrentDispatchTarget } from "../orchestration/dispatch-tracker.js";
 import { emit } from "../events/bus.js";
 import { appendChatEntry } from "../persistence/store.js";
 import { appendSessionTranscriptEntry } from "../persistence/dag-session-files.js";
@@ -394,10 +394,16 @@ export function setupNodeWebSocket(
           if (msg.data.event === "dag_activity") {
             try {
               if (!runId || !nodeId) throw new Error("DAG activity transport identity is missing");
+              const sessionId = dataSessionId(msg.data);
+              if (!sessionId) throw new Error("DAG activity transport session is missing");
+              if (!isCurrentDispatchTarget(runId, nodeId, "node", node_id)) {
+                throw new Error("DAG activity source does not match the current dispatch target");
+              }
+              if (shouldIgnoreStaleSession(node_id, "dag_activity", msg.data)) return;
               ingestDagActivityStream(msg.data, {
                 runId,
                 nodeId,
-                roundId: dataSessionId(msg.data),
+                roundId: sessionId,
               });
             } catch (error) {
               console.warn(

--- a/homerail_manager/src/node/websocket.ts
+++ b/homerail_manager/src/node/websocket.ts
@@ -32,6 +32,7 @@ import {
   isLoopbackRemoteAddress,
   rejectWebSocketUpgrade,
 } from "../server/control-plane-auth.js";
+import { ingestDagActivityStream } from "../runtime/dag-activity-stream.js";
 
 const WS_URL_PATTERN = /^\/ws\/projects\/([^\/]+)\/nodes\/([^\/]+)$/;
 const DEFAULT_REGISTRATION_TIMEOUT_MS = 10_000;
@@ -388,9 +389,24 @@ export function setupNodeWebSocket(
         }
 
         if (msg.type === "stream") {
-          if (shouldIgnoreStaleSession(node_id, "stream", msg.data)) return;
           const runId = streamRunId(msg.data);
           const nodeId = streamNodeId(msg.data);
+          if (msg.data.event === "dag_activity") {
+            try {
+              if (!runId || !nodeId) throw new Error("DAG activity transport identity is missing");
+              ingestDagActivityStream(msg.data, {
+                runId,
+                nodeId,
+                roundId: dataSessionId(msg.data),
+              });
+            } catch (error) {
+              console.warn(
+                `[homerail_manager] rejected DAG activity from node ${node_id}: ${error instanceof Error ? error.message : String(error)}`,
+              );
+            }
+            return;
+          }
+          if (shouldIgnoreStaleSession(node_id, "stream", msg.data)) return;
           if (runId && nodeId) {
             if (msg.data.event === "advisor_call_started" && typeof msg.data.advisor_id === "string") {
               recordAdvisorCall(runId, nodeId, msg.data.advisor_id);

--- a/homerail_manager/src/orchestration/dag-dispatcher.ts
+++ b/homerail_manager/src/orchestration/dag-dispatcher.ts
@@ -25,6 +25,13 @@ export interface DispatchEnvelope {
   workspaceAccess?: DagWorkspaceAccess;
   allowedBuiltinTools?: AgentBuiltinToolName[];
   allowedDagTools?: DagAgentToolName[];
+  activity?: {
+    roundId: string;
+    actorId: string;
+    generation: number;
+    surfaceId?: string;
+    sequenceStart: number;
+  };
 }
 
 export type DispatchResult =

--- a/homerail_manager/src/orchestration/dispatch-tracker.ts
+++ b/homerail_manager/src/orchestration/dispatch-tracker.ts
@@ -53,6 +53,19 @@ export function findDispatchTarget(
   return dispatches.get(key(runId, nodeId));
 }
 
+/** Bind an inbound transport message to the exact target selected at dispatch. */
+export function isCurrentDispatchTarget(
+  runId: string,
+  nodeId: string,
+  targetType: "worker" | "node",
+  targetId: string,
+): boolean {
+  const target = findDispatchTarget(runId, nodeId);
+  return target?.state === "dispatched"
+    && target.targetType === targetType
+    && target.targetId === targetId;
+}
+
 export function clearDispatchTarget(runId: string, nodeId: string): void {
   dispatches.delete(key(runId, nodeId));
 }

--- a/homerail_manager/src/persistence/dag-activity-journal.ts
+++ b/homerail_manager/src/persistence/dag-activity-journal.ts
@@ -9,6 +9,7 @@ import { getDb, parseJsonRow } from "./db.js";
 export const DEFAULT_DAG_ACTIVITY_REPLAY_LIMIT = 100;
 export const MAX_DAG_ACTIVITY_REPLAY_LIMIT = 500;
 export const MAX_DAG_ACTIVITY_EVENT_BYTES = 256 * 1024;
+export const MAX_DAG_ACTIVITY_SEQUENCE_AHEAD = 64;
 
 export interface DagActivityJournalEntry {
   /** Monotonic journal cursor. It does not imply a cross-actor causal order. */
@@ -39,12 +40,44 @@ export interface DagActivityEventPage {
 
 export class DagActivityJournalConflictError extends Error {
   constructor(
-    public readonly code: "event_id_collision" | "sequence_collision",
+    public readonly code: "event_id_collision" | "sequence_collision" | "sequence_gap",
     message: string,
   ) {
     super(message);
     this.name = "DagActivityJournalConflictError";
   }
+}
+
+/** Highest contiguous sequence starting at 1 for one actor generation. */
+export function getDagActivityContiguousSequenceCursor(
+  runId: string,
+  actorId: string,
+  generation: number,
+): number {
+  assertIdentifier(runId, "run_id");
+  assertIdentifier(actorId, "actor_id");
+  if (!Number.isSafeInteger(generation) || generation < 1) {
+    throw new Error("generation must be a positive safe integer");
+  }
+  const db = getDb();
+  const first = db.prepare(`
+    SELECT 1 AS present
+    FROM dag_activity_events
+    WHERE run_id = ? AND actor_id = ? AND generation = ? AND activity_sequence = 1
+  `).get(runId, actorId, generation);
+  if (!first) return 0;
+  const row = db.prepare(`
+    SELECT MIN(current.activity_sequence) AS sequence
+    FROM dag_activity_events current
+    LEFT JOIN dag_activity_events next
+      ON next.run_id = current.run_id
+      AND next.actor_id = current.actor_id
+      AND next.generation = current.generation
+      AND next.activity_sequence = current.activity_sequence + 1
+    WHERE current.run_id = ? AND current.actor_id = ? AND current.generation = ?
+      AND next.seq IS NULL
+  `).get(runId, actorId, generation) as { sequence: number | null };
+  return Number(row.sequence ?? 0);
 }
 
 interface ActivityRow {
@@ -201,6 +234,18 @@ export function appendDagActivityEvent(event: unknown): AppendDagActivityEventRe
       throw new DagActivityJournalConflictError(
         "sequence_collision",
         `DAG activity sequence ${storedEvent.sequence} is already used by actor ${storedEvent.actor_id} generation ${storedEvent.generation}`,
+      );
+    }
+
+    const contiguousSequence = getDagActivityContiguousSequenceCursor(
+      storedEvent.run_id,
+      storedEvent.actor_id,
+      storedEvent.generation,
+    );
+    if (storedEvent.sequence > contiguousSequence + MAX_DAG_ACTIVITY_SEQUENCE_AHEAD) {
+      throw new DagActivityJournalConflictError(
+        "sequence_gap",
+        `DAG activity sequence ${storedEvent.sequence} is more than ${MAX_DAG_ACTIVITY_SEQUENCE_AHEAD} entries ahead of contiguous sequence ${contiguousSequence}`,
       );
     }
 

--- a/homerail_manager/src/persistence/dag-activity-journal.ts
+++ b/homerail_manager/src/persistence/dag-activity-journal.ts
@@ -1,0 +1,289 @@
+import { createHash } from "node:crypto";
+import {
+  type DagActivityEventV1,
+  redactTelemetry,
+  validateDagActivityEventV1,
+} from "homerail-protocol";
+import { getDb, parseJsonRow } from "./db.js";
+
+export const DEFAULT_DAG_ACTIVITY_REPLAY_LIMIT = 100;
+export const MAX_DAG_ACTIVITY_REPLAY_LIMIT = 500;
+export const MAX_DAG_ACTIVITY_EVENT_BYTES = 256 * 1024;
+
+export interface DagActivityJournalEntry {
+  /** Monotonic journal cursor. It does not imply a cross-actor causal order. */
+  seq: number;
+  received_at: number;
+  event: DagActivityEventV1;
+}
+
+export interface AppendDagActivityEventResult extends DagActivityJournalEntry {
+  inserted: boolean;
+  deduplicated: boolean;
+}
+
+export interface ListDagActivityEventsOptions {
+  run_id: string;
+  actor_id?: string;
+  after_seq?: number;
+  limit?: number;
+}
+
+export interface DagActivityEventPage {
+  events: DagActivityJournalEntry[];
+  /** Cursor to pass as `after_seq` for the next page. */
+  next_after_seq: number;
+  has_more: boolean;
+  limit: number;
+}
+
+export class DagActivityJournalConflictError extends Error {
+  constructor(
+    public readonly code: "event_id_collision" | "sequence_collision",
+    message: string,
+  ) {
+    super(message);
+    this.name = "DagActivityJournalConflictError";
+  }
+}
+
+interface ActivityRow {
+  seq: number;
+  event_id: string;
+  run_id: string;
+  actor_id: string;
+  generation: number;
+  activity_sequence: number;
+  received_at: number;
+  event_digest: string;
+  event_json: string;
+}
+
+function validationDetails(event: unknown): string | undefined {
+  const result = validateDagActivityEventV1(event);
+  if (result.valid) return undefined;
+  return result.errors
+    .slice(0, 5)
+    .map((error) => `${error.path || "/"} ${error.message}`)
+    .join("; ");
+}
+
+function assertValidEvent(event: unknown): asserts event is DagActivityEventV1 {
+  const details = validationDetails(event);
+  if (details) throw new Error(`Invalid DAG activity event: ${details}`);
+}
+
+function assertEventSize(event: unknown): void {
+  let eventJson: string | undefined;
+  try {
+    eventJson = JSON.stringify(event);
+  } catch {
+    throw new Error("DAG activity event must be JSON serializable");
+  }
+  if (eventJson === undefined) {
+    throw new Error("DAG activity event must be JSON serializable");
+  }
+  if (Buffer.byteLength(eventJson, "utf8") > MAX_DAG_ACTIVITY_EVENT_BYTES) {
+    throw new Error(`DAG activity event exceeds ${MAX_DAG_ACTIVITY_EVENT_BYTES} bytes`);
+  }
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map((item) => canonicalize(item));
+  if (value && typeof value === "object") {
+    const result: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      const nested = (value as Record<string, unknown>)[key];
+      if (nested !== undefined) result[key] = canonicalize(nested);
+    }
+    return result;
+  }
+  return value;
+}
+
+function encodeCanonicalEvent(event: DagActivityEventV1): { event_json: string; event_digest: string } {
+  const eventJson = JSON.stringify(canonicalize(event));
+  return {
+    event_json: eventJson,
+    event_digest: createHash("sha256").update(eventJson).digest("hex"),
+  };
+}
+
+function redactEvent(event: DagActivityEventV1): DagActivityEventV1 {
+  const redacted = {
+    ...event,
+    payload: redactTelemetry(event.payload),
+  };
+  assertValidEvent(redacted);
+  return redacted;
+}
+
+function decodeEntry(row: Pick<ActivityRow, "seq" | "received_at" | "event_json">): DagActivityJournalEntry {
+  const event = parseJsonRow<unknown>(row.event_json);
+  assertValidEvent(event);
+  return { seq: row.seq, received_at: row.received_at, event };
+}
+
+function assertIdentifier(value: string, label: string): void {
+  if (!value || value.length > 256) throw new Error(`${label} must be between 1 and 256 characters`);
+}
+
+function normalizeCursor(value: number | undefined): number {
+  const cursor = value ?? 0;
+  if (!Number.isSafeInteger(cursor) || cursor < 0) {
+    throw new Error("after_seq must be a non-negative safe integer");
+  }
+  return cursor;
+}
+
+function normalizeLimit(value: number | undefined): number {
+  const requested = value ?? DEFAULT_DAG_ACTIVITY_REPLAY_LIMIT;
+  if (!Number.isSafeInteger(requested) || requested < 1) {
+    throw new Error("limit must be a positive safe integer");
+  }
+  return Math.min(requested, MAX_DAG_ACTIVITY_REPLAY_LIMIT);
+}
+
+/**
+ * Append one redacted activity to the durable journal.
+ *
+ * Replaying the same semantic event_id is idempotent. Reusing an event_id for
+ * different content, or reusing an actor generation sequence with another
+ * event_id, fails closed.
+ */
+export function appendDagActivityEvent(event: unknown): AppendDagActivityEventResult {
+  // Reject oversized untrusted input before schema traversal and regex redaction.
+  assertEventSize(event);
+  assertValidEvent(event);
+  const storedEvent = redactEvent(event);
+  const encoded = encodeCanonicalEvent(storedEvent);
+  const encodedBytes = Buffer.byteLength(encoded.event_json, "utf8");
+  if (encodedBytes > MAX_DAG_ACTIVITY_EVENT_BYTES) {
+    throw new Error(`DAG activity event exceeds ${MAX_DAG_ACTIVITY_EVENT_BYTES} bytes`);
+  }
+  const db = getDb();
+
+  return db.transaction(() => {
+    const byId = db.prepare(`
+      SELECT seq, event_id, run_id, actor_id, generation, activity_sequence,
+             received_at, event_digest, event_json
+      FROM dag_activity_events
+      WHERE event_id = ?
+    `).get(storedEvent.event_id) as ActivityRow | undefined;
+    if (byId) {
+      if (byId.event_digest !== encoded.event_digest || byId.event_json !== encoded.event_json) {
+        throw new DagActivityJournalConflictError(
+          "event_id_collision",
+          `DAG activity event_id ${storedEvent.event_id} already identifies different content`,
+        );
+      }
+      return {
+        ...decodeEntry(byId),
+        inserted: false,
+        deduplicated: true,
+      };
+    }
+
+    const run = db.prepare("SELECT 1 FROM dag_runs WHERE run_id = ?").get(storedEvent.run_id);
+    if (!run) throw new Error(`Unknown DAG run: ${storedEvent.run_id}`);
+
+    const byActorSequence = db.prepare(`
+      SELECT event_id
+      FROM dag_activity_events
+      WHERE run_id = ? AND actor_id = ? AND generation = ? AND activity_sequence = ?
+    `).get(
+      storedEvent.run_id,
+      storedEvent.actor_id,
+      storedEvent.generation,
+      storedEvent.sequence,
+    ) as { event_id: string } | undefined;
+    if (byActorSequence) {
+      throw new DagActivityJournalConflictError(
+        "sequence_collision",
+        `DAG activity sequence ${storedEvent.sequence} is already used by actor ${storedEvent.actor_id} generation ${storedEvent.generation}`,
+      );
+    }
+
+    const receivedAt = Date.now();
+    const inserted = db.prepare(`
+      INSERT INTO dag_activity_events(
+        event_id, schema_version, run_id, round_id, node_id, actor_id, generation,
+        surface_id, activity_sequence, activity_type, timestamp, received_at,
+        event_digest, event_json
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      storedEvent.event_id,
+      storedEvent.schema_version,
+      storedEvent.run_id,
+      storedEvent.round_id,
+      storedEvent.node_id,
+      storedEvent.actor_id,
+      storedEvent.generation,
+      storedEvent.surface_id ?? null,
+      storedEvent.sequence,
+      storedEvent.type,
+      storedEvent.timestamp,
+      receivedAt,
+      encoded.event_digest,
+      encoded.event_json,
+    );
+    const seq = Number(inserted.lastInsertRowid);
+    if (!Number.isSafeInteger(seq) || seq < 1) {
+      throw new Error("DAG activity journal returned an invalid sequence");
+    }
+    return {
+      seq,
+      received_at: receivedAt,
+      event: storedEvent,
+      inserted: true,
+      deduplicated: false,
+    };
+  }).immediate();
+}
+
+/** Replay a bounded journal page in durable insertion order. */
+export function listDagActivityEvents(options: ListDagActivityEventsOptions): DagActivityEventPage {
+  assertIdentifier(options.run_id, "run_id");
+  if (options.actor_id !== undefined) assertIdentifier(options.actor_id, "actor_id");
+  const afterSeq = normalizeCursor(options.after_seq);
+  const limit = normalizeLimit(options.limit);
+  const params: Array<string | number> = [options.run_id, afterSeq];
+  const actorClause = options.actor_id === undefined ? "" : " AND actor_id = ?";
+  if (options.actor_id !== undefined) params.push(options.actor_id);
+  params.push(limit + 1);
+
+  const rows = getDb().prepare(`
+    SELECT seq, received_at, event_json
+    FROM dag_activity_events
+    WHERE run_id = ? AND seq > ?${actorClause}
+    ORDER BY seq ASC
+    LIMIT ?
+  `).all(...params) as Array<Pick<ActivityRow, "seq" | "received_at" | "event_json">>;
+  const hasMore = rows.length > limit;
+  const events = rows.slice(0, limit).map(decodeEntry);
+  return {
+    events,
+    next_after_seq: events.at(-1)?.seq ?? afterSeq,
+    has_more: hasMore,
+    limit,
+  };
+}
+
+/** Last durable sequence assigned within one actor generation. */
+export function getDagActivitySequenceCursor(
+  runId: string,
+  actorId: string,
+  generation: number,
+): number {
+  assertIdentifier(runId, "run_id");
+  assertIdentifier(actorId, "actor_id");
+  if (!Number.isSafeInteger(generation) || generation < 1) {
+    throw new Error("generation must be a positive safe integer");
+  }
+  const row = getDb().prepare(`
+    SELECT COALESCE(MAX(activity_sequence), 0) AS sequence
+    FROM dag_activity_events
+    WHERE run_id = ? AND actor_id = ? AND generation = ?
+  `).get(runId, actorId, generation) as { sequence: number };
+  return row.sequence;
+}

--- a/homerail_manager/src/persistence/db.ts
+++ b/homerail_manager/src/persistence/db.ts
@@ -34,6 +34,7 @@ const CLEARABLE_TABLES = new Set([
   "dag_chats",
   "dag_handoffs",
   "dag_artifacts",
+  "dag_activity_events",
   "dag_events",
   "dag_run_admissions",
   "dag_runs",
@@ -498,6 +499,69 @@ function validateDagArtifactSchemaV18(db: SqliteDatabase): void {
       throw new Error(`Schema migration 18 is incomplete: dag_artifacts is missing column ${column}`);
     }
   }
+}
+
+function validateDagActivitySchemaV19(db: SqliteDatabase): void {
+  const table = "dag_activity_events";
+  if (!hasTable(db, table)) {
+    throw new Error(`Schema migration 19 is incomplete: missing table ${table}`);
+  }
+  for (const column of [
+    "seq",
+    "event_id",
+    "schema_version",
+    "run_id",
+    "round_id",
+    "node_id",
+    "actor_id",
+    "generation",
+    "surface_id",
+    "activity_sequence",
+    "activity_type",
+    "timestamp",
+    "received_at",
+    "event_digest",
+    "event_json",
+  ]) {
+    if (!hasColumn(db, table, column)) {
+      throw new Error(`Schema migration 19 is incomplete: ${table} is missing column ${column}`);
+    }
+  }
+
+  const indexes = new Map((db.prepare(`PRAGMA index_list(${table})`).all() as Array<{
+    name: string;
+    unique: number;
+  }>).map((index) => [index.name, index]));
+  for (const [name, unique, expectedColumns] of [
+    ["idx_dag_activity_events_event_id", 1, ["event_id"]],
+    ["idx_dag_activity_events_actor_sequence", 1, ["run_id", "actor_id", "generation", "activity_sequence"]],
+    ["idx_dag_activity_events_run_seq", 0, ["run_id", "seq"]],
+    ["idx_dag_activity_events_run_actor_seq", 0, ["run_id", "actor_id", "seq"]],
+  ] as const) {
+    if (indexes.get(name)?.unique !== unique) {
+      throw new Error(`Schema migration 19 is incomplete: index ${name} is missing or invalid`);
+    }
+    const columns = (db.prepare(`PRAGMA index_info(${name})`).all() as Array<{
+      seqno: number;
+      name: string;
+    }>).sort((left, right) => left.seqno - right.seqno).map((entry) => entry.name);
+    if (columns.length !== expectedColumns.length || columns.some((column, index) => column !== expectedColumns[index])) {
+      throw new Error(`Schema migration 19 is incomplete: index ${name} has invalid columns`);
+    }
+  }
+
+  const foreignKeys = db.prepare(`PRAGMA foreign_key_list(${table})`).all() as Array<{
+    table: string;
+    from: string;
+    to: string;
+    on_delete: string;
+  }>;
+  if (!foreignKeys.some((entry) => (
+    entry.table === "dag_runs"
+    && entry.from === "run_id"
+    && entry.to === "run_id"
+    && entry.on_delete.toUpperCase() === "CASCADE"
+  ))) throw new Error("Schema migration 19 is incomplete: activity run retention constraint is missing");
 }
 
 function validateGenerativeUiSchemaV3(db: SqliteDatabase): void {
@@ -1783,6 +1847,40 @@ const SCHEMA_MIGRATIONS: readonly SchemaMigration[] = [
         ON dag_artifacts(run_id, status, name);
     `),
     validate: validateDagArtifactSchemaV18,
+  },
+  {
+    version: 19,
+    up: (db) => db.exec(`
+      CREATE TABLE IF NOT EXISTS dag_activity_events (
+        seq INTEGER PRIMARY KEY AUTOINCREMENT,
+        event_id TEXT NOT NULL,
+        schema_version INTEGER NOT NULL CHECK(schema_version = 1),
+        run_id TEXT NOT NULL,
+        round_id TEXT NOT NULL,
+        node_id TEXT NOT NULL,
+        actor_id TEXT NOT NULL,
+        generation INTEGER NOT NULL CHECK(generation >= 1),
+        surface_id TEXT,
+        activity_sequence INTEGER NOT NULL CHECK(activity_sequence >= 1),
+        activity_type TEXT NOT NULL CHECK(activity_type IN (
+          'started', 'progress', 'finding', 'tool_used', 'blocked', 'completed', 'failed'
+        )),
+        timestamp INTEGER NOT NULL CHECK(timestamp >= 0),
+        received_at INTEGER NOT NULL CHECK(received_at >= 0),
+        event_digest TEXT NOT NULL CHECK(length(event_digest) = 64),
+        event_json TEXT NOT NULL,
+        FOREIGN KEY(run_id) REFERENCES dag_runs(run_id) ON DELETE CASCADE
+      );
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_dag_activity_events_event_id
+        ON dag_activity_events(event_id);
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_dag_activity_events_actor_sequence
+        ON dag_activity_events(run_id, actor_id, generation, activity_sequence);
+      CREATE INDEX IF NOT EXISTS idx_dag_activity_events_run_seq
+        ON dag_activity_events(run_id, seq);
+      CREATE INDEX IF NOT EXISTS idx_dag_activity_events_run_actor_seq
+        ON dag_activity_events(run_id, actor_id, seq);
+    `),
+    validate: validateDagActivitySchemaV19,
   },
 ];
 

--- a/homerail_manager/src/runtime/active-runs.ts
+++ b/homerail_manager/src/runtime/active-runs.ts
@@ -71,6 +71,7 @@ import {
   type DagApprovalRecord,
 } from "../persistence/dag-runtime-primitives.js";
 import type { RunWorkspaceRetention } from "../persistence/types.js";
+import { getDagActivitySequenceCursor } from "../persistence/dag-activity-journal.js";
 
 export interface InjectResult {
   runId: string;
@@ -2340,6 +2341,11 @@ function _allowedDagTools(node: DAGGraphNode): DagAgentToolName[] | undefined {
   ));
 }
 
+function _activitySurfaceId(node: DAGGraphNode): string | undefined {
+  const value = _agentRuntimeConfig(node).surface_id;
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
 function _buildDispatchEnvelope(run: ActiveRun, nodeId: string): DispatchEnvelopeBuildResult {
   if (run.status !== "active") return { ok: false, reason: `run ${run.runId} is not active` };
   if (getNodeState(run.dagRun, nodeId) !== "READY") {
@@ -2360,6 +2366,9 @@ function _buildDispatchEnvelope(run: ActiveRun, nodeId: string): DispatchEnvelop
 
   const inputs = _nodeInputs(run.dagRun, nodeId);
   const nodeSession = _ensureNodeSession(run, nodeId);
+  const actorId = nodeId;
+  const generation = 1;
+  const surfaceId = _activitySurfaceId(node);
   const dispatchInputs = nodeSession.resumeInstruction
     ? { ...inputs, checkpoint_resume: [nodeSession.resumeInstruction] }
     : inputs;
@@ -2395,6 +2404,13 @@ function _buildDispatchEnvelope(run: ActiveRun, nodeId: string): DispatchEnvelop
       workspaceAccess: _workspaceAccess(node),
       allowedBuiltinTools: _allowedBuiltinTools(node),
       allowedDagTools: _allowedDagTools(node),
+      activity: {
+        roundId: nodeSession.sessionId,
+        actorId,
+        generation,
+        ...(surfaceId ? { surfaceId } : {}),
+        sequenceStart: getDagActivitySequenceCursor(run.runId, actorId, generation),
+      },
     },
   };
 }

--- a/homerail_manager/src/runtime/dag-activity-stream.ts
+++ b/homerail_manager/src/runtime/dag-activity-stream.ts
@@ -1,0 +1,28 @@
+import { appendDagActivityEvent } from "../persistence/dag-activity-journal.js";
+
+export interface DagActivityStreamContext {
+  runId: string;
+  nodeId: string;
+  roundId?: string;
+}
+
+export function ingestDagActivityStream(
+  data: Record<string, unknown>,
+  context: DagActivityStreamContext,
+): ReturnType<typeof appendDagActivityEvent> | undefined {
+  if (data.event !== "dag_activity") return undefined;
+  const activity = data.activity;
+  if (typeof activity !== "object" || activity === null || Array.isArray(activity)) {
+    throw new Error("invalid DAG activity event: expected an object");
+  }
+
+  const event = activity as Record<string, unknown>;
+  if (
+    event.run_id !== context.runId
+    || event.node_id !== context.nodeId
+    || (context.roundId !== undefined && event.round_id !== context.roundId)
+  ) {
+    throw new Error("DAG activity identity does not match the transport stream context");
+  }
+  return appendDagActivityEvent(activity);
+}

--- a/homerail_manager/src/server/routes.ts
+++ b/homerail_manager/src/server/routes.ts
@@ -21,6 +21,7 @@ import {
 import { listActiveRuns } from "../runtime/active-runs.js";
 import { getDagState, listPendingApprovals } from "../persistence/dag-runtime-primitives.js";
 import { listDagTriggers } from "../persistence/dag-triggers.js";
+import { listDagActivityEvents } from "../persistence/dag-activity-journal.js";
 
 interface BaseResponse {
   success: boolean;
@@ -531,8 +532,49 @@ export function inspectionRoutesHandler(
     return true;
   }
 
+  // GET /api/runs/:run_id/activities?actor_id=&after_seq=&limit=
+  if (pathname.match(/^\/api\/runs\/[^/]+\/activities$/) && req.method === "GET") {
+    let runId = "";
+    try {
+      runId = decodeURIComponent(pathname.split("/")[3] ?? "");
+    } catch {
+      json(res, 400, { success: false, message: "Invalid encoded run ID", error: "Invalid encoded run ID" });
+      return true;
+    }
+    if (!runId) {
+      _notFound(res, "Invalid run ID");
+      return true;
+    }
+    if (!loadRunMetadata(runId)) {
+      _notFound(res, `Run not found: ${runId}`);
+      return true;
+    }
+    const url = new URL(req.url || "/", "http://localhost");
+    const parseInteger = (name: "after_seq" | "limit"): number | undefined => {
+      const raw = url.searchParams.get(name);
+      if (raw === null) return undefined;
+      if (!/^\d+$/.test(raw)) throw new Error(`${name} must be a non-negative integer`);
+      const value = Number(raw);
+      if (!Number.isSafeInteger(value)) throw new Error(`${name} must be a safe integer`);
+      return value;
+    };
+    try {
+      const page = listDagActivityEvents({
+        run_id: runId,
+        actor_id: url.searchParams.get("actor_id") ?? undefined,
+        after_seq: parseInteger("after_seq"),
+        limit: parseInteger("limit"),
+      });
+      _ok(res, `Activity history retrieved (${page.events.length} events)`, page);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      json(res, 400, { success: false, message, error: message });
+    }
+    return true;
+  }
+
   // GET /api/runs/:run_id
-  if (pathname.startsWith("/api/runs/") && !pathname.includes("/events") && !pathname.includes("/handoffs") && !pathname.includes("/chats") && !pathname.includes("/scorecard") && !pathname.includes("/eval-run") && !pathname.includes("/supervise") && !pathname.includes("/inject") && !pathname.includes("/experience") && !pathname.includes("/status") && !pathname.includes("/audit") && req.method === "GET") {
+  if (pathname.startsWith("/api/runs/") && !pathname.includes("/activities") && !pathname.includes("/events") && !pathname.includes("/handoffs") && !pathname.includes("/chats") && !pathname.includes("/scorecard") && !pathname.includes("/eval-run") && !pathname.includes("/supervise") && !pathname.includes("/inject") && !pathname.includes("/experience") && !pathname.includes("/status") && !pathname.includes("/audit") && req.method === "GET") {
     const runId = _parseRunId(pathname, "/api/runs/");
     if (!runId) {
       _notFound(res, "Invalid run ID");

--- a/homerail_manager/src/worker/websocket.ts
+++ b/homerail_manager/src/worker/websocket.ts
@@ -28,6 +28,7 @@ import {
   isControlPlaneUpgradeAuthorized,
   rejectWebSocketUpgrade,
 } from "../server/control-plane-auth.js";
+import { ingestDagActivityStream } from "../runtime/dag-activity-stream.js";
 
 const WS_URL_PATTERN = /^\/ws\/projects\/([^\/]+)\/workers\/([^\/]+)$/;
 const DEFAULT_REGISTRATION_TIMEOUT_MS = 10_000;
@@ -389,9 +390,24 @@ export function setupWorkerWebSocket(
         }
 
         if (msg.type === "stream") {
-          if (shouldIgnoreStaleSession(worker_id, "stream", msg.data)) return;
           const runId = streamRunId(msg.data);
           const nodeId = streamNodeId(msg.data);
+          if (msg.data.event === "dag_activity") {
+            try {
+              if (!runId || !nodeId) throw new Error("DAG activity transport identity is missing");
+              ingestDagActivityStream(msg.data, {
+                runId,
+                nodeId,
+                roundId: dataSessionId(msg.data),
+              });
+            } catch (error) {
+              console.warn(
+                `[homerail_manager] rejected DAG activity from worker ${worker_id}: ${error instanceof Error ? error.message : String(error)}`,
+              );
+            }
+            return;
+          }
+          if (shouldIgnoreStaleSession(worker_id, "stream", msg.data)) return;
           if (runId && nodeId) {
             if (msg.data.event === "advisor_call_started" && typeof msg.data.advisor_id === "string") {
               recordAdvisorCall(runId, nodeId, msg.data.advisor_id);

--- a/homerail_manager/src/worker/websocket.ts
+++ b/homerail_manager/src/worker/websocket.ts
@@ -13,7 +13,7 @@ import {
 } from "./registry.js";
 import { applyResponseHandoff } from "../orchestration/response-bridge.js";
 import { handleDagMessageResponse } from "../orchestration/dag-message-router.js";
-import { clearByTargetId } from "../orchestration/dispatch-tracker.js";
+import { clearByTargetId, isCurrentDispatchTarget } from "../orchestration/dispatch-tracker.js";
 import { emit } from "../events/bus.js";
 import { appendChatEntry, appendNodeUsage } from "../persistence/store.js";
 import { appendSessionTranscriptEntry } from "../persistence/dag-session-files.js";
@@ -395,10 +395,16 @@ export function setupWorkerWebSocket(
           if (msg.data.event === "dag_activity") {
             try {
               if (!runId || !nodeId) throw new Error("DAG activity transport identity is missing");
+              const sessionId = dataSessionId(msg.data);
+              if (!sessionId) throw new Error("DAG activity transport session is missing");
+              if (!isCurrentDispatchTarget(runId, nodeId, "worker", worker_id)) {
+                throw new Error("DAG activity source does not match the current dispatch target");
+              }
+              if (shouldIgnoreStaleSession(worker_id, "dag_activity", msg.data)) return;
               ingestDagActivityStream(msg.data, {
                 runId,
                 nodeId,
-                roundId: dataSessionId(msg.data),
+                roundId: sessionId,
               });
             } catch (error) {
               console.warn(

--- a/homerail_manager/tests/dag-activity-events.test.ts
+++ b/homerail_manager/tests/dag-activity-events.test.ts
@@ -9,9 +9,11 @@ import {
 import {
   appendDagActivityEvent,
   DagActivityJournalConflictError,
+  getDagActivityContiguousSequenceCursor,
   listDagActivityEvents,
   MAX_DAG_ACTIVITY_EVENT_BYTES,
   MAX_DAG_ACTIVITY_REPLAY_LIMIT,
+  MAX_DAG_ACTIVITY_SEQUENCE_AHEAD,
 } from "../src/persistence/dag-activity-journal.js";
 import { clearTables, closeDb, getDb } from "../src/persistence/db.js";
 import { appendEvent, ensureRunDir } from "../src/persistence/store.js";
@@ -147,6 +149,22 @@ describe("DAG activity journal persistence", () => {
       generation: 2,
       round_id: "round-2",
     })).inserted).toBe(true);
+  });
+
+  it("bounds out-of-order activity around the earliest gap and advances after repair", () => {
+    ensureRunDir("run-1");
+    appendDagActivityEvent(activity({ event_id: "activity-2", sequence: 2 }));
+    expect(getDagActivityContiguousSequenceCursor("run-1", "researcher", 1)).toBe(0);
+
+    expect(() => appendDagActivityEvent(activity({
+      event_id: "activity-too-far",
+      sequence: MAX_DAG_ACTIVITY_SEQUENCE_AHEAD + 1,
+    }))).toThrowError(expect.objectContaining<DagActivityJournalConflictError>({ code: "sequence_gap" }));
+
+    appendDagActivityEvent(activity({ event_id: "activity-1-repair", sequence: 1 }));
+    expect(getDagActivityContiguousSequenceCursor("run-1", "researcher", 1)).toBe(2);
+    expect(appendDagActivityEvent(activity({ event_id: "activity-3", sequence: 3 })).inserted).toBe(true);
+    expect(getDagActivityContiguousSequenceCursor("run-1", "researcher", 1)).toBe(3);
   });
 
   it("redacts secrets before persistence and supports explicit journal clearing", () => {

--- a/homerail_manager/tests/dag-activity-events.test.ts
+++ b/homerail_manager/tests/dag-activity-events.test.ts
@@ -1,0 +1,259 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  DAG_ACTIVITY_EVENT_SCHEMA_VERSION,
+  type DagActivityEventV1,
+} from "homerail-protocol";
+import {
+  appendDagActivityEvent,
+  DagActivityJournalConflictError,
+  listDagActivityEvents,
+  MAX_DAG_ACTIVITY_EVENT_BYTES,
+  MAX_DAG_ACTIVITY_REPLAY_LIMIT,
+} from "../src/persistence/dag-activity-journal.js";
+import { clearTables, closeDb, getDb } from "../src/persistence/db.js";
+import { appendEvent, ensureRunDir } from "../src/persistence/store.js";
+
+function activity(overrides: Partial<DagActivityEventV1> = {}): DagActivityEventV1 {
+  return {
+    schema_version: DAG_ACTIVITY_EVENT_SCHEMA_VERSION,
+    event_id: "activity-1",
+    run_id: "run-1",
+    round_id: "round-1",
+    node_id: "research-node",
+    actor_id: "researcher",
+    generation: 1,
+    surface_id: "surface-news",
+    sequence: 1,
+    timestamp: 1_784_000_000_000,
+    type: "progress",
+    payload: { message: "checking sources", percent: 10 },
+    ...overrides,
+  };
+}
+
+describe("DAG activity journal persistence", () => {
+  let home: string;
+  let oldHome: string | undefined;
+
+  beforeEach(() => {
+    closeDb();
+    oldHome = process.env.HOMERAIL_HOME;
+    home = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-activity-journal-"));
+    process.env.HOMERAIL_HOME = home;
+  });
+
+  afterEach(() => {
+    closeDb();
+    if (oldHome === undefined) delete process.env.HOMERAIL_HOME;
+    else process.env.HOMERAIL_HOME = oldHome;
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it("upgrades a v18 database without changing legacy dag_events", () => {
+    ensureRunDir("legacy-run");
+    appendEvent("legacy-run", {
+      type: "RUN_CREATED",
+      payload: { source: "legacy" },
+      timestamp: 1_700_000_000_000,
+    });
+    getDb().exec(`
+      DROP TABLE dag_activity_events;
+      DELETE FROM schema_migrations WHERE version = 19;
+    `);
+    closeDb();
+
+    const migrated = getDb();
+    expect(migrated.prepare("SELECT version FROM schema_migrations WHERE version = 19").get())
+      .toEqual({ version: 19 });
+    expect(migrated.prepare(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'dag_activity_events'",
+    ).get()).toEqual({ name: "dag_activity_events" });
+    expect(migrated.prepare("SELECT event_type, data FROM dag_events WHERE run_id = ?").get("legacy-run"))
+      .toMatchObject({ event_type: "RUN_CREATED" });
+  });
+
+  it("validates migration v19 on repeated startup without duplicating schema state", () => {
+    const first = getDb();
+    expect(first.prepare("SELECT COUNT(*) AS count FROM schema_migrations WHERE version = 19").get())
+      .toEqual({ count: 1 });
+    closeDb();
+
+    const reopened = getDb();
+    expect(reopened.prepare("SELECT COUNT(*) AS count FROM schema_migrations WHERE version = 19").get())
+      .toEqual({ count: 1 });
+    expect(reopened.prepare("PRAGMA index_list(dag_activity_events)").all())
+      .toEqual(expect.arrayContaining([
+        expect.objectContaining({ name: "idx_dag_activity_events_event_id", unique: 1 }),
+        expect.objectContaining({ name: "idx_dag_activity_events_actor_sequence", unique: 1 }),
+        expect.objectContaining({ name: "idx_dag_activity_events_run_seq", unique: 0 }),
+        expect.objectContaining({ name: "idx_dag_activity_events_run_actor_seq", unique: 0 }),
+      ]));
+  });
+
+  it("fails closed when a v19 migration marker points at an invalid uniqueness index", () => {
+    getDb().exec(`
+      DROP INDEX idx_dag_activity_events_actor_sequence;
+      CREATE UNIQUE INDEX idx_dag_activity_events_actor_sequence
+        ON dag_activity_events(run_id, actor_id, round_id, activity_sequence);
+    `);
+    closeDb();
+
+    expect(() => getDb()).toThrow(
+      "Schema migration 19 is incomplete: index idx_dag_activity_events_actor_sequence has invalid columns",
+    );
+  });
+
+  it("deduplicates the same semantic event_id and rejects semantic reuse", () => {
+    ensureRunDir("run-1");
+    const first = appendDagActivityEvent(activity({
+      payload: { message: "checking sources", detail: { z: 2, a: 1 } },
+    }));
+    const duplicate = appendDagActivityEvent(activity({
+      payload: { detail: { a: 1, z: 2 }, message: "checking sources" },
+    }));
+
+    expect(first).toMatchObject({ inserted: true, deduplicated: false });
+    expect(duplicate).toMatchObject({
+      seq: first.seq,
+      inserted: false,
+      deduplicated: true,
+    });
+    expect(getDb().prepare("SELECT COUNT(*) AS count FROM dag_activity_events").get())
+      .toEqual({ count: 1 });
+
+    expect(() => appendDagActivityEvent(activity({ payload: { message: "different meaning" } })))
+      .toThrowError(expect.objectContaining<DagActivityJournalConflictError>({ code: "event_id_collision" }));
+  });
+
+  it("enforces sequence identity across rounds but scopes it by actor generation", () => {
+    ensureRunDir("run-1");
+    appendDagActivityEvent(activity());
+
+    expect(() => appendDagActivityEvent(activity({
+      event_id: "activity-round-2",
+      round_id: "round-2",
+    }))).toThrowError(expect.objectContaining<DagActivityJournalConflictError>({ code: "sequence_collision" }));
+
+    expect(appendDagActivityEvent(activity({
+      event_id: "activity-other-actor",
+      actor_id: "writer",
+      round_id: "round-2",
+    })).inserted).toBe(true);
+    expect(appendDagActivityEvent(activity({
+      event_id: "activity-next-generation",
+      generation: 2,
+      round_id: "round-2",
+    })).inserted).toBe(true);
+  });
+
+  it("redacts secrets before persistence and supports explicit journal clearing", () => {
+    ensureRunDir("run-1");
+    appendDagActivityEvent(activity({
+      type: "tool_used",
+      payload: {
+        api_key: "sk-supersecretvalue123456",
+        nested: {
+          authorization: "Bearer abcdefghijklmnopqrstuvwxyz",
+          message: "request failed token=plain-secret-value",
+        },
+      },
+    }));
+
+    const raw = getDb().prepare("SELECT event_json FROM dag_activity_events").get() as { event_json: string };
+    expect(raw.event_json).not.toContain("supersecretvalue");
+    expect(raw.event_json).not.toContain("abcdefghijklmnopqrstuvwxyz");
+    expect(raw.event_json).not.toContain("plain-secret-value");
+    expect(listDagActivityEvents({ run_id: "run-1" }).events[0].event.payload)
+      .toEqual({
+        api_key: "***REDACTED***",
+        nested: {
+          authorization: "***REDACTED***",
+          message: "request failed token=***REDACTED***",
+        },
+      });
+
+    clearTables(["dag_activity_events"]);
+    expect(getDb().prepare("SELECT COUNT(*) AS count FROM dag_activity_events").get())
+      .toEqual({ count: 0 });
+  });
+
+  it("rejects an oversized event at the Manager persistence boundary", () => {
+    ensureRunDir("run-1");
+    expect(() => appendDagActivityEvent(activity({
+      payload: { message: "x".repeat(MAX_DAG_ACTIVITY_EVENT_BYTES) },
+    }))).toThrow(`exceeds ${MAX_DAG_ACTIVITY_EVENT_BYTES} bytes`);
+    expect(getDb().prepare("SELECT COUNT(*) AS count FROM dag_activity_events").get())
+      .toEqual({ count: 0 });
+  });
+
+  it("replays in journal order with actor filtering and an after_seq cursor", () => {
+    ensureRunDir("run-1");
+    const first = appendDagActivityEvent(activity({ event_id: "a-1", actor_id: "actor-a", sequence: 1 }));
+    const second = appendDagActivityEvent(activity({ event_id: "b-1", actor_id: "actor-b", sequence: 1 }));
+    const third = appendDagActivityEvent(activity({ event_id: "a-2", actor_id: "actor-a", sequence: 2 }));
+
+    expect(listDagActivityEvents({ run_id: "run-1" }).events.map((entry) => entry.event.event_id))
+      .toEqual(["a-1", "b-1", "a-2"]);
+    expect(listDagActivityEvents({ run_id: "run-1", actor_id: "actor-a" }).events.map((entry) => entry.seq))
+      .toEqual([first.seq, third.seq]);
+    const afterFirst = listDagActivityEvents({ run_id: "run-1", after_seq: first.seq, limit: 1 });
+    expect(afterFirst).toMatchObject({
+      has_more: true,
+      next_after_seq: second.seq,
+      limit: 1,
+    });
+    expect(afterFirst.events.map((entry) => entry.event.event_id)).toEqual(["b-1"]);
+  });
+
+  it("replays the complete durable sequence after a Manager database restart", () => {
+    ensureRunDir("restart-run");
+    appendDagActivityEvent(activity({
+      event_id: "restart-1",
+      run_id: "restart-run",
+      sequence: 1,
+      type: "started",
+    }));
+    appendDagActivityEvent(activity({
+      event_id: "restart-2",
+      run_id: "restart-run",
+      sequence: 2,
+      type: "completed",
+    }));
+
+    closeDb();
+
+    const replay = listDagActivityEvents({ run_id: "restart-run" });
+    expect(replay.events.map((entry) => ({
+      event_id: entry.event.event_id,
+      sequence: entry.event.sequence,
+      type: entry.event.type,
+    }))).toEqual([
+      { event_id: "restart-1", sequence: 1, type: "started" },
+      { event_id: "restart-2", sequence: 2, type: "completed" },
+    ]);
+  });
+
+  it("caps oversized replay pages and returns a resumable cursor", () => {
+    ensureRunDir("large-run");
+    for (let sequence = 1; sequence <= MAX_DAG_ACTIVITY_REPLAY_LIMIT + 1; sequence += 1) {
+      appendDagActivityEvent(activity({
+        event_id: `large-${sequence}`,
+        run_id: "large-run",
+        sequence,
+      }));
+    }
+
+    const first = listDagActivityEvents({ run_id: "large-run", limit: 50_000 });
+    expect(first.limit).toBe(MAX_DAG_ACTIVITY_REPLAY_LIMIT);
+    expect(first.events).toHaveLength(MAX_DAG_ACTIVITY_REPLAY_LIMIT);
+    expect(first.has_more).toBe(true);
+    const last = listDagActivityEvents({ run_id: "large-run", after_seq: first.next_after_seq });
+    expect(last.events.map((entry) => entry.event.event_id)).toEqual([
+      `large-${MAX_DAG_ACTIVITY_REPLAY_LIMIT + 1}`,
+    ]);
+    expect(last.has_more).toBe(false);
+  });
+});

--- a/homerail_manager/tests/dag-activity-stream.test.ts
+++ b/homerail_manager/tests/dag-activity-stream.test.ts
@@ -1,0 +1,167 @@
+import * as fs from "node:fs";
+import * as http from "node:http";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { DagActivityEventV1 } from "homerail-protocol";
+import { closeDb, getDb } from "../src/persistence/db.js";
+import { appendDagActivityEvent } from "../src/persistence/dag-activity-journal.js";
+import { ensureRunDir } from "../src/persistence/store.js";
+import { ingestDagActivityStream } from "../src/runtime/dag-activity-stream.js";
+import { _clearActiveRuns, buildCurrentDispatchEnvelope, createActiveRun } from "../src/runtime/active-runs.js";
+import { parseDAGYaml } from "../src/orchestration/yaml-loader.js";
+import { createServer } from "../src/server/http.js";
+
+function event(overrides: Partial<DagActivityEventV1> = {}): DagActivityEventV1 {
+  return {
+    schema_version: 1,
+    event_id: "event-1",
+    run_id: "run-activity",
+    round_id: "round-1",
+    node_id: "research",
+    actor_id: "researcher",
+    generation: 1,
+    sequence: 1,
+    timestamp: 1_784_000_000_000,
+    type: "progress",
+    payload: { message: "working" },
+    ...overrides,
+  };
+}
+
+async function listen(server: http.Server): Promise<number> {
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address !== "object") throw new Error("server did not bind");
+  return address.port;
+}
+
+async function close(server: http.Server): Promise<void> {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+describe("DAG activity stream and replay API", () => {
+  let home: string;
+  let oldHome: string | undefined;
+  let server: http.Server | undefined;
+
+  beforeEach(() => {
+    closeDb();
+    oldHome = process.env.HOMERAIL_HOME;
+    home = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-activity-stream-"));
+    process.env.HOMERAIL_HOME = home;
+    ensureRunDir("run-activity");
+    _clearActiveRuns();
+  });
+
+  afterEach(async () => {
+    if (server) await close(server);
+    server = undefined;
+    _clearActiveRuns();
+    closeDb();
+    if (oldHome === undefined) delete process.env.HOMERAIL_HOME;
+    else process.env.HOMERAIL_HOME = oldHome;
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it("accepts a valid stream event idempotently and rejects spoofed identity", () => {
+    const data = { event: "dag_activity", activity: event() };
+    const first = ingestDagActivityStream(data, { runId: "run-activity", nodeId: "research" });
+    const duplicate = ingestDagActivityStream(data, { runId: "run-activity", nodeId: "research" });
+
+    expect(first).toMatchObject({ inserted: true, deduplicated: false });
+    expect(duplicate).toMatchObject({ inserted: false, deduplicated: true, seq: first?.seq });
+    expect(() => ingestDagActivityStream(data, {
+      runId: "run-activity",
+      nodeId: "different-node",
+    })).toThrow("identity does not match");
+    expect(() => ingestDagActivityStream(data, {
+      runId: "run-activity",
+      nodeId: "research",
+      roundId: "different-round",
+    })).toThrow("identity does not match");
+    expect(getDb().prepare("SELECT COUNT(*) AS count FROM dag_activity_events").get())
+      .toEqual({ count: 1 });
+  });
+
+  it("keeps non-activity stream messages outside the journal", () => {
+    expect(ingestDagActivityStream({ event: "usage", usage: {} }, {
+      runId: "run-activity",
+      nodeId: "research",
+    })).toBeUndefined();
+    expect(getDb().prepare("SELECT COUNT(*) AS count FROM dag_activity_events").get())
+      .toEqual({ count: 0 });
+  });
+
+  it("dispatches the last durable actor sequence to a subsequent Worker round", () => {
+    const dag = parseDAGYaml(`
+name: activity-dispatch
+workflow_id: activity-dispatch
+agents:
+  worker:
+    agent_type: deterministic
+    system: HANDOFF port=done content=ok
+nodes:
+  research:
+    agent: worker
+    outputs:
+      done:
+        to: ""
+`);
+    createActiveRun("run-dispatch-activity", dag);
+    appendDagActivityEvent(event({
+      event_id: "dispatch-1",
+      run_id: "run-dispatch-activity",
+      node_id: "research",
+      actor_id: "research",
+      sequence: 1,
+    }));
+    appendDagActivityEvent(event({
+      event_id: "dispatch-2",
+      run_id: "run-dispatch-activity",
+      node_id: "research",
+      actor_id: "research",
+      sequence: 2,
+    }));
+
+    const built = buildCurrentDispatchEnvelope("run-dispatch-activity", "research");
+
+    expect(built.ok).toBe(true);
+    if (!built.ok) return;
+    expect(built.envelope.activity).toMatchObject({
+      actorId: "research",
+      generation: 1,
+      sequenceStart: 2,
+      roundId: built.envelope.sessionId,
+    });
+  });
+
+  it("replays bounded activity pages by run and actor", async () => {
+    appendDagActivityEvent(event({ event_id: "research-1", actor_id: "researcher", sequence: 1 }));
+    appendDagActivityEvent(event({ event_id: "writer-1", actor_id: "writer", sequence: 1 }));
+    appendDagActivityEvent(event({ event_id: "research-2", actor_id: "researcher", sequence: 2 }));
+    server = createServer(0, undefined, undefined, false, { autoDetectCodex: false });
+    const baseUrl = `http://127.0.0.1:${await listen(server)}`;
+
+    const firstResponse = await fetch(`${baseUrl}/api/runs/run-activity/activities?actor_id=researcher&limit=1`);
+    const first = await firstResponse.json() as {
+      success: boolean;
+      data: { events: Array<{ seq: number; event: DagActivityEventV1 }>; next_after_seq: number; has_more: boolean };
+    };
+    expect(firstResponse.status).toBe(200);
+    expect(first.data.events.map((entry) => entry.event.event_id)).toEqual(["research-1"]);
+    expect(first.data.has_more).toBe(true);
+
+    const nextResponse = await fetch(
+      `${baseUrl}/api/runs/run-activity/activities?actor_id=researcher&after_seq=${first.data.next_after_seq}`,
+    );
+    const next = await nextResponse.json() as typeof first;
+    expect(next.data.events.map((entry) => entry.event.event_id)).toEqual(["research-2"]);
+    expect(next.data.has_more).toBe(false);
+
+    const invalid = await fetch(`${baseUrl}/api/runs/run-activity/activities?limit=not-a-number`);
+    expect(invalid.status).toBe(400);
+    const missing = await fetch(`${baseUrl}/api/runs/missing/activities`);
+    expect(missing.status).toBe(404);
+  });
+});

--- a/homerail_manager/tests/dag-session-websocket.test.ts
+++ b/homerail_manager/tests/dag-session-websocket.test.ts
@@ -13,6 +13,7 @@ import { _clearAllDispatches } from "../src/orchestration/dispatch-tracker.js";
 import { _clearDagMessageRouter } from "../src/orchestration/dag-message-router.js";
 import { _clearListeners, subscribe } from "../src/events/bus.js";
 import { closeDb } from "../src/persistence/db.js";
+import { listDagActivityEvents } from "../src/persistence/dag-activity-journal.js";
 import { appendSessionTranscriptForTest, loadSessionTranscript } from "../src/persistence/dag-session-files.js";
 import { _clearAllPersistence, loadRunSnapshot } from "../src/persistence/store.js";
 import {
@@ -230,6 +231,66 @@ describe("worker websocket node session filtering", () => {
     expect(persisted).toContain("***REDACTED***");
     expect(persisted).toContain("...");
     expect(persisted).toContain("[truncated]");
+    ws.close();
+  });
+
+  it("persists stale-round activity idempotently for audit without copying it into chat evidence", async () => {
+    createActiveRun("run-ws-activity", simpleDag());
+    const dispatcher = new CaptureDispatcher();
+    expect(dispatchReadyNodes("run-ws-activity", dispatcher)).toBe(1);
+    const sessionId = dispatcher.dispatched[0].sessionId!;
+
+    server = http.createServer();
+    setupWorkerWebSocket(server, { registrationTimeoutMs: 500, pingIntervalMs: 5_000 });
+    const port = await listen(server);
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws/projects/default/workers/worker-activity`);
+    await new Promise<void>((resolve) => ws.once("open", () => resolve()));
+    ws.send(JSON.stringify({ type: "register", worker_id: "worker-activity" }));
+    await delay(20);
+
+    const activity = {
+      schema_version: 1,
+      event_id: "ws-activity-1",
+      run_id: "run-ws-activity",
+      round_id: "stale-round",
+      node_id: "work",
+      actor_id: "work",
+      generation: 1,
+      sequence: 1,
+      timestamp: Date.now(),
+      type: "finding",
+      payload: {
+        message: "durable finding token=raw-worker-secret",
+        api_key: "sk-raw-worker-secret-123456",
+      },
+    };
+    const stream = JSON.stringify({
+      type: "stream",
+      data: {
+        type: "dag_activity",
+        event: "dag_activity",
+        activity,
+        run_id: "run-ws-activity",
+        node_id: "work",
+        session_id: "stale-round",
+      },
+    });
+    ws.send(stream);
+    ws.send(stream);
+    await delay(30);
+
+    const page = listDagActivityEvents({ run_id: "run-ws-activity" });
+    expect(page.events).toHaveLength(1);
+    expect(page.events[0].event.payload).toEqual({
+      message: "durable finding token=***REDACTED***",
+      api_key: "***REDACTED***",
+    });
+    const genericEvidence = JSON.stringify({
+      chats: loadRunSnapshot("run-ws-activity")?.chats,
+      transcript: loadSessionTranscript(sessionId),
+    });
+    expect(genericEvidence).not.toContain("durable finding");
+    expect(genericEvidence).not.toContain("raw-worker-secret");
     ws.close();
   });
 

--- a/homerail_manager/tests/dag-session-websocket.test.ts
+++ b/homerail_manager/tests/dag-session-websocket.test.ts
@@ -9,7 +9,7 @@ import type { DAGDispatcher, DispatchEnvelope, DispatchResult } from "../src/orc
 import { parseDAGYaml } from "../src/orchestration/yaml-loader.js";
 import { setupWorkerWebSocket } from "../src/worker/websocket.js";
 import { _clearWorkers } from "../src/worker/registry.js";
-import { _clearAllDispatches } from "../src/orchestration/dispatch-tracker.js";
+import { _clearAllDispatches, recordDispatch } from "../src/orchestration/dispatch-tracker.js";
 import { _clearDagMessageRouter } from "../src/orchestration/dag-message-router.js";
 import { _clearListeners, subscribe } from "../src/events/bus.js";
 import { closeDb } from "../src/persistence/db.js";
@@ -234,11 +234,15 @@ describe("worker websocket node session filtering", () => {
     ws.close();
   });
 
-  it("persists stale-round activity idempotently for audit without copying it into chat evidence", async () => {
+  it("rejects stale-round activity before it reaches the journal or chat evidence", async () => {
     createActiveRun("run-ws-activity", simpleDag());
     const dispatcher = new CaptureDispatcher();
     expect(dispatchReadyNodes("run-ws-activity", dispatcher)).toBe(1);
     const sessionId = dispatcher.dispatched[0].sessionId!;
+    recordDispatch("run-ws-activity", "work", "worker", "worker-activity");
+
+    const staleEvents: unknown[] = [];
+    subscribe("dag:stale_session_ignored", (payload) => staleEvents.push(payload));
 
     server = http.createServer();
     setupWorkerWebSocket(server, { registrationTimeoutMs: 500, pingIntervalMs: 5_000 });
@@ -280,17 +284,57 @@ describe("worker websocket node session filtering", () => {
     await delay(30);
 
     const page = listDagActivityEvents({ run_id: "run-ws-activity" });
-    expect(page.events).toHaveLength(1);
-    expect(page.events[0].event.payload).toEqual({
-      message: "durable finding token=***REDACTED***",
-      api_key: "***REDACTED***",
-    });
+    expect(page.events).toHaveLength(0);
+    expect(staleEvents).toHaveLength(2);
     const genericEvidence = JSON.stringify({
       chats: loadRunSnapshot("run-ws-activity")?.chats,
       transcript: loadSessionTranscript(sessionId),
     });
     expect(genericEvidence).not.toContain("durable finding");
     expect(genericEvidence).not.toContain("raw-worker-secret");
+    ws.close();
+  });
+
+  it("rejects activity from a worker that does not own the current dispatch", async () => {
+    createActiveRun("run-ws-source-bound", simpleDag());
+    const dispatcher = new CaptureDispatcher();
+    expect(dispatchReadyNodes("run-ws-source-bound", dispatcher)).toBe(1);
+    const sessionId = dispatcher.dispatched[0].sessionId!;
+    recordDispatch("run-ws-source-bound", "work", "worker", "worker-owner");
+
+    server = http.createServer();
+    setupWorkerWebSocket(server, { registrationTimeoutMs: 500, pingIntervalMs: 5_000 });
+    const port = await listen(server);
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws/projects/default/workers/worker-attacker`);
+    await new Promise<void>((resolve) => ws.once("open", () => resolve()));
+    ws.send(JSON.stringify({ type: "register", worker_id: "worker-attacker" }));
+    await delay(20);
+    ws.send(JSON.stringify({
+      type: "stream",
+      data: {
+        type: "dag_activity",
+        event: "dag_activity",
+        run_id: "run-ws-source-bound",
+        node_id: "work",
+        session_id: sessionId,
+        activity: {
+          schema_version: 1,
+          event_id: "spoofed-source-activity",
+          run_id: "run-ws-source-bound",
+          round_id: sessionId,
+          node_id: "work",
+          actor_id: "work",
+          generation: 1,
+          sequence: 1,
+          timestamp: Date.now(),
+          type: "finding",
+          payload: { message: "must not persist" },
+        },
+      },
+    }));
+    await delay(30);
+
+    expect(listDagActivityEvents({ run_id: "run-ws-source-bound" }).events).toEqual([]);
     ws.close();
   });
 

--- a/homerail_manager/tests/generative-ui-persistent-document-service.test.ts
+++ b/homerail_manager/tests/generative-ui-persistent-document-service.test.ts
@@ -187,7 +187,7 @@ describe("PersistentGenerativeUiDocumentService", () => {
     legacy.close();
 
     expect(getDb().prepare("SELECT version FROM schema_migrations ORDER BY version").all())
-      .toEqual(Array.from({ length: 18 }, (_, index) => ({ version: index + 1 })));
+      .toEqual(Array.from({ length: 19 }, (_, index) => ({ version: index + 1 })));
     expect(getDb().prepare("SELECT data FROM voice_agent_sessions WHERE session_id = ?").get("legacy-v2"))
       .toEqual({ data: legacyPayload });
     expect(getDb().prepare(`
@@ -269,7 +269,7 @@ describe("PersistentGenerativeUiDocumentService", () => {
     mainDb.close();
 
     expect(getDb().prepare("SELECT version FROM schema_migrations ORDER BY version").all())
-      .toEqual(Array.from({ length: 18 }, (_, index) => ({ version: index + 1 })));
+      .toEqual(Array.from({ length: 19 }, (_, index) => ({ version: index + 1 })));
     expect(getDb().prepare(`
       SELECT name FROM sqlite_master
       WHERE type = 'table' AND name IN ('generative_ui_documents', 'generative_ui_user_overrides')

--- a/homerail_manager/tests/plugin-distribution.test.ts
+++ b/homerail_manager/tests/plugin-distribution.test.ts
@@ -149,6 +149,6 @@ describe("plugin publisher trust persistence", () => {
     expect(listPluginPublisherTrustEvents()).toHaveLength(1);
     expect(getDb().prepare(
       "SELECT MAX(version) AS version FROM schema_migrations",
-    ).get()).toEqual({ version: 18 });
+    ).get()).toEqual({ version: 19 });
   });
 });

--- a/homerail_manager/tests/plugin-package-lifecycle.test.ts
+++ b/homerail_manager/tests/plugin-package-lifecycle.test.ts
@@ -260,7 +260,7 @@ describe("external plugin package lifecycle", () => {
       expect.objectContaining({ plugin_version: "1.1.0", active: false, enabled: false }),
       expect.objectContaining({ plugin_version: "1.2.0", active: false, enabled: false }),
     ]));
-    expect(getDb().prepare("SELECT MAX(version) AS version FROM schema_migrations").get()).toEqual({ version: 18 });
+    expect(getDb().prepare("SELECT MAX(version) AS version FROM schema_migrations").get()).toEqual({ version: 19 });
     expect(inspectInstalledPlugin("com.example.release-notes")).toMatchObject({ healthy: true, issues: [] });
   });
 
@@ -455,7 +455,7 @@ describe("external plugin package lifecycle", () => {
 
     expect(getPluginRegistryState().revision).toBe(101);
     expect(getDb().prepare("SELECT MAX(version) AS version FROM schema_migrations").get())
-      .toEqual({ version: 18 });
+      .toEqual({ version: 19 });
   });
 
   it("rejects a stale uninstall when an inactive version was installed concurrently", () => {

--- a/homerail_manager/tests/plugin-remote-registry.test.ts
+++ b/homerail_manager/tests/plugin-remote-registry.test.ts
@@ -236,7 +236,7 @@ describe("signed remote plugin registry", () => {
     expect(listPluginRegistryUpdateAttempts("stable.example").filter((attempt) => attempt.status === "failed"))
       .toHaveLength(3);
     expect(getDb().prepare("SELECT MAX(version) AS version FROM schema_migrations").get())
-      .toEqual({ version: 18 });
+      .toEqual({ version: 19 });
   });
 
   it("rejects signed catalog releases whose payload or publisher digest disagrees with the HRP", () => {

--- a/homerail_manager/tests/workflow-concurrency.test.ts
+++ b/homerail_manager/tests/workflow-concurrency.test.ts
@@ -251,6 +251,7 @@ release:
     expect(orchestrator.createRun({ workflowId: "unrestricted", runId: "manual-2" }).status).toBe("active");
     expect(getDb().prepare("SELECT version FROM schema_migrations WHERE version = 17").get()).toEqual({ version: 17 });
     expect(getDb().prepare("SELECT version FROM schema_migrations WHERE version = 18").get()).toEqual({ version: 18 });
+    expect(getDb().prepare("SELECT version FROM schema_migrations WHERE version = 19").get()).toEqual({ version: 19 });
     expect(getDb().prepare("SELECT COUNT(*) AS count FROM dag_run_admissions").get()).toEqual({ count: 0 });
   });
 
@@ -271,6 +272,7 @@ release:
       .toEqual({ name: "dag_run_admissions" });
     expect(db.prepare("SELECT version FROM schema_migrations WHERE version = 17").get()).toEqual({ version: 17 });
     expect(db.prepare("SELECT version FROM schema_migrations WHERE version = 18").get()).toEqual({ version: 18 });
+    expect(db.prepare("SELECT version FROM schema_migrations WHERE version = 19").get()).toEqual({ version: 19 });
   });
 
   it("enforces the same admission policy through event and manual HTTP entrypoints", async () => {

--- a/homerail_protocol/src/dag-activity.ts
+++ b/homerail_protocol/src/dag-activity.ts
@@ -1,0 +1,109 @@
+/**
+ * Durable Worker Activity Event contract.
+ * @version 0.1.0
+ */
+
+export const DAG_ACTIVITY_EVENT_SCHEMA_VERSION = 1 as const;
+export const DAG_ACTIVITY_EVENT_V1_SCHEMA_ID = "dag-activity-event-v1" as const;
+
+export const DAG_ACTIVITY_TYPES = [
+  "started",
+  "progress",
+  "finding",
+  "tool_used",
+  "blocked",
+  "completed",
+  "failed",
+] as const;
+
+export type DagActivityType = (typeof DAG_ACTIVITY_TYPES)[number];
+
+export type DagActivityJsonPrimitive = string | number | boolean | null;
+export type DagActivityJsonValue =
+  | DagActivityJsonPrimitive
+  | DagActivityJsonValue[]
+  | { [key: string]: DagActivityJsonValue };
+export type DagActivityPayload = Record<string, DagActivityJsonValue>;
+
+/**
+ * Versioned, append-only activity emitted by one logical DAG actor generation.
+ * `sequence` is strictly increasing within `(run_id, actor_id, generation)`.
+ */
+export interface DagActivityEventV1 {
+  schema_version: typeof DAG_ACTIVITY_EVENT_SCHEMA_VERSION;
+  event_id: string;
+  run_id: string;
+  round_id: string;
+  node_id: string;
+  actor_id: string;
+  generation: number;
+  surface_id?: string;
+  sequence: number;
+  /** Unix epoch milliseconds assigned at the activity source. */
+  timestamp: number;
+  type: DagActivityType;
+  payload: DagActivityPayload;
+}
+
+const identifierSchema = {
+  type: "string",
+  minLength: 1,
+  maxLength: 256,
+} as const;
+
+const jsonValueSchema = {
+  oneOf: [
+    { type: "null" },
+    { type: "boolean" },
+    { type: "number" },
+    { type: "string" },
+    {
+      type: "array",
+      items: { $ref: "#/definitions/jsonValue" },
+    },
+    {
+      type: "object",
+      additionalProperties: { $ref: "#/definitions/jsonValue" },
+    },
+  ],
+} as const;
+
+export const dagActivityEventV1Schema = {
+  $id: DAG_ACTIVITY_EVENT_V1_SCHEMA_ID,
+  $schema: "http://json-schema.org/draft-07/schema#",
+  type: "object",
+  definitions: {
+    jsonValue: jsonValueSchema,
+  },
+  properties: {
+    schema_version: { type: "integer", const: DAG_ACTIVITY_EVENT_SCHEMA_VERSION },
+    event_id: identifierSchema,
+    run_id: identifierSchema,
+    round_id: identifierSchema,
+    node_id: identifierSchema,
+    actor_id: identifierSchema,
+    generation: { type: "integer", minimum: 1, maximum: Number.MAX_SAFE_INTEGER },
+    surface_id: identifierSchema,
+    sequence: { type: "integer", minimum: 1, maximum: Number.MAX_SAFE_INTEGER },
+    timestamp: { type: "integer", minimum: 0, maximum: Number.MAX_SAFE_INTEGER },
+    type: { type: "string", enum: DAG_ACTIVITY_TYPES },
+    payload: {
+      type: "object",
+      additionalProperties: { $ref: "#/definitions/jsonValue" },
+    },
+  },
+  required: [
+    "schema_version",
+    "event_id",
+    "run_id",
+    "round_id",
+    "node_id",
+    "actor_id",
+    "generation",
+    "sequence",
+    "timestamp",
+    "type",
+    "payload",
+  ],
+  additionalProperties: false,
+} as const;

--- a/homerail_protocol/src/index.ts
+++ b/homerail_protocol/src/index.ts
@@ -9,6 +9,7 @@
 export const PROTOCOL_VERSION = "0.1.0";
 
 export * from "./types.js";
+export * from "./dag-activity.js";
 export * from "./codec.js";
 export * from "./schemas.js";
 export * from "./validation.js";

--- a/homerail_protocol/src/schemas.ts
+++ b/homerail_protocol/src/schemas.ts
@@ -7,6 +7,7 @@ import {
   generativeUiSchemas,
 } from "./generative-ui/schemas.js";
 import { homerailPluginSchemas } from "./plugins/schemas.js";
+import { dagActivityEventV1Schema } from "./dag-activity.js";
 
 // ── DAG Tool Schemas ─────────────────────────────────────────────
 
@@ -198,6 +199,11 @@ export const dagNodeConfigSchema = {
     },
     graph_nodes: { type: "array", items: { type: "string" } },
     session_id: { type: "string", nullable: true as const },
+    round_id: { type: "string", minLength: 1, maxLength: 256 },
+    actor_id: { type: "string", minLength: 1, maxLength: 256 },
+    generation: { type: "integer", minimum: 1, maximum: Number.MAX_SAFE_INTEGER },
+    surface_id: { type: "string", minLength: 1, maxLength: 256 },
+    activity_sequence_start: { type: "integer", minimum: 0, maximum: Number.MAX_SAFE_INTEGER },
   },
   required: ["node_id", "agent_type", "model", "outgoing_edges", "incoming_edges", "graph_nodes"],
   additionalProperties: true,
@@ -391,6 +397,7 @@ export const asyncResultSchema = {
 export const allSchemas: Record<string, Record<string, unknown>> = {
   ...generativeUiSchemas,
   ...homerailPluginSchemas,
+  "dag-activity-event-v1": dagActivityEventV1Schema as Record<string, unknown>,
   "handoff-request": handoffRequestSchema as Record<string, unknown>,
   "handoff-response": handoffResponseSchema as Record<string, unknown>,
   "tool-call": toolCallSchema as Record<string, unknown>,

--- a/homerail_protocol/src/types.ts
+++ b/homerail_protocol/src/types.ts
@@ -451,6 +451,7 @@ export const DAG_AGENT_TOOL_NAMES = [
   "get_graph_context",
   "manager_command",
   "consult_advisor",
+  "report_activity",
 ] as const;
 
 export type DagAgentToolName = (typeof DAG_AGENT_TOOL_NAMES)[number];
@@ -472,6 +473,13 @@ export interface DagNodeConfig {
   incoming_edges: Edge[];
   graph_nodes: string[];
   session_id?: string;
+  /** Activity routing metadata. Defaults are assigned by the Worker when omitted. */
+  round_id?: string;
+  actor_id?: string;
+  generation?: number;
+  surface_id?: string;
+  /** Last persisted activity sequence; the next emitted event starts after this value. */
+  activity_sequence_start?: number;
   advisors?: DagAdvisorConfig[];
   workspace_access?: DagWorkspaceAccess;
   /** Optional exact allowlist for backend-provided shell and file tools. */

--- a/homerail_protocol/src/validation.ts
+++ b/homerail_protocol/src/validation.ts
@@ -6,6 +6,7 @@
 import AjvModule from "ajv";
 import type { ErrorObject, ValidateFunction } from "ajv";
 import { allSchemas } from "./schemas.js";
+import { DAG_ACTIVITY_EVENT_V1_SCHEMA_ID } from "./dag-activity.js";
 import {
   validateHomerailPluginManifest,
   validateHomerailPluginTurnContext,
@@ -103,4 +104,8 @@ export function validateMessage(data: unknown, schemaName: string): ValidationRe
     valid: valid as boolean,
     errors: normalizeErrors(validateFn.errors),
   };
+}
+
+export function validateDagActivityEventV1(value: unknown): ValidationResult {
+  return validateMessage(value, DAG_ACTIVITY_EVENT_V1_SCHEMA_ID);
 }

--- a/homerail_protocol/tests/cross-version.test.ts
+++ b/homerail_protocol/tests/cross-version.test.ts
@@ -60,6 +60,7 @@ describe("Protocol version consistency", () => {
       "homerail-resolved-plugin-descriptor-v1",
       "homerail-direct-ui-projection-v1",
       "homerail-plugin-tool-execution-envelope-v1",
+      "dag-activity-event-v1",
       "handoff-request", "handoff-response",
       "tool-call", "tool-result",
       "send-message", "receive-message",

--- a/homerail_protocol/tests/dag-activity.test.ts
+++ b/homerail_protocol/tests/dag-activity.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import {
+  DAG_ACTIVITY_EVENT_SCHEMA_VERSION,
+  DAG_ACTIVITY_EVENT_V1_SCHEMA_ID,
+  DAG_ACTIVITY_TYPES,
+  DAG_AGENT_TOOL_NAMES,
+  type DagActivityEventV1,
+  validateDagActivityEventV1,
+} from "../src/index.js";
+import { allSchemas } from "../src/schemas.js";
+import { validateMessage } from "../src/validation.js";
+
+function activity(overrides: Partial<DagActivityEventV1> = {}): DagActivityEventV1 {
+  return {
+    schema_version: DAG_ACTIVITY_EVENT_SCHEMA_VERSION,
+    event_id: "event-01",
+    run_id: "run-01",
+    round_id: "round-01",
+    node_id: "worker-01",
+    actor_id: "researcher",
+    generation: 1,
+    surface_id: "surface-news",
+    sequence: 1,
+    timestamp: 1_784_000_000_000,
+    type: "progress",
+    payload: {
+      message: "Checking primary sources",
+      percent: 25,
+      source_ids: ["source-a", "source-b"],
+      detail: { cached: false, note: null },
+    },
+    ...overrides,
+  };
+}
+
+describe("Worker Activity Event V1", () => {
+  it("registers the versioned schema", () => {
+    expect(DAG_ACTIVITY_EVENT_V1_SCHEMA_ID).toBe("dag-activity-event-v1");
+    expect(allSchemas[DAG_ACTIVITY_EVENT_V1_SCHEMA_ID]).toBeDefined();
+  });
+
+  it.each(DAG_ACTIVITY_TYPES)("accepts the %s activity type", (type) => {
+    expect(validateDagActivityEventV1(activity({ type }))).toEqual({
+      valid: true,
+      errors: [],
+    });
+  });
+
+  it("accepts an omitted surface and nested JSON payload", () => {
+    const event = activity();
+    delete event.surface_id;
+
+    expect(validateMessage(event, DAG_ACTIVITY_EVENT_V1_SCHEMA_ID).valid).toBe(true);
+  });
+
+  it("exposes report_activity as a DAG agent tool", () => {
+    expect(DAG_AGENT_TOOL_NAMES).toContain("report_activity");
+  });
+
+  it.each([
+    ["missing event id", { event_id: undefined }],
+    ["empty actor id", { actor_id: "" }],
+    ["unknown activity type", { type: "heartbeat" }],
+    ["future schema version", { schema_version: 2 }],
+    ["zero generation", { generation: 0 }],
+    ["fractional generation", { generation: 1.5 }],
+    ["unsafe generation", { generation: Number.MAX_SAFE_INTEGER + 1 }],
+    ["zero sequence", { sequence: 0 }],
+    ["fractional sequence", { sequence: 1.5 }],
+    ["unsafe sequence", { sequence: Number.MAX_SAFE_INTEGER + 1 }],
+    ["negative timestamp", { timestamp: -1 }],
+    ["fractional timestamp", { timestamp: 1.5 }],
+    ["unsafe timestamp", { timestamp: Number.MAX_SAFE_INTEGER + 1 }],
+    ["array payload", { payload: [] }],
+    ["scalar payload", { payload: "not-structured" }],
+  ])("rejects %s", (_name, overrides) => {
+    const candidate = { ...activity(), ...overrides };
+    expect(validateMessage(candidate, DAG_ACTIVITY_EVENT_V1_SCHEMA_ID).valid).toBe(false);
+  });
+
+  it("rejects unknown envelope fields", () => {
+    const candidate = { ...activity(), secret: "must-not-cross-the-wire" };
+    const result = validateMessage(candidate, DAG_ACTIVITY_EVENT_V1_SCHEMA_ID);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((error) => error.keyword === "additionalProperties")).toBe(true);
+  });
+
+  it("rejects non-JSON payload values", () => {
+    const candidate = activity({
+      payload: { callback: (() => undefined) as never },
+    });
+
+    expect(validateMessage(candidate, DAG_ACTIVITY_EVENT_V1_SCHEMA_ID).valid).toBe(false);
+  });
+});
+
+describe("DAG activity routing metadata", () => {
+  const config = {
+    node_id: "worker-01",
+    agent_type: "claude",
+    model: "model",
+    outgoing_edges: [],
+    incoming_edges: [],
+    graph_nodes: ["worker-01"],
+    round_id: "round-02",
+    actor_id: "researcher",
+    generation: 2,
+    surface_id: "surface-news",
+    activity_sequence_start: 41,
+  };
+
+  it("accepts optional routing metadata in DAG node config", () => {
+    expect(validateMessage(config, "dag-node-config").valid).toBe(true);
+    expect(validateMessage({ ...config, activity_sequence_start: 0 }, "dag-node-config").valid).toBe(true);
+  });
+
+  it.each([
+    ["round_id", ""],
+    ["actor_id", ""],
+    ["generation", 0],
+    ["surface_id", ""],
+    ["activity_sequence_start", -1],
+    ["activity_sequence_start", 1.5],
+    ["activity_sequence_start", Number.MAX_SAFE_INTEGER + 1],
+  ])("rejects invalid %s metadata", (key, value) => {
+    expect(validateMessage({ ...config, [key]: value }, "dag-node-config").valid).toBe(false);
+  });
+});

--- a/homerail_worker/src/__tests__/dag-activity.test.ts
+++ b/homerail_worker/src/__tests__/dag-activity.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from "vitest";
+import type { DagActivityEventV1, DagNodeConfig } from "homerail-protocol";
+import { createDagActivityEmitter } from "../dag-activity.js";
+import { createDagTools, createDagToolsState } from "../dag-tools/index.js";
+
+function config(overrides: Partial<DagNodeConfig> = {}): DagNodeConfig {
+  return {
+    node_id: "researcher",
+    agent_type: "deterministic",
+    model: "test",
+    outgoing_edges: [{ from_port: "done", to_port: "in", to_node: "writer" }],
+    incoming_edges: [],
+    graph_nodes: ["researcher", "writer"],
+    ...overrides,
+  };
+}
+
+describe("DAG activity emitter", () => {
+  it("preserves actor identity and continues a supplied generation sequence", () => {
+    const events: DagActivityEventV1[] = [];
+    const emitter = createDagActivityEmitter(config({
+      actor_id: "research-actor",
+      round_id: "round-2",
+      generation: 3,
+      surface_id: "surface-news",
+      activity_sequence_start: 7,
+    }), "run-1", (event) => events.push(event));
+
+    emitter.emit("started");
+    emitter.emit("finding", { message: "source verified" });
+
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({
+      schema_version: 1,
+      run_id: "run-1",
+      round_id: "round-2",
+      node_id: "researcher",
+      actor_id: "research-actor",
+      generation: 3,
+      surface_id: "surface-news",
+      sequence: 8,
+      type: "started",
+    });
+    expect(events[1]).toMatchObject({ sequence: 9, type: "finding" });
+    expect(events[0].event_id).not.toBe(events[1].event_id);
+    expect(emitter.currentSequence()).toBe(9);
+  });
+
+  it("uses stable current-runtime defaults when actor metadata is absent", () => {
+    const events: DagActivityEventV1[] = [];
+    const emitter = createDagActivityEmitter(config({ session_id: "session-round" }), "run-2", (event) => events.push(event));
+
+    emitter.emit("progress", { message: "working" });
+
+    expect(events[0]).toMatchObject({
+      actor_id: "researcher",
+      round_id: "session-round",
+      generation: 1,
+      sequence: 1,
+    });
+  });
+
+  it("falls back safely when untrusted routing counters are invalid", () => {
+    const events: DagActivityEventV1[] = [];
+    const emitter = createDagActivityEmitter(config({
+      generation: Number.NaN,
+      activity_sequence_start: -1,
+    }), "run-invalid", (event) => events.push(event));
+
+    emitter.emit("started");
+
+    expect(events[0]).toMatchObject({ generation: 1, sequence: 1 });
+  });
+});
+
+describe("report_activity tool", () => {
+  it("emits only supported structured activity", async () => {
+    const wsSend = vi.fn();
+    const state = createDagToolsState(config(), "run-3", wsSend);
+    const emit = vi.fn();
+    const tool = createDagTools(state, { activityEmitter: emit }).find((candidate) => candidate.name === "report_activity");
+    expect(tool).toBeDefined();
+
+    const result = await tool!.handler({
+      type: "finding",
+      message: "  two sources agree  ",
+      data: { sources: 2 },
+    });
+
+    expect(result.is_error).not.toBe(true);
+    expect(emit).toHaveBeenCalledWith("finding", {
+      message: "two sources agree",
+      data: { sources: 2 },
+    });
+    expect(wsSend).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid activity without emitting", async () => {
+    const state = createDagToolsState(config(), "run-4", vi.fn());
+    const emit = vi.fn();
+    const tool = createDagTools(state, { activityEmitter: emit }).find((candidate) => candidate.name === "report_activity")!;
+
+    const result = await tool.handler({ type: "completed", message: "not allowed" });
+
+    expect(result.is_error).toBe(true);
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  it("enforces the message limit in the handler as well as the tool schema", async () => {
+    const state = createDagToolsState(config(), "run-5", vi.fn());
+    const emit = vi.fn();
+    const tool = createDagTools(state, { activityEmitter: emit }).find((candidate) => candidate.name === "report_activity")!;
+
+    const result = await tool.handler({ type: "progress", message: "x".repeat(4001) });
+
+    expect(result.is_error).toBe(true);
+    expect(emit).not.toHaveBeenCalled();
+  });
+});

--- a/homerail_worker/src/__tests__/prompt-runner.test.ts
+++ b/homerail_worker/src/__tests__/prompt-runner.test.ts
@@ -69,6 +69,12 @@ describe("prompt runner", () => {
     expect(types).toContain("content");
     expect(types).toContain("node_error");
     expect(types).toContain("SESSION_END");
+    const activities = sent
+      .map((message) => JSON.parse(message))
+      .filter((message) => message.type === "stream" && message.data?.event === "dag_activity")
+      .map((message) => message.data.activity);
+    expect(activities.map((activity) => activity.type)).toEqual(["started", "failed"]);
+    expect(activities.map((activity) => activity.sequence)).toEqual([1, 2]);
   });
 
   it("sends node_error with agent error when a prompt ends without handoff", async () => {
@@ -703,6 +709,16 @@ describe("prompt runner", () => {
       port: "done",
       content: "Source Issue: #847\n\nArtifact: ok",
     });
+    const activities = parsed
+      .filter((message) => message.type === "stream" && message.data?.event === "dag_activity")
+      .map((message) => message.data.activity);
+    expect(activities.map((activity) => activity.type)).toEqual([
+      "started",
+      "tool_used",
+      "tool_used",
+      "completed",
+    ]);
+    expect(activities.map((activity) => activity.sequence)).toEqual([1, 2, 3, 4]);
     expect(parsed.map((msg) => msg.type)).toContain("SESSION_END");
   });
 });

--- a/homerail_worker/src/dag-activity.ts
+++ b/homerail_worker/src/dag-activity.ts
@@ -1,0 +1,58 @@
+import { randomUUID } from "node:crypto";
+import type {
+  DagActivityEventV1,
+  DagActivityPayload,
+  DagActivityType,
+  DagNodeConfig,
+} from "homerail-protocol";
+import { DAG_ACTIVITY_EVENT_SCHEMA_VERSION } from "homerail-protocol";
+
+export interface DagActivityEmitter {
+  emit(type: DagActivityType, payload?: Record<string, unknown>): DagActivityEventV1;
+  currentSequence(): number;
+}
+
+export function createDagActivityEmitter(
+  config: DagNodeConfig,
+  runId: string,
+  sink: (event: DagActivityEventV1) => void,
+): DagActivityEmitter {
+  const requestedSequence = config.activity_sequence_start;
+  const requestedGeneration = config.generation;
+  let sequence = Number.isSafeInteger(requestedSequence) && (requestedSequence ?? -1) >= 0
+    ? requestedSequence as number
+    : 0;
+  const generation = Number.isSafeInteger(requestedGeneration) && (requestedGeneration ?? 0) >= 1
+    ? requestedGeneration as number
+    : 1;
+  const actorId = config.actor_id?.trim() || config.node_id;
+  const roundId = config.round_id?.trim() || config.session_id?.trim() || `${runId}:round:1`;
+  const surfaceId = config.surface_id?.trim() || undefined;
+
+  return {
+    emit(type, payload = {}) {
+      sequence += 1;
+      const event: DagActivityEventV1 = {
+        schema_version: DAG_ACTIVITY_EVENT_SCHEMA_VERSION,
+        event_id: randomUUID(),
+        run_id: runId,
+        round_id: roundId,
+        node_id: config.node_id,
+        actor_id: actorId,
+        generation,
+        ...(surfaceId ? { surface_id: surfaceId } : {}),
+        sequence,
+        timestamp: Date.now(),
+        type,
+        // Agent tool arguments are JSON wire values. The Manager validates the
+        // serialized envelope again before accepting it into the journal.
+        payload: payload as DagActivityPayload,
+      };
+      sink(event);
+      return event;
+    },
+    currentSequence() {
+      return sequence;
+    },
+  };
+}

--- a/homerail_worker/src/dag-tools/index.ts
+++ b/homerail_worker/src/dag-tools/index.ts
@@ -11,6 +11,8 @@ import { createReceiveMessageTool } from "./receive-message.js";
 import { createGraphContextTool } from "./graph-context.js";
 import { createManagerCommandTool } from "./manager-command.js";
 import { createConsultAdvisorTool } from "./advisor.js";
+import { createReportActivityTool } from "./report-activity.js";
+import type { DagActivityType } from "homerail-protocol";
 
 export interface AdvisorCallResult {
   text: string;
@@ -19,6 +21,10 @@ export interface AdvisorCallResult {
 
 export interface DagToolsOptions {
   advisorRunner?: (advisor: DagAdvisorConfig, question: string) => Promise<AdvisorCallResult>;
+  activityEmitter?: (
+    type: Extract<DagActivityType, "progress" | "finding" | "blocked">,
+    payload: Record<string, unknown>,
+  ) => void;
 }
 
 /** Mutable state shared across all DAG tools for a single prompt run. */
@@ -105,6 +111,9 @@ export function createDagTools(state: DagToolsState, options: DagToolsOptions = 
   ];
   if (state.advisors.length > 0 && options.advisorRunner) {
     tools.push(createConsultAdvisorTool(state, options.advisorRunner));
+  }
+  if (options.activityEmitter) {
+    tools.push(createReportActivityTool(options.activityEmitter));
   }
   return tools;
 }

--- a/homerail_worker/src/dag-tools/report-activity.ts
+++ b/homerail_worker/src/dag-tools/report-activity.ts
@@ -1,0 +1,41 @@
+import type { DagActivityType } from "homerail-protocol";
+import type { DagToolDefinition } from "../agent/types.js";
+
+type ReportableActivityType = Extract<DagActivityType, "progress" | "finding" | "blocked">;
+
+export function createReportActivityTool(
+  emit: (type: ReportableActivityType, payload: Record<string, unknown>) => void,
+): DagToolDefinition {
+  return {
+    name: "report_activity",
+    description: "Report meaningful progress, a finding, or a blocker to the durable DAG activity journal.",
+    input_schema: {
+      type: "object",
+      properties: {
+        type: { type: "string", enum: ["progress", "finding", "blocked"] },
+        message: { type: "string", minLength: 1, maxLength: 4000 },
+        data: { type: "object", additionalProperties: true },
+      },
+      required: ["type", "message"],
+      additionalProperties: false,
+    },
+    async handler(args: Record<string, unknown>) {
+      const type = args.type;
+      const message = typeof args.message === "string" ? args.message.trim() : "";
+      if ((type !== "progress" && type !== "finding" && type !== "blocked") || !message || message.length > 4000) {
+        return {
+          content: [{ type: "text", text: "type must be progress, finding, or blocked and message must contain 1 to 4000 characters" }],
+          is_error: true,
+        };
+      }
+      const data = args.data;
+      emit(type, {
+        message,
+        ...(typeof data === "object" && data !== null && !Array.isArray(data) ? { data } : {}),
+      });
+      return {
+        content: [{ type: "text", text: `Activity ${type} recorded.` }],
+      };
+    },
+  };
+}

--- a/homerail_worker/src/index.ts
+++ b/homerail_worker/src/index.ts
@@ -112,6 +112,9 @@ client.on("task", async (msg) => {
     hasManagerEnvelope: Boolean(envelope),
   });
   const checkpointResume = envelope ? parseCheckpointResume(envelope.checkpointResume) : undefined;
+  const activity = envelope?.activity && typeof envelope.activity === "object"
+    ? envelope.activity as Record<string, unknown>
+    : undefined;
 
   // Task text: prefer envelope.inputs (flattened), then data.task/prompt
   let task: string;
@@ -136,6 +139,11 @@ client.on("task", async (msg) => {
         incoming_edges: [],
         graph_nodes: [nodeId],
         session_id: sessionId,
+        round_id: typeof activity?.roundId === "string" ? activity.roundId : sessionId,
+        actor_id: typeof activity?.actorId === "string" ? activity.actorId : nodeId,
+        generation: typeof activity?.generation === "number" ? activity.generation : 1,
+        surface_id: typeof activity?.surfaceId === "string" ? activity.surfaceId : undefined,
+        activity_sequence_start: typeof activity?.sequenceStart === "number" ? activity.sequenceStart : 0,
         advisors: Array.isArray(envelope.advisors) ? envelope.advisors as DagAdvisorConfig[] : undefined,
         workspace_access: envelope.workspaceAccess && typeof envelope.workspaceAccess === "object"
           ? envelope.workspaceAccess as unknown as DagWorkspaceAccess

--- a/homerail_worker/src/prompt-runner.ts
+++ b/homerail_worker/src/prompt-runner.ts
@@ -14,6 +14,7 @@ import type { AuditWriters } from "./audit/index.js";
 import { appendTranscriptEntry, redactAgentContext, saveSession } from "./session/session-store.js";
 import { redactTelemetry } from "./telemetry-redaction.js";
 import { snapshotWorkspace, verifyWorkspacePolicy, type WorkspaceSnapshot } from "./workspace-policy.js";
+import { createDagActivityEmitter } from "./dag-activity.js";
 
 export interface PromptJob {
   task: string;
@@ -196,8 +197,12 @@ export async function runPrompt(
   const dagState = createDagToolsState(job.dagConfig, job.runId, wsSend);
   const workspace = process.env.WORKSPACE ?? process.cwd();
   const correctionOnly = /(?:^|\n)## input:correction(?:\r?\n|$)/.test(job.task);
+  const activityEmitter = createDagActivityEmitter(job.dagConfig, job.runId, (activity) => {
+    sendStream({ event: "dag_activity", activity });
+  });
   const allDagTools = createDagTools(dagState, {
     advisorRunner: (advisor, question) => runAdvisorCall(advisor, question, workspace, deps.abortSignal),
+    activityEmitter: (type, payload) => activityEmitter.emit(type, payload),
   });
   const allowedDagTools = job.dagConfig.allowed_dag_tools === undefined
     ? undefined
@@ -280,6 +285,13 @@ export async function runPrompt(
   let nodeDurationMs: number | undefined;
   let nodeNumTurns: number | undefined;
   let workspaceBefore: WorkspaceSnapshot | undefined;
+  let terminalActivityEmitted = false;
+  const toolNamesById = new Map<string, string>();
+
+  activityEmitter.emit("started", {
+    session_id: job.dagConfig.session_id ?? job.runId,
+    sender: job.sender,
+  });
 
   try {
     if (dagState.workspaceAccess) {
@@ -361,6 +373,7 @@ export async function runPrompt(
           break;
         }
         case "tool_use":
+          toolNamesById.set(event.id, event.name);
           appendSessionTranscript("tool_use", undefined, {
             tool_name: event.name,
             tool_id: event.id,
@@ -372,6 +385,14 @@ export async function runPrompt(
             tool_id: event.id,
             tool_input: redactTelemetry(event.input),
           });
+          if (event.name !== "report_activity") {
+            activityEmitter.emit("tool_used", {
+              phase: "started",
+              tool_name: event.name,
+              tool_id: event.id,
+              input: event.input,
+            });
+          }
           audit?.toolEvents.write({
             event: "tool_use",
             tool_name: event.name,
@@ -393,6 +414,15 @@ export async function runPrompt(
             is_error: event.is_error,
             result_preview: redactTelemetry(event.content),
           });
+          if (toolNamesById.get(event.tool_use_id) !== "report_activity") {
+            activityEmitter.emit("tool_used", {
+              phase: "completed",
+              tool_name: toolNamesById.get(event.tool_use_id) ?? "unknown",
+              tool_id: event.tool_use_id,
+              is_error: event.is_error === true,
+              result_preview: String(redactTelemetry(event.content)).slice(0, 4000),
+            });
+          }
           audit?.toolEvents.write({
             event: "tool_result",
             tool_use_id: event.tool_use_id,
@@ -447,6 +477,14 @@ export async function runPrompt(
         }
       }
       if (workspaceValid && dagState.handoffData) {
+        const handoff = dagState.handoffData as Record<string, unknown>;
+        const port = typeof handoff.port === "string"
+          ? handoff.port
+          : typeof handoff.from_port === "string"
+            ? handoff.from_port
+            : undefined;
+        activityEmitter.emit("completed", port ? { port } : {});
+        terminalActivityEmitted = true;
         // This is the authoritative runtime payload, not telemetry. The
         // Manager applies it before writing redacted evidence copies.
         sendTerminalMessage(JSON.stringify({
@@ -505,6 +543,10 @@ export async function runPrompt(
 
   function sendNodeError(message: string) {
     const redactedMessage = String(redactTelemetry(message));
+    if (!terminalActivityEmitted) {
+      activityEmitter.emit("failed", { message: redactedMessage });
+      terminalActivityEmitted = true;
+    }
     const data = {
       runId: job.runId,
       nodeId: job.dagConfig.node_id,


### PR DESCRIPTION
Parent epic: #36

Closes #37

Base: `origin/main@9f720754` after the Windows CI fixes from PR #46.

## Why

Later durable actors, supervision, recovery, and live A2UI projection need one replayable source of Worker activity facts. Existing DAG events remain unchanged and continue to serve their current runtime purpose.

## What changed

- adds the versioned `dag-activity-event-v1` protocol for started, progress, finding, tool_used, blocked, completed, and failed events
- adds SQLite migration 19 with an append-only activity journal, semantic event-id deduplication, per-actor-generation sequence uniqueness, and old-database validation
- redacts activity payloads again at the Manager persistence boundary and rejects oversized raw events before recursive validation
- adds bounded run/actor replay at `GET /api/runs/:run_id/activities`
- passes the durable actor sequence cursor through Manager dispatch so correction and later rounds continue ordering
- emits runtime-owned lifecycle and tool events from Worker and exposes `report_activity` only for meaningful progress, findings, and blockers
- retains stale-round and stale-generation facts for audit while keeping Activity Plane separate from chat evidence and A2UI
- documents the contract and the boundaries for #38-#45

## Invariants

- replaying identical `event_id` content is idempotent; semantic ID reuse fails closed
- journal rows never contain plaintext credentials
- history has no update API and is not mutated by projection
- Activity Plane never writes A2UI directly
- ordering is defined only inside one `(run_id, actor_id, generation)`

## Migrations

Migration 19 creates and validates the append-only Activity Journal, indexes, constraints, old-database upgrade, and repeated startup behavior.

## Verification after rebase

- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run ci`: passed
- Protocol: 241 passed
- Plugin SDK: 34 passed
- Manager: 710 passed, 2 Docker-dependent tests skipped
- Node: 187 passed, 2 Docker-dependent tests skipped
- Worker: 212 passed, 1 skipped
- CLI: 235 passed
- UI: 287 passed
- live validators: 11 passed, 2 environment-dependent tests skipped
- typecheck and builds passed for every package
- `git diff --check`: passed

Previous runtime evidence on this implementation includes an ordered real Manager plus deterministic Worker sequence and replay after Manager restart using an isolated `HOMERAIL_HOME`.

Docker-specific suites were not executed because the local Docker daemon was not running.

## Out of scope

- logical Actors and command inbox: #38 / PR #48
- multi-round waiting: #39 / PR #49
- Worker lease and cold recovery: #40 / PR #50
- Live Surface projection: #41 / PR #51
- realtime task canvas: #42 / PR #52

## Residual risk

This PR remains Draft for review. Before merge it must be marked Ready so the repository CI runs on GitHub; only the repository maintainer may merge it.