### PR TITLE
Add durable DAG logical actors and command inbox

### DIFF
--- a/docs/architecture/durable-dag-actors.md
+++ b/docs/architecture/durable-dag-actors.md
@@ -1,6 +1,6 @@
 # Durable DAG Actors
 
-This document defines the durable activity boundary introduced by Epic #36. It is intentionally narrower than actor retention, command routing, UI projection, or supervision.
+This document defines the durable actor boundaries introduced by Epic #36. Activity is an append-only fact plane; actor identity and commands form a separate control plane. UI projection and supervision consume these records but do not own them.
 
 ## Activity Plane
 
@@ -15,7 +15,7 @@ The V1 envelope is `dag-activity-event-v1`:
 | `run_id` | Durable DAG run identity. |
 | `round_id` | Command/response round that produced the event. Until multi-round actors land, the node session is used. |
 | `node_id` | DAG node that owns the execution slot. It must match the authenticated Worker stream context. |
-| `actor_id` | Logical actor identity. It defaults to `node_id` until logical actors are introduced. |
+| `actor_id` | Stable logical actor identity from `dag_actors`. It defaults to `node_id` when the workflow does not declare one. |
 | `generation` | Actor process generation, starting at 1. A replacement process increments it; older generations remain auditable. |
 | `surface_id` | Optional logical UI surface association. It is routing metadata, not a request to update A2UI. |
 | `sequence` | Strictly increasing sequence inside one `(run_id, actor_id, generation)`. |
@@ -53,9 +53,45 @@ Journal writes enforce:
 
 Replay uses `GET /api/runs/:run_id/activities`, with optional `actor_id`, `after_seq`, and bounded `limit` query parameters. The cursor is the Manager journal sequence, so replay resumes without relying on producer clocks.
 
+## Logical Actor Registry
+
+`dag_actors` is the canonical identity source for one durable run. A row binds:
+
+- stable `actor_id`, role, and owning `node_id`;
+- stable `surface_id`, unique within the run;
+- current session, model profile, workspace, and checkpoint references;
+- monotonic actor `generation`, logical `attempt`, and row `version`.
+
+Physical Worker, container, node, and WebSocket identifiers are deliberately absent. Reconnecting the same logical actor on another Worker does not change its identity or surface. Binding updates require the current row version. Generation changes require both the current generation and version, so two recovery attempts cannot both become current.
+
+Workflow nodes may declare `extra.agent_runtime.actor_id`, `role`, and `surface_id`. Missing values receive deterministic defaults (`node_id`, agent id, and `actor:<actor_id>`). Gateway nodes are Manager-owned runtime primitives and do not receive logical actor rows.
+
+The persisted model profile contains only routing identity such as agent, provider, model, protocol, and setting id. Credentials are neither copied into the profile nor accepted without redaction at the persistence boundary.
+
+## Durable Command Inbox
+
+`dag_actor_commands` is the control-plane inbox. Every command records its `command_id`, idempotency key, `round_id`, target actor generation, status, payload, and lifecycle timestamps. The state machine is:
+
+```text
+pending -> delivered -> claimed -> acknowledged
+    |           |          `-----> failed
+    `-----------'
+```
+
+A Worker may claim a pending command directly after reconnect, so an unavailable immediate-delivery path does not lose work. The runtime follows these rules:
+
+1. create and commit the command before invoking an immediate-delivery callback;
+2. treat an identical `command_id` or actor-scoped idempotency key as the same command;
+3. reject semantic reuse of either identity;
+4. allow claims only when actor generation, target generation, and command state all match;
+5. allow only the claiming generation to acknowledge or fail the command;
+6. redact and size-bound model profiles, command payloads, and failure details before storage.
+
+The TypeScript runtime API exposes registration, binding CAS, generation advancement, command creation/listing/delivery/claim/ack/fail, and bounded reads. Manager LLM tools, long-lived waiting runs, Worker release, and A2UI writes remain follow-up responsibilities.
+
 ## Follow-up Boundaries
 
-- **Logical actors and inbox (#38):** assign stable `actor_id`, durable inbox records, and sequence starts.
+- **Logical actors and inbox (#38):** this registry and durable command control plane.
 - **Multi-round execution (#39):** create new `round_id` values while continuing the actor-generation sequence.
 - **Lease and cold recovery (#40):** increment `generation` when ownership changes and reject stale writes for live projection while retaining them for audit.
 - **Projector (#41):** consume journal events and produce A2UI transactions. It must not edit journal rows.

--- a/homerail_manager/src/persistence/dag-actors.ts
+++ b/homerail_manager/src/persistence/dag-actors.ts
@@ -1,0 +1,725 @@
+import { createHash } from "node:crypto";
+import { redactTelemetry } from "homerail-protocol";
+import { getDb, parseJsonRow } from "./db.js";
+
+export const MAX_DAG_ACTOR_DOCUMENT_BYTES = 256 * 1024;
+export const DEFAULT_DAG_ACTOR_COMMAND_LIMIT = 100;
+export const MAX_DAG_ACTOR_COMMAND_LIMIT = 500;
+
+export interface DagActorRecord {
+  run_id: string;
+  actor_id: string;
+  node_id: string;
+  role: string;
+  generation: number;
+  attempt: number;
+  version: number;
+  session_id?: string;
+  model_profile: Record<string, unknown>;
+  surface_id: string;
+  workspace_ref?: string;
+  checkpoint_ref?: string;
+  created_at: number;
+  updated_at: number;
+}
+
+export type DagActorCommandStatus = "pending" | "delivered" | "claimed" | "acknowledged" | "failed";
+const DAG_ACTOR_COMMAND_STATUSES: ReadonlySet<string> = new Set([
+  "pending",
+  "delivered",
+  "claimed",
+  "acknowledged",
+  "failed",
+]);
+
+export interface DagActorCommandRecord {
+  command_id: string;
+  run_id: string;
+  actor_id: string;
+  round_id: string;
+  target_generation: number;
+  status: DagActorCommandStatus;
+  idempotency_key: string;
+  payload: unknown;
+  claimed_generation?: number;
+  created_at: number;
+  delivered_at?: number;
+  claimed_at?: number;
+  completed_at?: number;
+  failure?: unknown;
+}
+
+export interface DagActorCommandMutationResult {
+  command: DagActorCommandRecord;
+  changed: boolean;
+  deduplicated: boolean;
+}
+
+export class DagActorConflictError extends Error {
+  constructor(
+    public readonly code:
+      | "actor_identity_conflict"
+      | "actor_version_conflict"
+      | "actor_generation_conflict"
+      | "command_identity_conflict"
+      | "command_generation_conflict"
+      | "command_status_conflict",
+    message: string,
+  ) {
+    super(message);
+    this.name = "DagActorConflictError";
+  }
+}
+
+interface DagActorRow extends Record<string, unknown> {
+  run_id: string;
+  actor_id: string;
+  node_id: string;
+  role: string;
+  generation: number;
+  attempt: number;
+  version: number;
+  session_id: string | null;
+  model_profile_json: string;
+  surface_id: string;
+  workspace_ref: string | null;
+  checkpoint_ref: string | null;
+  created_at: number;
+  updated_at: number;
+}
+
+interface DagActorCommandRow extends Record<string, unknown> {
+  command_id: string;
+  run_id: string;
+  actor_id: string;
+  round_id: string;
+  target_generation: number;
+  status: DagActorCommandStatus;
+  idempotency_key: string;
+  payload_digest: string;
+  payload_json: string;
+  claimed_generation: number | null;
+  created_at: number;
+  delivered_at: number | null;
+  claimed_at: number | null;
+  completed_at: number | null;
+  failure_json: string | null;
+}
+
+function assertIdentifier(value: string, label: string): string {
+  const normalized = value.trim();
+  if (!normalized || normalized.length > 256) {
+    throw new Error(`${label} must be between 1 and 256 characters`);
+  }
+  return normalized;
+}
+
+function assertOptionalReference(value: string | null | undefined, label: string): string | null | undefined {
+  if (value === undefined || value === null) return value;
+  const normalized = value.trim();
+  if (!normalized || normalized.length > 2_048) {
+    throw new Error(`${label} must be between 1 and 2048 characters when provided`);
+  }
+  return normalized;
+}
+
+function assertPositiveSafeInteger(value: number, label: string): number {
+  if (!Number.isSafeInteger(value) || value < 1) throw new Error(`${label} must be a positive safe integer`);
+  return value;
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object") {
+    const result: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      const nested = (value as Record<string, unknown>)[key];
+      if (nested !== undefined) result[key] = canonicalize(nested);
+    }
+    return result;
+  }
+  return value;
+}
+
+function encodeBoundedDocument(value: unknown, label: string): { json: string; digest: string } {
+  let raw: string | undefined;
+  try {
+    raw = JSON.stringify(value);
+  } catch {
+    throw new Error(`${label} must be JSON serializable`);
+  }
+  if (raw === undefined) throw new Error(`${label} must be JSON serializable`);
+  if (Buffer.byteLength(raw, "utf8") > MAX_DAG_ACTOR_DOCUMENT_BYTES) {
+    throw new Error(`${label} exceeds ${MAX_DAG_ACTOR_DOCUMENT_BYTES} bytes`);
+  }
+  const redacted = canonicalize(redactTelemetry(value));
+  const json = JSON.stringify(redacted);
+  if (Buffer.byteLength(json, "utf8") > MAX_DAG_ACTOR_DOCUMENT_BYTES) {
+    throw new Error(`${label} exceeds ${MAX_DAG_ACTOR_DOCUMENT_BYTES} bytes after redaction`);
+  }
+  return { json, digest: createHash("sha256").update(json).digest("hex") };
+}
+
+function actorFromRow(row: DagActorRow): DagActorRecord {
+  const modelProfile = parseJsonRow<unknown>(row.model_profile_json);
+  if (!modelProfile || typeof modelProfile !== "object" || Array.isArray(modelProfile)) {
+    throw new Error(`DAG actor ${row.actor_id} has an invalid model profile`);
+  }
+  return {
+    run_id: row.run_id,
+    actor_id: row.actor_id,
+    node_id: row.node_id,
+    role: row.role,
+    generation: Number(row.generation),
+    attempt: Number(row.attempt),
+    version: Number(row.version),
+    ...(row.session_id ? { session_id: row.session_id } : {}),
+    model_profile: modelProfile as Record<string, unknown>,
+    surface_id: row.surface_id,
+    ...(row.workspace_ref ? { workspace_ref: row.workspace_ref } : {}),
+    ...(row.checkpoint_ref ? { checkpoint_ref: row.checkpoint_ref } : {}),
+    created_at: Number(row.created_at),
+    updated_at: Number(row.updated_at),
+  };
+}
+
+function commandFromRow(row: DagActorCommandRow): DagActorCommandRecord {
+  return {
+    command_id: row.command_id,
+    run_id: row.run_id,
+    actor_id: row.actor_id,
+    round_id: row.round_id,
+    target_generation: Number(row.target_generation),
+    status: row.status,
+    idempotency_key: row.idempotency_key,
+    payload: parseJsonRow(row.payload_json),
+    ...(row.claimed_generation === null ? {} : { claimed_generation: Number(row.claimed_generation) }),
+    created_at: Number(row.created_at),
+    ...(row.delivered_at === null ? {} : { delivered_at: Number(row.delivered_at) }),
+    ...(row.claimed_at === null ? {} : { claimed_at: Number(row.claimed_at) }),
+    ...(row.completed_at === null ? {} : { completed_at: Number(row.completed_at) }),
+    ...(row.failure_json === null ? {} : { failure: parseJsonRow(row.failure_json) }),
+  };
+}
+
+function getActorRow(runId: string, actorId: string): DagActorRow | undefined {
+  return getDb().prepare("SELECT * FROM dag_actors WHERE run_id = ? AND actor_id = ?")
+    .get(runId, actorId) as DagActorRow | undefined;
+}
+
+function getCommandRow(commandId: string): DagActorCommandRow | undefined {
+  return getDb().prepare("SELECT * FROM dag_actor_commands WHERE command_id = ?")
+    .get(commandId) as DagActorCommandRow | undefined;
+}
+
+function requireActor(runId: string, actorId: string): DagActorRecord {
+  const actor = getDagActor(runId, actorId);
+  if (!actor) throw new Error(`Unknown DAG actor: ${runId}/${actorId}`);
+  return actor;
+}
+
+function requireCommand(commandId: string): DagActorCommandRecord {
+  const command = getDagActorCommand(commandId);
+  if (!command) throw new Error(`Unknown DAG actor command: ${commandId}`);
+  return command;
+}
+
+export function registerDagActor(input: {
+  run_id: string;
+  actor_id: string;
+  node_id: string;
+  role: string;
+  model_profile?: Record<string, unknown>;
+  surface_id: string;
+  session_id?: string;
+  workspace_ref?: string;
+  checkpoint_ref?: string;
+}): { actor: DagActorRecord; inserted: boolean; deduplicated: boolean } {
+  const runId = assertIdentifier(input.run_id, "run_id");
+  const actorId = assertIdentifier(input.actor_id, "actor_id");
+  const nodeId = assertIdentifier(input.node_id, "node_id");
+  const role = assertIdentifier(input.role, "role");
+  const surfaceId = assertIdentifier(input.surface_id, "surface_id");
+  const sessionId = assertOptionalReference(input.session_id, "session_id");
+  const workspaceRef = assertOptionalReference(input.workspace_ref, "workspace_ref");
+  const checkpointRef = assertOptionalReference(input.checkpoint_ref, "checkpoint_ref");
+  const modelProfile = encodeBoundedDocument(input.model_profile ?? {}, "model_profile");
+  const db = getDb();
+
+  return db.transaction(() => {
+    const existing = getActorRow(runId, actorId);
+    if (existing) {
+      if (existing.node_id !== nodeId || existing.role !== role || existing.surface_id !== surfaceId) {
+        throw new DagActorConflictError(
+          "actor_identity_conflict",
+          `DAG actor ${runId}/${actorId} is already bound to node ${existing.node_id}, role ${existing.role}, surface ${existing.surface_id}`,
+        );
+      }
+      return { actor: actorFromRow(existing), inserted: false, deduplicated: true };
+    }
+    if (!db.prepare("SELECT 1 FROM dag_runs WHERE run_id = ?").get(runId)) {
+      throw new Error(`Unknown DAG run: ${runId}`);
+    }
+    const nodeConflict = db.prepare("SELECT actor_id FROM dag_actors WHERE run_id = ? AND node_id = ?")
+      .get(runId, nodeId) as { actor_id: string } | undefined;
+    if (nodeConflict) {
+      throw new DagActorConflictError(
+        "actor_identity_conflict",
+        `DAG node ${runId}/${nodeId} is already owned by actor ${nodeConflict.actor_id}`,
+      );
+    }
+    const surfaceConflict = db.prepare("SELECT actor_id FROM dag_actors WHERE run_id = ? AND surface_id = ?")
+      .get(runId, surfaceId) as { actor_id: string } | undefined;
+    if (surfaceConflict) {
+      throw new DagActorConflictError(
+        "actor_identity_conflict",
+        `DAG surface ${runId}/${surfaceId} is already owned by actor ${surfaceConflict.actor_id}`,
+      );
+    }
+    const now = Date.now();
+    db.prepare(`
+      INSERT INTO dag_actors(
+        run_id, actor_id, node_id, role, generation, attempt, version, session_id,
+        model_profile_json, surface_id, workspace_ref, checkpoint_ref, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, 1, 1, 1, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      runId,
+      actorId,
+      nodeId,
+      role,
+      sessionId ?? null,
+      modelProfile.json,
+      surfaceId,
+      workspaceRef ?? null,
+      checkpointRef ?? null,
+      now,
+      now,
+    );
+    return { actor: actorFromRow(getActorRow(runId, actorId)!), inserted: true, deduplicated: false };
+  })();
+}
+
+export function getDagActor(runId: string, actorId: string): DagActorRecord | undefined {
+  const row = getActorRow(runId, actorId);
+  return row ? actorFromRow(row) : undefined;
+}
+
+export function getDagActorByNode(runId: string, nodeId: string): DagActorRecord | undefined {
+  const row = getDb().prepare("SELECT * FROM dag_actors WHERE run_id = ? AND node_id = ?")
+    .get(runId, nodeId) as DagActorRow | undefined;
+  return row ? actorFromRow(row) : undefined;
+}
+
+export function listDagActors(runId: string): DagActorRecord[] {
+  return (getDb().prepare("SELECT * FROM dag_actors WHERE run_id = ? ORDER BY actor_id")
+    .all(runId) as DagActorRow[]).map(actorFromRow);
+}
+
+export function updateDagActorBinding(input: {
+  run_id: string;
+  actor_id: string;
+  expected_version: number;
+  session_id?: string | null;
+  attempt?: number;
+  model_profile?: Record<string, unknown>;
+  workspace_ref?: string | null;
+  checkpoint_ref?: string | null;
+}): DagActorRecord {
+  const runId = assertIdentifier(input.run_id, "run_id");
+  const actorId = assertIdentifier(input.actor_id, "actor_id");
+  const expectedVersion = assertPositiveSafeInteger(input.expected_version, "expected_version");
+  const hasPatch = input.session_id !== undefined
+    || input.attempt !== undefined
+    || input.model_profile !== undefined
+    || input.workspace_ref !== undefined
+    || input.checkpoint_ref !== undefined;
+  if (!hasPatch) throw new Error("At least one actor binding field is required");
+  const sessionId = assertOptionalReference(input.session_id, "session_id");
+  const attempt = input.attempt === undefined ? undefined : assertPositiveSafeInteger(input.attempt, "attempt");
+  const workspaceRef = assertOptionalReference(input.workspace_ref, "workspace_ref");
+  const checkpointRef = assertOptionalReference(input.checkpoint_ref, "checkpoint_ref");
+  const modelProfile = input.model_profile === undefined
+    ? undefined
+    : encodeBoundedDocument(input.model_profile, "model_profile").json;
+  const db = getDb();
+
+  return db.transaction(() => {
+    const current = requireActor(runId, actorId);
+    if (current.version !== expectedVersion) {
+      throw new DagActorConflictError(
+        "actor_version_conflict",
+        `DAG actor ${runId}/${actorId} version is ${current.version}, expected ${expectedVersion}`,
+      );
+    }
+    const changed = db.prepare(`
+      UPDATE dag_actors SET
+        session_id = CASE WHEN ? THEN ? ELSE session_id END,
+        attempt = COALESCE(?, attempt),
+        model_profile_json = COALESCE(?, model_profile_json),
+        workspace_ref = CASE WHEN ? THEN ? ELSE workspace_ref END,
+        checkpoint_ref = CASE WHEN ? THEN ? ELSE checkpoint_ref END,
+        version = version + 1,
+        updated_at = ?
+      WHERE run_id = ? AND actor_id = ? AND version = ?
+    `).run(
+      input.session_id !== undefined ? 1 : 0,
+      sessionId ?? null,
+      attempt ?? null,
+      modelProfile ?? null,
+      input.workspace_ref !== undefined ? 1 : 0,
+      workspaceRef ?? null,
+      input.checkpoint_ref !== undefined ? 1 : 0,
+      checkpointRef ?? null,
+      Date.now(),
+      runId,
+      actorId,
+      expectedVersion,
+    );
+    if (changed.changes !== 1) {
+      throw new DagActorConflictError("actor_version_conflict", `DAG actor ${runId}/${actorId} changed concurrently`);
+    }
+    return requireActor(runId, actorId);
+  })();
+}
+
+export function advanceDagActorGeneration(input: {
+  run_id: string;
+  actor_id: string;
+  expected_generation: number;
+  expected_version: number;
+  session_id?: string | null;
+  attempt?: number;
+  checkpoint_ref?: string | null;
+}): DagActorRecord {
+  const runId = assertIdentifier(input.run_id, "run_id");
+  const actorId = assertIdentifier(input.actor_id, "actor_id");
+  const expectedGeneration = assertPositiveSafeInteger(input.expected_generation, "expected_generation");
+  const expectedVersion = assertPositiveSafeInteger(input.expected_version, "expected_version");
+  const sessionId = assertOptionalReference(input.session_id, "session_id");
+  const requestedAttempt = input.attempt === undefined
+    ? undefined
+    : assertPositiveSafeInteger(input.attempt, "attempt");
+  const checkpointRef = assertOptionalReference(input.checkpoint_ref, "checkpoint_ref");
+  const db = getDb();
+
+  return db.transaction(() => {
+    const current = requireActor(runId, actorId);
+    if (current.generation !== expectedGeneration) {
+      throw new DagActorConflictError(
+        "actor_generation_conflict",
+        `DAG actor ${runId}/${actorId} generation is ${current.generation}, expected ${expectedGeneration}`,
+      );
+    }
+    if (current.version !== expectedVersion) {
+      throw new DagActorConflictError(
+        "actor_version_conflict",
+        `DAG actor ${runId}/${actorId} version is ${current.version}, expected ${expectedVersion}`,
+      );
+    }
+    const attempt = requestedAttempt ?? assertPositiveSafeInteger(current.attempt + 1, "attempt");
+    const changed = db.prepare(`
+      UPDATE dag_actors SET
+        generation = generation + 1,
+        attempt = ?,
+        version = version + 1,
+        session_id = ?,
+        checkpoint_ref = CASE WHEN ? THEN ? ELSE checkpoint_ref END,
+        updated_at = ?
+      WHERE run_id = ? AND actor_id = ? AND generation = ? AND version = ?
+    `).run(
+      attempt,
+      sessionId ?? null,
+      input.checkpoint_ref !== undefined ? 1 : 0,
+      checkpointRef ?? null,
+      Date.now(),
+      runId,
+      actorId,
+      expectedGeneration,
+      expectedVersion,
+    );
+    if (changed.changes !== 1) {
+      throw new DagActorConflictError("actor_generation_conflict", `DAG actor ${runId}/${actorId} changed concurrently`);
+    }
+    return requireActor(runId, actorId);
+  })();
+}
+
+export function createDagActorCommand(input: {
+  command_id: string;
+  run_id: string;
+  actor_id: string;
+  round_id: string;
+  idempotency_key: string;
+  payload: unknown;
+  target_generation?: number;
+}): DagActorCommandMutationResult {
+  const commandId = assertIdentifier(input.command_id, "command_id");
+  const runId = assertIdentifier(input.run_id, "run_id");
+  const actorId = assertIdentifier(input.actor_id, "actor_id");
+  const roundId = assertIdentifier(input.round_id, "round_id");
+  const idempotencyKey = assertIdentifier(input.idempotency_key, "idempotency_key");
+  const encoded = encodeBoundedDocument(input.payload, "command payload");
+  const db = getDb();
+
+  return db.transaction(() => {
+    const actor = requireActor(runId, actorId);
+    const targetGeneration = input.target_generation === undefined
+      ? actor.generation
+      : assertPositiveSafeInteger(input.target_generation, "target_generation");
+    if (targetGeneration !== actor.generation) {
+      throw new DagActorConflictError(
+        "command_generation_conflict",
+        `Command targets generation ${targetGeneration}, but actor ${runId}/${actorId} is generation ${actor.generation}`,
+      );
+    }
+    const byId = getCommandRow(commandId);
+    if (byId) {
+      const same = byId.run_id === runId
+        && byId.actor_id === actorId
+        && byId.round_id === roundId
+        && byId.target_generation === targetGeneration
+        && byId.idempotency_key === idempotencyKey
+        && byId.payload_digest === encoded.digest
+        && byId.payload_json === encoded.json;
+      if (!same) {
+        throw new DagActorConflictError(
+          "command_identity_conflict",
+          `DAG actor command_id ${commandId} already identifies different content`,
+        );
+      }
+      return { command: commandFromRow(byId), changed: false, deduplicated: true };
+    }
+    const byKey = db.prepare(`
+      SELECT * FROM dag_actor_commands
+      WHERE run_id = ? AND actor_id = ? AND idempotency_key = ?
+    `).get(runId, actorId, idempotencyKey) as DagActorCommandRow | undefined;
+    if (byKey) {
+      const same = byKey.round_id === roundId
+        && byKey.target_generation === targetGeneration
+        && byKey.payload_digest === encoded.digest
+        && byKey.payload_json === encoded.json;
+      if (!same) {
+        throw new DagActorConflictError(
+          "command_identity_conflict",
+          `DAG actor idempotency_key ${idempotencyKey} already identifies different content`,
+        );
+      }
+      return { command: commandFromRow(byKey), changed: false, deduplicated: true };
+    }
+    db.prepare(`
+      INSERT INTO dag_actor_commands(
+        command_id, run_id, actor_id, round_id, target_generation, status,
+        idempotency_key, payload_digest, payload_json, created_at
+      ) VALUES (?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?)
+    `).run(
+      commandId,
+      runId,
+      actorId,
+      roundId,
+      targetGeneration,
+      idempotencyKey,
+      encoded.digest,
+      encoded.json,
+      Date.now(),
+    );
+    return { command: commandFromRow(getCommandRow(commandId)!), changed: true, deduplicated: false };
+  })();
+}
+
+export function getDagActorCommand(commandId: string): DagActorCommandRecord | undefined {
+  const row = getCommandRow(commandId);
+  return row ? commandFromRow(row) : undefined;
+}
+
+export function listDagActorCommands(input: {
+  run_id: string;
+  actor_id?: string;
+  round_id?: string;
+  status?: DagActorCommandStatus;
+  limit?: number;
+}): DagActorCommandRecord[] {
+  const conditions = ["run_id = ?"];
+  const params: unknown[] = [assertIdentifier(input.run_id, "run_id")];
+  if (input.actor_id !== undefined) {
+    conditions.push("actor_id = ?");
+    params.push(assertIdentifier(input.actor_id, "actor_id"));
+  }
+  if (input.round_id !== undefined) {
+    conditions.push("round_id = ?");
+    params.push(assertIdentifier(input.round_id, "round_id"));
+  }
+  if (input.status !== undefined) {
+    if (!DAG_ACTOR_COMMAND_STATUSES.has(input.status)) throw new Error(`Invalid command status: ${input.status}`);
+    conditions.push("status = ?");
+    params.push(input.status);
+  }
+  const requestedLimit = input.limit ?? DEFAULT_DAG_ACTOR_COMMAND_LIMIT;
+  if (!Number.isSafeInteger(requestedLimit) || requestedLimit < 1) {
+    throw new Error("limit must be a positive safe integer");
+  }
+  params.push(Math.min(requestedLimit, MAX_DAG_ACTOR_COMMAND_LIMIT));
+  return (getDb().prepare(`
+    SELECT * FROM dag_actor_commands
+    WHERE ${conditions.join(" AND ")}
+    ORDER BY created_at, command_id
+    LIMIT ?
+  `).all(...params) as DagActorCommandRow[]).map(commandFromRow);
+}
+
+function markCommandDelivered(commandId: string): DagActorCommandMutationResult {
+  const db = getDb();
+  return db.transaction(() => {
+    const current = requireCommand(commandId);
+    if (current.status === "delivered") {
+      return { command: current, changed: false, deduplicated: true };
+    }
+    if (current.status !== "pending") {
+      throw new DagActorConflictError(
+        "command_status_conflict",
+        `DAG actor command ${commandId} is ${current.status}, not pending`,
+      );
+    }
+    const changed = db.prepare(`
+      UPDATE dag_actor_commands SET status = 'delivered', delivered_at = ?
+      WHERE command_id = ? AND status = 'pending'
+    `).run(Date.now(), commandId);
+    if (changed.changes !== 1) {
+      throw new DagActorConflictError("command_status_conflict", `DAG actor command ${commandId} changed concurrently`);
+    }
+    return { command: requireCommand(commandId), changed: true, deduplicated: false };
+  })();
+}
+
+/** The command is already durable when `deliver` runs. A failed delivery leaves it pending. */
+export async function deliverDagActorCommand(input: {
+  command_id: string;
+  deliver: (command: DagActorCommandRecord) => boolean | void | Promise<boolean | void>;
+}): Promise<DagActorCommandMutationResult & { delivered: boolean }> {
+  const commandId = assertIdentifier(input.command_id, "command_id");
+  const current = requireCommand(commandId);
+  if (current.status === "delivered") {
+    return { command: current, changed: false, deduplicated: true, delivered: true };
+  }
+  if (current.status !== "pending") {
+    throw new DagActorConflictError(
+      "command_status_conflict",
+      `DAG actor command ${commandId} is ${current.status}, not pending`,
+    );
+  }
+  const delivered = await input.deliver(current);
+  if (delivered === false) {
+    return { command: requireCommand(commandId), changed: false, deduplicated: false, delivered: false };
+  }
+  return { ...markCommandDelivered(commandId), delivered: true };
+}
+
+export function claimDagActorCommand(input: {
+  command_id: string;
+  run_id: string;
+  actor_id: string;
+  generation: number;
+}): DagActorCommandMutationResult {
+  const commandId = assertIdentifier(input.command_id, "command_id");
+  const runId = assertIdentifier(input.run_id, "run_id");
+  const actorId = assertIdentifier(input.actor_id, "actor_id");
+  const generation = assertPositiveSafeInteger(input.generation, "generation");
+  const db = getDb();
+
+  return db.transaction(() => {
+    const actor = requireActor(runId, actorId);
+    if (actor.generation !== generation) {
+      throw new DagActorConflictError(
+        "command_generation_conflict",
+        `Actor ${runId}/${actorId} is generation ${actor.generation}, not ${generation}`,
+      );
+    }
+    const current = requireCommand(commandId);
+    if (current.run_id !== runId || current.actor_id !== actorId) {
+      throw new DagActorConflictError("command_identity_conflict", `Command ${commandId} belongs to another actor`);
+    }
+    if (current.target_generation !== generation) {
+      throw new DagActorConflictError(
+        "command_generation_conflict",
+        `Command ${commandId} targets generation ${current.target_generation}, not ${generation}`,
+      );
+    }
+    if (current.status === "claimed" && current.claimed_generation === generation) {
+      return { command: current, changed: false, deduplicated: true };
+    }
+    if (current.status !== "pending" && current.status !== "delivered") {
+      throw new DagActorConflictError(
+        "command_status_conflict",
+        `DAG actor command ${commandId} is ${current.status}, not claimable`,
+      );
+    }
+    const now = Date.now();
+    const changed = db.prepare(`
+      UPDATE dag_actor_commands SET
+        status = 'claimed',
+        delivered_at = COALESCE(delivered_at, ?),
+        claimed_generation = ?,
+        claimed_at = ?
+      WHERE command_id = ?
+        AND run_id = ?
+        AND actor_id = ?
+        AND target_generation = ?
+        AND status IN ('pending', 'delivered')
+    `).run(now, generation, now, commandId, runId, actorId, generation);
+    if (changed.changes !== 1) {
+      throw new DagActorConflictError("command_status_conflict", `DAG actor command ${commandId} changed concurrently`);
+    }
+    return { command: requireCommand(commandId), changed: true, deduplicated: false };
+  })();
+}
+
+export function acknowledgeDagActorCommand(input: {
+  command_id: string;
+  generation: number;
+}): DagActorCommandMutationResult {
+  return completeCommand(input.command_id, input.generation, "acknowledged");
+}
+
+export function failDagActorCommand(input: {
+  command_id: string;
+  generation: number;
+  failure: unknown;
+}): DagActorCommandMutationResult {
+  return completeCommand(input.command_id, input.generation, "failed", input.failure);
+}
+
+function completeCommand(
+  rawCommandId: string,
+  rawGeneration: number,
+  status: "acknowledged" | "failed",
+  failure?: unknown,
+): DagActorCommandMutationResult {
+  const commandId = assertIdentifier(rawCommandId, "command_id");
+  const generation = assertPositiveSafeInteger(rawGeneration, "generation");
+  const failureJson = status === "failed"
+    ? encodeBoundedDocument(failure ?? { message: "command failed" }, "command failure").json
+    : null;
+  const db = getDb();
+
+  return db.transaction(() => {
+    const current = requireCommand(commandId);
+    if (current.status === status && current.claimed_generation === generation) {
+      return { command: current, changed: false, deduplicated: true };
+    }
+    if (current.status !== "claimed" || current.claimed_generation !== generation) {
+      throw new DagActorConflictError(
+        current.claimed_generation !== undefined && current.claimed_generation !== generation
+          ? "command_generation_conflict"
+          : "command_status_conflict",
+        `DAG actor command ${commandId} is not claimed by generation ${generation}`,
+      );
+    }
+    const changed = db.prepare(`
+      UPDATE dag_actor_commands SET status = ?, completed_at = ?, failure_json = ?
+      WHERE command_id = ? AND status = 'claimed' AND claimed_generation = ?
+    `).run(status, Date.now(), failureJson, commandId, generation);
+    if (changed.changes !== 1) {
+      throw new DagActorConflictError("command_status_conflict", `DAG actor command ${commandId} changed concurrently`);
+    }
+    return { command: requireCommand(commandId), changed: true, deduplicated: false };
+  })();
+}

--- a/homerail_manager/src/persistence/db.ts
+++ b/homerail_manager/src/persistence/db.ts
@@ -34,6 +34,8 @@ const CLEARABLE_TABLES = new Set([
   "dag_chats",
   "dag_handoffs",
   "dag_artifacts",
+  "dag_actor_commands",
+  "dag_actors",
   "dag_activity_events",
   "dag_events",
   "dag_run_admissions",
@@ -562,6 +564,107 @@ function validateDagActivitySchemaV19(db: SqliteDatabase): void {
     && entry.to === "run_id"
     && entry.on_delete.toUpperCase() === "CASCADE"
   ))) throw new Error("Schema migration 19 is incomplete: activity run retention constraint is missing");
+}
+
+function validateDagActorSchemaV20(db: SqliteDatabase): void {
+  const requiredColumns: Record<string, readonly string[]> = {
+    dag_actors: [
+      "run_id",
+      "actor_id",
+      "node_id",
+      "role",
+      "generation",
+      "attempt",
+      "version",
+      "session_id",
+      "model_profile_json",
+      "surface_id",
+      "workspace_ref",
+      "checkpoint_ref",
+      "created_at",
+      "updated_at",
+    ],
+    dag_actor_commands: [
+      "command_id",
+      "run_id",
+      "actor_id",
+      "round_id",
+      "target_generation",
+      "status",
+      "idempotency_key",
+      "payload_digest",
+      "payload_json",
+      "claimed_generation",
+      "created_at",
+      "delivered_at",
+      "claimed_at",
+      "completed_at",
+      "failure_json",
+    ],
+  };
+  for (const [table, columns] of Object.entries(requiredColumns)) {
+    if (!hasTable(db, table)) {
+      throw new Error(`Schema migration 20 is incomplete: missing table ${table}`);
+    }
+    for (const column of columns) {
+      if (!hasColumn(db, table, column)) {
+        throw new Error(`Schema migration 20 is incomplete: ${table} is missing column ${column}`);
+      }
+    }
+  }
+
+  const expectedIndexes: Record<string, readonly string[]> = {
+    idx_dag_actors_run_node: ["run_id", "node_id"],
+    idx_dag_actors_run_surface: ["run_id", "surface_id"],
+    idx_dag_actor_commands_idempotency: ["run_id", "actor_id", "idempotency_key"],
+    idx_dag_actor_commands_actor_status: ["run_id", "actor_id", "status", "created_at", "command_id"],
+    idx_dag_actor_commands_round: ["run_id", "round_id", "created_at", "command_id"],
+  };
+  for (const [name, expectedColumns] of Object.entries(expectedIndexes)) {
+    const index = db.prepare("SELECT name, sql FROM sqlite_master WHERE type = 'index' AND name = ?")
+      .get(name) as { name: string; sql: string | null } | undefined;
+    if (!index) throw new Error(`Schema migration 20 is incomplete: missing index ${name}`);
+    const columns = (db.prepare(`PRAGMA index_info(${name})`).all() as Array<{
+      seqno: number;
+      name: string;
+    }>).sort((left, right) => left.seqno - right.seqno).map((entry) => entry.name);
+    if (columns.length !== expectedColumns.length || columns.some((column, position) => column !== expectedColumns[position])) {
+      throw new Error(`Schema migration 20 is incomplete: index ${name} has invalid columns`);
+    }
+    if (name !== "idx_dag_actor_commands_actor_status" && name !== "idx_dag_actor_commands_round") {
+      const unique = (db.prepare(`PRAGMA index_list(${name.startsWith("idx_dag_actors") ? "dag_actors" : "dag_actor_commands"})`)
+        .all() as Array<{ name: string; unique: number }>).find((entry) => entry.name === name)?.unique;
+      if (unique !== 1) throw new Error(`Schema migration 20 is incomplete: index ${name} must be unique`);
+    }
+  }
+
+  const actorForeignKeys = db.prepare("PRAGMA foreign_key_list(dag_actors)").all() as Array<{
+    table: string;
+    from: string;
+    to: string;
+    on_delete: string;
+  }>;
+  if (!actorForeignKeys.some((entry) => (
+    entry.table === "dag_runs"
+    && entry.from === "run_id"
+    && entry.to === "run_id"
+    && entry.on_delete.toUpperCase() === "CASCADE"
+  ))) throw new Error("Schema migration 20 is incomplete: actor run retention constraint is missing");
+
+  const commandForeignKeys = db.prepare("PRAGMA foreign_key_list(dag_actor_commands)").all() as Array<{
+    table: string;
+    from: string;
+    to: string;
+    on_delete: string;
+  }>;
+  for (const [from, to] of [["run_id", "run_id"], ["actor_id", "actor_id"]] as const) {
+    if (!commandForeignKeys.some((entry) => (
+      entry.table === "dag_actors"
+      && entry.from === from
+      && entry.to === to
+      && entry.on_delete.toUpperCase() === "CASCADE"
+    ))) throw new Error(`Schema migration 20 is incomplete: command actor ${from} constraint is missing`);
+  }
 }
 
 function validateGenerativeUiSchemaV3(db: SqliteDatabase): void {
@@ -1881,6 +1984,66 @@ const SCHEMA_MIGRATIONS: readonly SchemaMigration[] = [
         ON dag_activity_events(run_id, actor_id, seq);
     `),
     validate: validateDagActivitySchemaV19,
+  },
+  {
+    version: 20,
+    up: (db) => db.exec(`
+      CREATE TABLE IF NOT EXISTS dag_actors (
+        run_id TEXT NOT NULL,
+        actor_id TEXT NOT NULL,
+        node_id TEXT NOT NULL,
+        role TEXT NOT NULL,
+        generation INTEGER NOT NULL DEFAULT 1 CHECK(generation >= 1),
+        attempt INTEGER NOT NULL DEFAULT 1 CHECK(attempt >= 1),
+        version INTEGER NOT NULL DEFAULT 1 CHECK(version >= 1),
+        session_id TEXT,
+        model_profile_json TEXT NOT NULL,
+        surface_id TEXT NOT NULL,
+        workspace_ref TEXT,
+        checkpoint_ref TEXT,
+        created_at INTEGER NOT NULL CHECK(created_at >= 0),
+        updated_at INTEGER NOT NULL CHECK(updated_at >= 0),
+        PRIMARY KEY(run_id, actor_id),
+        FOREIGN KEY(run_id) REFERENCES dag_runs(run_id) ON DELETE CASCADE
+      );
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_dag_actors_run_node
+        ON dag_actors(run_id, node_id);
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_dag_actors_run_surface
+        ON dag_actors(run_id, surface_id);
+
+      CREATE TABLE IF NOT EXISTS dag_actor_commands (
+        command_id TEXT PRIMARY KEY,
+        run_id TEXT NOT NULL,
+        actor_id TEXT NOT NULL,
+        round_id TEXT NOT NULL,
+        target_generation INTEGER NOT NULL CHECK(target_generation >= 1),
+        status TEXT NOT NULL CHECK(status IN ('pending', 'delivered', 'claimed', 'acknowledged', 'failed')),
+        idempotency_key TEXT NOT NULL,
+        payload_digest TEXT NOT NULL CHECK(length(payload_digest) = 64),
+        payload_json TEXT NOT NULL,
+        claimed_generation INTEGER CHECK(claimed_generation IS NULL OR claimed_generation >= 1),
+        created_at INTEGER NOT NULL CHECK(created_at >= 0),
+        delivered_at INTEGER CHECK(delivered_at IS NULL OR delivered_at >= created_at),
+        claimed_at INTEGER CHECK(claimed_at IS NULL OR claimed_at >= created_at),
+        completed_at INTEGER CHECK(completed_at IS NULL OR completed_at >= created_at),
+        failure_json TEXT,
+        CHECK(
+          (status = 'pending' AND delivered_at IS NULL AND claimed_generation IS NULL AND claimed_at IS NULL AND completed_at IS NULL AND failure_json IS NULL)
+          OR (status = 'delivered' AND delivered_at IS NOT NULL AND claimed_generation IS NULL AND claimed_at IS NULL AND completed_at IS NULL AND failure_json IS NULL)
+          OR (status = 'claimed' AND claimed_generation IS NOT NULL AND claimed_at IS NOT NULL AND completed_at IS NULL AND failure_json IS NULL)
+          OR (status = 'acknowledged' AND claimed_generation IS NOT NULL AND claimed_at IS NOT NULL AND completed_at IS NOT NULL AND failure_json IS NULL)
+          OR (status = 'failed' AND claimed_generation IS NOT NULL AND claimed_at IS NOT NULL AND completed_at IS NOT NULL AND failure_json IS NOT NULL)
+        ),
+        FOREIGN KEY(run_id, actor_id) REFERENCES dag_actors(run_id, actor_id) ON DELETE CASCADE
+      );
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_dag_actor_commands_idempotency
+        ON dag_actor_commands(run_id, actor_id, idempotency_key);
+      CREATE INDEX IF NOT EXISTS idx_dag_actor_commands_actor_status
+        ON dag_actor_commands(run_id, actor_id, status, created_at, command_id);
+      CREATE INDEX IF NOT EXISTS idx_dag_actor_commands_round
+        ON dag_actor_commands(run_id, round_id, created_at, command_id);
+    `),
+    validate: validateDagActorSchemaV20,
   },
 ];
 

--- a/homerail_manager/src/runtime/active-runs.ts
+++ b/homerail_manager/src/runtime/active-runs.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import { mkdirSync, realpathSync } from "node:fs";
 import path from "node:path";
@@ -72,6 +72,14 @@ import {
 } from "../persistence/dag-runtime-primitives.js";
 import type { RunWorkspaceRetention } from "../persistence/types.js";
 import { getDagActivitySequenceCursor } from "../persistence/dag-activity-journal.js";
+import {
+  advanceDagActorGeneration,
+  DagActorConflictError,
+  getDagActorByNode,
+  registerDagActor,
+  updateDagActorBinding,
+  type DagActorRecord,
+} from "../persistence/dag-actors.js";
 
 export interface InjectResult {
   runId: string;
@@ -271,6 +279,94 @@ function _projectKey(run: ActiveRun): string {
   );
 }
 
+function _runtimeString(node: DAGGraphNode, key: string): string | undefined {
+  const value = _agentRuntimeConfig(node)[key] ?? node.extra?.[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function _logicalActorId(node: DAGGraphNode): string {
+  return _runtimeString(node, "actor_id") ?? node.node_id;
+}
+
+function _logicalActorRole(node: DAGGraphNode): string {
+  return _runtimeString(node, "role") ?? node.agent ?? node.name ?? node.node_id;
+}
+
+function _logicalActorSurface(node: DAGGraphNode, actorId: string): string {
+  const configured = _activitySurfaceId(node);
+  if (configured) return configured;
+  const candidate = `actor:${actorId}`;
+  return candidate.length <= 256
+    ? candidate
+    : `actor:${createHash("sha256").update(actorId).digest("hex")}`;
+}
+
+function _logicalActorModelProfile(run: ActiveRun, node: DAGGraphNode): Record<string, unknown> {
+  const agent = run.agents?.[node.agent] ?? {};
+  const model = agent.llm?.model ?? agent.model;
+  return {
+    agent_id: node.agent,
+    ...(agent.agent_type ? { agent_type: agent.agent_type } : {}),
+    ...(agent.llm_setting_id ? { llm_setting_id: agent.llm_setting_id } : {}),
+    ...(agent.llm?.provider ? { provider: agent.llm.provider } : {}),
+    ...(model ? { model } : {}),
+    ...(agent.llm?.protocol ? { protocol: agent.llm.protocol } : {}),
+  };
+}
+
+function _ensureLogicalActor(run: ActiveRun, node: DAGGraphNode): DagActorRecord {
+  const existing = getDagActorByNode(run.runId, node.node_id);
+  if (existing) return existing;
+  const actorId = _logicalActorId(node);
+  return registerDagActor({
+    run_id: run.runId,
+    actor_id: actorId,
+    node_id: node.node_id,
+    role: _logicalActorRole(node),
+    model_profile: _logicalActorModelProfile(run, node),
+    surface_id: _logicalActorSurface(node, actorId),
+    workspace_ref: _projectKey(run),
+  }).actor;
+}
+
+function _registerLogicalActors(run: ActiveRun): void {
+  for (const node of run.dagRun.graph.nodes) {
+    if (!_isGatewayNode(node)) _ensureLogicalActor(run, node);
+  }
+}
+
+function _bindLogicalActorSession(
+  run: ActiveRun,
+  nodeId: string,
+  sessionId: string,
+  attempt: number,
+): DagActorRecord | undefined {
+  const node = run.dagRun.graph.nodes.find((candidate) => candidate.node_id === nodeId);
+  if (!node || _isGatewayNode(node)) return undefined;
+  let actor = _ensureLogicalActor(run, node);
+  if (actor.session_id === sessionId && actor.attempt === attempt) return actor;
+  try {
+    return updateDagActorBinding({
+      run_id: run.runId,
+      actor_id: actor.actor_id,
+      expected_version: actor.version,
+      session_id: sessionId,
+      attempt,
+    });
+  } catch (error) {
+    if (!(error instanceof DagActorConflictError) || error.code !== "actor_version_conflict") throw error;
+    actor = getDagActorByNode(run.runId, nodeId) ?? _ensureLogicalActor(run, node);
+    if (actor.session_id === sessionId && actor.attempt === attempt) return actor;
+    return updateDagActorBinding({
+      run_id: run.runId,
+      actor_id: actor.actor_id,
+      expected_version: actor.version,
+      session_id: sessionId,
+      attempt,
+    });
+  }
+}
+
 function _newSessionId(runId: string, nodeId: string): string {
   return _safeIndexSegment(`dag-${runId}-${nodeId}-${randomUUID()}`, `dag-${randomUUID()}`);
 }
@@ -306,6 +402,7 @@ function _persistNodeSession(run: ActiveRun, nodeId: string, state: NodeSessionS
   });
   const persisted = _entryToNodeSession(entry);
   run.nodeSessions.set(nodeId, persisted);
+  _bindLogicalActorSession(run, nodeId, persisted.sessionId, persisted.attempt);
   return persisted;
 }
 
@@ -444,8 +541,9 @@ export function createActiveRun(
     nodeIndex: _buildNodeIndex(parsedDAG.graph.nodes),
     nodeSessions: new Map(),
   };
-  store.set(runId, run);
   writeRunMetadata(runId, serializeRunMetadata(run));
+  _registerLogicalActors(run);
+  store.set(runId, run);
   emit("dag:run_created", {
     runId,
     workflowId: run.workflowId,
@@ -706,9 +804,12 @@ export function restoreActiveRun(
     nodeSessions: new Map(),
   };
 
+  _registerLogicalActors(run);
   // Restore per-node sessions from dag_session_index.
   for (const entry of listDagSessionIndex(metadata.runId)) {
-    run.nodeSessions.set(entry.node_id, _entryToNodeSession(entry));
+    const state = _entryToNodeSession(entry);
+    run.nodeSessions.set(entry.node_id, state);
+    _bindLogicalActorSession(run, entry.node_id, state.sessionId, state.attempt);
   }
 
   store.set(metadata.runId, run);
@@ -1084,6 +1185,25 @@ export function checkpointResumeActiveRun(
     };
   }
   _persistNodeSession(run, nodeId, nextSession);
+  try {
+    const actorNode = run.dagRun.graph.nodes.find((candidate) => candidate.node_id === nodeId);
+    if (!actorNode || _isGatewayNode(actorNode)) throw new Error(`Node ${nodeId} has no logical actor`);
+    const actor = _ensureLogicalActor(run, actorNode);
+    advanceDagActorGeneration({
+      run_id: runId,
+      actor_id: actor.actor_id,
+      expected_generation: actor.generation,
+      expected_version: actor.version,
+      session_id: nextSession.sessionId,
+      attempt: nextSession.attempt,
+      checkpoint_ref: fork.entryUuid,
+    });
+  } catch (err) {
+    return {
+      status: "unavailable",
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  }
 
   const mailbox = run.dagRun.mailboxes.get(nodeId);
   if (mailbox) {
@@ -1406,6 +1526,7 @@ export function appendRunNode(
   }
 
   writeRunMetadata(runId, serializeRunMetadata(run));
+  if (!_isGatewayNode(node)) _ensureLogicalActor(run, node);
   _emitNodeStateChanges(run, before);
   emit("dag:node_added", { runId, nodeId: node.node_id, after: node.after });
   if (depsSatisfied) emit("dag:node_ready", { runId, nodeId: node.node_id });
@@ -2366,9 +2487,10 @@ function _buildDispatchEnvelope(run: ActiveRun, nodeId: string): DispatchEnvelop
 
   const inputs = _nodeInputs(run.dagRun, nodeId);
   const nodeSession = _ensureNodeSession(run, nodeId);
-  const actorId = nodeId;
-  const generation = 1;
-  const surfaceId = _activitySurfaceId(node);
+  const actor = _ensureLogicalActor(run, node);
+  const actorId = actor.actor_id;
+  const generation = actor.generation;
+  const surfaceId = actor.surface_id;
   const dispatchInputs = nodeSession.resumeInstruction
     ? { ...inputs, checkpoint_resume: [nodeSession.resumeInstruction] }
     : inputs;

--- a/homerail_manager/src/runtime/active-runs.ts
+++ b/homerail_manager/src/runtime/active-runs.ts
@@ -50,6 +50,7 @@ import type {
   PersistedGraphData,
   PersistedRunMetadata,
 } from "../persistence/types.js";
+import { dbTransaction } from "../persistence/db.js";
 import {
   getDagSessionIndex,
   upsertDagSessionIndex,
@@ -314,6 +315,33 @@ function _logicalActorModelProfile(run: ActiveRun, node: DAGGraphNode): Record<s
   };
 }
 
+function _assertLogicalActorIdentities(nodes: readonly DAGGraphNode[]): void {
+  const actorOwners = new Map<string, string>();
+  const surfaceOwners = new Map<string, string>();
+  for (const node of nodes) {
+    if (_isGatewayNode(node)) continue;
+    const actorId = _logicalActorId(node);
+    const actorOwner = actorOwners.get(actorId);
+    if (actorOwner) {
+      throw new DagActorConflictError(
+        "actor_identity_conflict",
+        `DAG actor ${actorId} is configured for both nodes ${actorOwner} and ${node.node_id}`,
+      );
+    }
+    actorOwners.set(actorId, node.node_id);
+
+    const surfaceId = _logicalActorSurface(node, actorId);
+    const surfaceOwner = surfaceOwners.get(surfaceId);
+    if (surfaceOwner) {
+      throw new DagActorConflictError(
+        "actor_identity_conflict",
+        `DAG surface ${surfaceId} is configured for both nodes ${surfaceOwner} and ${node.node_id}`,
+      );
+    }
+    surfaceOwners.set(surfaceId, node.node_id);
+  }
+}
+
 function _ensureLogicalActor(run: ActiveRun, node: DAGGraphNode): DagActorRecord {
   const existing = getDagActorByNode(run.runId, node.node_id);
   if (existing) return existing;
@@ -330,6 +358,7 @@ function _ensureLogicalActor(run: ActiveRun, node: DAGGraphNode): DagActorRecord
 }
 
 function _registerLogicalActors(run: ActiveRun): void {
+  _assertLogicalActorIdentities(run.dagRun.graph.nodes);
   for (const node of run.dagRun.graph.nodes) {
     if (!_isGatewayNode(node)) _ensureLogicalActor(run, node);
   }
@@ -541,8 +570,11 @@ export function createActiveRun(
     nodeIndex: _buildNodeIndex(parsedDAG.graph.nodes),
     nodeSessions: new Map(),
   };
-  writeRunMetadata(runId, serializeRunMetadata(run));
-  _registerLogicalActors(run);
+  _assertLogicalActorIdentities(run.dagRun.graph.nodes);
+  dbTransaction(() => {
+    writeRunMetadata(runId, serializeRunMetadata(run));
+    _registerLogicalActors(run);
+  });
   store.set(runId, run);
   emit("dag:run_created", {
     runId,
@@ -1508,6 +1540,7 @@ export function appendRunNode(
     edges: [...run.dagRun.graph.edges, ...afterEdges, ...outputEdges],
   };
   assertGraphValid(nextGraph);
+  _assertLogicalActorIdentities(nextGraph.nodes);
 
   run.dagRun.graph.nodes.push(node);
   run.dagRun.graph.edges.push(...afterEdges, ...outputEdges);

--- a/homerail_manager/src/runtime/dag-activity-stream.ts
+++ b/homerail_manager/src/runtime/dag-activity-stream.ts
@@ -1,4 +1,5 @@
 import { appendDagActivityEvent } from "../persistence/dag-activity-journal.js";
+import { getDagActorByNode } from "../persistence/dag-actors.js";
 
 export interface DagActivityStreamContext {
   runId: string;
@@ -23,6 +24,18 @@ export function ingestDagActivityStream(
     || (context.roundId !== undefined && event.round_id !== context.roundId)
   ) {
     throw new Error("DAG activity identity does not match the transport stream context");
+  }
+  const actor = getDagActorByNode(context.runId, context.nodeId);
+  if (actor) {
+    if (event.actor_id !== actor.actor_id) {
+      throw new Error("DAG activity actor identity does not match the logical actor registry");
+    }
+    if (typeof event.generation !== "number" || event.generation > actor.generation) {
+      throw new Error("DAG activity generation is ahead of the logical actor registry");
+    }
+    if (event.surface_id !== undefined && event.surface_id !== actor.surface_id) {
+      throw new Error("DAG activity surface identity does not match the logical actor registry");
+    }
   }
   return appendDagActivityEvent(activity);
 }

--- a/homerail_manager/tests/dag-activity-stream.test.ts
+++ b/homerail_manager/tests/dag-activity-stream.test.ts
@@ -136,6 +136,68 @@ nodes:
     });
   });
 
+  it("checks streamed activity against the logical actor registry", () => {
+    const dag = parseDAGYaml(`
+name: activity-actor-identity
+workflow_id: activity-actor-identity
+agents:
+  worker:
+    agent_type: deterministic
+    system: HANDOFF port=done content=ok
+nodes:
+  research:
+    agent: worker
+    extra:
+      agent_runtime:
+        actor_id: researcher
+        surface_id: surface-research
+    outputs:
+      done:
+        to: ""
+`);
+    createActiveRun("run-actor-activity", dag);
+    const built = buildCurrentDispatchEnvelope("run-actor-activity", "research");
+    expect(built.ok).toBe(true);
+    if (!built.ok) return;
+    const valid = event({
+      event_id: "registry-valid",
+      run_id: "run-actor-activity",
+      round_id: built.envelope.sessionId,
+      actor_id: "researcher",
+      surface_id: "surface-research",
+    });
+
+    expect(ingestDagActivityStream({ event: "dag_activity", activity: valid }, {
+      runId: "run-actor-activity",
+      nodeId: "research",
+      roundId: built.envelope.sessionId,
+    })).toMatchObject({ inserted: true });
+    expect(() => ingestDagActivityStream({
+      event: "dag_activity",
+      activity: { ...valid, event_id: "spoofed-actor", actor_id: "other", sequence: 2 },
+    }, {
+      runId: "run-actor-activity",
+      nodeId: "research",
+      roundId: built.envelope.sessionId,
+    })).toThrow("actor identity does not match");
+    expect(() => ingestDagActivityStream({
+      event: "dag_activity",
+      activity: { ...valid, event_id: "future-generation", generation: 2, sequence: 2 },
+    }, {
+      runId: "run-actor-activity",
+      nodeId: "research",
+      roundId: built.envelope.sessionId,
+    })).toThrow("generation is ahead");
+    expect(() => ingestDagActivityStream({
+      event: "dag_activity",
+      activity: { ...valid, event_id: "spoofed-surface", surface_id: "other", sequence: 2 },
+    }, {
+      runId: "run-actor-activity",
+      nodeId: "research",
+      roundId: built.envelope.sessionId,
+    })).toThrow("surface identity does not match");
+  });
+
   it("replays bounded activity pages by run and actor", async () => {
     appendDagActivityEvent(event({ event_id: "research-1", actor_id: "researcher", sequence: 1 }));
     appendDagActivityEvent(event({ event_id: "writer-1", actor_id: "writer", sequence: 1 }));

--- a/homerail_manager/tests/dag-actors.test.ts
+++ b/homerail_manager/tests/dag-actors.test.ts
@@ -24,6 +24,7 @@ import {
   _clearActiveRuns,
   buildCurrentDispatchEnvelope,
   createActiveRun,
+  getActiveRun,
   recoverAllActiveRuns,
 } from "../src/runtime/active-runs.js";
 
@@ -50,6 +51,36 @@ function createCommand(overrides: Partial<Parameters<typeof createDagActorComman
     payload: { instruction: "Find three primary sources" },
     ...overrides,
   });
+}
+
+function twoActorDag(secondActorId: string, secondSurfaceId: string) {
+  return parseDAGYaml(`
+name: logical-actor-identity
+workflow_id: logical-actor-identity
+agents:
+  worker:
+    agent_type: deterministic
+    system: HANDOFF port=done content=ok
+nodes:
+  first:
+    agent: worker
+    extra:
+      agent_runtime:
+        actor_id: shared
+        surface_id: surface-first
+    outputs:
+      done:
+        to: ""
+  second:
+    agent: worker
+    extra:
+      agent_runtime:
+        actor_id: ${secondActorId}
+        surface_id: ${secondSurfaceId}
+    outputs:
+      done:
+        to: ""
+`);
 }
 
 describe("durable DAG logical actors and command inbox", () => {
@@ -259,6 +290,30 @@ nodes:
       },
     });
     expect(listDagActors("runtime-run")).toHaveLength(3);
+  });
+
+  it.each([
+    ["actor", "shared", "surface-second", "DAG actor shared is configured for both nodes"],
+    ["surface", "second", "surface-first", "DAG surface surface-first is configured for both nodes"],
+  ])("rejects duplicate %s ownership before persisting a run", (_kind, actorId, surfaceId, message) => {
+    const runId = `duplicate-${_kind}-run`;
+    expect(() => createActiveRun(runId, twoActorDag(actorId, surfaceId))).toThrow(message);
+
+    expect(getActiveRun(runId)).toBeUndefined();
+    expect(getDb().prepare("SELECT run_id FROM dag_runs WHERE run_id = ?").get(runId)).toBeUndefined();
+    expect(listDagActors(runId)).toEqual([]);
+  });
+
+  it("rolls back the run and previously registered actors when actor persistence fails", () => {
+    const runId = "actor-registration-rollback";
+    const dag = twoActorDag("second", "surface-second");
+    const secondRuntime = dag.graph.nodes[1]?.extra?.agent_runtime as Record<string, unknown>;
+    secondRuntime.role = "x".repeat(257);
+
+    expect(() => createActiveRun(runId, dag)).toThrow("role must be between 1 and 256 characters");
+    expect(getActiveRun(runId)).toBeUndefined();
+    expect(getDb().prepare("SELECT run_id FROM dag_runs WHERE run_id = ?").get(runId)).toBeUndefined();
+    expect(listDagActors(runId)).toEqual([]);
   });
 
   it("persists a command before immediate delivery and retains it when the actor is offline", async () => {

--- a/homerail_manager/tests/dag-actors.test.ts
+++ b/homerail_manager/tests/dag-actors.test.ts
@@ -1,0 +1,380 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  acknowledgeDagActorCommand,
+  advanceDagActorGeneration,
+  claimDagActorCommand,
+  createDagActorCommand,
+  DagActorConflictError,
+  deliverDagActorCommand,
+  failDagActorCommand,
+  getDagActor,
+  getDagActorCommand,
+  listDagActorCommands,
+  listDagActors,
+  registerDagActor,
+  updateDagActorBinding,
+} from "../src/persistence/dag-actors.js";
+import { closeDb, getDb } from "../src/persistence/db.js";
+import { ensureRunDir } from "../src/persistence/store.js";
+import { parseDAGYaml } from "../src/orchestration/yaml-loader.js";
+import {
+  _clearActiveRuns,
+  buildCurrentDispatchEnvelope,
+  createActiveRun,
+  recoverAllActiveRuns,
+} from "../src/runtime/active-runs.js";
+
+function registerActor(overrides: Partial<Parameters<typeof registerDagActor>[0]> = {}) {
+  return registerDagActor({
+    run_id: "run-1",
+    actor_id: "researcher",
+    node_id: "research-node",
+    role: "research",
+    model_profile: { agent_id: "research-agent", provider: "local", model: "test-model" },
+    surface_id: "surface-research",
+    workspace_ref: "project-1",
+    ...overrides,
+  });
+}
+
+function createCommand(overrides: Partial<Parameters<typeof createDagActorCommand>[0]> = {}) {
+  return createDagActorCommand({
+    command_id: "command-1",
+    run_id: "run-1",
+    actor_id: "researcher",
+    round_id: "round-1",
+    idempotency_key: "research-round-1",
+    payload: { instruction: "Find three primary sources" },
+    ...overrides,
+  });
+}
+
+describe("durable DAG logical actors and command inbox", () => {
+  let home: string;
+  let oldHome: string | undefined;
+
+  beforeEach(() => {
+    closeDb();
+    oldHome = process.env.HOMERAIL_HOME;
+    home = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-dag-actors-"));
+    process.env.HOMERAIL_HOME = home;
+    ensureRunDir("run-1");
+    _clearActiveRuns();
+  });
+
+  afterEach(() => {
+    _clearActiveRuns();
+    closeDb();
+    if (oldHome === undefined) delete process.env.HOMERAIL_HOME;
+    else process.env.HOMERAIL_HOME = oldHome;
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it("upgrades a v19 database and validates migration v20 on repeated startup", () => {
+    getDb().exec(`
+      DROP TABLE dag_actor_commands;
+      DROP TABLE dag_actors;
+      DELETE FROM schema_migrations WHERE version = 20;
+    `);
+    closeDb();
+
+    const migrated = getDb();
+    expect(migrated.prepare("SELECT version FROM schema_migrations WHERE version = 20").get())
+      .toEqual({ version: 20 });
+    expect(migrated.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'dag_actors'").get())
+      .toEqual({ name: "dag_actors" });
+    closeDb();
+
+    const reopened = getDb();
+    expect(reopened.prepare("SELECT COUNT(*) AS count FROM schema_migrations WHERE version = 20").get())
+      .toEqual({ count: 1 });
+    expect(reopened.prepare("PRAGMA index_list(dag_actor_commands)").all())
+      .toEqual(expect.arrayContaining([
+        expect.objectContaining({ name: "idx_dag_actor_commands_idempotency", unique: 1 }),
+        expect.objectContaining({ name: "idx_dag_actor_commands_actor_status", unique: 0 }),
+        expect.objectContaining({ name: "idx_dag_actor_commands_round", unique: 0 }),
+      ]));
+  });
+
+  it("fails closed when a v20 migration marker points at a non-unique surface index", () => {
+    getDb().exec(`
+      DROP INDEX idx_dag_actors_run_surface;
+      CREATE INDEX idx_dag_actors_run_surface ON dag_actors(run_id, surface_id);
+    `);
+    closeDb();
+
+    expect(() => getDb()).toThrow(
+      "Schema migration 20 is incomplete: index idx_dag_actors_run_surface must be unique",
+    );
+  });
+
+  it("keeps actor identity and surface ownership stable across registration and restart", () => {
+    const first = registerActor();
+    const duplicate = registerActor({ model_profile: { api_key: "sk-should-not-replace-existing" } });
+    registerActor({
+      actor_id: "writer",
+      node_id: "write-node",
+      role: "writing",
+      surface_id: "surface-write",
+    });
+    registerActor({
+      actor_id: "visualizer",
+      node_id: "visualize-node",
+      role: "visualization",
+      surface_id: "surface-visualize",
+    });
+
+    expect(first).toMatchObject({ inserted: true, deduplicated: false });
+    expect(duplicate).toMatchObject({ inserted: false, deduplicated: true });
+    expect(listDagActors("run-1").map((actor) => [actor.actor_id, actor.surface_id]))
+      .toEqual([
+        ["researcher", "surface-research"],
+        ["visualizer", "surface-visualize"],
+        ["writer", "surface-write"],
+      ]);
+    expect(() => registerActor({ actor_id: "other", surface_id: "surface-research" }))
+      .toThrowError(expect.objectContaining<DagActorConflictError>({ code: "actor_identity_conflict" }));
+
+    closeDb();
+    expect(listDagActors("run-1").map((actor) => [actor.actor_id, actor.surface_id]))
+      .toEqual([
+        ["researcher", "surface-research"],
+        ["visualizer", "surface-visualize"],
+        ["writer", "surface-write"],
+      ]);
+  });
+
+  it("redacts model bindings and enforces version CAS updates", () => {
+    const actor = registerActor({
+      model_profile: {
+        provider: "remote",
+        api_key: "sk-supersecretvalue123456",
+        authorization: "Bearer abcdefghijklmnopqrstuvwxyz",
+      },
+    }).actor;
+    expect(actor.model_profile).toEqual({
+      api_key: "***REDACTED***",
+      authorization: "***REDACTED***",
+      provider: "remote",
+    });
+
+    const updated = updateDagActorBinding({
+      run_id: "run-1",
+      actor_id: "researcher",
+      expected_version: actor.version,
+      session_id: "session-1",
+      checkpoint_ref: "checkpoint-1",
+    });
+    expect(updated).toMatchObject({ session_id: "session-1", attempt: 1, checkpoint_ref: "checkpoint-1", version: 2 });
+    expect(() => updateDagActorBinding({
+      run_id: "run-1",
+      actor_id: "researcher",
+      expected_version: actor.version,
+      workspace_ref: "other-project",
+    })).toThrowError(expect.objectContaining<DagActorConflictError>({ code: "actor_version_conflict" }));
+  });
+
+  it("registers graph actors once and dispatches the durable actor identity after restart", () => {
+    const dag = parseDAGYaml(`
+name: logical-actor-runtime
+workflow_id: logical-actor-runtime
+workspace:
+  project_id: showcase
+agents:
+  worker:
+    agent_type: deterministic
+    system: HANDOFF port=done content=ok
+nodes:
+  research:
+    agent: worker
+    extra:
+      agent_runtime:
+        actor_id: researcher
+        role: research
+        surface_id: surface-research
+    outputs:
+      done:
+        to: ""
+  compare:
+    agent: worker
+    extra:
+      agent_runtime:
+        actor_id: comparator
+        role: comparison
+        surface_id: surface-compare
+    outputs:
+      done:
+        to: ""
+  present:
+    agent: worker
+    extra:
+      agent_runtime:
+        actor_id: presenter
+        role: presentation
+        surface_id: surface-present
+    outputs:
+      done:
+        to: ""
+`);
+    createActiveRun("runtime-run", dag);
+
+    expect(listDagActors("runtime-run").map((actor) => ({
+      actor_id: actor.actor_id,
+      node_id: actor.node_id,
+      role: actor.role,
+      surface_id: actor.surface_id,
+    }))).toEqual([
+      { actor_id: "comparator", node_id: "compare", role: "comparison", surface_id: "surface-compare" },
+      { actor_id: "presenter", node_id: "present", role: "presentation", surface_id: "surface-present" },
+      { actor_id: "researcher", node_id: "research", role: "research", surface_id: "surface-research" },
+    ]);
+    const first = buildCurrentDispatchEnvelope("runtime-run", "research");
+    expect(first).toMatchObject({
+      ok: true,
+      envelope: {
+        activity: {
+          actorId: "researcher",
+          generation: 1,
+          surfaceId: "surface-research",
+        },
+      },
+    });
+
+    _clearActiveRuns();
+    closeDb();
+    expect(recoverAllActiveRuns().recovered).toContain("runtime-run");
+    const afterRestart = buildCurrentDispatchEnvelope("runtime-run", "research");
+    expect(afterRestart).toMatchObject({
+      ok: true,
+      envelope: {
+        sessionId: first.ok ? first.envelope.sessionId : undefined,
+        activity: {
+          actorId: "researcher",
+          generation: 1,
+          surfaceId: "surface-research",
+        },
+      },
+    });
+    expect(listDagActors("runtime-run")).toHaveLength(3);
+  });
+
+  it("persists a command before immediate delivery and retains it when the actor is offline", async () => {
+    registerActor();
+    const created = createCommand();
+    expect(created).toMatchObject({ changed: true, deduplicated: false });
+
+    const offline = await deliverDagActorCommand({
+      command_id: "command-1",
+      deliver: (command) => {
+        expect(getDagActorCommand(command.command_id)?.status).toBe("pending");
+        return false;
+      },
+    });
+    expect(offline).toMatchObject({ delivered: false, changed: false });
+    expect(getDagActorCommand("command-1")?.status).toBe("pending");
+
+    closeDb();
+    expect(getDagActorCommand("command-1")?.status).toBe("pending");
+    const delivered = await deliverDagActorCommand({
+      command_id: "command-1",
+      deliver: () => true,
+    });
+    expect(delivered).toMatchObject({ delivered: true, changed: true });
+    expect(getDagActorCommand("command-1")?.status).toBe("delivered");
+  });
+
+  it("deduplicates command ids and idempotency keys without duplicate execution", () => {
+    registerActor();
+    const first = createCommand();
+    const duplicateId = createCommand();
+    const duplicateKey = createCommand({ command_id: "command-retry" });
+
+    expect(first).toMatchObject({ changed: true, deduplicated: false });
+    expect(duplicateId).toMatchObject({ changed: false, deduplicated: true });
+    expect(duplicateKey).toMatchObject({ changed: false, deduplicated: true });
+    expect(duplicateKey.command.command_id).toBe("command-1");
+    expect(listDagActorCommands({ run_id: "run-1" })).toHaveLength(1);
+    expect(() => createCommand({ payload: { instruction: "Different work" } }))
+      .toThrowError(expect.objectContaining<DagActorConflictError>({ code: "command_identity_conflict" }));
+  });
+
+  it("allows only the current generation to claim and complete a command", () => {
+    const actor = registerActor().actor;
+    const generationTwo = advanceDagActorGeneration({
+      run_id: "run-1",
+      actor_id: "researcher",
+      expected_generation: actor.generation,
+      expected_version: actor.version,
+      session_id: "session-2",
+      attempt: 2,
+      checkpoint_ref: "checkpoint-2",
+    });
+    expect(generationTwo).toMatchObject({ generation: 2, attempt: 2, version: 2, session_id: "session-2" });
+    expect(() => advanceDagActorGeneration({
+      run_id: "run-1",
+      actor_id: "researcher",
+      expected_generation: 1,
+      expected_version: 1,
+    })).toThrowError(expect.objectContaining<DagActorConflictError>({ code: "actor_generation_conflict" }));
+
+    createCommand({ target_generation: 2 });
+    expect(() => claimDagActorCommand({
+      command_id: "command-1",
+      run_id: "run-1",
+      actor_id: "researcher",
+      generation: 1,
+    })).toThrowError(expect.objectContaining<DagActorConflictError>({ code: "command_generation_conflict" }));
+
+    const claimed = claimDagActorCommand({
+      command_id: "command-1",
+      run_id: "run-1",
+      actor_id: "researcher",
+      generation: 2,
+    });
+    const duplicateClaim = claimDagActorCommand({
+      command_id: "command-1",
+      run_id: "run-1",
+      actor_id: "researcher",
+      generation: 2,
+    });
+    expect(claimed).toMatchObject({ changed: true, command: { status: "claimed", claimed_generation: 2 } });
+    expect(duplicateClaim).toMatchObject({ changed: false, deduplicated: true });
+    expect(acknowledgeDagActorCommand({ command_id: "command-1", generation: 2 }))
+      .toMatchObject({ changed: true, command: { status: "acknowledged" } });
+    expect(() => failDagActorCommand({
+      command_id: "command-1",
+      generation: 2,
+      failure: { message: "too late" },
+    })).toThrowError(expect.objectContaining<DagActorConflictError>({ code: "command_status_conflict" }));
+  });
+
+  it("redacts a failed command before persistence", () => {
+    registerActor();
+    createCommand();
+    claimDagActorCommand({
+      command_id: "command-1",
+      run_id: "run-1",
+      actor_id: "researcher",
+      generation: 1,
+    });
+    const failed = failDagActorCommand({
+      command_id: "command-1",
+      generation: 1,
+      failure: { message: "request failed token=plain-secret-value", api_key: "sk-anothersecretvalue123" },
+    });
+    expect(failed.command).toMatchObject({
+      status: "failed",
+      failure: {
+        message: "request failed token=***REDACTED***",
+        api_key: "***REDACTED***",
+      },
+    });
+    const raw = getDb().prepare("SELECT failure_json FROM dag_actor_commands WHERE command_id = ?")
+      .get("command-1") as { failure_json: string };
+    expect(raw.failure_json).not.toContain("plain-secret-value");
+    expect(raw.failure_json).not.toContain("anothersecretvalue");
+  });
+});

--- a/homerail_manager/tests/dag-session-resume.test.ts
+++ b/homerail_manager/tests/dag-session-resume.test.ts
@@ -9,6 +9,7 @@ import { _clearListeners, subscribe } from "../src/events/bus.js";
 import { closeDb } from "../src/persistence/db.js";
 import { getDagSessionIndex } from "../src/persistence/dag-session-index.js";
 import { appendSessionTranscriptForTest, loadSessionTranscript } from "../src/persistence/dag-session-files.js";
+import { getDagActorByNode } from "../src/persistence/dag-actors.js";
 import { _clearAllPersistence } from "../src/persistence/store.js";
 import {
   _clearActiveRuns,
@@ -133,6 +134,11 @@ describe("DAG node SessionStore resume control plane", () => {
     const dispatcher = new CaptureDispatcher();
     expect(dispatchReadyNodes("run-checkpoint-resume", dispatcher)).toBe(1);
     const parentSessionId = dispatcher.dispatched[0].sessionId!;
+    expect(getDagActorByNode("run-checkpoint-resume", "work")).toMatchObject({
+      generation: 1,
+      attempt: 1,
+      session_id: parentSessionId,
+    });
     appendSessionTranscriptForTest(parentSessionId, [
       { uuid: "entry-1", type: "prompt_start", runId: "run-checkpoint-resume", nodeId: "work", content: "first" },
       { uuid: "entry-123", parentUuid: "entry-1", type: "text", runId: "run-checkpoint-resume", nodeId: "work", content: "checkpoint" },
@@ -170,6 +176,13 @@ describe("DAG node SessionStore resume control plane", () => {
       parentSessionId,
       entryUuid: "entry-123",
       attempt: 2,
+    });
+    expect(resumeEnvelope.activity).toMatchObject({ generation: 2 });
+    expect(getDagActorByNode("run-checkpoint-resume", "work")).toMatchObject({
+      generation: 2,
+      attempt: 2,
+      session_id: resumeEnvelope.sessionId,
+      checkpoint_ref: "entry-123",
     });
 
     const current = getCurrentNodeSession("run-checkpoint-resume", "work");

--- a/homerail_manager/tests/generative-ui-persistent-document-service.test.ts
+++ b/homerail_manager/tests/generative-ui-persistent-document-service.test.ts
@@ -187,7 +187,7 @@ describe("PersistentGenerativeUiDocumentService", () => {
     legacy.close();
 
     expect(getDb().prepare("SELECT version FROM schema_migrations ORDER BY version").all())
-      .toEqual(Array.from({ length: 19 }, (_, index) => ({ version: index + 1 })));
+      .toEqual(Array.from({ length: 20 }, (_, index) => ({ version: index + 1 })));
     expect(getDb().prepare("SELECT data FROM voice_agent_sessions WHERE session_id = ?").get("legacy-v2"))
       .toEqual({ data: legacyPayload });
     expect(getDb().prepare(`
@@ -269,7 +269,7 @@ describe("PersistentGenerativeUiDocumentService", () => {
     mainDb.close();
 
     expect(getDb().prepare("SELECT version FROM schema_migrations ORDER BY version").all())
-      .toEqual(Array.from({ length: 19 }, (_, index) => ({ version: index + 1 })));
+      .toEqual(Array.from({ length: 20 }, (_, index) => ({ version: index + 1 })));
     expect(getDb().prepare(`
       SELECT name FROM sqlite_master
       WHERE type = 'table' AND name IN ('generative_ui_documents', 'generative_ui_user_overrides')

--- a/homerail_manager/tests/plugin-distribution.test.ts
+++ b/homerail_manager/tests/plugin-distribution.test.ts
@@ -149,6 +149,6 @@ describe("plugin publisher trust persistence", () => {
     expect(listPluginPublisherTrustEvents()).toHaveLength(1);
     expect(getDb().prepare(
       "SELECT MAX(version) AS version FROM schema_migrations",
-    ).get()).toEqual({ version: 19 });
+    ).get()).toEqual({ version: 20 });
   });
 });

--- a/homerail_manager/tests/plugin-package-lifecycle.test.ts
+++ b/homerail_manager/tests/plugin-package-lifecycle.test.ts
@@ -260,7 +260,7 @@ describe("external plugin package lifecycle", () => {
       expect.objectContaining({ plugin_version: "1.1.0", active: false, enabled: false }),
       expect.objectContaining({ plugin_version: "1.2.0", active: false, enabled: false }),
     ]));
-    expect(getDb().prepare("SELECT MAX(version) AS version FROM schema_migrations").get()).toEqual({ version: 19 });
+    expect(getDb().prepare("SELECT MAX(version) AS version FROM schema_migrations").get()).toEqual({ version: 20 });
     expect(inspectInstalledPlugin("com.example.release-notes")).toMatchObject({ healthy: true, issues: [] });
   });
 
@@ -455,7 +455,7 @@ describe("external plugin package lifecycle", () => {
 
     expect(getPluginRegistryState().revision).toBe(101);
     expect(getDb().prepare("SELECT MAX(version) AS version FROM schema_migrations").get())
-      .toEqual({ version: 19 });
+      .toEqual({ version: 20 });
   });
 
   it("rejects a stale uninstall when an inactive version was installed concurrently", () => {

--- a/homerail_manager/tests/plugin-remote-registry.test.ts
+++ b/homerail_manager/tests/plugin-remote-registry.test.ts
@@ -236,7 +236,7 @@ describe("signed remote plugin registry", () => {
     expect(listPluginRegistryUpdateAttempts("stable.example").filter((attempt) => attempt.status === "failed"))
       .toHaveLength(3);
     expect(getDb().prepare("SELECT MAX(version) AS version FROM schema_migrations").get())
-      .toEqual({ version: 19 });
+      .toEqual({ version: 20 });
   });
 
   it("rejects signed catalog releases whose payload or publisher digest disagrees with the HRP", () => {


### PR DESCRIPTION
Parent epic: #36

Implements: #38
Blocked by: #37 / PR #47

> Stacked review PR. Review only; do not merge into the parent feature branch. After PR #47 is merged, this branch will be rebased onto latest `main`, retargeted to `main`, and verified again.

## Why

Manager must address stable logical actors rather than temporary Worker processes. Commands must survive offline Workers and Manager restarts.

## What changed

- adds migration 20 for `dag_actors` and `dag_actor_commands`
- persists stable actor, node, session, model profile, surface, workspace, checkpoint, generation, and attempt bindings
- adds a durable command inbox with idempotent create, claim, acknowledge, fail, and replay behavior
- requires commands to be committed before delivery
- uses generation and CAS checks to reject conflicting or stale ownership
- restores actors and pending commands after Manager restart
- documents the durable actor contract and later PR boundaries

## Invariants

- `actor_id` remains stable across rounds
- physical Worker identity is not logical Actor identity
- one command can be claimed by only one generation
- duplicate command/idempotency keys do not create duplicate execution
- three Actors may own three stable `surface_id` values

## Migrations

Migration 20 creates and validates the Actor and Inbox tables, constraints, indexes, foreign keys, old-database upgrade, and repeat-start behavior.

## Verification

- rebased transitively onto `origin/main@9f720754`
- Runtime stack through #40 passed full `npm run ci`: Protocol 247, Manager 835, Node 187, Worker 216, CLI 241, UI 287
- focused actor, command inbox, activity stream, and session resume tests are included in this delta
- Docker-only tests remain environment-skipped because the local Docker daemon is not running

## Out of scope

- multi-round waiting and wakeup: #39
- Worker release and cold recovery: #40
- A2UI projection: #41

## Residual risk

This PR remains Draft until PR #47 is merged, the branch is retargeted to `main`, and branch-local CI is rerun.