### PR TITLE
Add durable multi-round DAG execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,9 @@ jobs:
       - name: Typecheck, build, and test
         env:
           HOMERAIL_HOME: ${{ runner.temp }}/homerail-ci
+          # Windows filesystem and process startup contention makes the default
+          # CPU-minus-one Vitest pool prone to unrelated short-test timeouts.
+          VITEST_MAX_WORKERS: "2"
         run: npm run ci
 
   agent-ui-coverage:

--- a/README.md
+++ b/README.md
@@ -175,6 +175,11 @@ hr scorecard <run_id>
 hr eval-run <run_id>
 ```
 
+For workflows that pause at a durable command boundary and resume selected
+logical actors under the same run, see [Multi-Round DAGs](docs/multi-round-dags.md).
+The guide covers strict WorkflowSpec v1 authoring, round fencing, CLI and HTTP
+commands, recovery, expiry, and concurrency-slot behavior.
+
 For a topology check without a live model provider, the two-node template ships
 an offline deterministic profile:
 

--- a/agent-ui/src/api/services/dag-api.test.ts
+++ b/agent-ui/src/api/services/dag-api.test.ts
@@ -101,6 +101,13 @@ describe('DAG API', () => {
     [{ complete: true, failed_nodes: [] }, 'completed'],
     [{ complete: true, failed_nodes: ['review'] }, 'failed'],
     [{ complete: false, active_nodes: [], ready_nodes: ['review'] }, 'running'],
+    [{
+      complete: false,
+      active_nodes: [],
+      ready_nodes: [],
+      waiting_nodes: ['plan'],
+      nodes: { plan: { status: 'waiting_for_command', retry_count: 0, started_at: null, completed_at: null } }
+    }, 'waiting'],
     [{ complete: false, active_nodes: [], ready_nodes: [] }, 'pending']
   ])('derives the overall DAG status from execution state', async (execution, status) => {
     vi.spyOn(http, 'get').mockResolvedValue({

--- a/agent-ui/src/api/services/dag-api.ts
+++ b/agent-ui/src/api/services/dag-api.ts
@@ -38,6 +38,7 @@ interface BackendDagResponse {
     completed_nodes: string[]
     failed_nodes: string[]
     ready_nodes: string[]
+    waiting_nodes?: string[]
     node_count: number
     nodes: Record<string, {
       status: string
@@ -109,6 +110,11 @@ function transformDagResponse(raw: BackendDagResponse): DAGExecution {
     status = 'running'
   } else if (raw.execution.ready_nodes.length > 0) {
     status = 'running'
+  } else if (
+    (raw.execution.waiting_nodes?.length ?? 0) > 0
+    || Object.values(execNodes).some(node => node.status === 'waiting_for_command')
+  ) {
+    status = 'waiting'
   }
 
   return {

--- a/agent-ui/src/api/types/dag.types.ts
+++ b/agent-ui/src/api/types/dag.types.ts
@@ -10,9 +10,9 @@
 // DAG 节点状态
 // ============================================================================
 
-export type DAGNodeStatus = 'pending' | 'ready' | 'running' | 'completed' | 'failed' | 'skipped'
+export type DAGNodeStatus = 'pending' | 'ready' | 'running' | 'waiting_for_command' | 'completed' | 'failed' | 'skipped'
 
-export type DAGExecutionStatus = 'pending' | 'running' | 'completed' | 'failed'
+export type DAGExecutionStatus = 'pending' | 'running' | 'waiting' | 'completed' | 'failed'
 
 // ============================================================================
 // DAG 节点

--- a/agent-ui/src/components/agent/AgentModeTopBar.test.ts
+++ b/agent-ui/src/components/agent/AgentModeTopBar.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, nextTick, type App } from 'vue'
+import { http } from '@/api/clients/http-client'
 import { i18n } from '@/plugins/i18n'
 import AgentModeTopBar from './AgentModeTopBar.vue'
 
@@ -16,6 +17,7 @@ describe('AgentModeTopBar localization', () => {
     root?.remove()
     app = null
     root = null
+    vi.restoreAllMocks()
   })
 
   it('updates primary controls immediately when the locale changes', async () => {
@@ -40,5 +42,30 @@ describe('AgentModeTopBar localization', () => {
     expect(root.textContent).toContain('Details')
     expect(root.textContent).toContain('Settings')
     expect(root.textContent).not.toContain('文字模式')
+  })
+
+  it('shows waiting runs without presenting them as actively executing', async () => {
+    vi.spyOn(http, 'get').mockResolvedValue({
+      data: {
+        runs: [{ runId: 'run-waiting', status: 'waiting' }],
+        total: 1,
+      },
+    } as any)
+    root = document.createElement('div')
+    document.body.appendChild(root)
+    app = createApp(AgentModeTopBar, {
+      activeMode: 'text',
+      showRuntime: true,
+    })
+    app.use(i18n)
+    app.mount(root)
+
+    await vi.waitFor(() => {
+      const button = root?.querySelector<HTMLElement>('[data-testid="dag-runtime-button"]')
+      expect(button?.dataset.state).toBe('waiting')
+      expect(button?.title).toContain('1 个运行等待指令')
+      expect(button?.textContent).toContain('1')
+      expect(button?.querySelector('.animate-spin')).toBeNull()
+    })
   })
 })

--- a/agent-ui/src/components/agent/AgentModeTopBar.vue
+++ b/agent-ui/src/components/agent/AgentModeTopBar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
-import { Eye, EyeOff, Loader2, Network, RotateCcw, Settings } from 'lucide-vue-next'
+import { CirclePause, Eye, EyeOff, Loader2, Network, RotateCcw, Settings } from 'lucide-vue-next'
 import { useI18n } from 'vue-i18n'
 import { http } from '@/api/clients/http-client'
 
@@ -35,18 +35,27 @@ interface ActiveRunsResponse {
 }
 
 const activeRunCount = ref(0)
+const waitingRunCount = ref(0)
 let activeRunTimer: ReturnType<typeof setInterval> | null = null
 
 const hasActiveRuns = computed(() => activeRunCount.value > 0)
+const hasWaitingRuns = computed(() => waitingRunCount.value > 0)
+const runtimeRunCount = computed(() => activeRunCount.value + waitingRunCount.value)
 const desktopUpdateStatus = ref<DesktopUpdateStatus | null>(null)
 const updateInstalling = ref(false)
 let removeUpdateListener: (() => void) | null = null
 
-const runtimeTitle = computed(() =>
-  hasActiveRuns.value
-    ? t('shell.dashboard.running', { count: activeRunCount.value })
-    : t('shell.dashboard.title'),
-)
+const runtimeTitle = computed(() => {
+  if (hasActiveRuns.value && hasWaitingRuns.value) {
+    return t('shell.dashboard.runningAndWaiting', {
+      active: activeRunCount.value,
+      waiting: waitingRunCount.value,
+    })
+  }
+  if (hasActiveRuns.value) return t('shell.dashboard.running', { count: activeRunCount.value })
+  if (hasWaitingRuns.value) return t('shell.dashboard.waiting', { count: waitingRunCount.value })
+  return t('shell.dashboard.title')
+})
 const downloadedUpdate = computed(() =>
   Boolean(desktopUpdateStatus.value?.supported && desktopUpdateStatus.value.state === 'downloaded'),
 )
@@ -58,14 +67,22 @@ const updateButtonTitle = computed(() => {
 async function refreshActiveRuns(): Promise<void> {
   if (!props.showRuntime) {
     activeRunCount.value = 0
+    waitingRunCount.value = 0
     return
   }
   try {
     const res = await http.get<ActiveRunsResponse>('/api/runs/active/list')
     const data = (res.data ?? res) as ActiveRunsResponse
-    activeRunCount.value = Number(data.total ?? data.runs?.length ?? 0)
+    if (data.runs) {
+      activeRunCount.value = data.runs.filter(run => run.status === 'active').length
+      waitingRunCount.value = data.runs.filter(run => run.status === 'waiting').length
+    } else {
+      activeRunCount.value = Number(data.total ?? 0)
+      waitingRunCount.value = 0
+    }
   } catch {
     activeRunCount.value = 0
+    waitingRunCount.value = 0
   }
 }
 
@@ -140,6 +157,7 @@ watch(() => props.showRuntime, (showRuntime) => {
   } else {
     stopActiveRunPolling()
     activeRunCount.value = 0
+    waitingRunCount.value = 0
   }
 })
 
@@ -191,19 +209,29 @@ onBeforeUnmount(() => {
       <button
         v-if="showRuntime"
         class="flex h-9 items-center gap-2 rounded-full border px-3 text-sm transition-colors hover:bg-cyan-200/10 hover:text-white"
-        :class="hasActiveRuns ? 'border-emerald-300/45 bg-emerald-300/10 text-emerald-100 shadow-[0_0_18px_rgba(52,211,153,0.16)]' : 'border-cyan-200/14 text-white/60'"
+        :class="hasActiveRuns
+          ? 'border-emerald-300/45 bg-emerald-300/10 text-emerald-100 shadow-[0_0_18px_rgba(52,211,153,0.16)]'
+          : hasWaitingRuns
+            ? 'border-amber-300/40 bg-amber-300/10 text-amber-100'
+            : 'border-cyan-200/14 text-white/60'"
+        :data-state="hasActiveRuns ? 'active' : hasWaitingRuns ? 'waiting' : 'idle'"
+        data-testid="dag-runtime-button"
         :title="runtimeTitle"
         type="button"
         @click="emit('openRuntime')"
       >
         <Loader2 v-if="hasActiveRuns" class="h-4 w-4 animate-spin" />
+        <CirclePause v-else-if="hasWaitingRuns" class="h-4 w-4" />
         <Network v-else class="h-4 w-4" />
         {{ t('shell.dashboard.button') }}
         <span
-          v-if="hasActiveRuns"
-          class="min-w-5 rounded-full border border-emerald-200/35 bg-emerald-300/15 px-1.5 text-center text-[11px] font-semibold leading-5 text-emerald-50"
+          v-if="runtimeRunCount > 0"
+          class="min-w-5 rounded-full border px-1.5 text-center text-[11px] font-semibold leading-5"
+          :class="hasActiveRuns
+            ? 'border-emerald-200/35 bg-emerald-300/15 text-emerald-50'
+            : 'border-amber-200/35 bg-amber-300/15 text-amber-50'"
         >
-          {{ activeRunCount }}
+          {{ runtimeRunCount }}
         </span>
       </button>
       <button

--- a/agent-ui/src/components/agent/dag-runtime/DagNodeDetailDrawer.vue
+++ b/agent-ui/src/components/agent/dag-runtime/DagNodeDetailDrawer.vue
@@ -106,6 +106,7 @@ watch(
 function statusLabel(status: string): string {
   const map: Record<string, string> = {
     pending: t('dag.status.pending'), ready: t('dag.status.ready'), running: t('dag.status.running'),
+    waiting_for_command: t('dag.status.waitingForCommand'),
     completed: t('dag.status.completed'), failed: t('dag.status.failed'), skipped: t('dag.status.skipped'),
   }
   return map[status] ?? status
@@ -114,6 +115,7 @@ function statusLabel(status: string): string {
 function statusClass(status: string): string {
   switch (status) {
     case 'running': return 'border-emerald-300/30 bg-emerald-300/10 text-emerald-200'
+    case 'waiting_for_command': return 'border-amber-300/30 bg-amber-300/10 text-amber-200'
     case 'completed': return 'border-blue-300/30 bg-blue-300/10 text-blue-200'
     case 'failed': return 'border-red-400/30 bg-red-500/15 text-red-300'
     case 'ready': return 'border-cyan-200/25 bg-cyan-200/10 text-cyan-100'

--- a/agent-ui/src/components/agent/dag-runtime/DagRunList.test.ts
+++ b/agent-ui/src/components/agent/dag-runtime/DagRunList.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createApp, type App } from 'vue'
+import { i18n } from '@/plugins/i18n'
+import DagRunList from './DagRunList.vue'
+
+describe('DagRunList waiting state', () => {
+  let app: App<Element> | null = null
+  let root: HTMLElement | null = null
+
+  beforeEach(() => {
+    i18n.global.locale.value = 'zh-Hans'
+  })
+
+  afterEach(() => {
+    app?.unmount()
+    root?.remove()
+    app = null
+    root = null
+  })
+
+  it('renders a waiting run as paused rather than running', () => {
+    root = document.createElement('div')
+    document.body.appendChild(root)
+    app = createApp(DagRunList, {
+      runs: [{
+        runId: 'run-waiting-for-command',
+        workflowName: 'Review workflow',
+        nodeCount: 2,
+        status: 'waiting',
+        createdAt: Date.now(),
+      }],
+      loading: false,
+      focusedIndex: 0,
+      currentRunId: 'run-waiting-for-command',
+    })
+    app.use(i18n)
+    app.mount(root)
+
+    expect(root.textContent).toContain('等待指令')
+    expect(root.querySelector('[data-status="waiting"]')).not.toBeNull()
+    expect(root.querySelector('.animate-spin')).toBeNull()
+  })
+})

--- a/agent-ui/src/components/agent/dag-runtime/DagRunList.vue
+++ b/agent-ui/src/components/agent/dag-runtime/DagRunList.vue
@@ -12,7 +12,7 @@ import { useI18n } from 'vue-i18n'
 import type { RunListItem } from './useRunList'
 import { getAgentPersona } from '@/lib/agentPersonas'
 import { cn } from '@/lib/utils'
-import { CheckCircle2, XCircle, Loader2, Clock, ChevronRight, Network } from 'lucide-vue-next'
+import { CheckCircle2, XCircle, Loader2, Clock, ChevronRight, Network, CirclePause } from 'lucide-vue-next'
 
 const props = defineProps<{
   runs: RunListItem[]
@@ -33,6 +33,8 @@ const statusMeta = computed(() => (status: string) => {
   switch (status) {
     case 'active':
       return { icon: Loader2, color: 'text-emerald-300', bg: 'border-emerald-300/25 bg-emerald-300/10', spin: true, label: t('dag.status.active') }
+    case 'waiting':
+      return { icon: CirclePause, color: 'text-amber-300', bg: 'border-amber-300/25 bg-amber-300/10', spin: false, label: t('dag.status.waitingForCommand') }
     case 'completed':
       return { icon: CheckCircle2, color: 'text-blue-300', bg: 'border-blue-300/25 bg-blue-300/10', spin: false, label: t('dag.status.completed') }
     case 'failed':
@@ -115,6 +117,7 @@ watch(() => props.focusedIndex, async (idx) => {
 
         <!-- 状态图标 -->
         <div
+          :data-status="run.status"
           :class="cn(
             'flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-xl border',
             statusMeta(run.status).bg

--- a/agent-ui/src/components/agent/dag-runtime/DagRuntimeCanvas.vue
+++ b/agent-ui/src/components/agent/dag-runtime/DagRuntimeCanvas.vue
@@ -72,6 +72,7 @@ let flowTick = 0
 function statusGlow(status: string): { color: string; pulse: boolean } {
   switch (status) {
     case 'running': return { color: '52, 211, 153', pulse: true }
+    case 'waiting_for_command': return { color: '251, 191, 36', pulse: false }
     case 'completed': return { color: '96, 165, 250', pulse: false }
     case 'failed': return { color: '248, 113, 113', pulse: false }
     case 'ready': return { color: '147, 197, 253', pulse: false }

--- a/agent-ui/src/components/agent/dag-runtime/DagRuntimeOverlay.vue
+++ b/agent-ui/src/components/agent/dag-runtime/DagRuntimeOverlay.vue
@@ -185,7 +185,7 @@ function initNodeFocus(): void {
     focusedNodeId.value = null
     return
   }
-  const running = nodes.find(n => n.status === 'running' || n.status === 'ready')
+  const running = nodes.find(n => n.status === 'running' || n.status === 'ready' || n.status === 'waiting_for_command')
   const completed = nodes.find(n => n.status === 'completed')
   focusedNodeId.value = (running ?? completed ?? nodes[0]).id
 }

--- a/agent-ui/src/components/agent/dag-runtime/DagRuntimeToolbar.vue
+++ b/agent-ui/src/components/agent/dag-runtime/DagRuntimeToolbar.vue
@@ -40,6 +40,13 @@ const progressPct = computed(() => {
   return Math.round((completedCount.value / store.nodes.length) * 100)
 })
 
+const executionStatusLabel = computed(() => {
+  const status = store.dagExecution?.status
+  if (!status) return 'idle'
+  if (status === 'waiting') return t('dag.status.waitingForCommand')
+  return t(`dag.status.${status}`)
+})
+
 const totals = computed(() => {
   if (props.metrics) {
     return {
@@ -59,6 +66,7 @@ const totals = computed(() => {
 
 const statusItems = computed(() => [
   { key: 'running', label: t('dag.toolbar.legend.running'), color: 'bg-emerald-400' },
+  { key: 'waiting_for_command', label: t('dag.status.waitingForCommand'), color: 'bg-amber-400' },
   { key: 'completed', label: t('dag.toolbar.legend.completed'), color: 'bg-blue-500' },
   { key: 'failed', label: t('dag.toolbar.legend.failed'), color: 'bg-red-500' },
   { key: 'ready', label: t('dag.toolbar.legend.ready'), color: 'bg-blue-300' },
@@ -91,12 +99,13 @@ const statusItems = computed(() => [
             :class="cn(
               'rounded-full border px-3 py-1 text-sm font-medium',
               store.isRunning ? 'border-emerald-300/25 bg-emerald-300/10 text-emerald-200' :
+              store.isWaiting ? 'border-amber-300/25 bg-amber-300/10 text-amber-200' :
               store.isCompleted ? 'border-cyan-200/20 bg-cyan-200/10 text-cyan-100' :
               store.isFailed ? 'border-red-400/30 bg-red-500/15 text-red-300' :
               'border-white/10 bg-white/[0.04] text-white/45'
             )"
           >
-            {{ store.dagExecution?.status ?? 'idle' }}
+            {{ executionStatusLabel }}
           </span>
         </div>
         <div class="mt-1 flex items-center gap-2 text-sm text-white/50">

--- a/agent-ui/src/locales/en-US/dag.json
+++ b/agent-ui/src/locales/en-US/dag.json
@@ -2,6 +2,7 @@
   "status": {
     "active": "Running",
     "running": "Running",
+    "waitingForCommand": "Waiting for command",
     "completed": "Completed",
     "failed": "Failed",
     "cancelled": "Cancelled",

--- a/agent-ui/src/locales/en-US/shell.json
+++ b/agent-ui/src/locales/en-US/shell.json
@@ -11,6 +11,8 @@
   "dashboard": {
     "title": "DAG dashboard",
     "running": "DAG dashboard: {count} run in progress | DAG dashboard: {count} runs in progress",
+    "waiting": "DAG dashboard: {count} run waiting for a command | DAG dashboard: {count} runs waiting for a command",
+    "runningAndWaiting": "DAG dashboard: {active} running, {waiting} awaiting command",
     "button": "Dashboard"
   },
   "details": {

--- a/agent-ui/src/locales/zh-Hans/dag.json
+++ b/agent-ui/src/locales/zh-Hans/dag.json
@@ -2,6 +2,7 @@
   "status": {
     "active": "运行中",
     "running": "运行中",
+    "waitingForCommand": "等待指令",
     "completed": "已完成",
     "failed": "失败",
     "cancelled": "已取消",

--- a/agent-ui/src/locales/zh-Hans/shell.json
+++ b/agent-ui/src/locales/zh-Hans/shell.json
@@ -11,6 +11,8 @@
   "dashboard": {
     "title": "DAG 仪表盘",
     "running": "DAG 仪表盘：{count} 个运行正在执行",
+    "waiting": "DAG 仪表盘：{count} 个运行等待指令",
+    "runningAndWaiting": "DAG 仪表盘：{active} 个运行中，{waiting} 个等待指令",
     "button": "仪表盘"
   },
   "details": {

--- a/agent-ui/src/locales/zh-Hant/dag.json
+++ b/agent-ui/src/locales/zh-Hant/dag.json
@@ -2,6 +2,7 @@
   "status": {
     "active": "運行中",
     "running": "運行中",
+    "waitingForCommand": "等待指令",
     "completed": "已完成",
     "failed": "失敗",
     "cancelled": "已取消",

--- a/agent-ui/src/locales/zh-Hant/shell.json
+++ b/agent-ui/src/locales/zh-Hant/shell.json
@@ -11,6 +11,8 @@
   "dashboard": {
     "title": "DAG 儀表盤",
     "running": "DAG 儀表盤：{count} 個運行正在執行",
+    "waiting": "DAG 儀表盤：{count} 個運行等待指令",
+    "runningAndWaiting": "DAG 儀表盤：{active} 個運行中，{waiting} 個等待指令",
     "button": "儀表盤"
   },
   "details": {

--- a/agent-ui/src/stores/agent-store.ts
+++ b/agent-ui/src/stores/agent-store.ts
@@ -78,6 +78,7 @@ export const useAgentStore = defineStore('agent', () => {
       pending: 0,
       ready: 0,
       running: 0,
+      waiting_for_command: 0,
       completed: 0,
       failed: 0,
       skipped: 0,
@@ -90,6 +91,10 @@ export const useAgentStore = defineStore('agent', () => {
 
   const isRunning = computed(() => {
     return dagExecution.value?.status === 'running'
+  })
+
+  const isWaiting = computed(() => {
+    return dagExecution.value?.status === 'waiting'
   })
 
   const isCompleted = computed(() => {
@@ -588,6 +593,7 @@ export const useAgentStore = defineStore('agent', () => {
     selectedNodeIsManager,
     statusSummary,
     isRunning,
+    isWaiting,
     isCompleted,
     isFailed,
     selectedSessionInfo,

--- a/docs/multi-round-dags.md
+++ b/docs/multi-round-dags.md
@@ -1,0 +1,296 @@
+# Multi-Round DAGs
+
+Multi-round execution keeps one durable `run_id` and its logical actors alive
+across command/response rounds. An `await_command` node closes the current
+round and moves the run to `waiting`; an actor command opens the next round, or
+the caller can explicitly complete or cancel the waiting run.
+
+## Strict WorkflowSpec v1
+
+`await_command` is a first-class WorkflowSpec v1 node. It is an outputless
+persistent boundary, not a terminal alias and not a prompt convention:
+
+```yaml
+api_version: homerail.ai/v1
+kind: Workflow
+
+metadata:
+  id: multi-round-research
+  name: Multi-Round Research
+
+spec:
+  contracts:
+    Summary:
+      type: string
+      maxLength: 20000
+
+  agents:
+    researcher:
+      system: >
+        Use the run prompt on the first round. On later rounds, follow the
+        command input and hand off a concise summary.
+
+  nodes:
+    researcher:
+      kind: agent
+      agent: researcher
+      outputs:
+        summary: { contract: Summary }
+
+    wait_for_command:
+      kind: await_command
+      inputs:
+        summary: { contract: Summary }
+      config:
+        primitive_version: 1
+        target_actors: [researcher]
+        command_port: command
+        expires_after_ms: 86400000
+
+  edges:
+    - { from: researcher.summary, to: wait_for_command.summary }
+```
+
+This is strict `homerail.ai/v1`: it uses `kind`, `config`, and explicit
+`spec.edges`, not legacy `type`, `gateway_config`, or inline `outputs.*.to`
+fields. There is deliberately no synthetic `terminal` node. Workflow
+validation accepts `await_command` as the persistent boundary.
+
+The source agent intentionally has no input edge. Manager seeds the initial
+`hr run --prompt` value into the default `prompt` input of a ready source node;
+later rounds wake the selected actor through the configured command port.
+
+The node rules are:
+
+- A workflow may contain at most one `await_command` node. A run has one
+  durable round boundary, so multiple independent wait points would be
+  ambiguous.
+- `primitive_version` must be the integer `1`.
+- `target_actors`, when present, contains unique agent node IDs. The default
+  logical actor ID for a strict v1 agent is its node ID, so the example is
+  addressed as actor `researcher` through the CLI and API.
+- `command_port` defaults to `command`. A resumed actor receives a structured
+  command envelope on that runtime input, including `command_id`, `round_id`,
+  `actor_id`, and the caller's `payload`.
+- `expires_after_ms` is optional and, when set, must be an integer of at least
+  1000 milliseconds.
+- The node may declare inputs and upstream dependencies but no outputs,
+  outgoing routes, or downstream `depends_on` consumers. It is the durable end
+  of a round, not a pass-through control node.
+
+Validate and sync the document through the live Manager contract:
+
+```bash
+hr --json dag validate ./multi-round.yaml
+hr dag sync ./multi-round.yaml
+hr profile sync ./runtime.profile.yaml --workflow multi-round-research
+hr run --workflow multi-round-research --profile local-main \
+  --prompt "Research the current release risk"
+```
+
+## Waiting And Round Lifecycle
+
+`waiting` is non-terminal. The terminal run states remain `completed`,
+`failed`, and `cancelled`.
+
+```text
+run active, round N active
+  -> await_command
+run waiting, round N waiting
+  -> send actor command: round N completed, round N+1 active, run active
+  -> explicit complete: round N completed, run completed
+  -> cancel: round N cancelled, run cancelled
+  -> expiry: round N failed, run failed
+```
+
+Round IDs are durable and monotonically ordered (`round-0001`,
+`round-0002`, ...). Resuming atomically completes the expected waiting round,
+opens the next active round, persists its actor commands, and updates run
+metadata. At most one round is current (`active` or `waiting`) for a run.
+If an `await_command` node becomes ready before another parallel branch has
+settled, it remains ready and closes the round only after every sibling node is
+quiescent. Graph scheduling order therefore cannot prematurely fail or suspend
+live work.
+
+`hr dag watch` and continuous `hr dag supervise` stop polling and return
+success when they observe `waiting`. That means "a command boundary was
+reached", not "the run completed". Read the run status or rounds before making
+the next lifecycle decision.
+
+## CLI Flow
+
+Always take the expected round ID from current state instead of constructing
+it locally:
+
+```bash
+hr dag supervise "$RUN_ID"
+hr dag rounds "$RUN_ID"
+hr dag commands "$RUN_ID"
+```
+
+Resume one actor with stable command identities for retry safety:
+
+```bash
+hr dag send-command "$RUN_ID" \
+  --expected-round round-0001 \
+  --actor researcher \
+  --payload '{"task":"continue","focus":"new evidence"}' \
+  --command-id command-research-round-2 \
+  --idempotency-key research-round-2-v1
+```
+
+Inspect the new round and its command:
+
+```bash
+hr dag rounds "$RUN_ID"
+hr dag commands "$RUN_ID" --round round-0002
+```
+
+As an alternative request shape, resume multiple actors from one waiting
+boundary by repeating paired `--actor` and `--payload` options in the same
+order:
+
+```bash
+hr dag send-command "$RUN_ID" \
+  --expected-round "$CURRENT_ROUND" \
+  --actor researcher --payload '{"task":"refresh sources"}' \
+  --actor reviewer --payload "review the updated evidence"
+```
+
+A payload is parsed as JSON when valid and otherwise remains a string.
+`--command-id` and `--idempotency-key` are available only for a single-command
+CLI request. Use the HTTP API when a batch needs explicit identity per command.
+The global `--json` option makes all four commands machine-readable.
+
+When the current round reaches `waiting` again and no further round is needed,
+complete it explicitly:
+
+```bash
+CURRENT_ROUND=round-0002
+hr dag complete "$RUN_ID" --expected-round "$CURRENT_ROUND"
+```
+
+Completion is valid only at the current waiting boundary. A premature request
+or stale round ID returns a conflict. To abort instead, `hr stop "$RUN_ID"`
+cancels either an active or waiting run.
+
+## Fencing And Idempotency
+
+There are two related fences:
+
+1. Control-plane writes require `expected_round_id`. A send or complete request
+   for any round other than the current waiting round is rejected with HTTP
+   `409 Conflict`.
+2. Worker handoffs after round 1 carry the current `round_id`, logical
+   `actor_id`, actor `generation`, and `command_id`. Manager rejects missing or
+   stale fences, including a late handoff from an earlier round, before it can
+   mutate current DAG state.
+
+Each resumed actor receives at most one command per round. Commands target the
+actor's current generation and normally follow `pending -> delivered -> claimed
+-> acknowledged`; a reconnecting Worker may claim directly from `pending`.
+`failed` and `cancelled` are exit states. Manager persists a command before
+dispatch and acknowledges it only after a fenced handoff is accepted.
+
+For retryable clients, reuse the same `command_id` or actor-scoped
+`idempotency_key` with byte-equivalent semantic content. An exact retry returns
+the already-opened round with `deduplicated: true`; reusing either identity for
+a different actor, round, generation, or payload is rejected. For a batch, the
+retry must reproduce the complete accepted command set; a subset is not an
+idempotent retry. Supplying stable IDs is recommended whenever a client might
+lose the first response.
+
+## HTTP API
+
+Manager exposes the following run-scoped endpoints:
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/api/runs/:run_id/status` | Read `status` and `current_round`. |
+| `GET` | `/api/runs/:run_id/rounds` | List durable rounds in ordinal order. |
+| `GET` | `/api/runs/:run_id/commands` | List commands; supports `actor_id`, `round_id`, `status`, and `limit`. |
+| `POST` | `/api/runs/:run_id/commands` | Fence the waiting round and resume one or more actors. |
+| `POST` | `/api/runs/:run_id/complete` | Explicitly complete the current waiting round. |
+| `POST` | `/api/runs/:run_id/cancel` | Cancel an active or waiting run. |
+
+The response envelope is `{ success, message, data }`. A command request is:
+
+```bash
+curl -sS -X POST "$HOMERAIL_MANAGER_URL/api/runs/$RUN_ID/commands" \
+  -H 'Content-Type: application/json' \
+  -H "X-Homerail-Dag-Token: $HOMERAIL_DAG_MUTATION_TOKEN" \
+  -d '{
+    "expected_round_id": "round-0001",
+    "commands": [{
+      "actor_id": "researcher",
+      "command_id": "command-research-round-2",
+      "idempotency_key": "research-round-2-v1",
+      "payload": {"task": "continue", "focus": "new evidence"}
+    }]
+  }'
+```
+
+The response data includes `previous_round_id`, the new `round_id` and
+`ordinal`, selected `actor_ids` and `node_ids`, durable `command_ids`, ready
+nodes, and dispatch count. Exact retries also include `deduplicated: true`.
+
+Explicit completion uses the same current-round fence:
+
+```bash
+curl -sS -X POST "$HOMERAIL_MANAGER_URL/api/runs/$RUN_ID/complete" \
+  -H 'Content-Type: application/json' \
+  -H "X-Homerail-Dag-Token: $HOMERAIL_DAG_MUTATION_TOKEN" \
+  -d '{"expected_round_id":"round-0002"}'
+```
+
+When `HOMERAIL_DAG_MUTATION_TOKEN` is configured, all listed mutation requests
+must send it as `X-Homerail-Dag-Token`, including loopback requests; the `hr`
+client adds the header from the environment automatically. Without a configured
+token, mutations are restricted to loopback clients. Malformed input returns
+`400`, unknown runs or actors return `404`, and stale/not-waiting lifecycle
+writes return `409`.
+
+## Cancellation, Expiry, And Recovery
+
+Cancellation terminalizes the current round as `cancelled`, marks waiting or
+running nodes accordingly, cancels unclaimed commands, persists the result,
+and starts terminal resource cleanup.
+
+If `expires_after_ms` is present, Manager stores an absolute `expires_at` when
+the run enters `waiting`. Crossing that deadline marks the `await_command` node,
+current round, and run as `failed` with an `await_command expired` reason. The
+deadline is durable, so a wait that expires while Manager is down is failed by
+the scheduler after recovery. A terminal run cannot be resumed.
+
+On startup, Manager cold-recovers both active and waiting runs from persisted
+graph/runtime state, handoffs, rounds, actors, sessions, and commands. A
+recovered waiting run keeps the same `run_id`, current round, actor generation,
+and session binding. It is not redispatched until a valid command opens the
+next round.
+
+If no compatible Worker is connected when a round opens, the selected actor
+stays `READY` and its command stays `pending`. Offline attempts and capability
+mismatches do not consume `max_dispatches`; registration of a compatible
+Worker triggers a retry. Socket-send failures remain real failed attempts.
+
+## Concurrency Slot Release
+
+A waiting run remains durable but does not count as an active run. Runtime
+status reports `active_runs` and `waiting_runs` separately, and workflow-level
+trigger admission counts only rows whose status is `active`. Reaching
+`await_command` therefore releases the workflow's overlap/`max_concurrency`
+admission slot, so another run may start while the first waits.
+
+Resuming continues the existing `run_id`, but it must reacquire workflow
+admission before changing the waiting round or persisting commands. Manager
+re-evaluates the workflow's enabled trigger policies using the same strictest
+`overlap` and `max_concurrency` limits used for a new run. If another active run
+holds the available slot, resume returns `409 Conflict` and leaves the original
+run, round, node states, and command set unchanged in `waiting`. A successful
+admission changes the resumed run back to `active`; releasing the slot while it
+waited never erased its actors, rounds, commands, or recovery state.
+
+An exact retry of an already accepted resume is resolved before admission, so
+a lost HTTP response can be recovered even if the workflow slot is occupied by
+the time the caller retries. Crash-window resume reservations are discarded as
+soon as the corresponding durable run is observed active or terminal.

--- a/homerail_cli/src/commands/dag-multiround.ts
+++ b/homerail_cli/src/commands/dag-multiround.ts
@@ -1,0 +1,282 @@
+import type { Command } from "commander";
+import type { HomeRailClient } from "../client.js";
+import { getClient } from "../index.js";
+
+interface GlobalOpts {
+  baseUrl?: string;
+  json?: boolean;
+  requestTimeout?: number;
+}
+
+interface DagRoundRecord {
+  run_id: string;
+  round_id: string;
+  ordinal: number;
+  status: string;
+  target_actor_ids: string[];
+  await_node_id?: string;
+  opened_at: number;
+  closed_at?: number;
+  expires_at?: number;
+}
+
+interface DagCommandRecord {
+  command_id: string;
+  run_id: string;
+  actor_id: string;
+  round_id: string;
+  target_generation: number;
+  status: string;
+  idempotency_key: string;
+  payload: unknown;
+  created_at?: number;
+  updated_at?: number;
+}
+
+interface DataResponse<T> {
+  data?: T;
+}
+
+export interface SendCommandOptions {
+  expectedRound: string;
+  actor: string[];
+  payload: string[];
+  commandId?: string;
+  idempotencyKey?: string;
+}
+
+function collect(value: string, previous: string[]): string[] {
+  return [...previous, value];
+}
+
+export function parseCommandPayload(value: string): unknown {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return value;
+  }
+}
+
+export function buildSendCommandBody(options: SendCommandOptions): {
+  expected_round_id: string;
+  commands: Array<{
+    actor_id: string;
+    payload: unknown;
+    command_id?: string;
+    idempotency_key?: string;
+  }>;
+} {
+  const expectedRound = options.expectedRound?.trim();
+  if (!expectedRound) throw new Error("--expected-round is required");
+  if (options.actor.length === 0) throw new Error("At least one --actor is required");
+  if (options.payload.length === 0) throw new Error("At least one --payload is required");
+  if (options.actor.length !== options.payload.length) {
+    throw new Error(
+      `Mismatched command arguments: received ${options.actor.length} --actor value(s) and ${options.payload.length} --payload value(s)`,
+    );
+  }
+  if (options.actor.length > 1 && (options.commandId || options.idempotencyKey)) {
+    throw new Error("--command-id and --idempotency-key are only valid for a single command");
+  }
+
+  const commands = options.actor.map((rawActor, index) => {
+    const actorId = rawActor.trim();
+    if (!actorId) throw new Error(`--actor value ${index + 1} must not be empty`);
+    return {
+      actor_id: actorId,
+      payload: parseCommandPayload(options.payload[index]!),
+      ...(options.commandId?.trim() ? { command_id: options.commandId.trim() } : {}),
+      ...(options.idempotencyKey?.trim()
+        ? { idempotency_key: options.idempotencyKey.trim() }
+        : {}),
+    };
+  });
+
+  return { expected_round_id: expectedRound, commands };
+}
+
+export async function cmdDagRounds(
+  client: HomeRailClient,
+  runId: string,
+  json: boolean,
+): Promise<number> {
+  try {
+    const response = await client.get<DataResponse<{ rounds?: DagRoundRecord[] }>>(
+      `/api/runs/${encodeURIComponent(runId)}/rounds`,
+    );
+    const rounds = response.data?.rounds;
+    if (!Array.isArray(rounds)) throw new Error("Manager returned no round list");
+    if (json) {
+      console.log(JSON.stringify(rounds));
+      return 0;
+    }
+    if (rounds.length === 0) {
+      console.log(`Run ${runId} has no recorded rounds.`);
+      return 0;
+    }
+    console.log(`${"ROUND".padEnd(18)} ${"#".padEnd(4)} ${"STATUS".padEnd(12)} ${"ACTORS".padEnd(24)} AWAIT NODE`);
+    for (const round of rounds) {
+      console.log(
+        `${round.round_id.padEnd(18)} ${String(round.ordinal).padEnd(4)} ${round.status.padEnd(12)} ${round.target_actor_ids.join(",").padEnd(24)} ${round.await_node_id ?? "-"}`,
+      );
+    }
+    return 0;
+  } catch (error) {
+    console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    return 1;
+  }
+}
+
+export async function cmdDagCommands(
+  client: HomeRailClient,
+  runId: string,
+  roundId: string | undefined,
+  json: boolean,
+): Promise<number> {
+  try {
+    const query = new URLSearchParams();
+    if (roundId?.trim()) query.set("round_id", roundId.trim());
+    const suffix = query.size > 0 ? `?${query.toString()}` : "";
+    const response = await client.get<DataResponse<{ commands?: DagCommandRecord[] }>>(
+      `/api/runs/${encodeURIComponent(runId)}/commands${suffix}`,
+    );
+    const commands = response.data?.commands;
+    if (!Array.isArray(commands)) throw new Error("Manager returned no command list");
+    if (json) {
+      console.log(JSON.stringify(commands));
+      return 0;
+    }
+    if (commands.length === 0) {
+      console.log(`Run ${runId} has no recorded commands${roundId ? ` for ${roundId}` : ""}.`);
+      return 0;
+    }
+    console.log(`${"COMMAND".padEnd(24)} ${"ROUND".padEnd(18)} ${"ACTOR".padEnd(20)} ${"STATUS".padEnd(14)} PAYLOAD`);
+    for (const command of commands) {
+      console.log(
+        `${command.command_id.padEnd(24)} ${command.round_id.padEnd(18)} ${command.actor_id.padEnd(20)} ${command.status.padEnd(14)} ${previewPayload(command.payload)}`,
+      );
+    }
+    return 0;
+  } catch (error) {
+    console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    return 1;
+  }
+}
+
+export async function cmdDagSendCommand(
+  client: HomeRailClient,
+  runId: string,
+  options: SendCommandOptions,
+  json: boolean,
+): Promise<number> {
+  try {
+    const body = buildSendCommandBody(options);
+    const response = await client.post<DataResponse<Record<string, unknown>>>(
+      `/api/runs/${encodeURIComponent(runId)}/commands`,
+      body,
+    );
+    if (!response.data) throw new Error("Manager returned no command result");
+    if (json) {
+      console.log(JSON.stringify(response.data));
+    } else {
+      const roundId = String(response.data.round_id ?? "unknown");
+      const actors = Array.isArray(response.data.actor_ids)
+        ? response.data.actor_ids.join(", ")
+        : body.commands.map((command) => command.actor_id).join(", ");
+      const deduplicated = response.data.deduplicated === true ? " (deduplicated)" : "";
+      console.log(`Run ${runId} resumed as ${roundId} for ${actors}${deduplicated}.`);
+    }
+    return 0;
+  } catch (error) {
+    console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    return 1;
+  }
+}
+
+export async function cmdDagComplete(
+  client: HomeRailClient,
+  runId: string,
+  expectedRound: string,
+  json: boolean,
+): Promise<number> {
+  try {
+    const roundId = expectedRound?.trim();
+    if (!roundId) throw new Error("--expected-round is required");
+    const response = await client.post<DataResponse<Record<string, unknown>>>(
+      `/api/runs/${encodeURIComponent(runId)}/complete`,
+      { expected_round_id: roundId },
+    );
+    if (!response.data) throw new Error("Manager returned no completion result");
+    if (json) console.log(JSON.stringify(response.data));
+    else console.log(`Run ${runId} completed at ${roundId}.`);
+    return 0;
+  } catch (error) {
+    console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    return 1;
+  }
+}
+
+export function registerDagMultiroundCommands(
+  dag: Command,
+  program: Command,
+): void {
+  dag
+    .command("rounds <runId>")
+    .description("List durable rounds for a multi-round DAG run")
+    .action(async (runId: string) => {
+      const globalOpts = program.opts<GlobalOpts>();
+      process.exitCode = await cmdDagRounds(getClient(globalOpts), runId, !!globalOpts.json);
+    });
+
+  dag
+    .command("commands <runId>")
+    .description("List durable actor commands for a multi-round DAG run")
+    .option("--round <id>", "Only commands from this round")
+    .action(async (runId: string, options: { round?: string }) => {
+      const globalOpts = program.opts<GlobalOpts>();
+      process.exitCode = await cmdDagCommands(
+        getClient(globalOpts),
+        runId,
+        options.round,
+        !!globalOpts.json,
+      );
+    });
+
+  dag
+    .command("send-command <runId>")
+    .description("Resume a waiting DAG run with one or more actor commands")
+    .requiredOption("--expected-round <id>", "Current waiting round ID")
+    .requiredOption("--actor <id>", "Target logical actor; repeat with --payload", collect, [])
+    .requiredOption("--payload <json-or-string>", "Command payload; repeat with --actor", collect, [])
+    .option("--command-id <id>", "Explicit ID for a single command")
+    .option("--idempotency-key <key>", "Idempotency key for a single command")
+    .action(async (runId: string, options: SendCommandOptions) => {
+      const globalOpts = program.opts<GlobalOpts>();
+      process.exitCode = await cmdDagSendCommand(
+        getClient(globalOpts),
+        runId,
+        options,
+        !!globalOpts.json,
+      );
+    });
+
+  dag
+    .command("complete <runId>")
+    .description("Explicitly complete a DAG run at a waiting command boundary")
+    .requiredOption("--expected-round <id>", "Current waiting round ID")
+    .action(async (runId: string, options: { expectedRound: string }) => {
+      const globalOpts = program.opts<GlobalOpts>();
+      process.exitCode = await cmdDagComplete(
+        getClient(globalOpts),
+        runId,
+        options.expectedRound,
+        !!globalOpts.json,
+      );
+    });
+}
+
+function previewPayload(payload: unknown): string {
+  const value = typeof payload === "string" ? payload : JSON.stringify(payload);
+  if (value === undefined) return "undefined";
+  return value.length > 80 ? `${value.slice(0, 77)}...` : value;
+}

--- a/homerail_cli/src/commands/dag-supervise.ts
+++ b/homerail_cli/src/commands/dag-supervise.ts
@@ -81,6 +81,16 @@ export async function cmdDagSuperviseContinuous(
       return result.exit_code;
     }
 
+    if (result.waiting_for_command) {
+      if (json) {
+        console.log(JSON.stringify(result.report));
+      } else {
+        console.log(renderSuperviseTick(runId, result));
+        console.log("Run is waiting for a command.");
+      }
+      return 0;
+    }
+
     // Print if changed or heartbeat interval elapsed
     const elapsedSinceReport = (Date.now() - lastReport) / 1000;
     if (result.changed || elapsedSinceReport >= reportEvery) {

--- a/homerail_cli/src/commands/dag-watch.ts
+++ b/homerail_cli/src/commands/dag-watch.ts
@@ -50,6 +50,14 @@ export async function cmdDagWatch(
       return snap.run_status === "failed" ? 1 : 0;
     }
 
+    if (snap.waiting_for_command) {
+      if (!json) {
+        const round = snap.current_round_id ? ` (${snap.current_round_id})` : "";
+        console.log(`Run is waiting for a command${round}.`);
+      }
+      return 0;
+    }
+
     // Sleep
     const sleepMs = normalizedPollIntervalSecs(interval) * 1000;
     await new Promise((resolve) => setTimeout(resolve, sleepMs));

--- a/homerail_cli/src/commands/dag.ts
+++ b/homerail_cli/src/commands/dag.ts
@@ -14,6 +14,7 @@ import { cmdResume, type ResumeOptions } from "./resume.js";
 import { orchestrationsDir, resolveTemplatePath } from "./templates.js";
 import { registerDagRunTemplateCommands } from "./dag-run-template.js";
 import { cmdDagArtifact, cmdDagArtifacts, type DagArtifactDownloadOptions } from "./dag-artifacts.js";
+import { registerDagMultiroundCommands } from "./dag-multiround.js";
 
 interface GlobalOpts {
   baseUrl?: string;
@@ -49,6 +50,7 @@ interface WorkflowValidationResult {
 export function registerDagCommands(program: Command): void {
   const dagCmd = program.command("dag").description("DAG status and supervision commands");
   registerDagRunTemplateCommands(dagCmd, program);
+  registerDagMultiroundCommands(dagCmd, program);
   const registerResumeCommand = (command: Command) => {
     command
       .command("resume <runId> <nodeId>")

--- a/homerail_cli/src/dag.ts
+++ b/homerail_cli/src/dag.ts
@@ -9,6 +9,8 @@ import type { HomeRailClient, BaseResponse } from "./client.js";
 export interface DagSnapshot {
   run_id: string;
   run_status: string;
+  waiting_for_command: boolean;
+  current_round_id: string | null;
   current_phase: string | null;
   dag_status: string | null;
   node_counts: Record<string, number>;
@@ -26,6 +28,7 @@ export interface DagSnapshot {
 export interface SuperviseTickResult {
   new_cursor: string;
   terminal: boolean;
+  waiting_for_command: boolean;
   changed: boolean;
   severity: string;
   summary: string;
@@ -53,6 +56,24 @@ function extractNodes(
 function extractEvents(eventsData: Record<string, unknown>): unknown[] {
   const arr = eventsData.events;
   return Array.isArray(arr) ? arr : [];
+}
+
+function extractCurrentRoundId(...sources: Record<string, unknown>[]): string | null {
+  for (const source of sources) {
+    for (const key of ["current_round_id", "currentRoundId"] as const) {
+      if (typeof source[key] === "string" && source[key].trim()) {
+        return source[key].trim();
+      }
+    }
+    for (const key of ["current_round", "currentRound"] as const) {
+      const round = source[key];
+      if (!round || typeof round !== "object" || Array.isArray(round)) continue;
+      const record = round as Record<string, unknown>;
+      const value = record.round_id ?? record.roundId;
+      if (typeof value === "string" && value.trim()) return value.trim();
+    }
+  }
+  return null;
 }
 
 export function countNodeStatuses(
@@ -99,6 +120,7 @@ export function computeStalledHint(
 ): string {
   if (runHasError) return `run_status_api_error: ${runStatus}`;
   if (dagHasError) return "dag_status_api_error";
+  if (runStatus === "waiting") return "waiting_for_command";
   if (["completed", "failed", "cancelled"].includes(runStatus)) {
     return "terminal";
   }
@@ -188,6 +210,8 @@ export async function buildDagSnapshot(
 
   const runStatus =
     typeof runData.status === "string" ? runData.status : "?";
+  const waitingForCommand = runStatus === "waiting";
+  const currentRoundId = extractCurrentRoundId(runData, dagData, exec ?? {});
   const currentPhase =
     typeof runData.current_phase === "string" ? runData.current_phase : null;
   const dagStatus =
@@ -214,6 +238,8 @@ export async function buildDagSnapshot(
   return {
     run_id: runId,
     run_status: runStatus,
+    waiting_for_command: waitingForCommand,
+    current_round_id: currentRoundId,
     current_phase: currentPhase,
     dag_status: dagStatus,
     node_counts: nodeCounts,
@@ -515,6 +541,13 @@ export function renderSnapshot(snapshot: DagSnapshot): string {
     `  Run: ${snapshot.run_status}  Phase: ${snapshot.current_phase ?? "-"}  DAG: ${snapshot.dag_status ?? "-"}`,
   ];
 
+  if (snapshot.current_round_id) {
+    lines.push(`  Round: ${snapshot.current_round_id}`);
+  }
+  if (snapshot.waiting_for_command) {
+    lines.push("  Boundary: waiting for command");
+  }
+
   const counts = Object.entries(snapshot.node_counts)
     .map(([k, v]) => `${k}: ${v}`)
     .join(", ");
@@ -544,6 +577,8 @@ export function renderSnapshotJson(snapshot: DagSnapshot): string {
   return JSON.stringify({
     run_id: snapshot.run_id,
     run_status: snapshot.run_status,
+    waiting_for_command: snapshot.waiting_for_command,
+    current_round_id: snapshot.current_round_id,
     current_phase: snapshot.current_phase,
     dag_status: snapshot.dag_status,
     node_counts: snapshot.node_counts,
@@ -816,12 +851,15 @@ export async function superviseTickData(
   const terminal = ["completed", "failed", "cancelled"].includes(
     snap.run_status,
   );
+  const waitingForCommand = snap.waiting_for_command;
 
   const newCursor = `events:${snap.event_count}`;
   const changed = cursor === "" || cursor !== newCursor;
 
   const summary = terminal
     ? `run ${snap.run_status}; failed=${JSON.stringify(snap.failed_nodes)}`
+    : waitingForCommand
+      ? `run waiting for command${snap.current_round_id ? ` at ${snap.current_round_id}` : ""}`
     : changed
       ? `${snap.event_count} new event(s); running=${JSON.stringify(snap.running_nodes)}`
       : `no change; running=${JSON.stringify(snap.running_nodes)}`;
@@ -830,6 +868,8 @@ export async function superviseTickData(
     ? snap.run_status === "failed"
       ? "fail"
       : "done"
+    : waitingForCommand
+      ? "waiting"
     : changed
       ? "update"
       : "heartbeat";
@@ -839,9 +879,12 @@ export async function superviseTickData(
     cursor: newCursor,
     changed,
     terminal,
+    waiting_for_command: waitingForCommand,
     summary,
     snapshot: {
       run_status: snap.run_status,
+      waiting_for_command: waitingForCommand,
+      current_round_id: snap.current_round_id,
       current_phase: snap.current_phase,
       dag_status: snap.dag_status,
       node_counts: snap.node_counts,
@@ -861,6 +904,7 @@ export async function superviseTickData(
   return {
     new_cursor: newCursor,
     terminal,
+    waiting_for_command: waitingForCommand,
     changed,
     severity,
     summary,

--- a/homerail_cli/tests/dag-multiround.test.ts
+++ b/homerail_cli/tests/dag-multiround.test.ts
@@ -1,0 +1,341 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HomeRailClient } from "../src/client.js";
+import { cmdDagQuick } from "../src/commands/dag-quick.js";
+import {
+  buildSendCommandBody,
+} from "../src/commands/dag-multiround.js";
+import {
+  cmdDagSuperviseContinuous,
+  cmdDagSuperviseTick,
+} from "../src/commands/dag-supervise.js";
+import { cmdDagWatch } from "../src/commands/dag-watch.js";
+import { createProgram } from "../src/index.js";
+
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe("multi-round DAG observation", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+  });
+
+  it("reports waiting as a command boundary and exits watch/supervise without polling", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const pathname = new URL(String(input)).pathname;
+      if (pathname === "/api/runs/run-waiting/status") {
+        return jsonResponse({
+          success: true,
+          message: "ok",
+          data: {
+            status: "waiting",
+            current_phase: "waiting",
+            currentRound: { round_id: "round-0002", status: "waiting" },
+          },
+        });
+      }
+      if (pathname === "/api/dag-status/run-waiting") {
+        return jsonResponse({
+          success: true,
+          message: "ok",
+          data: {
+            status: "waiting",
+            execution: { nodes: {}, ready_nodes: [], failed_nodes: [] },
+          },
+        });
+      }
+      if (pathname === "/api/dag-status/run-waiting/events/history") {
+        return jsonResponse({ success: true, message: "ok", data: { events: [] } });
+      }
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    const client = new HomeRailClient({ baseUrl: "http://manager.test" });
+    const output = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    expect(await cmdDagQuick(client, "run-waiting", 5, true)).toBe(0);
+    const quick = JSON.parse(String(output.mock.calls.at(-1)?.[0])) as Record<string, unknown>;
+    expect(quick).toMatchObject({
+      run_status: "waiting",
+      waiting_for_command: true,
+      current_round_id: "round-0002",
+      stalled_hint: "waiting_for_command",
+    });
+
+    output.mockClear();
+    fetchSpy.mockClear();
+    expect(await cmdDagWatch(client, "run-waiting", 5, 60, 60, true)).toBe(0);
+    expect(output).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(String(output.mock.calls[0]?.[0]))).toMatchObject({
+      run_status: "waiting",
+      waiting_for_command: true,
+      current_round_id: "round-0002",
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+
+    output.mockClear();
+    fetchSpy.mockClear();
+    expect(await cmdDagSuperviseContinuous(
+      client,
+      "run-waiting",
+      60,
+      60,
+      5,
+      3,
+      300,
+      60,
+      true,
+    )).toBe(0);
+    expect(output).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(String(output.mock.calls[0]?.[0]))).toMatchObject({
+      terminal: false,
+      waiting_for_command: true,
+      severity: "waiting",
+      snapshot: {
+        run_status: "waiting",
+        waiting_for_command: true,
+        current_round_id: "round-0002",
+      },
+    });
+
+    output.mockClear();
+    const tickExit = await cmdDagSuperviseTick(
+      client,
+      "run-waiting",
+      "events:0",
+      5,
+      3,
+      300,
+      true,
+    );
+    expect(tickExit).toBe(0);
+    expect(JSON.parse(String(output.mock.calls[0]?.[0]))).toMatchObject({
+      terminal: false,
+      waiting_for_command: true,
+    });
+  });
+});
+
+describe("multi-round DAG commands", () => {
+  let tempHome: string;
+  let previousHome: string | undefined;
+  let previousMutationToken: string | undefined;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-cli-multiround-"));
+    previousHome = process.env.HOMERAIL_HOME;
+    previousMutationToken = process.env.HOMERAIL_DAG_MUTATION_TOKEN;
+    process.env.HOMERAIL_HOME = tempHome;
+    process.env.HOMERAIL_DAG_MUTATION_TOKEN = "test-mutation-token";
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+    if (previousHome === undefined) delete process.env.HOMERAIL_HOME;
+    else process.env.HOMERAIL_HOME = previousHome;
+    if (previousMutationToken === undefined) delete process.env.HOMERAIL_DAG_MUTATION_TOKEN;
+    else process.env.HOMERAIL_DAG_MUTATION_TOKEN = previousMutationToken;
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  it("lists rounds and commands with an optional round filter", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse({
+        success: true,
+        message: "ok",
+        data: {
+          rounds: [{
+            run_id: "run/one",
+            round_id: "round-0001",
+            ordinal: 1,
+            status: "waiting",
+            target_actor_ids: ["researcher"],
+            await_node_id: "await",
+            opened_at: 1,
+          }],
+          total: 1,
+        },
+      }))
+      .mockResolvedValueOnce(jsonResponse({
+        success: true,
+        message: "ok",
+        data: {
+          commands: [{
+            command_id: "command-1",
+            run_id: "run/one",
+            actor_id: "researcher",
+            round_id: "round/0002",
+            target_generation: 1,
+            status: "acknowledged",
+            idempotency_key: "idem-1",
+            payload: { task: "continue" },
+          }],
+          total: 1,
+        },
+      }));
+    const output = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await createProgram().parseAsync([
+      "node", "hr", "--base-url", "http://manager.test", "--json",
+      "dag", "rounds", "run/one",
+    ]);
+    expect(JSON.parse(String(output.mock.calls.at(-1)?.[0]))).toHaveLength(1);
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      1,
+      "http://manager.test/api/runs/run%2Fone/rounds",
+      expect.objectContaining({ method: "GET" }),
+    );
+
+    await createProgram().parseAsync([
+      "node", "hr", "--base-url", "http://manager.test", "--json",
+      "dag", "commands", "run/one", "--round", "round/0002",
+    ]);
+    expect(JSON.parse(String(output.mock.calls.at(-1)?.[0]))[0]).toMatchObject({
+      command_id: "command-1",
+      round_id: "round/0002",
+    });
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      2,
+      "http://manager.test/api/runs/run%2Fone/commands?round_id=round%2F0002",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("sends one command with parsed JSON identity fields and mutation auth", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({
+      success: true,
+      message: "resumed",
+      data: {
+        resumed: true,
+        previous_round_id: "round-0001",
+        round_id: "round-0002",
+        actor_ids: ["researcher"],
+        command_ids: ["command-2"],
+      },
+    }));
+    const output = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await createProgram().parseAsync([
+      "node", "hr", "--base-url", "http://manager.test", "--json",
+      "dag", "send-command", "run-1",
+      "--expected-round", "round-0001",
+      "--actor", "researcher",
+      "--payload", "{\"task\":\"continue\",\"limit\":3}",
+      "--command-id", "command-2",
+      "--idempotency-key", "retry-2",
+    ]);
+
+    expect(JSON.parse(String(output.mock.calls[0]?.[0]))).toMatchObject({
+      round_id: "round-0002",
+      command_ids: ["command-2"],
+    });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "http://manager.test/api/runs/run-1/commands",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "X-Homerail-Dag-Token": "test-mutation-token",
+          "Content-Type": "application/json",
+        }),
+        body: JSON.stringify({
+          expected_round_id: "round-0001",
+          commands: [{
+            actor_id: "researcher",
+            payload: { task: "continue", limit: 3 },
+            command_id: "command-2",
+            idempotency_key: "retry-2",
+          }],
+        }),
+      }),
+    );
+  });
+
+  it("pairs repeated actors and payloads while preserving plain strings", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({
+      success: true,
+      message: "resumed",
+      data: { resumed: true, round_id: "round-0002", actor_ids: ["a", "b"] },
+    }));
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await createProgram().parseAsync([
+      "node", "hr", "--base-url", "http://manager.test",
+      "dag", "send-command", "run-2",
+      "--expected-round", "round-0001",
+      "--actor", "a", "--payload", "refresh headlines",
+      "--actor", "b", "--payload", "{\"limit\":4}",
+    ]);
+
+    const request = fetchSpy.mock.calls[0]?.[1];
+    expect(JSON.parse(String(request?.body))).toEqual({
+      expected_round_id: "round-0001",
+      commands: [
+        { actor_id: "a", payload: "refresh headlines" },
+        { actor_id: "b", payload: { limit: 4 } },
+      ],
+    });
+  });
+
+  it("rejects malformed actor/payload pairs before making a request", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const errors = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await createProgram().parseAsync([
+      "node", "hr", "--base-url", "http://manager.test",
+      "dag", "send-command", "run-3",
+      "--expected-round", "round-0001",
+      "--actor", "a", "--actor", "b", "--payload", "only one",
+    ]);
+
+    expect(process.exitCode).toBe(1);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(String(errors.mock.calls[0]?.[0])).toContain(
+      "received 2 --actor value(s) and 1 --payload value(s)",
+    );
+    expect(() => buildSendCommandBody({
+      expectedRound: "round-0001",
+      actor: ["a", "b"],
+      payload: ["one", "two"],
+      commandId: "not-valid-for-batch",
+    })).toThrow("only valid for a single command");
+  });
+
+  it("completes only the expected waiting round", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({
+      success: true,
+      message: "completed",
+      data: { completed: true },
+    }));
+    const output = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await createProgram().parseAsync([
+      "node", "hr", "--base-url", "http://manager.test", "--json",
+      "dag", "complete", "run/complete", "--expected-round", "round-0004",
+    ]);
+
+    expect(JSON.parse(String(output.mock.calls[0]?.[0]))).toEqual({ completed: true });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "http://manager.test/api/runs/run%2Fcomplete/complete",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ "X-Homerail-Dag-Token": "test-mutation-token" }),
+        body: JSON.stringify({ expected_round_id: "round-0004" }),
+      }),
+    );
+  });
+});

--- a/homerail_cli/tests/dag.test.ts
+++ b/homerail_cli/tests/dag.test.ts
@@ -391,6 +391,8 @@ describe("renderSnapshot", () => {
     const snap: DagSnapshot = {
       run_id: "run-001",
       run_status: "running",
+      waiting_for_command: false,
+      current_round_id: null,
       current_phase: "execute",
       dag_status: "active",
       node_counts: { running: 1, completed: 1 },
@@ -418,6 +420,8 @@ describe("renderSnapshotJson", () => {
     const snap: DagSnapshot = {
       run_id: "run-001",
       run_status: "completed",
+      waiting_for_command: false,
+      current_round_id: null,
       current_phase: null,
       dag_status: "done",
       node_counts: { completed: 3 },

--- a/homerail_manager/src/events/bus.ts
+++ b/homerail_manager/src/events/bus.ts
@@ -18,6 +18,12 @@ export type DAGEventType =
   | "dag:run_completed"
   | "dag:run_failed"
   | "dag:run_cancelled"
+  | "dag:run_waiting"
+  | "dag:run_resumed"
+  | "dag:run_expired"
+  | "dag:round_started"
+  | "dag:round_closed"
+  | "dag:command_queued"
   | "dag:artifact_pending"
   | "dag:artifact_ready"
   | "dag:artifact_failed"
@@ -80,6 +86,12 @@ export const DAG_EVENT_TYPES: DAGEventType[] = [
   "dag:run_completed",
   "dag:run_failed",
   "dag:run_cancelled",
+  "dag:run_waiting",
+  "dag:run_resumed",
+  "dag:run_expired",
+  "dag:round_started",
+  "dag:round_closed",
+  "dag:command_queued",
   "dag:artifact_pending",
   "dag:artifact_ready",
   "dag:artifact_failed",

--- a/homerail_manager/src/node/websocket.ts
+++ b/homerail_manager/src/node/websocket.ts
@@ -14,7 +14,10 @@ import {
   type NodeState,
 } from "./registry.js";
 import { resolveLifecycleResponse, rejectAllPendingRequests } from "./lifecycle-request.js";
-import { applyResponseHandoff } from "../orchestration/response-bridge.js";
+import {
+  applyResponseHandoff,
+  assessDagTransportFence,
+} from "../orchestration/response-bridge.js";
 import { handleDagMessageResponse } from "../orchestration/dag-message-router.js";
 import { clearByTargetId, isCurrentDispatchTarget } from "../orchestration/dispatch-tracker.js";
 import { emit } from "../events/bus.js";
@@ -23,6 +26,7 @@ import { appendSessionTranscriptEntry } from "../persistence/dag-session-files.j
 import {
   autoHandoffAfterCorrectionExhausted,
   failActiveRun,
+  getActiveRun,
   getCurrentNodeSession,
   recordAdvisorCall,
   requestNodeCorrection,
@@ -78,6 +82,28 @@ function objectData(value: unknown): Record<string, unknown> | undefined {
   return typeof value === "object" && value !== null && !Array.isArray(value)
     ? value as Record<string, unknown>
     : undefined;
+}
+
+function dagActivityRoundContext(data: Record<string, unknown>, runId: string): string {
+  const run = getActiveRun(runId);
+  if (!run) throw new Error(`DAG activity run ${runId} is not active`);
+  const currentRoundId = run.currentRound.round_id;
+  if (data.round_id !== undefined) {
+    if (typeof data.round_id !== "string" || !data.round_id.trim()) {
+      throw new Error("DAG activity transport round is invalid");
+    }
+    if (data.round_id !== currentRoundId) {
+      throw new Error(`DAG activity transport round ${data.round_id} is not current (${currentRoundId})`);
+    }
+    return currentRoundId;
+  }
+
+  const activityRoundId = objectData(data.activity)?.round_id;
+  const sessionId = dataSessionId(data);
+  if (run.currentRound.ordinal === 1 && typeof activityRoundId === "string" && activityRoundId === sessionId) {
+    return activityRoundId;
+  }
+  return currentRoundId;
 }
 
 function shouldIgnoreStaleSession(
@@ -228,9 +254,10 @@ export function setupNodeWebSocket(
 
       ws.on("message", (raw: Buffer) => {
         let msg: IncomingNodeMessage | null;
+        let rawMessage: unknown;
         try {
-          const parsed = JSON.parse(raw.toString());
-          msg = parseIncomingNodeMessage(parsed);
+          rawMessage = JSON.parse(raw.toString());
+          msg = parseIncomingNodeMessage(rawMessage);
         } catch {
           msg = null;
         }
@@ -369,18 +396,30 @@ export function setupNodeWebSocket(
             });
             options.onHandoffApplied?.(result.runId);
           } else {
+            const reason = result.status === "malformed_payload"
+              ? result.reason
+              : result.status === "unknown_run"
+                ? `unknown run ${result.runId}`
+                : result.reason;
             emit("dag:response_handoff_failed", {
               runId: "runId" in result ? (result.runId as string) : undefined,
-              nodeId: result.status === "handoff_failed" ? result.nodeId : undefined,
-              reason:
-                result.status === "malformed_payload"
-                  ? result.reason
-                  : result.status === "unknown_run"
-                    ? `unknown run ${result.runId}`
-                    : result.reason,
+              nodeId: result.status === "handoff_failed" || result.status === "handoff_ignored"
+                ? result.nodeId
+                : undefined,
+              reason,
               source: "node",
               sourceId: node_id,
             });
+            if (result.status === "handoff_ignored") {
+              mirrorSessionTranscript(
+                node_id,
+                `handoff_${result.disposition}_ignored`,
+                result.runId,
+                result.nodeId,
+                responseSessionId,
+                { disposition: result.disposition, reason, payload: msg.data },
+              );
+            }
             if (result.status === "handoff_failed") {
               tryCorrectNode(result.runId, result.nodeId, result.reason);
             }
@@ -400,10 +439,11 @@ export function setupNodeWebSocket(
                 throw new Error("DAG activity source does not match the current dispatch target");
               }
               if (shouldIgnoreStaleSession(node_id, "dag_activity", msg.data)) return;
+              const roundId = dagActivityRoundContext(msg.data, runId);
               ingestDagActivityStream(msg.data, {
                 runId,
                 nodeId,
-                roundId: sessionId,
+                roundId,
               });
             } catch (error) {
               console.warn(
@@ -438,16 +478,42 @@ export function setupNodeWebSocket(
         }
 
         if (msg.type === "node_error") {
+          const rawData = objectData(objectData(rawMessage)?.data) ?? msg.data;
           if (shouldIgnoreStaleSession(node_id, "node_error", {
             runId: msg.data.runId,
             nodeId: msg.data.nodeId,
             session_id: msg.data.session_id,
           })) return;
+          const assessment = assessDagTransportFence(rawData);
+          if (assessment.status !== "current") {
+            const runId = assessment.status === "malformed_payload" ? msg.data.runId : assessment.runId;
+            const dagNodeId = assessment.status === "malformed_payload" ? msg.data.nodeId : assessment.nodeId;
+            const disposition = assessment.status === "ignored" ? assessment.disposition : assessment.status;
+            const reason = assessment.status === "unknown_run"
+              ? `unknown run ${assessment.runId}`
+              : assessment.reason;
+            emit("dag:response_handoff_failed", {
+              runId,
+              nodeId: dagNodeId,
+              reason: `node_error ${disposition} ignored: ${reason}`,
+              source: "node",
+              sourceId: node_id,
+            });
+            mirrorSessionTranscript(
+              node_id,
+              `node_error_${disposition}_ignored`,
+              runId,
+              dagNodeId,
+              msg.data.session_id,
+              { disposition, reason, payload: rawData },
+            );
+            return;
+          }
           appendChatEntry(msg.data.runId, msg.data.nodeId, {
             role: "node",
             type: "response",
             targetId: node_id,
-            content: msg.data,
+            content: rawData,
             timestamp: Date.now(),
           });
           mirrorSessionTranscript(
@@ -456,7 +522,7 @@ export function setupNodeWebSocket(
             msg.data.runId,
             msg.data.nodeId,
             msg.data.session_id,
-            msg.data,
+            rawData,
           );
           if (tryCorrectNode(msg.data.runId, msg.data.nodeId, msg.data.message)) {
             return;

--- a/homerail_manager/src/orchestration/change-orchestrator.ts
+++ b/homerail_manager/src/orchestration/change-orchestrator.ts
@@ -13,12 +13,24 @@ import {
   parseStoredDagWorkflow,
   resolveDagRuntimeProfile,
 } from "../persistence/dag-workflows.js";
-import { appendRunNode, cancelActiveRun, cancelAllActiveRuns, checkpointResumeActiveRun, decideActiveRunApproval, injectActiveRun } from "../runtime/active-runs.js";
+import {
+  appendRunNode,
+  cancelActiveRun,
+  cancelAllActiveRuns,
+  checkpointResumeActiveRun,
+  completeActiveRun,
+  deduplicateWaitingActiveRunResume,
+  decideActiveRunApproval,
+  injectActiveRun,
+  resumeWaitingActiveRun,
+  type ResumeWaitingRunRequest,
+} from "../runtime/active-runs.js";
 import type { DagApprovalRecord } from "../persistence/dag-runtime-primitives.js";
 import type { InjectResult, CancelAllResult, CheckpointResumeRequest } from "../runtime/active-runs.js";
 import { emit } from "../events/bus.js";
 import {
   deriveWorkflowConcurrencyPolicy,
+  loadWorkflowConcurrencyPolicy,
   releaseWorkflowRunReservation,
   reserveWorkflowRun,
 } from "../persistence/dag-run-admission.js";
@@ -63,6 +75,19 @@ export interface InjectRunResponse {
   delivery_target_type?: "worker" | "node";
   delivery_target_id?: string;
   delivery_gap?: string;
+}
+
+export interface ResumeRunResponse {
+  resumed: true;
+  previous_round_id: string;
+  round_id: string;
+  ordinal: number;
+  actor_ids: string[];
+  node_ids: string[];
+  command_ids: string[];
+  ready_node_ids: string[];
+  dispatched: number;
+  deduplicated?: boolean;
 }
 
 export interface CheckpointResumeResponse {
@@ -332,6 +357,53 @@ export class ChangeOrchestrator {
     }
     cancelActiveRun(runId);
     return true;
+  }
+
+  completeRun(runId: string, expectedRoundId: string): boolean {
+    const run = this.graphExecutor.getRun(runId);
+    if (!run) throw new Error(`Run not found: ${runId}`);
+    if (run.status !== "waiting") throw new Error(`Run ${runId} is not waiting for explicit completion`);
+    if (!expectedRoundId.trim() || run.currentRound.round_id !== expectedRoundId.trim()) {
+      throw new Error(`Waiting round conflict: current round is ${run.currentRound.round_id}`);
+    }
+    completeActiveRun(runId);
+    return true;
+  }
+
+  resumeRun(runId: string, request: ResumeWaitingRunRequest): ResumeRunResponse {
+    const run = this.graphExecutor.getRun(runId);
+    if (!run) throw new Error(`Run not found: ${runId}`);
+
+    const alreadyResumed = deduplicateWaitingActiveRunResume(runId, request);
+    const resumed = alreadyResumed ?? (() => {
+      const reservationId = `resume:${runId}`;
+      const reservation = run.status === "waiting" && run.workflowId
+        ? reserveWorkflowRun({
+            runId: reservationId,
+            workflowId: run.workflowId,
+            source: "resume:command",
+            policy: loadWorkflowConcurrencyPolicy(run.workflowId),
+          })
+        : { reserved: false };
+      try {
+        return resumeWaitingActiveRun(runId, request);
+      } finally {
+        if (reservation.reserved) releaseWorkflowRunReservation(reservationId);
+      }
+    })();
+    const dispatched = this.graphExecutor.tick(runId);
+    return {
+      resumed: true,
+      previous_round_id: resumed.previousRoundId,
+      round_id: resumed.roundId,
+      ordinal: resumed.ordinal,
+      actor_ids: resumed.actorIds,
+      node_ids: resumed.nodeIds,
+      command_ids: resumed.commandIds,
+      ready_node_ids: resumed.readyNodeIds,
+      dispatched,
+      ...(resumed.deduplicated ? { deduplicated: true } : {}),
+    };
   }
 
   emergencyStopAllRuns(): { stopped: number; run_ids: string[]; active_before: number; active_after: number } {

--- a/homerail_manager/src/orchestration/dag-dispatcher.ts
+++ b/homerail_manager/src/orchestration/dag-dispatcher.ts
@@ -29,6 +29,7 @@ export interface DispatchEnvelope {
     roundId: string;
     actorId: string;
     generation: number;
+    commandId?: string;
     surfaceId?: string;
     sequenceStart: number;
   };

--- a/homerail_manager/src/orchestration/dag-engine.ts
+++ b/homerail_manager/src/orchestration/dag-engine.ts
@@ -6,6 +6,7 @@ export type NodeState =
   | "READY"
   | "RUNNING"
   | "WAITING_FOR_APPROVAL"
+  | "WAITING_FOR_COMMAND"
   | "COMPLETED"
   | "FAILED"
   | "CANCELLED"
@@ -29,6 +30,21 @@ export interface DAGTransitionResult {
   routedNodes: string[];
   terminalFailure?: boolean;
   terminalOutcome?: "success" | "failure" | "cancelled";
+}
+
+export interface DAGRoundResetInput {
+  resetNodeIds: Iterable<string>;
+  commandInputs?: ReadonlyMap<string, { port: string; value: unknown }>;
+  carryoverInputs?: ReadonlyMap<string, ReadonlyArray<{
+    fromNode: string;
+    port: string;
+    value: unknown;
+  }>>;
+}
+
+export interface DAGRoundResetResult {
+  resetNodes: string[];
+  readyNodes: string[];
 }
 
 export function isFailurePort(port: string): boolean {
@@ -181,6 +197,7 @@ function _hasAlternativePath(run: DAGRun, nodeId: string, excludePred: string): 
     if (
       status === "COMPLETED" ||
       status === "RUNNING" ||
+      status === "WAITING_FOR_COMMAND" ||
       status === "PENDING" ||
       status === "READY"
     ) {
@@ -421,6 +438,7 @@ export function failNode(
 export function isRunTerminal(run: DAGRun): boolean {
   for (const [id, state] of run.nodeStates) {
     if (state === "READY") return false;
+    if (state === "WAITING_FOR_COMMAND" || state === "WAITING_FOR_APPROVAL") return false;
     if (state === "FAILED") continue;
     if (state === "SKIPPED" || state === "CANCELLED") continue;
     if (run.loopSources.has(id) && state === "RUNNING") continue;
@@ -428,6 +446,65 @@ export function isRunTerminal(run: DAGRun): boolean {
     if (state !== "COMPLETED") return false;
   }
   return true;
+}
+
+/**
+ * Re-opens a bounded subset of a completed DAG for a new command round.
+ * Nodes outside the subset retain their latest result and satisfy structural
+ * dependencies, but their payload is not replayed into the new round. This
+ * keeps a round scoped to the explicitly selected logical actors.
+ */
+export function resetNodesForRound(
+  run: DAGRun,
+  input: DAGRoundResetInput,
+): DAGRoundResetResult {
+  const resetNodes = Array.from(new Set(input.resetNodeIds)).sort();
+  if (resetNodes.length === 0) throw new Error("A DAG round must reset at least one node");
+  for (const nodeId of resetNodes) {
+    if (!run.nodeStates.has(nodeId)) throw new Error(`Unknown node: ${nodeId}`);
+  }
+
+  const reset = new Set(resetNodes);
+  const previousStates = new Map(run.nodeStates);
+  const previousHandoffs = new Set(run.handoffedNodes);
+
+  for (const nodeId of resetNodes) {
+    run.nodeStates.set(nodeId, "PENDING");
+    run.handoffedNodes.delete(nodeId);
+    run.afterSatisfied.set(nodeId, new Set<string>());
+    run.inputSatisfied.set(nodeId, new Set<string>());
+    run.mailboxes.set(nodeId, new Map<string, unknown[]>());
+  }
+
+  for (const nodeId of resetNodes) {
+    const afterSatisfied = run.afterSatisfied.get(nodeId)!;
+    const inputSatisfied = run.inputSatisfied.get(nodeId)!;
+    for (const carryover of input.carryoverInputs?.get(nodeId) ?? []) {
+      const mailbox = run.mailboxes.get(nodeId)!;
+      const values = mailbox.get(carryover.port) ?? [];
+      values.push(carryover.value);
+      mailbox.set(carryover.port, values);
+      inputSatisfied.add(carryover.fromNode);
+    }
+    for (const dependency of _incomingAfterDeps(run.graph.edges, nodeId)) {
+      if (reset.has(dependency.from_node)) continue;
+      const previous = previousStates.get(dependency.from_node);
+      const supplied = previousHandoffs.has(dependency.from_node)
+        && previous !== "FAILED"
+        && previous !== "CANCELLED"
+        && previous !== "SKIPPED";
+      if (!supplied) continue;
+      afterSatisfied.add(dependency.from_node);
+    }
+    const command = input.commandInputs?.get(nodeId);
+    if (command) run.mailboxes.get(nodeId)!.set(command.port, [command.value]);
+  }
+
+  for (const nodeId of resetNodes) _tryPromote(run, nodeId);
+  return {
+    resetNodes,
+    readyNodes: resetNodes.filter((nodeId) => run.nodeStates.get(nodeId) === "READY"),
+  };
 }
 
 export function getReadyNodes(run: DAGRun): string[] {

--- a/homerail_manager/src/orchestration/graph-validator.ts
+++ b/homerail_manager/src/orchestration/graph-validator.ts
@@ -18,6 +18,18 @@ function _isTerminalEdge(edge: DAGEdge): boolean {
   return edge.to_node === "";
 }
 
+function _isGatewayNodeType(nodeType: string): boolean {
+  return nodeType === "loop_gateway" ||
+    nodeType === "condition_gateway" ||
+    nodeType === "join_gateway" ||
+    nodeType === "while_gateway" ||
+    nodeType === "command_gateway" ||
+    nodeType === "approval_gateway" ||
+    nodeType === "state_gateway" ||
+    nodeType === "fanout_gateway" ||
+    nodeType === "await_command_gateway";
+}
+
 function _isLoopFeedbackEdge(graph: DAGGraphData, edge: DAGEdge): boolean {
   if (_isTerminalEdge(edge)) return false;
   const target = graph.nodes.find((node) => node.node_id === edge.to_node);
@@ -52,12 +64,17 @@ function _entryNodes(graph: DAGGraphData): string[] {
 
 function _terminalNodes(graph: DAGGraphData): string[] {
   const ids = new Set(_nodeIds(graph));
+  const suspensionNodes = new Set(
+    graph.nodes
+      .filter((node) => node.node_type === "await_command_gateway")
+      .map((node) => node.node_id),
+  );
   const outgoing = new Set<string>();
   for (const edge of graph.edges) {
     if (_isFailureEdge(edge) || _isTerminalEdge(edge)) continue;
     if (ids.has(edge.from_node)) outgoing.add(edge.from_node);
   }
-  return Array.from(ids).filter((id) => !outgoing.has(id)).sort();
+  return Array.from(ids).filter((id) => !outgoing.has(id) && !suspensionNodes.has(id)).sort();
 }
 
 function _explicitTerminalNodes(graph: DAGGraphData): Set<string> {
@@ -136,8 +153,27 @@ function _maxRetries(edge: DAGEdge): number | undefined {
 
 const JOIN_MODES = new Set(["all", "any", "n_of_m"]);
 const WHILE_OPERATORS = new Set(["eq", "ne", "gt", "gte", "lt", "lte", "truthy", "falsy"]);
+const NODE_IDENTIFIER = /^[a-z][a-z0-9]*(?:[-_][a-z0-9]+)*$/;
+const AWAIT_COMMAND_CONFIG_FIELDS = new Set([
+  "type",
+  "kind",
+  "primitive_version",
+  "target_actors",
+  "expires_after_ms",
+  "command_port",
+]);
 
 function _validateGatewayConfigs(graph: DAGGraphData, errors: string[]): void {
+  const nodesById = new Map(graph.nodes.map((node) => [node.node_id, node]));
+  const awaitCommandNodes = graph.nodes.filter((node) => node.node_type === "await_command_gateway");
+  if (awaitCommandNodes.length > 1) {
+    errors.push(
+      `Graph supports at most one await_command gateway: ${awaitCommandNodes
+        .map((node) => node.node_id)
+        .sort()
+        .join(", ")}`,
+    );
+  }
   for (const node of graph.nodes) {
     const config = node.gateway_config;
     if (node.node_type === "join_gateway") {
@@ -185,6 +221,66 @@ function _validateGatewayConfigs(graph: DAGGraphData, errors: string[]): void {
       const maxIterations = config?.max_iterations ?? 3;
       if (!Number.isInteger(maxIterations) || maxIterations < 1) {
         errors.push(`While gateway ${node.node_id} requires max_iterations to be a positive integer`);
+      }
+    }
+    if (node.node_type === "await_command_gateway") {
+      if (Object.keys(node.outputs).length > 0) {
+        errors.push(`await_command ${node.node_id} does not support output routes`);
+      }
+      if (graph.edges.some((edge) => edge.from_node === node.node_id)) {
+        errors.push(
+          `await_command ${node.node_id} cannot have outgoing edges or downstream dependents`,
+        );
+      }
+      const unknownFields = Object.keys(config ?? {}).filter((field) => !AWAIT_COMMAND_CONFIG_FIELDS.has(field));
+      if (unknownFields.length > 0) {
+        errors.push(`await_command ${node.node_id} has unsupported config fields: ${unknownFields.sort().join(", ")}`);
+      }
+      if (config?.primitive_version !== 1 || !Number.isInteger(config.primitive_version)) {
+        errors.push(`await_command ${node.node_id} requires primitive_version 1`);
+      }
+      if (
+        config?.expires_after_ms !== undefined &&
+        (!Number.isInteger(config.expires_after_ms) || config.expires_after_ms < 1_000)
+      ) {
+        errors.push(`await_command ${node.node_id} requires expires_after_ms to be an integer of at least 1000`);
+      }
+      if (
+        config?.command_port !== undefined &&
+        (typeof config.command_port !== "string" || !NODE_IDENTIFIER.test(config.command_port))
+      ) {
+        errors.push(`await_command ${node.node_id} has invalid command_port identifier`);
+      }
+
+      const targetActors: unknown = config?.target_actors;
+      if (targetActors !== undefined) {
+        if (!Array.isArray(targetActors) || targetActors.length > 256) {
+          errors.push(`await_command ${node.node_id} requires target_actors to contain at most 256 unique node identifiers`);
+          continue;
+        }
+        const seen = new Set<string>();
+        for (let index = 0; index < targetActors.length; index++) {
+          const targetActor: unknown = targetActors[index];
+          if (typeof targetActor !== "string" || !NODE_IDENTIFIER.test(targetActor)) {
+            errors.push(`await_command ${node.node_id} target_actors[${index}] is not a valid node identifier`);
+            continue;
+          }
+          if (seen.has(targetActor)) {
+            errors.push(`await_command ${node.node_id} has duplicate target actor: ${targetActor}`);
+            continue;
+          }
+          seen.add(targetActor);
+          if (targetActor === node.node_id) {
+            errors.push(`await_command ${node.node_id} cannot target itself`);
+            continue;
+          }
+          const targetNode = nodesById.get(targetActor);
+          if (!targetNode) {
+            errors.push(`await_command ${node.node_id} references unknown target actor: ${targetActor}`);
+          } else if (_isGatewayNodeType(targetNode.node_type) || targetNode.node_type !== "agent") {
+            errors.push(`await_command ${node.node_id} target actor ${targetActor} must reference an agent node`);
+          }
+        }
       }
     }
   }
@@ -245,7 +341,8 @@ export function validateGraph(graph: DAGGraphData): GraphValidationResult {
     if (idSet.has(edge.from_node) && !_isFailureEdge(edge)) outgoing.add(edge.from_node);
   }
   for (const id of ids) {
-    if (!outgoing.has(id) && !explicitTerminal.has(id)) {
+    const node = graph.nodes.find((candidate) => candidate.node_id === id);
+    if (!outgoing.has(id) && !explicitTerminal.has(id) && node?.node_type !== "await_command_gateway") {
       warnings.push(`Dead-end node (no terminal or outgoing edges): ${id}`);
     }
   }

--- a/homerail_manager/src/orchestration/graph.ts
+++ b/homerail_manager/src/orchestration/graph.ts
@@ -34,8 +34,8 @@ export interface DAGNodeRequirements {
 }
 
 export interface DAGGatewayConfig {
-  type?: "loop" | "condition" | "join" | "while" | "command" | "approval" | "state" | "fanout" | string;
-  kind?: "loop" | "condition" | "join" | "while" | "command" | "approval" | "state" | "fanout" | string;
+  type?: "loop" | "condition" | "join" | "while" | "command" | "approval" | "state" | "fanout" | "await_command" | string;
+  kind?: "loop" | "condition" | "join" | "while" | "command" | "approval" | "state" | "fanout" | "await_command" | string;
   mode?: "all" | "any" | "n_of_m" | string;
   field?: string;
   routes?: Record<string, string>;
@@ -73,7 +73,10 @@ export interface DAGGatewayConfig {
   authorized_actors?: string[];
   approved_port?: string;
   rejected_port?: string;
+  primitive_version?: 1;
+  target_actors?: string[];
   expires_after_ms?: number;
+  command_port?: string;
   namespace?: string;
   key?: string;
   key_field?: string;

--- a/homerail_manager/src/orchestration/response-bridge.ts
+++ b/homerail_manager/src/orchestration/response-bridge.ts
@@ -1,10 +1,177 @@
-import { handoffActiveRun } from "../runtime/active-runs.js";
+import type { DagTransportFenceMetadata } from "homerail-protocol";
+import { getDagActorByNode, getDagActorCommand } from "../persistence/dag-actors.js";
+import { getActiveRun, handoffActiveRun } from "../runtime/active-runs.js";
+
+export type TransportFenceDisposition = "stale" | "duplicate" | "invalid";
+
+export type TransportFenceAssessment =
+  | ({ status: "current"; runId: string; nodeId: string } & DagTransportFenceMetadata)
+  | { status: "unknown_run"; runId: string; nodeId: string }
+  | {
+      status: "ignored";
+      disposition: TransportFenceDisposition;
+      runId: string;
+      nodeId: string;
+      reason: string;
+    }
+  | { status: "malformed_payload"; reason: string };
 
 export type ResponseBridgeResult =
   | { status: "handoff_applied"; runId: string; nodeId: string; port: string }
+  | {
+      status: "handoff_ignored";
+      disposition: TransportFenceDisposition;
+      runId: string;
+      nodeId: string;
+      reason: string;
+    }
   | { status: "malformed_payload"; reason: string }
   | { status: "unknown_run"; runId: string }
   | { status: "handoff_failed"; runId: string; nodeId: string; reason: string };
+
+function transportMetadataError(obj: Record<string, unknown>): string | undefined {
+  for (const field of ["round_id", "actor_id", "command_id"] as const) {
+    const value = obj[field];
+    if (value !== undefined && (typeof value !== "string" || value.trim().length === 0 || value.length > 256)) {
+      return `${field} must be a non-empty string of at most 256 characters`;
+    }
+  }
+  if (obj.generation !== undefined && (
+    typeof obj.generation !== "number"
+    || !Number.isSafeInteger(obj.generation)
+    || obj.generation < 1
+  )) {
+    return "generation must be a positive safe integer";
+  }
+  return undefined;
+}
+
+function ignored(
+  disposition: TransportFenceDisposition,
+  runId: string,
+  nodeId: string,
+  reason: string,
+): TransportFenceAssessment {
+  return { status: "ignored", disposition, runId, nodeId, reason };
+}
+
+/**
+ * Resolve terminal transport identity without mutating the active run. Fence
+ * conflicts are ignored here so they can never enter correction/failure paths.
+ */
+export function assessDagTransportFence(payload: unknown): TransportFenceAssessment {
+  if (typeof payload !== "object" || payload === null || Array.isArray(payload)) {
+    return { status: "malformed_payload", reason: "payload is not an object" };
+  }
+  const obj = payload as Record<string, unknown>;
+  if (typeof obj.runId !== "string") {
+    return { status: "malformed_payload", reason: "runId must be a string" };
+  }
+  if (typeof obj.nodeId !== "string") {
+    return { status: "malformed_payload", reason: "nodeId must be a string" };
+  }
+  const metadataError = transportMetadataError(obj);
+  if (metadataError) return { status: "malformed_payload", reason: metadataError };
+
+  const runId = obj.runId;
+  const nodeId = obj.nodeId;
+  const run = getActiveRun(runId);
+  if (!run) return { status: "unknown_run", runId, nodeId };
+  const actor = getDagActorByNode(runId, nodeId);
+  if (!actor) {
+    return ignored("invalid", runId, nodeId, `DAG_TRANSPORT_ACTOR_FENCE_MISSING ${runId}/${nodeId}`);
+  }
+
+  const roundId = typeof obj.round_id === "string" ? obj.round_id : undefined;
+  const actorId = typeof obj.actor_id === "string" ? obj.actor_id : undefined;
+  const generation = typeof obj.generation === "number" ? obj.generation : undefined;
+  const commandId = typeof obj.command_id === "string" ? obj.command_id : undefined;
+  const currentRoundId = run.currentRound.round_id;
+  const requiresDurableFence = run.currentRound.ordinal > 1;
+
+  if (!roundId) {
+    if (requiresDurableFence) {
+      return ignored(
+        "stale",
+        runId,
+        nodeId,
+        `DAG_TRANSPORT_ROUND_FENCE_MISSING ${runId}/${nodeId}: current ${currentRoundId}`,
+      );
+    }
+    if (run.dagRun.handoffedNodes.has(nodeId)) {
+      return ignored("duplicate", runId, nodeId, `DAG_TRANSPORT_HANDOFF_DUPLICATE ${runId}/${nodeId}`);
+    }
+    if (run.status !== "active") {
+      return ignored("stale", runId, nodeId, `DAG_TRANSPORT_RUN_NOT_ACTIVE ${runId}: ${run.status}`);
+    }
+    return { status: "current", runId, nodeId };
+  }
+
+  if (roundId !== currentRoundId) {
+    return ignored(
+      "stale",
+      runId,
+      nodeId,
+      `DAG_TRANSPORT_ROUND_STALE ${runId}/${nodeId}: received ${roundId}, current ${currentRoundId}`,
+    );
+  }
+  if (actorId !== undefined && actorId !== actor.actor_id) {
+    return ignored("invalid", runId, nodeId, `DAG_TRANSPORT_ACTOR_CONFLICT ${runId}/${nodeId}`);
+  }
+  if (generation !== undefined && generation !== actor.generation) {
+    const disposition = generation < actor.generation ? "stale" : "invalid";
+    return ignored(
+      disposition,
+      runId,
+      nodeId,
+      `DAG_TRANSPORT_GENERATION_${disposition === "stale" ? "STALE" : "CONFLICT"} ${runId}/${nodeId}: received ${generation}, current ${actor.generation}`,
+    );
+  }
+
+  if (commandId) {
+    const command = getDagActorCommand(commandId);
+    if (!command) {
+      return ignored("invalid", runId, nodeId, `DAG_TRANSPORT_COMMAND_UNKNOWN ${runId}/${nodeId}: ${commandId}`);
+    }
+    if (command.run_id !== runId || command.actor_id !== actor.actor_id) {
+      return ignored("invalid", runId, nodeId, `DAG_TRANSPORT_COMMAND_CONFLICT ${runId}/${nodeId}`);
+    }
+    if (command.round_id !== currentRoundId || command.target_generation !== actor.generation) {
+      const disposition = command.round_id !== currentRoundId || command.target_generation < actor.generation
+        ? "stale"
+        : "invalid";
+      return ignored(
+        disposition,
+        runId,
+        nodeId,
+        `DAG_TRANSPORT_COMMAND_${disposition === "stale" ? "STALE" : "CONFLICT"} ${runId}/${nodeId}: ${commandId}`,
+      );
+    }
+    if (command.status === "acknowledged") {
+      return ignored("duplicate", runId, nodeId, `DAG_TRANSPORT_COMMAND_DUPLICATE ${runId}/${nodeId}: ${commandId}`);
+    }
+  }
+
+  if (run.dagRun.handoffedNodes.has(nodeId)) {
+    return ignored("duplicate", runId, nodeId, `DAG_TRANSPORT_HANDOFF_DUPLICATE ${runId}/${nodeId}`);
+  }
+  if (run.status !== "active") {
+    return ignored("stale", runId, nodeId, `DAG_TRANSPORT_RUN_NOT_ACTIVE ${runId}: ${run.status}`);
+  }
+  if (requiresDurableFence && (!actorId || generation === undefined || !commandId)) {
+    return ignored("invalid", runId, nodeId, `DAG_TRANSPORT_COMMAND_FENCE_MISSING ${runId}/${nodeId}`);
+  }
+
+  return {
+    status: "current",
+    runId,
+    nodeId,
+    round_id: roundId,
+    ...(actorId === undefined ? {} : { actor_id: actorId }),
+    ...(generation === undefined ? {} : { generation }),
+    ...(commandId === undefined ? {} : { command_id: commandId }),
+  };
+}
 
 export function applyResponseHandoff(payload: unknown): ResponseBridgeResult {
   if (typeof payload !== "object" || payload === null) {
@@ -37,9 +204,30 @@ export function applyResponseHandoff(payload: unknown): ResponseBridgeResult {
     };
   }
 
+  const assessment = assessDagTransportFence(obj);
+  if (assessment.status === "malformed_payload") return assessment;
+  if (assessment.status === "unknown_run") {
+    return { status: "unknown_run", runId: assessment.runId };
+  }
+  if (assessment.status === "ignored") {
+    return {
+      status: "handoff_ignored",
+      disposition: assessment.disposition,
+      runId: assessment.runId,
+      nodeId: assessment.nodeId,
+      reason: assessment.reason,
+    };
+  }
+
   let run;
   try {
-    run = handoffActiveRun(obj.runId, obj.nodeId, obj.port, obj.content);
+    run = handoffActiveRun(obj.runId, obj.nodeId, obj.port, obj.content, {
+      transport: true,
+      ...(typeof obj.round_id === "string" ? { roundId: obj.round_id } : {}),
+      ...(typeof obj.actor_id === "string" ? { actorId: obj.actor_id } : {}),
+      ...(typeof obj.generation === "number" ? { generation: obj.generation } : {}),
+      ...(typeof obj.command_id === "string" ? { commandId: obj.command_id } : {}),
+    });
   } catch (error) {
     return {
       status: "handoff_failed",

--- a/homerail_manager/src/orchestration/workflow-spec-v1-schema.ts
+++ b/homerail_manager/src/orchestration/workflow-spec-v1-schema.ts
@@ -3,7 +3,7 @@ import { AGENT_BUILTIN_TOOL_NAMES, DAG_AGENT_TOOL_NAMES } from "homerail-protoco
 
 export const WORKFLOW_API_VERSION = "homerail.ai/v1" as const;
 export const WORKFLOW_KIND = "Workflow" as const;
-export const WORKFLOW_COMPILER_VERSION = "4" as const;
+export const WORKFLOW_COMPILER_VERSION = "5" as const;
 
 const IDENTIFIER_PATTERN = "^[a-z][a-z0-9]*(?:[-_][a-z0-9]+)*$";
 const PORT_REFERENCE_PATTERN = "^(?:\\$run\\.input|[a-z][a-z0-9]*(?:[-_][a-z0-9]+)*\\.[a-z][a-z0-9]*(?:[-_][a-z0-9]+)*)$";
@@ -244,6 +244,25 @@ const FanoutNode = Type.Object({
   }, { additionalProperties: false }),
 }, { additionalProperties: false });
 
+const AwaitCommandNode = Type.Object({
+  kind: Type.Literal("await_command"),
+  description: Type.Optional(ShortText),
+  depends_on: Type.Optional(Type.Array(Identifier, {
+    uniqueItems: true,
+    maxItems: 256,
+  })),
+  inputs: Type.Optional(PortMap),
+  config: Type.Object({
+    primitive_version: Type.Literal(1),
+    target_actors: Type.Optional(Type.Array(Identifier, {
+      uniqueItems: true,
+      maxItems: 256,
+    })),
+    expires_after_ms: Type.Optional(Type.Integer({ minimum: 1_000 })),
+    command_port: Type.Optional(Identifier),
+  }, { additionalProperties: false }),
+}, { additionalProperties: false });
+
 const ConditionNode = Type.Object({
   kind: Type.Literal("condition"),
   ...NodeBase,
@@ -328,6 +347,7 @@ const WorkflowNode = Type.Union([
   ApprovalNode,
   StateNode,
   FanoutNode,
+  AwaitCommandNode,
   ConditionNode,
   JoinNode,
   ForeachNode,

--- a/homerail_manager/src/orchestration/workflow-spec-v1.ts
+++ b/homerail_manager/src/orchestration/workflow-spec-v1.ts
@@ -44,7 +44,7 @@ export interface CanonicalPort {
 
 export interface CanonicalNode {
   id: string;
-  kind: "agent" | "command" | "approval" | "state" | "fanout" | "condition" | "join" | "foreach" | "while" | "terminal";
+  kind: "agent" | "command" | "approval" | "state" | "fanout" | "await_command" | "condition" | "join" | "foreach" | "while" | "terminal";
   description?: string;
   agent?: string;
   depends_on: string[];
@@ -260,7 +260,7 @@ function portEntries(ports: Record<string, { contract?: string; description?: st
 
 function nodePorts(node: WorkflowSpecV1Node, direction: "inputs" | "outputs"): Record<string, { contract?: string }> {
   if (direction === "inputs") return node.inputs ?? {};
-  if (node.kind === "terminal") return {};
+  if (node.kind === "terminal" || node.kind === "await_command") return {};
   return node.outputs ?? {};
 }
 
@@ -283,6 +283,18 @@ function semanticDiagnostics(context: SourceContext, workflow: WorkflowSpecV1): 
       ...(hint ? { hint } : {}),
     }));
   };
+
+  const awaitCommandNodeIds = Object.entries(nodes)
+    .filter(([, node]) => node.kind === "await_command")
+    .map(([nodeId]) => nodeId)
+    .sort();
+  if (awaitCommandNodeIds.length > 1) {
+    add(
+      "/spec/nodes",
+      "DAG_SEMANTIC_MULTIPLE_AWAIT_COMMAND",
+      `workflow supports at most one await_command node: ${awaitCommandNodeIds.join(", ")}`,
+    );
+  }
 
   for (const [contractName, contract] of Object.entries(contracts)) {
     const validation = validateJsonContractSchema(contract);
@@ -389,6 +401,12 @@ function semanticDiagnostics(context: SourceContext, workflow: WorkflowSpecV1): 
         add(`${nodePath}/depends_on`, "DAG_SEMANTIC_UNKNOWN_NODE", `unknown dependency '${dependency}'`);
       } else if (dependency === nodeId) {
         add(`${nodePath}/depends_on`, "DAG_SEMANTIC_SELF_DEPENDENCY", "a node cannot depend on itself");
+      } else if (nodes[dependency].kind === "await_command") {
+        add(
+          `${nodePath}/depends_on`,
+          "DAG_SEMANTIC_AWAIT_COMMAND_DOWNSTREAM",
+          `await_command '${dependency}' cannot have downstream dependents`,
+        );
       }
     }
     for (const direction of ["inputs", "outputs"] as const) {
@@ -494,6 +512,25 @@ function semanticDiagnostics(context: SourceContext, workflow: WorkflowSpecV1): 
       }
       if (node.config.max_parallelism > node.config.max_items) {
         add(`${nodePath}/config/max_parallelism`, "DAG_SEMANTIC_INVALID_PARALLELISM", "max_parallelism cannot exceed max_items");
+      }
+    }
+    if (node.kind === "await_command") {
+      for (let index = 0; index < (node.config.target_actors ?? []).length; index++) {
+        const targetActor = node.config.target_actors![index];
+        const targetNode = nodes[targetActor];
+        if (!targetNode) {
+          add(
+            `${nodePath}/config/target_actors/${index}`,
+            "DAG_SEMANTIC_UNKNOWN_NODE",
+            `unknown target actor node '${targetActor}'`,
+          );
+        } else if (targetActor === nodeId || targetNode.kind !== "agent") {
+          add(
+            `${nodePath}/config/target_actors/${index}`,
+            "DAG_SEMANTIC_INVALID_TARGET_ACTOR",
+            `target actor '${targetActor}' must reference an agent node`,
+          );
+        }
       }
     }
     if (node.kind === "foreach") {
@@ -638,11 +675,18 @@ function semanticDiagnostics(context: SourceContext, workflow: WorkflowSpecV1): 
   const terminalNodes = Object.entries(nodes)
     .filter(([, node]) => node.kind === "terminal")
     .map(([id]) => id);
-  if (terminalNodes.length === 0) {
-    add("/spec/nodes", "DAG_SEMANTIC_TERMINAL_REQUIRED", "workflow must contain at least one terminal node");
+  const suspensionNodes = Object.entries(nodes)
+    .filter(([, node]) => node.kind === "await_command")
+    .map(([id]) => id);
+  if (terminalNodes.length === 0 && suspensionNodes.length === 0) {
+    add(
+      "/spec/nodes",
+      "DAG_SEMANTIC_TERMINAL_REQUIRED",
+      "workflow must contain at least one terminal or await_command node",
+    );
   } else {
-    const reachesTerminal = new Set(terminalNodes);
-    const queue = [...terminalNodes];
+    const reachesTerminal = new Set([...terminalNodes, ...suspensionNodes]);
+    const queue = [...reachesTerminal];
     while (queue.length > 0) {
       const current = queue.shift()!;
       for (const predecessor of reverseReachability.get(current) ?? []) {
@@ -654,7 +698,11 @@ function semanticDiagnostics(context: SourceContext, workflow: WorkflowSpecV1): 
     }
     for (const [nodeId, node] of Object.entries(nodes)) {
       if (node.kind !== "terminal" && !reachesTerminal.has(nodeId)) {
-        add(`/spec/nodes/${nodeId}`, "DAG_SEMANTIC_NO_TERMINAL_PATH", `node '${nodeId}' has no path to a terminal node`);
+        add(
+          `/spec/nodes/${nodeId}`,
+          "DAG_SEMANTIC_NO_TERMINAL_PATH",
+          `node '${nodeId}' has no path to a terminal or await_command node`,
+        );
       }
     }
   }
@@ -683,7 +731,7 @@ function canonicalNode(id: string, node: WorkflowSpecV1Node): CanonicalNode {
     ...(node.description ? { description: node.description } : {}),
     depends_on: [...(node.depends_on ?? [])].sort(),
     inputs: portEntries(node.inputs),
-    outputs: node.kind === "terminal" ? [] : portEntries(node.outputs),
+    outputs: node.kind === "terminal" || node.kind === "await_command" ? [] : portEntries(node.outputs),
   };
   if (node.kind === "agent") {
     const config = {
@@ -866,11 +914,21 @@ function compileV1(workflow: WorkflowSpecV1): CanonicalWorkflowIR {
 }
 
 function legacyKind(node: DAGGraphNode): CanonicalNode["kind"] {
+  if (node.node_type === "await_command_gateway") return "await_command";
   if (node.node_type === "condition_gateway") return "condition";
   if (node.node_type === "join_gateway") return "join";
   if (node.node_type === "loop_gateway") return "foreach";
   if (node.node_type === "while_gateway") return "while";
   return "agent";
+}
+
+function legacyConfig(node: DAGGraphNode, kind: CanonicalNode["kind"]): Record<string, unknown> {
+  const config = node.gateway_config ?? {};
+  if (kind === "await_command") {
+    const { type: _type, kind: _kind, ...strictConfig } = config;
+    return deepSort(strictConfig) as Record<string, unknown>;
+  }
+  return deepSort(config) as Record<string, unknown>;
 }
 
 function legacyTerminalId(edge: DAGEdge, index: number): string {
@@ -890,16 +948,19 @@ function compileLegacy(parsed: ParsedDAG): CanonicalWorkflowIR {
       inputPorts.get(edge.to_node)?.add(edge.to_port);
     }
   }
-  const nodes: CanonicalNode[] = parsed.graph.nodes.map((node) => ({
-    id: node.node_id,
-    kind: legacyKind(node),
-    ...(node.description ? { description: node.description } : {}),
-    ...(legacyKind(node) === "agent" ? { agent: node.agent } : {}),
-    depends_on: [...node.after].sort(),
-    inputs: [...(inputPorts.get(node.node_id) ?? [])].sort().map((name) => ({ name })),
-    outputs: Object.keys(node.outputs).sort().map((name) => ({ name })),
-    ...(legacyKind(node) !== "agent" ? { config: deepSort(node.gateway_config ?? {}) as Record<string, unknown> } : {}),
-  }));
+  const nodes: CanonicalNode[] = parsed.graph.nodes.map((node) => {
+    const kind = legacyKind(node);
+    return {
+      id: node.node_id,
+      kind,
+      ...(node.description ? { description: node.description } : {}),
+      ...(kind === "agent" ? { agent: node.agent } : {}),
+      depends_on: [...node.after].sort(),
+      inputs: [...(inputPorts.get(node.node_id) ?? [])].sort().map((name) => ({ name })),
+      outputs: Object.keys(node.outputs).sort().map((name) => ({ name })),
+      ...(kind !== "agent" ? { config: legacyConfig(node, kind) } : {}),
+    };
+  });
   const sourceNodes = new Map(parsed.graph.nodes.map((node) => [node.node_id, node]));
   const edges: CanonicalEdge[] = [];
   parsed.graph.edges.forEach((edge, index) => {
@@ -1129,6 +1190,7 @@ export function workflowSchemaResponse(): {
 }
 
 function runtimeNodeType(kind: CanonicalNode["kind"]): string {
+  if (kind === "await_command") return "await_command_gateway";
   if (kind === "command") return "command_gateway";
   if (kind === "approval") return "approval_gateway";
   if (kind === "state") return "state_gateway";
@@ -1154,7 +1216,7 @@ function runtimeGatewayConfig(node: CanonicalNode): Record<string, unknown> | un
   if (node.kind === "join") return { type: "join", ...node.config };
   if (node.kind === "foreach") return { type: "loop", ...node.config };
   if (node.kind === "while") return { type: "while", ...node.config };
-  if (node.kind === "command" || node.kind === "approval" || node.kind === "state" || node.kind === "fanout") {
+  if (node.kind === "command" || node.kind === "approval" || node.kind === "state" || node.kind === "fanout" || node.kind === "await_command") {
     return { type: node.kind, ...node.config };
   }
   return undefined;
@@ -1336,7 +1398,7 @@ function authoringNode(node: CanonicalNode, canonical: CanonicalWorkflowIR): Rec
     ...(node.description ? { description: node.description } : {}),
     ...(dependsOn.length > 0 ? { depends_on: dependsOn } : {}),
     ...(authoringPorts(node.inputs) ? { inputs: authoringPorts(node.inputs) } : {}),
-    ...(node.kind !== "terminal" && authoringPorts(node.outputs) ? { outputs: authoringPorts(node.outputs) } : {}),
+    ...(node.kind !== "terminal" && node.kind !== "await_command" && authoringPorts(node.outputs) ? { outputs: authoringPorts(node.outputs) } : {}),
   };
   if (node.kind === "agent") {
     return {
@@ -1379,7 +1441,7 @@ function authoringNode(node: CanonicalNode, canonical: CanonicalWorkflowIR): Rec
       },
     };
   }
-  if (node.kind === "command" || node.kind === "approval" || node.kind === "state" || node.kind === "fanout") {
+  if (node.kind === "command" || node.kind === "approval" || node.kind === "state" || node.kind === "fanout" || node.kind === "await_command") {
     return { ...base, config };
   }
   if (node.kind === "foreach") {

--- a/homerail_manager/src/orchestration/ws-dispatch-adapter.ts
+++ b/homerail_manager/src/orchestration/ws-dispatch-adapter.ts
@@ -9,6 +9,8 @@ import { emit } from "../events/bus.js";
 import { appendChatEntry } from "../persistence/store.js";
 import { appendSessionTranscriptEntry } from "../persistence/dag-session-files.js";
 import {
+  findDispatchTarget,
+  clearDispatchTarget,
   recordDispatch,
   recordProvisioning,
   recordDispatchFailed,
@@ -20,14 +22,27 @@ import {
 } from "../node/worker-provisioner.js";
 import {
   buildCurrentDispatchEnvelope,
+  dispatchReadyNodes,
   failActiveRun,
+  getActiveRun,
   markNodeDispatched,
+  recordProvisionedNodeDispatchAttempt,
   recordNodeDispatchRetry,
 } from "../runtime/active-runs.js";
 import { getPort } from "../config/env.js";
 import { registerProvisionedWorker } from "./provisioned-cleanup.js";
 import { normalizeManagerAgentRuntimeAgentType, redactTelemetry } from "homerail-protocol";
 import WebSocket from "ws";
+
+const OFFLINE_RETRY_MIN_MS = 1_000;
+const OFFLINE_RETRY_MAX_MS = 30_000;
+
+interface DeferredOfflineDispatch {
+  runId: string;
+  nodeId: string;
+  targetSignature: string;
+  forceRetry?: boolean;
+}
 
 export interface WsDispatchAdapterOptions {
   provisioner?: ProvisionerOptions | false;
@@ -91,12 +106,17 @@ export function normalizeAgentBackend(agentType: string | undefined): string | u
  * is returned as a skipped result.
  */
 export class WsDispatchAdapter implements DAGDispatcher {
+  private static offlineRetryAdapters = new Set<WsDispatchAdapter>();
+  private static offlineRetryTimer?: ReturnType<typeof setTimeout>;
+  private static offlineRetryDelayMs = OFFLINE_RETRY_MIN_MS;
+
   private provisionerOpts?: ProvisionerOptions;
   private managerBaseUrl: string | (() => string);
   private managerWorkerWsBaseUrl?: string | (() => string);
   private projectId: string;
   private inflightProvisioning = new Set<string>();
   private nextWorkerIndex = 0;
+  private deferredOfflineDispatches = new Map<string, DeferredOfflineDispatch>();
 
   constructor(options?: WsDispatchAdapterOptions) {
     this.provisionerOpts = options?.provisioner === false ? undefined : options?.provisioner;
@@ -120,7 +140,131 @@ export class WsDispatchAdapter implements DAGDispatcher {
     return `${base.replace(/\/$/, "")}/ws/projects/${this.projectId}/workers/${workerId}`;
   }
 
+  private _dispatchKey(runId: string, nodeId: string): string {
+    return `${runId}\0${nodeId}`;
+  }
+
+  private _targetSignature(): string {
+    const workers = getAllWorkers()
+      .filter((worker) => worker.socket.readyState === WebSocket.OPEN)
+      .map((worker) => `worker:${worker.worker_id}:${worker.registered_at}:${worker.capabilities.slice().sort().join(",")}`);
+    const nodes = getAllNodes()
+      .filter((node) => node.socket.readyState === WebSocket.OPEN)
+      .map((node) => `node:${node.node_id}:${node.registered_at}:${node.capabilities.slice().sort().join(",")}`);
+    return [...workers, ...nodes].sort().join("|");
+  }
+
+  private static _ensureOfflineRetryTimer(resetDelay = false): void {
+    if (resetDelay) {
+      WsDispatchAdapter.offlineRetryDelayMs = OFFLINE_RETRY_MIN_MS;
+      if (WsDispatchAdapter.offlineRetryTimer) {
+        clearTimeout(WsDispatchAdapter.offlineRetryTimer);
+        WsDispatchAdapter.offlineRetryTimer = undefined;
+      }
+    }
+    if (WsDispatchAdapter.offlineRetryTimer || WsDispatchAdapter.offlineRetryAdapters.size === 0) return;
+    WsDispatchAdapter.offlineRetryTimer = setTimeout(() => {
+      WsDispatchAdapter.offlineRetryTimer = undefined;
+      let targetChanged = false;
+      for (const adapter of Array.from(WsDispatchAdapter.offlineRetryAdapters)) {
+        try {
+          targetChanged = adapter._retryDeferredOfflineDispatches() || targetChanged;
+        } catch (error) {
+          console.error(
+            `[homerail_manager] deferred DAG dispatch retry failed: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+        if (adapter.deferredOfflineDispatches.size === 0) {
+          WsDispatchAdapter.offlineRetryAdapters.delete(adapter);
+        }
+      }
+      if (WsDispatchAdapter.offlineRetryAdapters.size === 0) {
+        WsDispatchAdapter.offlineRetryDelayMs = OFFLINE_RETRY_MIN_MS;
+        return;
+      }
+      WsDispatchAdapter.offlineRetryDelayMs = targetChanged
+        ? OFFLINE_RETRY_MIN_MS
+        : Math.min(OFFLINE_RETRY_MAX_MS, WsDispatchAdapter.offlineRetryDelayMs * 2);
+      WsDispatchAdapter._ensureOfflineRetryTimer();
+    }, WsDispatchAdapter.offlineRetryDelayMs);
+    WsDispatchAdapter.offlineRetryTimer.unref?.();
+  }
+
+  private static _removeOfflineRetryAdapter(adapter: WsDispatchAdapter): void {
+    WsDispatchAdapter.offlineRetryAdapters.delete(adapter);
+    if (WsDispatchAdapter.offlineRetryAdapters.size > 0) return;
+    if (WsDispatchAdapter.offlineRetryTimer) clearTimeout(WsDispatchAdapter.offlineRetryTimer);
+    WsDispatchAdapter.offlineRetryTimer = undefined;
+    WsDispatchAdapter.offlineRetryDelayMs = OFFLINE_RETRY_MIN_MS;
+  }
+
+  private _scheduleOfflineRetry(): void {
+    if (this.deferredOfflineDispatches.size === 0) return;
+    WsDispatchAdapter.offlineRetryAdapters.add(this);
+    WsDispatchAdapter._ensureOfflineRetryTimer(true);
+  }
+
+  private _forgetDeferredOfflineDispatch(runId: string, nodeId: string): void {
+    this.deferredOfflineDispatches.delete(this._dispatchKey(runId, nodeId));
+    if (this.deferredOfflineDispatches.size === 0) {
+      WsDispatchAdapter._removeOfflineRetryAdapter(this);
+    }
+  }
+
+  private _retryDeferredOfflineDispatches(): boolean {
+    const targetSignature = this._targetSignature();
+    const pendingByRun = new Map<string, DeferredOfflineDispatch[]>();
+    let targetChanged = false;
+    for (const [key, pending] of this.deferredOfflineDispatches) {
+      const run = getActiveRun(pending.runId);
+      if (!run || run.status !== "active" || run.dagRun.nodeStates.get(pending.nodeId) !== "READY") {
+        this.deferredOfflineDispatches.delete(key);
+        continue;
+      }
+      if (!pending.forceRetry && pending.targetSignature === targetSignature) continue;
+      targetChanged = true;
+      this.deferredOfflineDispatches.delete(key);
+      const entries = pendingByRun.get(pending.runId) ?? [];
+      entries.push(pending);
+      pendingByRun.set(pending.runId, entries);
+    }
+    for (const [runId, pendingEntries] of pendingByRun) {
+      try {
+        dispatchReadyNodes(runId, this);
+      } catch (error) {
+        console.error(
+          `[homerail_manager] deferred DAG dispatch failed for ${runId}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        for (const pending of pendingEntries) {
+          const run = getActiveRun(pending.runId);
+          if (!run || run.status !== "active" || run.dagRun.nodeStates.get(pending.nodeId) !== "READY") continue;
+          this.deferredOfflineDispatches.set(this._dispatchKey(pending.runId, pending.nodeId), {
+            ...pending,
+            targetSignature,
+            forceRetry: true,
+          });
+        }
+      }
+    }
+    return targetChanged;
+  }
+
+  private _deferOfflineDispatch(
+    envelope: DispatchEnvelope,
+    reason = "no available worker or node",
+  ): DispatchResult {
+    const key = this._dispatchKey(envelope.runId, envelope.nodeId);
+    this.deferredOfflineDispatches.set(key, {
+      runId: envelope.runId,
+      nodeId: envelope.nodeId,
+      targetSignature: this._targetSignature(),
+    });
+    this._scheduleOfflineRetry();
+    return { status: "skipped", reason };
+  }
+
   dispatch(envelope: DispatchEnvelope): DispatchResult {
+    this._forgetDeferredOfflineDispatch(envelope.runId, envelope.nodeId);
     const requiredCapabilities = envelope.requiredCapabilities
       ?.map((capability) => capability.trim())
       .filter((capability) => capability.length > 0);
@@ -151,22 +295,12 @@ export class WsDispatchAdapter implements DAGDispatcher {
       };
     }
 
-    if (requiredCapabilities && requiredCapabilities.length > 0) {
-      const reason = `no available worker satisfies required capabilities: ${requiredCapabilitiesText(requiredCapabilities)}`;
-      emit("dag:ws_dispatch_failed", {
-        runId: envelope.runId,
-        nodeId: envelope.nodeId,
-        reason,
-      });
-      return { status: "failed", reason, retryable: false };
-    }
-
+    const openWorkers = getAllWorkers().filter((candidate) => candidate.socket.readyState === WebSocket.OPEN);
+    const openNodes = getAllNodes().filter((candidate) => candidate.socket.readyState === WebSocket.OPEN);
     // Try to find a Docker-capable node for provisioning.
     if (this.provisionerOpts) {
-      const nodes = getAllNodes();
-      const dockerNode = nodes.find(
+      const dockerNode = openNodes.find(
         (n) =>
-          n.socket.readyState === WebSocket.OPEN &&
           isDockerCapableNode(n),
       );
       if (dockerNode) {
@@ -175,9 +309,16 @@ export class WsDispatchAdapter implements DAGDispatcher {
       }
     }
 
-    // Fallback: dispatch directly to any connected node (previous behavior)
-    const nodes = getAllNodes();
-    const node = nodes.find((n) => n.socket.readyState === WebSocket.OPEN);
+    if (requiredCapabilities && requiredCapabilities.length > 0) {
+      return this._deferOfflineDispatch(
+        envelope,
+        `no available worker satisfies required capabilities: ${requiredCapabilitiesText(requiredCapabilities)}`,
+      );
+    }
+
+    // Fallback: dispatch directly to any connected node when the task has no
+    // worker capability contract.
+    const node = openNodes[0];
     if (node) {
       try {
         this._dispatchToNode(envelope, node.node_id, node.socket);
@@ -198,17 +339,7 @@ export class WsDispatchAdapter implements DAGDispatcher {
       };
     }
 
-    // No worker, no node — fail
-    emit("dag:ws_dispatch_failed", {
-      runId: envelope.runId,
-      nodeId: envelope.nodeId,
-      reason: "no available worker or node",
-    });
-    return {
-      status: "failed",
-      reason: "no available worker or node",
-      retryable: true,
-    };
+    return this._deferOfflineDispatch(envelope);
   }
 
   private _selectOpenWorker(
@@ -222,6 +353,12 @@ export class WsDispatchAdapter implements DAGDispatcher {
         hasCapabilities(w.capabilities, envelope.requiredCapabilities),
     );
     if (workers.length === 0) return undefined;
+
+    const previousTarget = findDispatchTarget(envelope.runId, envelope.nodeId);
+    if (previousTarget?.state === "dispatched" && previousTarget.targetType === "worker") {
+      const hotWorker = workers.find((worker) => worker.worker_id === previousTarget.targetId);
+      if (hotWorker) return hotWorker;
+    }
 
     const runScopedPrefix = `provisioned-${sanitizeProvisionedWorkerToken(envelope.runId)}-`;
     const exactRunScopedWorkerId = sanitizeProvisionedWorkerToken(
@@ -382,12 +519,26 @@ export class WsDispatchAdapter implements DAGDispatcher {
       (w) => w.worker_id === workerId && w.socket.readyState === WebSocket.OPEN,
     );
     if (newWorker) {
+      if (!hasCapabilities(newWorker.capabilities, currentEnvelope.envelope.requiredCapabilities)) {
+        clearDispatchTarget(currentEnvelope.envelope.runId, currentEnvelope.envelope.nodeId);
+        this._deferOfflineDispatch(
+          currentEnvelope.envelope,
+          `provisioned worker ${workerId} does not satisfy required capabilities: ${requiredCapabilitiesText(currentEnvelope.envelope.requiredCapabilities)}`,
+        );
+        return;
+      }
+      if (!recordProvisionedNodeDispatchAttempt(
+        currentEnvelope.envelope.runId,
+        currentEnvelope.envelope.nodeId,
+      )) {
+        return;
+      }
+      this._dispatchToWorker(currentEnvelope.envelope, workerId, newWorker.socket);
       if (!markNodeDispatched(currentEnvelope.envelope.runId, currentEnvelope.envelope.nodeId)) {
         recordDispatchFailed(currentEnvelope.envelope.runId, currentEnvelope.envelope.nodeId);
         this._failProvisioning(currentEnvelope.envelope, `node ${currentEnvelope.envelope.nodeId} was not READY after worker provisioning`);
         return;
       }
-      this._dispatchToWorker(currentEnvelope.envelope, workerId, newWorker.socket);
     } else {
       // Worker registered but socket not ready — mark failed
       recordDispatchFailed(envelope.runId, envelope.nodeId);

--- a/homerail_manager/src/orchestration/yaml-loader.ts
+++ b/homerail_manager/src/orchestration/yaml-loader.ts
@@ -83,11 +83,13 @@ function _normalizeNodeType(cfg: DAGNodeConfig): string {
   if (type === "condition" || type === "condition_gateway") return "condition_gateway";
   if (type === "join" || type === "join_gateway") return "join_gateway";
   if (type === "while" || type === "while_gateway") return "while_gateway";
+  if (type === "await_command" || type === "await_command_gateway") return "await_command_gateway";
   if (type === "gateway") {
     if (kind === "loop") return "loop_gateway";
     if (kind === "condition") return "condition_gateway";
     if (kind === "join") return "join_gateway";
     if (kind === "while") return "while_gateway";
+    if (kind === "await_command") return "await_command_gateway";
   }
   return type || "agent";
 }
@@ -96,7 +98,12 @@ function _isGatewayNodeType(nodeType: string): boolean {
   return nodeType === "loop_gateway" ||
     nodeType === "condition_gateway" ||
     nodeType === "join_gateway" ||
-    nodeType === "while_gateway";
+    nodeType === "while_gateway" ||
+    nodeType === "command_gateway" ||
+    nodeType === "approval_gateway" ||
+    nodeType === "state_gateway" ||
+    nodeType === "fanout_gateway" ||
+    nodeType === "await_command_gateway";
 }
 
 export function _detectLoopSources(

--- a/homerail_manager/src/persistence/dag-actors.ts
+++ b/homerail_manager/src/persistence/dag-actors.ts
@@ -23,13 +23,14 @@ export interface DagActorRecord {
   updated_at: number;
 }
 
-export type DagActorCommandStatus = "pending" | "delivered" | "claimed" | "acknowledged" | "failed";
+export type DagActorCommandStatus = "pending" | "delivered" | "claimed" | "acknowledged" | "failed" | "cancelled";
 const DAG_ACTOR_COMMAND_STATUSES: ReadonlySet<string> = new Set([
   "pending",
   "delivered",
   "claimed",
   "acknowledged",
   "failed",
+  "cancelled",
 ]);
 
 export interface DagActorCommandRecord {
@@ -566,7 +567,8 @@ export function listDagActorCommands(input: {
   `).all(...params) as DagActorCommandRow[]).map(commandFromRow);
 }
 
-function markCommandDelivered(commandId: string): DagActorCommandMutationResult {
+export function markDagActorCommandDelivered(rawCommandId: string): DagActorCommandMutationResult {
+  const commandId = assertIdentifier(rawCommandId, "command_id");
   const db = getDb();
   return db.transaction(() => {
     const current = requireCommand(commandId);
@@ -610,7 +612,57 @@ export async function deliverDagActorCommand(input: {
   if (delivered === false) {
     return { command: requireCommand(commandId), changed: false, deduplicated: false, delivered: false };
   }
-  return { ...markCommandDelivered(commandId), delivered: true };
+  return { ...markDagActorCommandDelivered(commandId), delivered: true };
+}
+
+export function cancelUnclaimedDagActorCommands(runId: string, completedAt?: number): DagActorCommandRecord[];
+export function cancelUnclaimedDagActorCommands(input: {
+  run_id: string;
+  completed_at?: number;
+  reason?: unknown;
+}): DagActorCommandRecord[];
+export function cancelUnclaimedDagActorCommands(
+  input: string | { run_id: string; completed_at?: number; reason?: unknown },
+  requestedCompletedAt?: number,
+): DagActorCommandRecord[] {
+  const runId = assertIdentifier(typeof input === "string" ? input : input.run_id, "run_id");
+  const completedAt = typeof input === "string"
+    ? requestedCompletedAt ?? Date.now()
+    : input.completed_at ?? Date.now();
+  if (!Number.isSafeInteger(completedAt) || completedAt < 0) {
+    throw new Error("completed_at must be a non-negative epoch millisecond integer");
+  }
+  const reason = typeof input === "string"
+    ? { message: "command cancelled" }
+    : input.reason ?? { message: "command cancelled" };
+  const reasonJson = encodeBoundedDocument(reason, "command cancellation reason").json;
+  const db = getDb();
+
+  return db.transaction(() => {
+    const candidates = db.prepare(`
+      SELECT * FROM dag_actor_commands
+      WHERE run_id = ? AND status IN ('pending', 'delivered')
+      ORDER BY created_at, command_id
+    `).all(runId) as DagActorCommandRow[];
+    if (candidates.length === 0) return [];
+    if (candidates.some((command) => completedAt < Number(command.created_at))) {
+      throw new Error("completed_at must not precede command creation");
+    }
+    const changed = db.prepare(`
+      UPDATE dag_actor_commands SET
+        status = 'cancelled',
+        completed_at = ?,
+        failure_json = ?
+      WHERE run_id = ? AND status IN ('pending', 'delivered')
+    `).run(completedAt, reasonJson, runId);
+    if (changed.changes !== candidates.length) {
+      throw new DagActorConflictError(
+        "command_status_conflict",
+        `Unclaimed DAG actor commands for run ${runId} changed concurrently`,
+      );
+    }
+    return candidates.map((candidate) => requireCommand(candidate.command_id));
+  })();
 }
 
 export function claimDagActorCommand(input: {

--- a/homerail_manager/src/persistence/dag-run-admission.ts
+++ b/homerail_manager/src/persistence/dag-run-admission.ts
@@ -1,4 +1,5 @@
 import { getDb } from "./db.js";
+import { listDagTriggers } from "./dag-triggers.js";
 
 export interface WorkflowConcurrencyPolicy {
   overlap: "skip" | "allow";
@@ -14,7 +15,7 @@ export class WorkflowRunAdmissionError extends Error {
     readonly policy: WorkflowConcurrencyPolicy,
   ) {
     super(
-      `Workflow '${workflowId}' rejected a new run: ${reason} `
+      `Workflow '${workflowId}' admission conflict: ${reason} `
         + `(active=${activeCount}, max=${policy.max_concurrency}, triggers=${policy.trigger_ids.join(",")})`,
     );
     this.name = "WorkflowRunAdmissionError";
@@ -41,6 +42,21 @@ export function deriveWorkflowConcurrencyPolicy(
   };
 }
 
+export function loadWorkflowConcurrencyPolicy(
+  workflowId: string,
+): WorkflowConcurrencyPolicy | undefined {
+  const triggers = Object.fromEntries(
+    listDagTriggers()
+      .filter((record) => record.workflow_id === workflowId)
+      .map((record) => [record.trigger_id, {
+        overlap: record.config.overlap,
+        max_concurrency: record.config.max_concurrency,
+        enabled: record.enabled && record.config.enabled,
+      }]),
+  );
+  return deriveWorkflowConcurrencyPolicy(triggers);
+}
+
 export function reserveWorkflowRun(input: {
   runId: string;
   workflowId: string;
@@ -63,6 +79,11 @@ export function reserveWorkflowRun(input: {
         OR EXISTS (
           SELECT 1 FROM dag_runs
           WHERE dag_runs.run_id = dag_run_admissions.run_id
+            OR (
+              dag_run_admissions.source = 'resume:command'
+              AND dag_run_admissions.run_id = 'resume:' || dag_runs.run_id
+              AND dag_runs.status <> 'waiting'
+            )
         )
     `).run(now - 300_000);
     const activeRuns = Number((getDb().prepare(`

--- a/homerail_manager/src/persistence/dag-run-rounds.ts
+++ b/homerail_manager/src/persistence/dag-run-rounds.ts
@@ -1,0 +1,357 @@
+import { getDb, parseJsonRow } from "./db.js";
+import type { DagRunRoundStatus } from "./types.js";
+
+export interface DagRunRoundRecord {
+  run_id: string;
+  round_id: string;
+  ordinal: number;
+  status: DagRunRoundStatus;
+  target_actor_ids: string[];
+  await_node_id?: string;
+  opened_at: number;
+  closed_at?: number;
+  expires_at?: number;
+}
+
+export type DagRunRoundConflictCode =
+  | "initial_round_conflict"
+  | "round_not_found"
+  | "round_identity_conflict"
+  | "round_status_conflict"
+  | "current_round_conflict";
+
+export class DagRunRoundConflictError extends Error {
+  constructor(
+    public readonly code: DagRunRoundConflictCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "DagRunRoundConflictError";
+  }
+}
+
+interface DagRunRoundRow extends Record<string, unknown> {
+  run_id: string;
+  round_id: string;
+  ordinal: number;
+  status: DagRunRoundStatus;
+  target_actor_ids_json: string;
+  await_node_id: string | null;
+  opened_at: number;
+  closed_at: number | null;
+  expires_at: number | null;
+}
+
+function assertIdentifier(value: string, label: string): string {
+  const normalized = value.trim();
+  if (!normalized || normalized.length > 256) {
+    throw new Error(`${label} must be between 1 and 256 characters`);
+  }
+  return normalized;
+}
+
+function assertTimestamp(value: number, label: string): number {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${label} must be a non-negative epoch millisecond integer`);
+  }
+  return value;
+}
+
+function normalizeTargetActorIds(values: readonly string[]): string[] {
+  return Array.from(new Set(values.map((value) => assertIdentifier(value, "target_actor_id")))).sort();
+}
+
+function roundFromRow(row: DagRunRoundRow): DagRunRoundRecord {
+  const targetActorIds = parseJsonRow<unknown>(row.target_actor_ids_json);
+  if (!Array.isArray(targetActorIds) || targetActorIds.some((value) => typeof value !== "string")) {
+    throw new Error(`DAG run round ${row.run_id}/${row.round_id} has invalid target_actor_ids_json`);
+  }
+  return {
+    run_id: row.run_id,
+    round_id: row.round_id,
+    ordinal: Number(row.ordinal),
+    status: row.status,
+    target_actor_ids: [...targetActorIds],
+    ...(row.await_node_id === null ? {} : { await_node_id: row.await_node_id }),
+    opened_at: Number(row.opened_at),
+    ...(row.closed_at === null ? {} : { closed_at: Number(row.closed_at) }),
+    ...(row.expires_at === null ? {} : { expires_at: Number(row.expires_at) }),
+  };
+}
+
+function getRoundRow(runId: string, roundId: string): DagRunRoundRow | undefined {
+  return getDb().prepare("SELECT * FROM dag_run_rounds WHERE run_id = ? AND round_id = ?")
+    .get(runId, roundId) as DagRunRoundRow | undefined;
+}
+
+function requireRound(runId: string, roundId: string): DagRunRoundRecord {
+  const row = getRoundRow(runId, roundId);
+  if (!row) {
+    throw new DagRunRoundConflictError(
+      "round_not_found",
+      `Unknown DAG run round: ${runId}/${roundId}`,
+    );
+  }
+  return roundFromRow(row);
+}
+
+function assertExpectedCurrentRound(runId: string, roundId: string): DagRunRoundRecord {
+  const requested = requireRound(runId, roundId);
+  const current = getCurrentDagRunRound(runId);
+  if (!current || current.round_id !== roundId) {
+    throw new DagRunRoundConflictError(
+      "current_round_conflict",
+      `DAG run ${runId} current round is ${current?.round_id ?? "absent"}, expected ${roundId}`,
+    );
+  }
+  return requested;
+}
+
+export function createInitialDagRunRound(input: {
+  run_id: string;
+  round_id: string;
+  target_actor_ids: readonly string[];
+  status?: DagRunRoundStatus;
+  await_node_id?: string;
+  opened_at?: number;
+  closed_at?: number;
+  expires_at?: number;
+}): DagRunRoundRecord {
+  const runId = assertIdentifier(input.run_id, "run_id");
+  const roundId = assertIdentifier(input.round_id, "round_id");
+  const targetActorIds = normalizeTargetActorIds(input.target_actor_ids);
+  const status = input.status ?? "active";
+  const awaitNodeId = input.await_node_id === undefined
+    ? undefined
+    : assertIdentifier(input.await_node_id, "await_node_id");
+  const openedAt = assertTimestamp(input.opened_at ?? Date.now(), "opened_at");
+  const closedAt = input.closed_at === undefined
+    ? undefined
+    : assertTimestamp(input.closed_at, "closed_at");
+  const expiresAt = input.expires_at === undefined
+    ? undefined
+    : assertTimestamp(input.expires_at, "expires_at");
+  if (expiresAt !== undefined && expiresAt < openedAt) {
+    throw new Error("expires_at must not precede opened_at");
+  }
+  if (closedAt !== undefined && closedAt < openedAt) {
+    throw new Error("closed_at must not precede opened_at");
+  }
+  if (status === "active" && (awaitNodeId !== undefined || closedAt !== undefined)) {
+    throw new Error("An active initial round cannot have await_node_id or closed_at");
+  }
+  if (status === "waiting" && (awaitNodeId === undefined || closedAt === undefined)) {
+    throw new Error("A waiting initial round requires await_node_id and closed_at");
+  }
+  if (
+    (status === "completed" || status === "cancelled" || status === "failed")
+    && closedAt === undefined
+  ) {
+    throw new Error(`A ${status} initial round requires closed_at`);
+  }
+  const db = getDb();
+
+  return db.transaction(() => {
+    if (!db.prepare("SELECT 1 FROM dag_runs WHERE run_id = ?").get(runId)) {
+      throw new Error(`Unknown DAG run: ${runId}`);
+    }
+    const existing = db.prepare("SELECT round_id FROM dag_run_rounds WHERE run_id = ? LIMIT 1")
+      .get(runId) as { round_id: string } | undefined;
+    if (existing) {
+      throw new DagRunRoundConflictError(
+        "initial_round_conflict",
+        `DAG run ${runId} already has round ${existing.round_id}`,
+      );
+    }
+    db.prepare(`
+      INSERT INTO dag_run_rounds(
+        run_id, round_id, ordinal, status, target_actor_ids_json,
+        await_node_id, opened_at, closed_at, expires_at
+      ) VALUES (?, ?, 1, ?, ?, ?, ?, ?, ?)
+    `).run(
+      runId,
+      roundId,
+      status,
+      JSON.stringify(targetActorIds),
+      awaitNodeId ?? null,
+      openedAt,
+      closedAt ?? null,
+      expiresAt ?? null,
+    );
+    return requireRound(runId, roundId);
+  })();
+}
+
+export function getDagRunRound(runId: string, roundId: string): DagRunRoundRecord | undefined {
+  const row = getRoundRow(
+    assertIdentifier(runId, "run_id"),
+    assertIdentifier(roundId, "round_id"),
+  );
+  return row ? roundFromRow(row) : undefined;
+}
+
+export function getCurrentDagRunRound(runId: string): DagRunRoundRecord | undefined {
+  const normalizedRunId = assertIdentifier(runId, "run_id");
+  const row = getDb().prepare(`
+    SELECT * FROM dag_run_rounds
+    WHERE run_id = ? AND status IN ('active', 'waiting')
+  `).get(normalizedRunId) as DagRunRoundRow | undefined;
+  return row ? roundFromRow(row) : undefined;
+}
+
+export function listDagRunRounds(runId: string): DagRunRoundRecord[] {
+  const normalizedRunId = assertIdentifier(runId, "run_id");
+  return (getDb().prepare(`
+    SELECT * FROM dag_run_rounds
+    WHERE run_id = ?
+    ORDER BY ordinal, round_id
+  `).all(normalizedRunId) as DagRunRoundRow[]).map(roundFromRow);
+}
+
+export function transitionDagRunRoundToWaiting(input: {
+  run_id: string;
+  round_id: string;
+  await_node_id: string;
+  closed_at?: number;
+  expires_at?: number;
+}): DagRunRoundRecord {
+  const runId = assertIdentifier(input.run_id, "run_id");
+  const roundId = assertIdentifier(input.round_id, "round_id");
+  const awaitNodeId = assertIdentifier(input.await_node_id, "await_node_id");
+  const closedAt = assertTimestamp(input.closed_at ?? Date.now(), "closed_at");
+  const expiresAt = input.expires_at === undefined
+    ? undefined
+    : assertTimestamp(input.expires_at, "expires_at");
+  const db = getDb();
+
+  return db.transaction(() => {
+    const current = assertExpectedCurrentRound(runId, roundId);
+    if (current.status !== "active") {
+      throw new DagRunRoundConflictError(
+        "round_status_conflict",
+        `DAG run round ${runId}/${roundId} is ${current.status}, not active`,
+      );
+    }
+    if (closedAt < current.opened_at) throw new Error("closed_at must not precede opened_at");
+    if (expiresAt !== undefined && expiresAt < closedAt) {
+      throw new Error("expires_at must not precede closed_at");
+    }
+    const changed = db.prepare(`
+      UPDATE dag_run_rounds SET
+        status = 'waiting',
+        await_node_id = ?,
+        closed_at = ?,
+        expires_at = ?
+      WHERE run_id = ? AND round_id = ? AND status = 'active' AND closed_at IS NULL
+    `).run(awaitNodeId, closedAt, expiresAt ?? null, runId, roundId);
+    if (changed.changes !== 1) {
+      throw new DagRunRoundConflictError(
+        "round_status_conflict",
+        `DAG run round ${runId}/${roundId} changed concurrently`,
+      );
+    }
+    return requireRound(runId, roundId);
+  })();
+}
+
+export function openNextDagRunRound(input: {
+  run_id: string;
+  expected_round_id: string;
+  round_id: string;
+  target_actor_ids: readonly string[];
+  opened_at?: number;
+  expires_at?: number;
+}): DagRunRoundRecord {
+  const runId = assertIdentifier(input.run_id, "run_id");
+  const currentRoundId = assertIdentifier(input.expected_round_id, "expected_round_id");
+  const nextRoundId = assertIdentifier(input.round_id, "round_id");
+  const targetActorIds = normalizeTargetActorIds(input.target_actor_ids);
+  const openedAt = assertTimestamp(input.opened_at ?? Date.now(), "opened_at");
+  const expiresAt = input.expires_at === undefined
+    ? undefined
+    : assertTimestamp(input.expires_at, "expires_at");
+  const db = getDb();
+
+  return db.transaction(() => {
+    const current = assertExpectedCurrentRound(runId, currentRoundId);
+    if (current.status !== "waiting") {
+      throw new DagRunRoundConflictError(
+        "round_status_conflict",
+        `DAG run round ${runId}/${currentRoundId} is ${current.status}, not waiting`,
+      );
+    }
+    if (openedAt < (current.closed_at ?? current.opened_at)) {
+      throw new Error("opened_at must not precede the previous round closure");
+    }
+    if (expiresAt !== undefined && expiresAt < openedAt) {
+      throw new Error("expires_at must not precede opened_at");
+    }
+    if (getRoundRow(runId, nextRoundId)) {
+      throw new DagRunRoundConflictError(
+        "round_identity_conflict",
+        `DAG run round ${runId}/${nextRoundId} already exists`,
+      );
+    }
+
+    const completed = db.prepare(`
+      UPDATE dag_run_rounds SET status = 'completed'
+      WHERE run_id = ? AND round_id = ? AND status = 'waiting'
+    `).run(runId, currentRoundId);
+    if (completed.changes !== 1) {
+      throw new DagRunRoundConflictError(
+        "round_status_conflict",
+        `DAG run round ${runId}/${currentRoundId} changed concurrently`,
+      );
+    }
+    db.prepare(`
+      INSERT INTO dag_run_rounds(
+        run_id, round_id, ordinal, status, target_actor_ids_json,
+        await_node_id, opened_at, closed_at, expires_at
+      ) VALUES (?, ?, ?, 'active', ?, NULL, ?, NULL, ?)
+    `).run(
+      runId,
+      nextRoundId,
+      current.ordinal + 1,
+      JSON.stringify(targetActorIds),
+      openedAt,
+      expiresAt ?? null,
+    );
+    return requireRound(runId, nextRoundId);
+  })();
+}
+
+export function terminalizeCurrentDagRunRound(input: {
+  run_id: string;
+  round_id: string;
+  status: "completed" | "cancelled" | "failed";
+  closed_at?: number;
+}): DagRunRoundRecord {
+  const runId = assertIdentifier(input.run_id, "run_id");
+  const roundId = assertIdentifier(input.round_id, "round_id");
+  const closedAt = assertTimestamp(input.closed_at ?? Date.now(), "closed_at");
+  const db = getDb();
+
+  return db.transaction(() => {
+    const current = assertExpectedCurrentRound(runId, roundId);
+    if (current.status !== "active" && current.status !== "waiting") {
+      throw new DagRunRoundConflictError(
+        "round_status_conflict",
+        `DAG run round ${runId}/${roundId} is already ${current.status}`,
+      );
+    }
+    if (closedAt < current.opened_at) throw new Error("closed_at must not precede opened_at");
+    const changed = db.prepare(`
+      UPDATE dag_run_rounds SET
+        status = ?,
+        closed_at = COALESCE(closed_at, ?)
+      WHERE run_id = ? AND round_id = ? AND status IN ('active', 'waiting')
+    `).run(input.status, closedAt, runId, roundId);
+    if (changed.changes !== 1) {
+      throw new DagRunRoundConflictError(
+        "round_status_conflict",
+        `DAG run round ${runId}/${roundId} changed concurrently`,
+      );
+    }
+    return requireRound(runId, roundId);
+  })();
+}

--- a/homerail_manager/src/persistence/db.ts
+++ b/homerail_manager/src/persistence/db.ts
@@ -34,6 +34,7 @@ const CLEARABLE_TABLES = new Set([
   "dag_chats",
   "dag_handoffs",
   "dag_artifacts",
+  "dag_run_rounds",
   "dag_actor_commands",
   "dag_actors",
   "dag_activity_events",
@@ -664,6 +665,180 @@ function validateDagActorSchemaV20(db: SqliteDatabase): void {
       && entry.to === to
       && entry.on_delete.toUpperCase() === "CASCADE"
     ))) throw new Error(`Schema migration 20 is incomplete: command actor ${from} constraint is missing`);
+  }
+}
+
+function compactSchemaSql(db: SqliteDatabase, type: "table" | "index", name: string): string {
+  const row = db.prepare("SELECT sql FROM sqlite_master WHERE type = ? AND name = ?")
+    .get(type, name) as { sql: string | null } | undefined;
+  return row?.sql?.toLowerCase().replace(/\s+/g, "") ?? "";
+}
+
+function dagActorCommandsSupportsCancelled(db: SqliteDatabase): boolean {
+  const sql = compactSchemaSql(db, "table", "dag_actor_commands");
+  return sql.includes(
+    "statusin('pending','delivered','claimed','acknowledged','failed','cancelled')",
+  ) && sql.includes(
+    "(status='cancelled'andclaimed_generationisnullandclaimed_atisnullandcompleted_atisnotnullandfailure_jsonisnotnull)",
+  );
+}
+
+function upgradeDagActorCommandsV23(db: SqliteDatabase): void {
+  if (dagActorCommandsSupportsCancelled(db)) return;
+
+  db.exec(`
+    DROP TABLE IF EXISTS dag_actor_commands_v23;
+    CREATE TABLE dag_actor_commands_v23 (
+      command_id TEXT PRIMARY KEY,
+      run_id TEXT NOT NULL,
+      actor_id TEXT NOT NULL,
+      round_id TEXT NOT NULL,
+      target_generation INTEGER NOT NULL CHECK(target_generation >= 1),
+      status TEXT NOT NULL CHECK(status IN ('pending', 'delivered', 'claimed', 'acknowledged', 'failed', 'cancelled')),
+      idempotency_key TEXT NOT NULL,
+      payload_digest TEXT NOT NULL CHECK(length(payload_digest) = 64),
+      payload_json TEXT NOT NULL,
+      claimed_generation INTEGER CHECK(claimed_generation IS NULL OR claimed_generation >= 1),
+      created_at INTEGER NOT NULL CHECK(created_at >= 0),
+      delivered_at INTEGER CHECK(delivered_at IS NULL OR delivered_at >= created_at),
+      claimed_at INTEGER CHECK(claimed_at IS NULL OR claimed_at >= created_at),
+      completed_at INTEGER CHECK(completed_at IS NULL OR completed_at >= created_at),
+      failure_json TEXT,
+      CHECK(
+        (status = 'pending' AND delivered_at IS NULL AND claimed_generation IS NULL AND claimed_at IS NULL AND completed_at IS NULL AND failure_json IS NULL)
+        OR (status = 'delivered' AND delivered_at IS NOT NULL AND claimed_generation IS NULL AND claimed_at IS NULL AND completed_at IS NULL AND failure_json IS NULL)
+        OR (status = 'claimed' AND claimed_generation IS NOT NULL AND claimed_at IS NOT NULL AND completed_at IS NULL AND failure_json IS NULL)
+        OR (status = 'acknowledged' AND claimed_generation IS NOT NULL AND claimed_at IS NOT NULL AND completed_at IS NOT NULL AND failure_json IS NULL)
+        OR (status = 'failed' AND claimed_generation IS NOT NULL AND claimed_at IS NOT NULL AND completed_at IS NOT NULL AND failure_json IS NOT NULL)
+        OR (status = 'cancelled' AND claimed_generation IS NULL AND claimed_at IS NULL AND completed_at IS NOT NULL AND failure_json IS NOT NULL)
+      ),
+      FOREIGN KEY(run_id, actor_id) REFERENCES dag_actors(run_id, actor_id) ON DELETE CASCADE
+    );
+    INSERT INTO dag_actor_commands_v23(
+      command_id, run_id, actor_id, round_id, target_generation, status,
+      idempotency_key, payload_digest, payload_json, claimed_generation,
+      created_at, delivered_at, claimed_at, completed_at, failure_json
+    )
+    SELECT
+      command_id, run_id, actor_id, round_id, target_generation, status,
+      idempotency_key, payload_digest, payload_json, claimed_generation,
+      created_at, delivered_at, claimed_at, completed_at, failure_json
+    FROM dag_actor_commands;
+    DROP TABLE dag_actor_commands;
+    ALTER TABLE dag_actor_commands_v23 RENAME TO dag_actor_commands;
+    CREATE UNIQUE INDEX idx_dag_actor_commands_idempotency
+      ON dag_actor_commands(run_id, actor_id, idempotency_key);
+    CREATE INDEX idx_dag_actor_commands_actor_status
+      ON dag_actor_commands(run_id, actor_id, status, created_at, command_id);
+    CREATE INDEX idx_dag_actor_commands_round
+      ON dag_actor_commands(run_id, round_id, created_at, command_id);
+  `);
+}
+
+function validateDagRunRoundSchemaV23(db: SqliteDatabase): void {
+  const table = "dag_run_rounds";
+  if (!hasTable(db, table)) {
+    throw new Error(`Schema migration 23 is incomplete: missing table ${table}`);
+  }
+
+  const columns = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{
+    cid: number;
+    name: string;
+    type: string;
+    notnull: number;
+    pk: number;
+  }>;
+  const expectedColumns = [
+    ["run_id", "TEXT", 1, 1],
+    ["round_id", "TEXT", 1, 2],
+    ["ordinal", "INTEGER", 1, 0],
+    ["status", "TEXT", 1, 0],
+    ["target_actor_ids_json", "TEXT", 1, 0],
+    ["await_node_id", "TEXT", 0, 0],
+    ["opened_at", "INTEGER", 1, 0],
+    ["closed_at", "INTEGER", 0, 0],
+    ["expires_at", "INTEGER", 0, 0],
+  ] as const;
+  if (columns.length !== expectedColumns.length) {
+    throw new Error(`Schema migration 23 is incomplete: ${table} has invalid columns`);
+  }
+  for (const [position, [name, type, notnull, pk]] of expectedColumns.entries()) {
+    const column = columns[position];
+    if (
+      column.name !== name
+      || column.type.toUpperCase() !== type
+      || column.notnull !== notnull
+      || column.pk !== pk
+    ) {
+      throw new Error(`Schema migration 23 is incomplete: ${table} column ${name} is invalid`);
+    }
+  }
+
+  const tableSql = compactSchemaSql(db, "table", table);
+  for (const fragment of [
+    "statusin('active','waiting','completed','cancelled','failed')",
+    "check(ordinal>=1)",
+    "check(opened_at>=0)",
+    "check(closed_atisnullorclosed_at>=opened_at)",
+    "check(expires_atisnullorexpires_at>=opened_at)",
+    "(status='active'andawait_node_idisnullandclosed_atisnull)",
+    "(status='waiting'andawait_node_idisnotnullandclosed_atisnotnull)",
+    "(statusin('completed','cancelled','failed')andclosed_atisnotnull)",
+  ]) {
+    if (!tableSql.includes(fragment)) {
+      throw new Error(`Schema migration 23 is incomplete: ${table} constraints are invalid`);
+    }
+  }
+
+  const indexes = new Map((db.prepare(`PRAGMA index_list(${table})`).all() as Array<{
+    name: string;
+    unique: number;
+    partial: number;
+  }>).map((index) => [index.name, index]));
+  for (const [name, expectedColumnsForIndex, partial] of [
+    ["idx_dag_run_rounds_run_ordinal", ["run_id", "ordinal"], 0],
+    ["idx_dag_run_rounds_current", ["run_id"], 1],
+  ] as const) {
+    const index = indexes.get(name);
+    if (index?.unique !== 1 || index.partial !== partial) {
+      throw new Error(`Schema migration 23 is incomplete: index ${name} is missing or invalid`);
+    }
+    const actualColumns = (db.prepare(`PRAGMA index_info(${name})`).all() as Array<{
+      seqno: number;
+      name: string;
+    }>).sort((left, right) => left.seqno - right.seqno).map((entry) => entry.name);
+    if (
+      actualColumns.length !== expectedColumnsForIndex.length
+      || actualColumns.some((column, indexPosition) => column !== expectedColumnsForIndex[indexPosition])
+    ) {
+      throw new Error(`Schema migration 23 is incomplete: index ${name} has invalid columns`);
+    }
+  }
+  if (!compactSchemaSql(db, "index", "idx_dag_run_rounds_current").includes(
+    "wherestatusin('active','waiting')",
+  )) {
+    throw new Error("Schema migration 23 is incomplete: current round index predicate is invalid");
+  }
+
+  const foreignKeys = db.prepare(`PRAGMA foreign_key_list(${table})`).all() as Array<{
+    table: string;
+    from: string;
+    to: string;
+    on_delete: string;
+  }>;
+  if (
+    foreignKeys.length !== 1
+    || foreignKeys[0].table !== "dag_runs"
+    || foreignKeys[0].from !== "run_id"
+    || foreignKeys[0].to !== "run_id"
+    || foreignKeys[0].on_delete.toUpperCase() !== "CASCADE"
+  ) {
+    throw new Error("Schema migration 23 is incomplete: round run retention constraint is invalid");
+  }
+
+  validateDagActorSchemaV20(db);
+  if (!dagActorCommandsSupportsCancelled(db)) {
+    throw new Error("Schema migration 23 is incomplete: dag_actor_commands does not support cancelled commands");
   }
 }
 
@@ -2044,6 +2219,39 @@ const SCHEMA_MIGRATIONS: readonly SchemaMigration[] = [
         ON dag_actor_commands(run_id, round_id, created_at, command_id);
     `),
     validate: validateDagActorSchemaV20,
+  },
+  // Versions 21 and 22 are reserved for the parallel live-surface projector work.
+  {
+    version: 23,
+    up: (db) => {
+      upgradeDagActorCommandsV23(db);
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS dag_run_rounds (
+          run_id TEXT NOT NULL,
+          round_id TEXT NOT NULL,
+          ordinal INTEGER NOT NULL CHECK(ordinal >= 1),
+          status TEXT NOT NULL CHECK(status IN ('active', 'waiting', 'completed', 'cancelled', 'failed')),
+          target_actor_ids_json TEXT NOT NULL,
+          await_node_id TEXT,
+          opened_at INTEGER NOT NULL CHECK(opened_at >= 0),
+          closed_at INTEGER CHECK(closed_at IS NULL OR closed_at >= opened_at),
+          expires_at INTEGER CHECK(expires_at IS NULL OR expires_at >= opened_at),
+          PRIMARY KEY(run_id, round_id),
+          CHECK(
+            (status = 'active' AND await_node_id IS NULL AND closed_at IS NULL)
+            OR (status = 'waiting' AND await_node_id IS NOT NULL AND closed_at IS NOT NULL)
+            OR (status IN ('completed', 'cancelled', 'failed') AND closed_at IS NOT NULL)
+          ),
+          FOREIGN KEY(run_id) REFERENCES dag_runs(run_id) ON DELETE CASCADE
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_dag_run_rounds_run_ordinal
+          ON dag_run_rounds(run_id, ordinal);
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_dag_run_rounds_current
+          ON dag_run_rounds(run_id)
+          WHERE status IN ('active', 'waiting');
+      `);
+    },
+    validate: validateDagRunRoundSchemaV23,
   },
 ];
 

--- a/homerail_manager/src/persistence/status.ts
+++ b/homerail_manager/src/persistence/status.ts
@@ -1,5 +1,5 @@
 export const PERSISTENCE_STATUS_VALUES = {
-  dag_run: ["active", "completed", "failed", "cancelled"] as const,
+  dag_run: ["active", "waiting", "completed", "failed", "cancelled"] as const,
   session: [
     "active",
     "closed",

--- a/homerail_manager/src/persistence/store.ts
+++ b/homerail_manager/src/persistence/store.ts
@@ -8,6 +8,8 @@ import type {
   PersistedGraphData,
   NodeUsageRecord,
   RunWorkspaceRetention,
+  PersistedCurrentDagRunRound,
+  PersistedDagRuntimeState,
 } from "./types.js";
 import type { DAGArtifactDeclaration, DAGGraphData, DAGPatternInstanceMeta, ScorecardPolicyConfig } from "../orchestration/graph.js";
 import { DAG_EVENT_TYPES, subscribe, type DAGEventPayload } from "../events/bus.js";
@@ -18,7 +20,7 @@ import { redactTelemetry } from "homerail-protocol";
 
 // Contract marker for regression: "dag:instruction_terminal_no_active_target"
 // is persisted through DAG_EVENT_TYPES.
-interface SerializableRun {
+export interface SerializableRun {
   runId: string;
   workflowId?: string;
   workflowName?: string;
@@ -38,6 +40,7 @@ interface SerializableRun {
   pattern?: DAGPatternInstanceMeta;
   createdAt: number;
   status: DagRunStatus;
+  currentRound?: PersistedCurrentDagRunRound;
   completedAt?: number;
   limits?: DAGRunLimits;
   counters?: DAGRunCounters;
@@ -45,6 +48,10 @@ interface SerializableRun {
     nodeStates: Map<string, string>;
     handoffedNodes: Set<string>;
     graph: DAGGraphData;
+    afterSatisfied?: ReadonlyMap<string, ReadonlySet<string>>;
+    inputSatisfied?: ReadonlyMap<string, ReadonlySet<string>>;
+    mailboxes?: ReadonlyMap<string, ReadonlyMap<string, readonly unknown[]>>;
+    loopSources?: ReadonlySet<string>;
   };
 }
 
@@ -187,11 +194,67 @@ function _serializeGraph(graph: DAGGraphData): PersistedGraphData {
   };
 }
 
+function _serializeSetMap(
+  values: ReadonlyMap<string, ReadonlySet<string>>,
+): Record<string, string[]> {
+  const result: Record<string, string[]> = {};
+  for (const key of Array.from(values.keys()).sort()) {
+    result[key] = Array.from(values.get(key) ?? []).sort();
+  }
+  return result;
+}
+
+function _serializeMailboxes(
+  mailboxes: ReadonlyMap<string, ReadonlyMap<string, readonly unknown[]>>,
+): Record<string, Record<string, unknown[]>> {
+  const result: Record<string, Record<string, unknown[]>> = {};
+  for (const nodeId of Array.from(mailboxes.keys()).sort()) {
+    const ports: Record<string, unknown[]> = {};
+    const mailbox = mailboxes.get(nodeId);
+    if (mailbox) {
+      for (const port of Array.from(mailbox.keys()).sort()) {
+        ports[port] = Array.from(mailbox.get(port) ?? []);
+      }
+    }
+    result[nodeId] = ports;
+  }
+  return result;
+}
+
+function _serializeDagRuntimeState(run: SerializableRun): PersistedDagRuntimeState | undefined {
+  const { afterSatisfied, inputSatisfied, mailboxes, loopSources } = run.dagRun;
+  if (!afterSatisfied || !inputSatisfied || !mailboxes || !loopSources) return undefined;
+  return {
+    after_satisfied: _serializeSetMap(afterSatisfied),
+    input_satisfied: _serializeSetMap(inputSatisfied),
+    mailboxes: _serializeMailboxes(mailboxes),
+    loop_sources: Array.from(loopSources).sort(),
+  };
+}
+
+function _serializeCurrentRound(
+  round: SerializableRun["currentRound"],
+): PersistedCurrentDagRunRound | undefined {
+  if (!round) return undefined;
+  return {
+    round_id: round.round_id,
+    ordinal: round.ordinal,
+    status: round.status,
+    target_actor_ids: Array.from(new Set(round.target_actor_ids)).sort(),
+    ...(round.await_node_id === undefined ? {} : { await_node_id: round.await_node_id }),
+    opened_at: round.opened_at,
+    ...(round.closed_at === undefined ? {} : { closed_at: round.closed_at }),
+    ...(round.expires_at === undefined ? {} : { expires_at: round.expires_at }),
+  };
+}
+
 export function serializeRunMetadata(run: SerializableRun): PersistedRunMetadata {
   const nodeStates: Record<string, string> = {};
-  for (const [nodeId, state] of run.dagRun.nodeStates) {
-    nodeStates[nodeId] = state;
+  for (const nodeId of Array.from(run.dagRun.nodeStates.keys()).sort()) {
+    nodeStates[nodeId] = run.dagRun.nodeStates.get(nodeId)!;
   }
+  const currentRound = _serializeCurrentRound(run.currentRound);
+  const dagRuntimeState = _serializeDagRuntimeState(run);
   return {
     runId: run.runId,
     workflowId: run.workflowId,
@@ -212,11 +275,13 @@ export function serializeRunMetadata(run: SerializableRun): PersistedRunMetadata
     pattern: run.pattern,
     createdAt: run.createdAt,
     status: run.status,
+    ...(currentRound ? { currentRound } : {}),
+    ...(dagRuntimeState ? { dagRuntimeState } : {}),
     completedAt: run.completedAt,
     limits: run.limits,
     counters: run.counters,
     nodeStates,
-    handoffedNodes: Array.from(run.dagRun.handoffedNodes),
+    handoffedNodes: Array.from(run.dagRun.handoffedNodes).sort(),
     graph: _serializeGraph(run.dagRun.graph),
   };
 }

--- a/homerail_manager/src/persistence/types.ts
+++ b/homerail_manager/src/persistence/types.ts
@@ -46,6 +46,26 @@ export interface RunWorkspaceRetention {
   cleanedAt?: number;
 }
 
+export type DagRunRoundStatus = "active" | "waiting" | "completed" | "cancelled" | "failed";
+
+export interface PersistedCurrentDagRunRound {
+  round_id: string;
+  ordinal: number;
+  status: DagRunRoundStatus;
+  target_actor_ids: string[];
+  await_node_id?: string;
+  opened_at: number;
+  closed_at?: number;
+  expires_at?: number;
+}
+
+export interface PersistedDagRuntimeState {
+  after_satisfied: Record<string, string[]>;
+  input_satisfied: Record<string, string[]>;
+  mailboxes: Record<string, Record<string, unknown[]>>;
+  loop_sources: string[];
+}
+
 export interface PersistedRunMetadata {
   runId: string;
   workflowId?: string;
@@ -66,6 +86,8 @@ export interface PersistedRunMetadata {
   pattern?: DAGPatternInstanceMeta;
   createdAt: number;
   status: DagRunStatus;
+  currentRound?: PersistedCurrentDagRunRound;
+  dagRuntimeState?: PersistedDagRuntimeState;
   completedAt?: number;
   limits?: DAGRunLimits;
   counters?: DAGRunCounters;
@@ -82,6 +104,7 @@ export interface PersistedEvent {
 
 export interface HandoffRecord {
   runId: string;
+  roundId?: string;
   fromNode: string;
   port: string;
   content?: unknown;

--- a/homerail_manager/src/runtime/active-runs.ts
+++ b/homerail_manager/src/runtime/active-runs.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import { mkdirSync, realpathSync } from "node:fs";
 import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
 import { getHomerailHome } from "../config/env.js";
 import { emit } from "../events/bus.js";
 import type { DAGDispatcher, DispatchEnvelope } from "../orchestration/dag-dispatcher.js";
@@ -16,6 +17,7 @@ import {
   handoff,
   isFailurePort,
   isRunTerminal,
+  resetNodesForRound,
   resetSkippedSuccessDescendants,
   startNode,
 } from "../orchestration/dag-engine.js";
@@ -29,6 +31,7 @@ import { getNode } from "../node/registry.js";
 import {
   AGENT_BUILTIN_TOOL_NAMES,
   DAG_AGENT_TOOL_NAMES,
+  DAG_TRANSPORT_FENCE_CAPABILITY,
   isDisabledDirectLlmAgentType,
   normalizeManagerAgentRuntimeAgentType,
   redactTelemetry,
@@ -51,6 +54,7 @@ import type {
   PersistedRunMetadata,
 } from "../persistence/types.js";
 import { dbTransaction } from "../persistence/db.js";
+import type { DagRunStatus } from "../persistence/status.js";
 import {
   getDagSessionIndex,
   upsertDagSessionIndex,
@@ -73,10 +77,27 @@ import {
 } from "../persistence/dag-runtime-primitives.js";
 import type { RunWorkspaceRetention } from "../persistence/types.js";
 import { getDagActivitySequenceCursor } from "../persistence/dag-activity-journal.js";
+import { getDb } from "../persistence/db.js";
 import {
+  createInitialDagRunRound,
+  getCurrentDagRunRound,
+  listDagRunRounds,
+  openNextDagRunRound,
+  terminalizeCurrentDagRunRound,
+  transitionDagRunRoundToWaiting,
+} from "../persistence/dag-run-rounds.js";
+import {
+  acknowledgeDagActorCommand,
   advanceDagActorGeneration,
+  cancelUnclaimedDagActorCommands,
+  claimDagActorCommand,
+  createDagActorCommand,
   DagActorConflictError,
+  getDagActorCommand,
   getDagActorByNode,
+  listDagActors,
+  listDagActorCommands,
+  markDagActorCommandDelivered,
   registerDagActor,
   updateDagActorBinding,
   type DagActorRecord,
@@ -114,12 +135,32 @@ export interface ActiveRun {
   pattern?: DAGPatternInstanceMeta;
   dagRun: DAGRun;
   createdAt: number;
-  status: "active" | "completed" | "failed" | "cancelled";
+  status: DagRunStatus;
+  currentRound: ActiveRunRound;
   completedAt?: number;
   limits: DAGRunLimits;
   counters: DAGRunCounters;
   nodeIndex: Map<string, number>;
   nodeSessions: Map<string, NodeSessionState>;
+}
+
+export interface ActiveRunRound {
+  round_id: string;
+  ordinal: number;
+  status: "active" | "waiting" | "completed" | "cancelled" | "failed";
+  target_actor_ids: string[];
+  await_node_id?: string;
+  opened_at: number;
+  closed_at?: number;
+  expires_at?: number;
+}
+
+export interface HandoffTransportFence {
+  transport?: boolean;
+  roundId?: string;
+  actorId?: string;
+  generation?: number;
+  commandId?: string;
 }
 
 export interface NodeSessionState {
@@ -152,6 +193,30 @@ export type CheckpointResumeResult =
       instruction: string;
     }
   | { status: "unavailable"; reason: string };
+
+export interface WaitingRunCommandInput {
+  actor_id: string;
+  payload: unknown;
+  command_id?: string;
+  idempotency_key?: string;
+}
+
+export interface ResumeWaitingRunRequest {
+  expected_round_id: string;
+  commands: WaitingRunCommandInput[];
+}
+
+export interface ResumeWaitingRunResult {
+  runId: string;
+  previousRoundId: string;
+  roundId: string;
+  ordinal: number;
+  actorIds: string[];
+  nodeIds: string[];
+  commandIds: string[];
+  readyNodeIds: string[];
+  deduplicated?: boolean;
+}
 
 export interface DAGRunLimits {
   max_nodes: number;
@@ -207,6 +272,7 @@ const RECOVERABLE_NODE_STATES: ReadonlySet<string> = new Set([
   "READY",
   "RUNNING",
   "WAITING_FOR_APPROVAL",
+  "WAITING_FOR_COMMAND",
   "COMPLETED",
   "FAILED",
   "CANCELLED",
@@ -469,6 +535,35 @@ function _snapshotNodeStates(run: ActiveRun): Map<string, string> {
   return new Map(run.dagRun.nodeStates);
 }
 
+interface MutableRunSnapshot {
+  dagRun: DAGRun;
+  status: DagRunStatus;
+  currentRound: ActiveRunRound;
+  completedAt?: number;
+  counters: DAGRunCounters;
+  nodeSessions: Map<string, NodeSessionState>;
+}
+
+function _snapshotMutableRun(run: ActiveRun): MutableRunSnapshot {
+  return {
+    dagRun: structuredClone(run.dagRun),
+    status: run.status,
+    currentRound: structuredClone(run.currentRound),
+    completedAt: run.completedAt,
+    counters: structuredClone(run.counters),
+    nodeSessions: structuredClone(run.nodeSessions),
+  };
+}
+
+function _restoreMutableRun(run: ActiveRun, snapshot: MutableRunSnapshot): void {
+  run.dagRun = snapshot.dagRun;
+  run.status = snapshot.status;
+  run.currentRound = snapshot.currentRound;
+  run.completedAt = snapshot.completedAt;
+  run.counters = snapshot.counters;
+  run.nodeSessions = snapshot.nodeSessions;
+}
+
 function _nodeName(run: ActiveRun, nodeId: string): string {
   return run.dagRun.graph.nodes.find((node) => node.node_id === nodeId)?.name ?? nodeId;
 }
@@ -521,12 +616,30 @@ export function _clearActiveRuns(): void {
   store.clear();
 }
 
+function _roundId(ordinal: number): string {
+  return `round-${String(ordinal).padStart(4, "0")}`;
+}
+
+function _initialRound(parsedDAG: ParsedDAG, openedAt: number): ActiveRunRound {
+  return {
+    round_id: _roundId(1),
+    ordinal: 1,
+    status: "active",
+    target_actor_ids: parsedDAG.graph.nodes
+      .filter((node) => !_isGatewayNode(node))
+      .map(_logicalActorId)
+      .sort(),
+    opened_at: openedAt,
+  };
+}
+
 export function createActiveRun(
   runId: string,
   parsedDAG: ParsedDAG,
   options: CreateActiveRunOptions = {},
 ): ActiveRun {
   const dagRun = createDAGRun(parsedDAG, runId);
+  const createdAt = Date.now();
   seedInitialPrompt(
     dagRun,
     options.initialPrompt,
@@ -563,8 +676,9 @@ export function createActiveRun(
       ? { ...parsedDAG.meta.pattern, parameters: { ...(parsedDAG.meta.pattern.parameters ?? {}) } }
       : undefined,
     dagRun,
-    createdAt: Date.now(),
+    createdAt,
     status: "active",
+    currentRound: _initialRound(parsedDAG, createdAt),
     limits: _resolveLimits(parsedDAG.meta.limits),
     counters: _initialCounters(),
     nodeIndex: _buildNodeIndex(parsedDAG.graph.nodes),
@@ -573,6 +687,12 @@ export function createActiveRun(
   _assertLogicalActorIdentities(run.dagRun.graph.nodes);
   dbTransaction(() => {
     writeRunMetadata(runId, serializeRunMetadata(run));
+    createInitialDagRunRound({
+      run_id: runId,
+      round_id: run.currentRound.round_id,
+      target_actor_ids: run.currentRound.target_actor_ids,
+      opened_at: run.currentRound.opened_at,
+    });
     _registerLogicalActors(run);
   });
   store.set(runId, run);
@@ -703,9 +823,21 @@ function _rebuildDagRunFromPersisted(metadata: PersistedRunMetadata, graphData: 
     mailboxes,
   };
 
-  const snapshot = loadRunSnapshot(metadata.runId);
-  if (snapshot && snapshot.handoffs.length > 0) {
-    _replayHandoffsInto(dagRun, snapshot.handoffs);
+  const runtimeState = metadata.dagRuntimeState;
+  if (runtimeState) {
+    dagRun.loopSources = new Set(runtimeState.loop_sources);
+    for (const node of nodes) {
+      dagRun.afterSatisfied.set(node.node_id, new Set(runtimeState.after_satisfied[node.node_id] ?? []));
+      dagRun.inputSatisfied.set(node.node_id, new Set(runtimeState.input_satisfied[node.node_id] ?? []));
+      dagRun.mailboxes.set(node.node_id, new Map(
+        Object.entries(runtimeState.mailboxes[node.node_id] ?? {}).map(([port, values]) => [port, structuredClone(values)]),
+      ));
+    }
+  } else {
+    const snapshot = loadRunSnapshot(metadata.runId);
+    if (snapshot && snapshot.handoffs.length > 0) {
+      _replayHandoffsInto(dagRun, snapshot.handoffs);
+    }
   }
 
   // Layer the authoritative node-state snapshot on top of the replay. The replay
@@ -752,6 +884,7 @@ function _applyOrphanedNodeDemotion(run: ActiveRun): string[] {
   if (hasFailedNodes && isRunTerminal(run.dagRun)) {
     run.status = "failed";
     run.completedAt = Date.now();
+    _persistTerminalRun(run, "failed");
     emit("dag:run_failed", {
       runId: run.runId,
       nodeId: demotedFromRunning[0],
@@ -769,7 +902,7 @@ function _skipPendingNodesWhenFailureStalls(run: ActiveRun): string[] {
   const states = Array.from(run.dagRun.nodeStates.values());
   if (!states.some((state) => state === "FAILED")) return [];
   if (states.some((state) =>
-    state === "READY" || state === "RUNNING" || state === "WAITING_FOR_APPROVAL"
+    state === "READY" || state === "RUNNING" || state === "WAITING_FOR_APPROVAL" || state === "WAITING_FOR_COMMAND"
   )) return [];
 
   const skipped: string[] = [];
@@ -786,12 +919,11 @@ export type RestoreActiveRunResult =
   | { status: "restored"; run: ActiveRun; demotedFromRunning: string[] }
   | { status: "skipped"; reason: string };
 
-/** Reconstruct a single ActiveRun from persisted metadata and replay it into
- * the in-memory store. Only `status: "active"` runs are recoverable. */
+/** Reconstruct a single nonterminal run from persisted metadata. */
 export function restoreActiveRun(
   metadata: PersistedRunMetadata,
 ): RestoreActiveRunResult {
-  if (metadata.status !== "active") {
+  if (metadata.status !== "active" && metadata.status !== "waiting") {
     return { status: "skipped", reason: `run is ${metadata.status}` };
   }
   if (!metadata.graph) {
@@ -802,7 +934,38 @@ export function restoreActiveRun(
   }
 
   const { dagRun, nodes } = _rebuildDagRunFromPersisted(metadata, metadata.graph);
-  seedInitialPrompt(dagRun, metadata.initialPrompt, metadata.runInputTargets, metadata.contracts);
+  if (!metadata.dagRuntimeState) {
+    seedInitialPrompt(dagRun, metadata.initialPrompt, metadata.runInputTargets, metadata.contracts);
+  }
+  const persistedRound = getCurrentDagRunRound(metadata.runId);
+  const currentRound = persistedRound ? {
+    round_id: persistedRound.round_id,
+    ordinal: persistedRound.ordinal,
+    status: persistedRound.status,
+    target_actor_ids: persistedRound.target_actor_ids,
+    ...(persistedRound.await_node_id ? { await_node_id: persistedRound.await_node_id } : {}),
+    opened_at: persistedRound.opened_at,
+    ...(persistedRound.closed_at === undefined ? {} : { closed_at: persistedRound.closed_at }),
+    ...(persistedRound.expires_at === undefined ? {} : { expires_at: persistedRound.expires_at }),
+  } : metadata.currentRound ?? {
+    round_id: _roundId(1),
+    ordinal: 1,
+    status: metadata.status,
+    target_actor_ids: nodes.filter((node) => !_isGatewayNode(node)).map(_logicalActorId).sort(),
+    opened_at: metadata.createdAt,
+  };
+  if (!persistedRound) {
+    createInitialDagRunRound({
+      run_id: metadata.runId,
+      round_id: currentRound.round_id,
+      target_actor_ids: currentRound.target_actor_ids,
+      opened_at: currentRound.opened_at,
+      status: currentRound.status,
+      await_node_id: currentRound.await_node_id,
+      closed_at: currentRound.closed_at,
+      expires_at: currentRound.expires_at,
+    });
+  }
   const run: ActiveRun = {
     runId: metadata.runId,
     workflowId: metadata.workflowId,
@@ -829,7 +992,8 @@ export function restoreActiveRun(
       : undefined,
     dagRun,
     createdAt: metadata.createdAt,
-    status: "active",
+    status: metadata.status,
+    currentRound,
     limits: metadata.limits ?? { ...DEFAULT_LIMITS },
     counters: _restoreCounters(metadata.counters),
     nodeIndex: _buildNodeIndex(nodes),
@@ -846,7 +1010,7 @@ export function restoreActiveRun(
 
   store.set(metadata.runId, run);
 
-  const demotedFromRunning = _applyOrphanedNodeDemotion(run);
+  const demotedFromRunning = run.status === "active" ? _applyOrphanedNodeDemotion(run) : [];
   writeRunMetadata(metadata.runId, serializeRunMetadata(run));
 
   emit("dag:run_recovered", {
@@ -932,16 +1096,283 @@ export function listActiveRuns(): ActiveRun[] {
   return Array.from(store.values());
 }
 
+function _deduplicatedResumeResult(
+  run: ActiveRun,
+  request: ResumeWaitingRunRequest,
+  expectedRoundId: string,
+): ResumeWaitingRunResult | undefined {
+  if ((run.status !== "active" && run.status !== "waiting") || run.currentRound.ordinal <= 1) return undefined;
+  const previous = listDagRunRounds(run.runId).find(
+    (round) => round.round_id === expectedRoundId && round.ordinal === run.currentRound.ordinal - 1,
+  );
+  if (!previous || previous.status !== "completed") return undefined;
+  const commands = listDagActorCommands({
+    run_id: run.runId,
+    round_id: run.currentRound.round_id,
+    // Fetch one extra row so a strict subset cannot masquerade as a retry of
+    // the complete command set accepted for this round.
+    limit: request.commands.length + 1,
+  });
+  if (commands.length !== request.commands.length) return undefined;
+  const actorsById = new Map(listDagActors(run.runId).map((actor) => [actor.actor_id, actor]));
+  const commandsByActor = new Map(commands.map((command) => [command.actor_id, command]));
+  if (commandsByActor.size !== commands.length) return undefined;
+  const matched = request.commands.map((requested) => {
+    const actorId = requested.actor_id.trim();
+    const command = commandsByActor.get(actorId);
+    if (!command) return undefined;
+    const expectedKey = requested.idempotency_key?.trim() || `${run.currentRound.round_id}:${actorId}`;
+    if (requested.command_id?.trim() && requested.command_id.trim() !== command.command_id) return undefined;
+    if (expectedKey !== command.idempotency_key || !isDeepStrictEqual(requested.payload, command.payload)) return undefined;
+    return { command, actor: actorsById.get(actorId) };
+  });
+  if (matched.some((entry) => !entry?.actor)) return undefined;
+  const entries = matched as Array<{
+    command: NonNullable<ReturnType<typeof getDagActorCommand>>;
+    actor: DagActorRecord;
+  }>;
+  return {
+    runId: run.runId,
+    previousRoundId: expectedRoundId,
+    roundId: run.currentRound.round_id,
+    ordinal: run.currentRound.ordinal,
+    actorIds: entries.map((entry) => entry.actor.actor_id),
+    nodeIds: entries.map((entry) => entry.actor.node_id),
+    commandIds: entries.map((entry) => entry.command.command_id),
+    readyNodeIds: entries
+      .map((entry) => entry.actor.node_id)
+      .filter((nodeId) => run.dagRun.nodeStates.get(nodeId) === "READY"),
+    deduplicated: true,
+  };
+}
+
+function _validateResumeRequest(request: ResumeWaitingRunRequest): void {
+  if (!Array.isArray(request.commands) || request.commands.length < 1 || request.commands.length > 128) {
+    throw new Error("commands must contain between 1 and 128 entries");
+  }
+  const actorIds = request.commands.map((command) => {
+    if (!command || typeof command.actor_id !== "string") throw new Error("actor_id is required");
+    const actorId = command.actor_id.trim();
+    if (!actorId) throw new Error("actor_id is required");
+    return actorId;
+  });
+  if (new Set(actorIds).size !== actorIds.length) {
+    throw new Error("Each actor may receive at most one command per round");
+  }
+}
+
+export function deduplicateWaitingActiveRunResume(
+  runId: string,
+  request: ResumeWaitingRunRequest,
+): ResumeWaitingRunResult | undefined {
+  _validateResumeRequest(request);
+  const run = store.get(runId);
+  if (!run) return undefined;
+  const expectedRoundId = request.expected_round_id.trim();
+  if (!expectedRoundId) throw new Error("expected_round_id is required");
+  return _deduplicatedResumeResult(run, request, expectedRoundId);
+}
+
+export function resumeWaitingActiveRun(
+  runId: string,
+  request: ResumeWaitingRunRequest,
+): ResumeWaitingRunResult {
+  const run = store.get(runId);
+  if (!run) throw new Error(`Run not found: ${runId}`);
+  _validateResumeRequest(request);
+  const expectedRoundId = request.expected_round_id.trim();
+  if (!expectedRoundId) throw new Error("expected_round_id is required");
+  const deduplicated = _deduplicatedResumeResult(run, request, expectedRoundId);
+  if (deduplicated) return deduplicated;
+  if (run.status !== "waiting" || run.currentRound.status !== "waiting") {
+    throw new Error(`Run ${runId} is not waiting`);
+  }
+  if (expectedRoundId !== run.currentRound.round_id) {
+    throw new Error(`Waiting round conflict: current round is ${run.currentRound.round_id}`);
+  }
+  const persistedRound = getCurrentDagRunRound(runId);
+  if (!persistedRound || persistedRound.round_id !== expectedRoundId || persistedRound.status !== "waiting") {
+    throw new Error(`Persisted waiting round conflict for ${runId}/${expectedRoundId}`);
+  }
+  const awaitNodeId = run.currentRound.await_node_id;
+  const awaitNode = awaitNodeId
+    ? run.dagRun.graph.nodes.find((node) => node.node_id === awaitNodeId)
+    : undefined;
+  if (!awaitNode || awaitNode.node_type !== "await_command_gateway") {
+    throw new Error(`Run ${runId} has no active await_command node`);
+  }
+
+  const actorsById = new Map(listDagActors(runId).map((actor) => [actor.actor_id, actor]));
+  const requestedActorIds = request.commands.map((command) => command.actor_id.trim());
+  const actors = requestedActorIds.map((actorId) => {
+    const actor = actorsById.get(actorId);
+    if (!actor) throw new Error(`Unknown DAG actor: ${runId}/${actorId}`);
+    return actor;
+  });
+  const configuredTargets = awaitNode.gateway_config?.target_actors;
+  if (configuredTargets && configuredTargets.length > 0) {
+    const allowed = new Set(configuredTargets);
+    for (const actor of actors) {
+      if (!allowed.has(actor.actor_id) && !allowed.has(actor.node_id)) {
+        throw new Error(`Actor ${actor.actor_id} is not allowed by await_command ${awaitNode.node_id}`);
+      }
+    }
+  }
+
+  const selectedNodeIds = new Set(actors.map((actor) => actor.node_id));
+  const resetNodeIds = _roundResetNodeIds(run, selectedNodeIds, awaitNode.node_id);
+  const nextOrdinal = run.currentRound.ordinal + 1;
+  const nextRoundId = _roundId(nextOrdinal);
+  const openedAt = Date.now();
+  const commandPort = awaitNode.gateway_config?.command_port || "command";
+  const commandRows = request.commands.map((command, index) => {
+    const actor = actors[index];
+    const commandId = command.command_id?.trim() || `command-${randomUUID()}`;
+    const idempotencyKey = command.idempotency_key?.trim() || `${nextRoundId}:${actor.actor_id}`;
+    return {
+      command_id: commandId,
+      run_id: runId,
+      actor_id: actor.actor_id,
+      round_id: nextRoundId,
+      idempotency_key: idempotencyKey,
+      target_generation: actor.generation,
+      payload: command.payload,
+      node_id: actor.node_id,
+    };
+  });
+  const commandInputs = new Map(commandRows.map((command) => [command.node_id, {
+    port: commandPort,
+    value: {
+      command_id: command.command_id,
+      round_id: command.round_id,
+      actor_id: command.actor_id,
+      payload: command.payload,
+    },
+  }]));
+
+  const previousDagRun = structuredClone(run.dagRun);
+  const previousRound = structuredClone(run.currentRound);
+  const previousCounters = structuredClone(run.counters);
+  const before = _snapshotNodeStates(run);
+  const resetNodeSet = new Set(resetNodeIds);
+  const reset = resetNodesForRound(run.dagRun, {
+    resetNodeIds,
+    commandInputs,
+    carryoverInputs: _roundCarryoverInputs(run, resetNodeSet),
+  });
+  run.status = "active";
+  run.completedAt = undefined;
+  run.currentRound = {
+    round_id: nextRoundId,
+    ordinal: nextOrdinal,
+    status: "active",
+    target_actor_ids: requestedActorIds.slice().sort(),
+    opened_at: openedAt,
+  };
+  run.counters = _initialCounters();
+
+  try {
+    getDb().transaction(() => {
+      openNextDagRunRound({
+        run_id: runId,
+        expected_round_id: expectedRoundId,
+        round_id: nextRoundId,
+        target_actor_ids: run.currentRound.target_actor_ids,
+        opened_at: openedAt,
+      });
+      for (const command of commandRows) createDagActorCommand(command);
+      writeRunMetadata(runId, serializeRunMetadata(run));
+    }).immediate();
+  } catch (error) {
+    run.dagRun = previousDagRun;
+    run.currentRound = previousRound;
+    run.counters = previousCounters;
+    run.status = "waiting";
+    throw error;
+  }
+
+  _emitNodeStateChanges(run, before);
+  for (const nodeId of reset.readyNodes) emit("dag:node_ready", { runId, nodeId });
+  emit("dag:round_started", {
+    runId,
+    roundId: nextRoundId,
+    ordinal: nextOrdinal,
+    actorIds: requestedActorIds,
+  });
+  for (const command of commandRows) {
+    emit("dag:command_queued", {
+      runId,
+      roundId: nextRoundId,
+      commandId: command.command_id,
+      actorId: command.actor_id,
+      nodeId: command.node_id,
+    });
+  }
+  emit("dag:run_resumed", {
+    runId,
+    previousRoundId: expectedRoundId,
+    roundId: nextRoundId,
+    actorIds: requestedActorIds,
+  });
+  return {
+    runId,
+    previousRoundId: expectedRoundId,
+    roundId: nextRoundId,
+    ordinal: nextOrdinal,
+    actorIds: requestedActorIds,
+    nodeIds: actors.map((actor) => actor.node_id),
+    commandIds: commandRows.map((command) => command.command_id),
+    readyNodeIds: reset.readyNodes,
+  };
+}
+
+function _persistTerminalRun(
+  run: ActiveRun,
+  status: "completed" | "cancelled" | "failed",
+): void {
+  const closedAt = run.completedAt ?? Date.now();
+  run.currentRound = {
+    ...run.currentRound,
+    status,
+    closed_at: run.currentRound.closed_at ?? closedAt,
+  };
+  getDb().transaction(() => {
+    terminalizeCurrentDagRunRound({
+      run_id: run.runId,
+      round_id: run.currentRound.round_id,
+      status,
+      closed_at: closedAt,
+    });
+    cancelUnclaimedDagActorCommands({
+      run_id: run.runId,
+      reason: { status, message: `run ${status}` },
+    });
+    writeRunMetadata(run.runId, serializeRunMetadata(run));
+  }).immediate();
+}
+
 export function completeActiveRun(runId: string): ActiveRun | undefined {
   const run = store.get(runId);
   if (!run) return undefined;
+  if (run.status === "completed" || run.status === "failed" || run.status === "cancelled") return run;
+  const mutableBefore = _snapshotMutableRun(run);
   const before = _snapshotNodeStates(run);
-  run.status = "completed";
-  run.completedAt = Date.now();
-  for (const nodeId of run.nodeSessions.keys()) {
-    _markNodeSessionStatus(run, nodeId, "completed");
+  try {
+    getDb().transaction(() => {
+      if (run.currentRound.await_node_id && run.dagRun.nodeStates.get(run.currentRound.await_node_id) === "WAITING_FOR_COMMAND") {
+        run.dagRun.nodeStates.set(run.currentRound.await_node_id, "COMPLETED");
+      }
+      run.status = "completed";
+      run.completedAt = Date.now();
+      for (const nodeId of run.nodeSessions.keys()) {
+        _markNodeSessionStatus(run, nodeId, "completed");
+      }
+      _persistTerminalRun(run, "completed");
+    }).immediate();
+  } catch (error) {
+    _restoreMutableRun(run, mutableBefore);
+    throw error;
   }
-  writeRunMetadata(runId, serializeRunMetadata(run));
   _emitNodeStateChanges(run, before);
   emit("dag:run_completed", { runId });
   emit("dag:engine_completed", { runId });
@@ -952,19 +1383,27 @@ export function completeActiveRun(runId: string): ActiveRun | undefined {
 export function cancelActiveRun(runId: string): ActiveRun | undefined {
   const run = store.get(runId);
   if (!run) return undefined;
-  if (run.status !== "active") return run;
+  if (run.status !== "active" && run.status !== "waiting") return run;
+  const mutableBefore = _snapshotMutableRun(run);
   const before = _snapshotNodeStates(run);
-  for (const [nodeId, state] of run.dagRun.nodeStates.entries()) {
-    if (state === "RUNNING" || state === "READY") {
-      run.dagRun.nodeStates.set(nodeId, "CANCELLED");
-      _markNodeSessionStatus(run, nodeId, "cancelled");
-    } else if (state === "PENDING") {
-      run.dagRun.nodeStates.set(nodeId, "SKIPPED");
-    }
+  try {
+    getDb().transaction(() => {
+      for (const [nodeId, state] of run.dagRun.nodeStates.entries()) {
+        if (state === "RUNNING" || state === "READY" || state === "WAITING_FOR_COMMAND" || state === "WAITING_FOR_APPROVAL") {
+          run.dagRun.nodeStates.set(nodeId, "CANCELLED");
+          _markNodeSessionStatus(run, nodeId, "cancelled");
+        } else if (state === "PENDING") {
+          run.dagRun.nodeStates.set(nodeId, "SKIPPED");
+        }
+      }
+      run.status = "cancelled";
+      run.completedAt = Date.now();
+      _persistTerminalRun(run, "cancelled");
+    }).immediate();
+  } catch (error) {
+    _restoreMutableRun(run, mutableBefore);
+    throw error;
   }
-  run.status = "cancelled";
-  run.completedAt = Date.now();
-  writeRunMetadata(runId, serializeRunMetadata(run));
   _emitNodeStateChanges(run, before);
   emit("dag:run_cancelled", { runId });
   deprovisionProvisionedForRun(runId);
@@ -975,24 +1414,32 @@ export function abortActiveRun(runId: string, reason: string, nodeId?: string): 
   const run = store.get(runId);
   if (!run) return undefined;
   if (run.status !== "active") return run;
+  const mutableBefore = _snapshotMutableRun(run);
   const before = _snapshotNodeStates(run);
-  if (nodeId && run.dagRun.nodeStates.has(nodeId)) {
-    run.dagRun.nodeStates.set(nodeId, "FAILED");
-    _markNodeSessionStatus(run, nodeId, "failed");
+  try {
+    getDb().transaction(() => {
+      if (nodeId && run.dagRun.nodeStates.has(nodeId)) {
+        run.dagRun.nodeStates.set(nodeId, "FAILED");
+        _markNodeSessionStatus(run, nodeId, "failed");
+      }
+      for (const [id, state] of run.dagRun.nodeStates.entries()) {
+        if (id === nodeId) continue;
+        if (state === "READY" || state === "RUNNING") {
+          run.dagRun.nodeStates.set(id, "CANCELLED");
+          _markNodeSessionStatus(run, id, "cancelled");
+        } else if (state === "PENDING") {
+          run.dagRun.nodeStates.set(id, "SKIPPED");
+        }
+      }
+      run.status = "failed";
+      run.completedAt = Date.now();
+      run.counters.abort_reason = reason;
+      _persistTerminalRun(run, "failed");
+    }).immediate();
+  } catch (error) {
+    _restoreMutableRun(run, mutableBefore);
+    throw error;
   }
-  for (const [id, state] of run.dagRun.nodeStates.entries()) {
-    if (id === nodeId) continue;
-    if (state === "READY" || state === "RUNNING") {
-      run.dagRun.nodeStates.set(id, "CANCELLED");
-      _markNodeSessionStatus(run, id, "cancelled");
-    } else if (state === "PENDING") {
-      run.dagRun.nodeStates.set(id, "SKIPPED");
-    }
-  }
-  run.status = "failed";
-  run.completedAt = Date.now();
-  run.counters.abort_reason = reason;
-  writeRunMetadata(runId, serializeRunMetadata(run));
   _emitNodeStateChanges(run, before);
   emit("dag:engine_aborted", { runId, nodeId, reason });
   emit("dag:run_failed", { runId, nodeId: nodeId ?? "", reason });
@@ -1030,7 +1477,7 @@ export function failActiveRun(runId: string, nodeId: string, reason: string): Ac
   if (isRunTerminal(run.dagRun)) {
     run.status = "failed";
     run.completedAt = Date.now();
-    writeRunMetadata(runId, serializeRunMetadata(run));
+    _persistTerminalRun(run, "failed");
     _emitStatusUpdate(run);
     emit("dag:run_failed", { runId, nodeId, reason });
     deprovisionProvisionedForRun(runId);
@@ -1276,47 +1723,72 @@ export function handoffActiveRun(
   fromNode: string,
   port: string,
   content: unknown,
+  fence?: HandoffTransportFence,
 ): ActiveRun | undefined {
   const run = store.get(runId);
   if (!run) return undefined;
   if (run.status !== "active") throw new Error(`Run ${runId} is not active`);
+  const fencedCommand = _validateHandoffTransportFence(run, fromNode, fence);
   const sourceState = getNodeState(run.dagRun, fromNode);
   if (sourceState === "COMPLETED" || sourceState === "FAILED" || sourceState === "CANCELLED" || sourceState === "SKIPPED") {
     throw new Error(`Node ${fromNode} cannot hand off from terminal state ${sourceState}`);
   }
   _assertHandoffPreconditions(run, fromNode, port, content, true);
+  const mutableBefore = _snapshotMutableRun(run);
   const before = _snapshotNodeStates(run);
   const readyBefore = new Set(getReadyNodes(run.dagRun));
-  run.counters.handoffs++;
+  let transition!: ReturnType<typeof handoff>;
+  try {
+    getDb().transaction(() => {
+      run.counters.handoffs++;
 
-  for (const edge of run.dagRun.graph.edges) {
-    if (edge.from_node !== fromNode || edge.to_node === "" || edge.label === "after_dep") continue;
-    if (!edgeMatchesHandoff(edge, port)) continue;
-    if (!_isBackwardEdge(run, edge)) continue;
-    const key = `${edge.from_node}/${edge.from_port}->${edge.to_node}/${edge.to_port}`;
-    const nextCount = (run.counters.edge_traversals[key] ?? 0) + 1;
-    run.counters.edge_traversals[key] = nextCount;
-    const edgeLimit = edge.retry_policy?.max_retries ?? run.limits.max_edge_traversals;
-    if (nextCount > edgeLimit) {
-      abortActiveRun(runId, `edge retry limit (${edgeLimit}) exceeded for ${key}`, fromNode);
-      throw new Error(`edge retry limit (${edgeLimit}) exceeded for ${key}`);
-    }
+      for (const edge of run.dagRun.graph.edges) {
+        if (edge.from_node !== fromNode || edge.to_node === "" || edge.label === "after_dep") continue;
+        if (!edgeMatchesHandoff(edge, port) || !_isBackwardEdge(run, edge)) continue;
+        const key = `${edge.from_node}/${edge.from_port}->${edge.to_node}/${edge.to_port}`;
+        run.counters.edge_traversals[key] = (run.counters.edge_traversals[key] ?? 0) + 1;
+      }
+
+      if (fencedCommand) {
+        claimDagActorCommand({
+          command_id: fencedCommand.command_id,
+          run_id: runId,
+          actor_id: fencedCommand.actor_id,
+          generation: fencedCommand.target_generation,
+        });
+      }
+      transition = handoff(run.dagRun, fromNode, port, content);
+      _markNodeSessionStatus(
+        run,
+        fromNode,
+        transition.terminalOutcome === "cancelled"
+          ? "cancelled"
+          : transition.terminalFailure
+            ? "failed"
+            : "completed",
+      );
+      appendHandoff(runId, {
+        runId,
+        roundId: run.currentRound.round_id,
+        fromNode,
+        port,
+        content,
+        timestamp: Date.now(),
+      });
+      if (fencedCommand) {
+        acknowledgeDagActorCommand({
+          command_id: fencedCommand.command_id,
+          generation: fencedCommand.target_generation,
+        });
+      }
+      const handedOffNode = run.dagRun.graph.nodes.find((candidate) => candidate.node_id === fromNode);
+      if (handedOffNode) _recordFanoutChild(run, handedOffNode, port, content);
+      writeRunMetadata(runId, serializeRunMetadata(run));
+    }).immediate();
+  } catch (error) {
+    _restoreMutableRun(run, mutableBefore);
+    throw error;
   }
-
-  const transition = handoff(run.dagRun, fromNode, port, content);
-  _markNodeSessionStatus(
-    run,
-    fromNode,
-    transition.terminalOutcome === "cancelled"
-      ? "cancelled"
-      : transition.terminalFailure
-        ? "failed"
-        : "completed",
-  );
-  appendHandoff(runId, { runId, fromNode, port, content, timestamp: Date.now() });
-  const handedOffNode = run.dagRun.graph.nodes.find((candidate) => candidate.node_id === fromNode);
-  if (handedOffNode) _recordFanoutChild(run, handedOffNode, port, content);
-  writeRunMetadata(runId, serializeRunMetadata(run));
   _emitNodeStateChanges(run, before);
   emit("dag:handoff", { runId, fromNode, port });
   if (transition.terminalFailure) {
@@ -1333,18 +1805,58 @@ export function handoffActiveRun(
 
   if (run.status === "active" && isRunTerminal(run.dagRun)) {
     if (transition.terminalOutcome === "cancelled") {
-      run.status = "cancelled";
-      run.completedAt = Date.now();
-      writeRunMetadata(runId, serializeRunMetadata(run));
-      _emitStatusUpdate(run);
-      emit("dag:run_cancelled", { runId, nodeId: fromNode, reason: `terminal cancelled handoff on port ${port}` });
-      deprovisionProvisionedForRun(runId);
+      cancelActiveRun(runId);
     } else {
       completeActiveRun(runId);
     }
   }
 
   return run;
+}
+
+function _validateHandoffTransportFence(
+  run: ActiveRun,
+  fromNode: string,
+  fence: HandoffTransportFence | undefined,
+): ReturnType<typeof getDagActorCommand> {
+  if (fence?.transport !== true) return undefined;
+  const actor = getDagActorByNode(run.runId, fromNode);
+  if (!actor) throw new Error(`DAG_HANDOFF_ACTOR_FENCE_MISSING ${run.runId}/${fromNode}`);
+  const requiresDurableFence = run.currentRound.ordinal > 1;
+  if (!fence.roundId) {
+    if (requiresDurableFence) {
+      throw new Error(`DAG_HANDOFF_ROUND_FENCE_MISSING ${run.runId}/${fromNode}`);
+    }
+    return undefined;
+  }
+  if (fence.roundId !== run.currentRound.round_id) {
+    throw new Error(
+      `DAG_HANDOFF_ROUND_CONFLICT ${run.runId}/${fromNode}: received ${fence.roundId}, current ${run.currentRound.round_id}`,
+    );
+  }
+  if (fence.actorId !== undefined && fence.actorId !== actor.actor_id) {
+    throw new Error(`DAG_HANDOFF_ACTOR_CONFLICT ${run.runId}/${fromNode}`);
+  }
+  if (fence.generation !== undefined && fence.generation !== actor.generation) {
+    throw new Error(
+      `DAG_HANDOFF_GENERATION_CONFLICT ${run.runId}/${fromNode}: received ${String(fence.generation)}, current ${actor.generation}`,
+    );
+  }
+  if (requiresDurableFence && (!fence.actorId || fence.generation === undefined || !fence.commandId)) {
+    throw new Error(`DAG_HANDOFF_COMMAND_FENCE_MISSING ${run.runId}/${fromNode}`);
+  }
+  if (!fence.commandId) return undefined;
+  const command = getDagActorCommand(fence.commandId);
+  if (!command
+    || command.run_id !== run.runId
+    || command.actor_id !== actor.actor_id
+    || command.round_id !== run.currentRound.round_id) {
+    throw new Error(`DAG_HANDOFF_COMMAND_CONFLICT ${run.runId}/${fromNode}`);
+  }
+  if (command.target_generation !== actor.generation) {
+    throw new Error(`DAG_HANDOFF_COMMAND_GENERATION_CONFLICT ${run.runId}/${fromNode}`);
+  }
+  return command;
 }
 
 function _assertHandoffPreconditions(
@@ -1463,6 +1975,49 @@ export function expireActiveRunApprovals(now = Date.now()): DagApprovalRecord[] 
   return expired;
 }
 
+export function expireWaitingActiveRuns(now = Date.now()): string[] {
+  const expired: string[] = [];
+  for (const run of store.values()) {
+    if (run.status !== "waiting") continue;
+    if (run.currentRound.expires_at === undefined || run.currentRound.expires_at > now) continue;
+    const mutableBefore = _snapshotMutableRun(run);
+    const before = _snapshotNodeStates(run);
+    const awaitNodeId = run.currentRound.await_node_id;
+    try {
+      getDb().transaction(() => {
+        if (awaitNodeId && run.dagRun.nodeStates.get(awaitNodeId) === "WAITING_FOR_COMMAND") {
+          run.dagRun.nodeStates.set(awaitNodeId, "FAILED");
+        }
+        run.status = "failed";
+        run.completedAt = now;
+        run.counters.abort_reason = `await_command expired at ${run.currentRound.expires_at}`;
+        _persistTerminalRun(run, "failed");
+      }).immediate();
+    } catch (error) {
+      _restoreMutableRun(run, mutableBefore);
+      console.error(
+        `[homerail_manager] failed to expire waiting run ${run.runId}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      continue;
+    }
+    _emitNodeStateChanges(run, before);
+    emit("dag:run_expired", {
+      runId: run.runId,
+      roundId: run.currentRound.round_id,
+      awaitNodeId,
+      expiredAt: now,
+    });
+    emit("dag:run_failed", {
+      runId: run.runId,
+      nodeId: awaitNodeId ?? "",
+      reason: "await_command expired",
+    });
+    deprovisionProvisionedForRun(run.runId);
+    expired.push(run.runId);
+  }
+  return expired.sort();
+}
+
 function _handoffContractViolation(
   run: ActiveRun,
   fromNode: string,
@@ -1487,6 +2042,14 @@ export function getActiveRunCount(): number {
   let count = 0;
   for (const run of store.values()) {
     if (run.status === "active") count++;
+  }
+  return count;
+}
+
+export function getWaitingRunCount(): number {
+  let count = 0;
+  for (const run of store.values()) {
+    if (run.status === "waiting") count++;
   }
   return count;
 }
@@ -1580,15 +2143,18 @@ export interface CancelAllResult {
 }
 
 export function cancelAllActiveRuns(): CancelAllResult {
-  const activeBefore = getActiveRunCount();
+  const activeBefore = Array.from(store.values())
+    .filter((run) => run.status === "active" || run.status === "waiting").length;
   const cancelled: string[] = [];
   for (const run of store.values()) {
-    if (run.status === "active") {
+    if (run.status === "active" || run.status === "waiting") {
       cancelActiveRun(run.runId);
       cancelled.push(run.runId);
     }
   }
-  return { cancelled, activeBefore, activeAfter: getActiveRunCount() };
+  const activeAfter = Array.from(store.values())
+    .filter((run) => run.status === "active" || run.status === "waiting").length;
+  return { cancelled, activeBefore, activeAfter };
 }
 
 export function injectActiveRun(
@@ -1690,7 +2256,69 @@ function _isGatewayNode(node: DAGGraphNode): boolean {
     node.node_type === "command_gateway" ||
     node.node_type === "approval_gateway" ||
     node.node_type === "state_gateway" ||
-    node.node_type === "fanout_gateway";
+    node.node_type === "fanout_gateway" ||
+    node.node_type === "await_command_gateway";
+}
+
+function _roundResetNodeIds(
+  run: ActiveRun,
+  selectedNodeIds: ReadonlySet<string>,
+  awaitNodeId: string,
+): string[] {
+  const reset = new Set(selectedNodeIds);
+  const reachedAwait = new Set<string>();
+  for (const selectedNodeId of selectedNodeIds) {
+    const queue = [selectedNodeId];
+    const visited = new Set<string>();
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      if (visited.has(current)) continue;
+      visited.add(current);
+      for (const edge of run.dagRun.graph.edges) {
+        if (edge.from_node !== current || !edge.to_node) continue;
+        if (edge.to_node === awaitNodeId) {
+          reset.add(awaitNodeId);
+          reachedAwait.add(selectedNodeId);
+          continue;
+        }
+        const target = run.dagRun.graph.nodes.find((node) => node.node_id === edge.to_node);
+        if (!target || !_isGatewayNode(target)) continue;
+        reset.add(target.node_id);
+        queue.push(target.node_id);
+      }
+    }
+  }
+  const missing = Array.from(selectedNodeIds).filter((nodeId) => !reachedAwait.has(nodeId));
+  if (missing.length > 0) {
+    throw new Error(`Selected actors have no gateway-only path to await_command ${awaitNodeId}: ${missing.join(", ")}`);
+  }
+  return Array.from(reset).sort();
+}
+
+function _roundCarryoverInputs(
+  run: ActiveRun,
+  resetNodeIds: ReadonlySet<string>,
+): Map<string, Array<{ fromNode: string; port: string; value: unknown }>> {
+  const handoffs = loadRunSnapshot(run.runId)?.handoffs ?? [];
+  const carryover = new Map<string, Array<{ fromNode: string; port: string; value: unknown }>>();
+  for (const edge of run.dagRun.graph.edges) {
+    if (!edge.to_node || edge.label === "after_dep" || !resetNodeIds.has(edge.to_node) || resetNodeIds.has(edge.from_node)) {
+      continue;
+    }
+    let previous: (typeof handoffs)[number] | undefined;
+    for (let index = handoffs.length - 1; index >= 0; index -= 1) {
+      const record = handoffs[index];
+      if (record.fromNode === edge.from_node && edgeMatchesHandoff(edge, record.port)) {
+        previous = record;
+        break;
+      }
+    }
+    if (!previous) continue;
+    const inputs = carryover.get(edge.to_node) ?? [];
+    inputs.push({ fromNode: edge.from_node, port: edge.to_port, value: previous.content });
+    carryover.set(edge.to_node, inputs);
+  }
+  return carryover;
 }
 
 function _firstInputValue(inputs: Record<string, unknown[]>): unknown {
@@ -2111,6 +2739,70 @@ function _startApproval(run: ActiveRun, node: DAGGraphNode): DagApprovalRecord {
   return approval;
 }
 
+function _startAwaitCommand(run: ActiveRun, node: DAGGraphNode): boolean {
+  const config = node.gateway_config;
+  if (config?.primitive_version !== 1) {
+    throw new Error(`await_command ${node.node_id} requires primitive_version 1`);
+  }
+  if (run.status !== "active" || run.currentRound.status !== "active") {
+    throw new Error(`Run ${run.runId} cannot enter await_command from ${run.status}/${run.currentRound.status}`);
+  }
+  const nonQuiescent = Array.from(run.dagRun.nodeStates.entries())
+    .filter(([nodeId, state]) => nodeId !== node.node_id &&
+      state !== "COMPLETED" && state !== "FAILED" && state !== "CANCELLED" && state !== "SKIPPED")
+    .map(([nodeId, state]) => `${nodeId}:${state}`)
+    .sort();
+  if (nonQuiescent.length > 0) {
+    return false;
+  }
+  const before = _snapshotNodeStates(run);
+  const previousRound = structuredClone(run.currentRound);
+  const now = Date.now();
+  const expiresAt = config.expires_after_ms === undefined
+    ? undefined
+    : now + Math.max(1_000, Math.floor(config.expires_after_ms));
+  run.dagRun.nodeStates.set(node.node_id, "WAITING_FOR_COMMAND");
+  run.status = "waiting";
+  run.currentRound = {
+    ...run.currentRound,
+    status: "waiting",
+    await_node_id: node.node_id,
+    closed_at: now,
+    ...(expiresAt === undefined ? {} : { expires_at: expiresAt }),
+  };
+  try {
+    getDb().transaction(() => {
+      transitionDagRunRoundToWaiting({
+        run_id: run.runId,
+        round_id: previousRound.round_id,
+        await_node_id: node.node_id,
+        closed_at: now,
+        expires_at: expiresAt,
+      });
+      writeRunMetadata(run.runId, serializeRunMetadata(run));
+    }).immediate();
+  } catch (error) {
+    run.status = "active";
+    run.currentRound = previousRound;
+    run.dagRun.nodeStates.set(node.node_id, before.get(node.node_id) as NodeState);
+    throw error;
+  }
+  _emitNodeStateChanges(run, before);
+  emit("dag:round_closed", {
+    runId: run.runId,
+    roundId: run.currentRound.round_id,
+    ordinal: run.currentRound.ordinal,
+    awaitNodeId: node.node_id,
+  });
+  emit("dag:run_waiting", {
+    runId: run.runId,
+    roundId: run.currentRound.round_id,
+    awaitNodeId: node.node_id,
+    expiresAt,
+  });
+  return true;
+}
+
 interface FanoutRuntimeState {
   items: unknown[];
   context?: unknown;
@@ -2258,6 +2950,17 @@ function _recordFanoutChild(run: ActiveRun, child: DAGGraphNode, port: string, c
 }
 
 function _executeGatewayNode(runId: string, run: ActiveRun, node: DAGGraphNode): boolean {
+  if (node.node_type === "await_command_gateway") {
+    if (!_startAwaitCommand(run, node)) return false;
+    emit("dag:gateway_executed", {
+      runId,
+      nodeId: node.node_id,
+      gatewayType: node.node_type,
+      port: "waiting",
+    });
+    return true;
+  }
+
   if (node.node_type === "command_gateway") {
     const result = _commandGatewayResult(run, node);
     return Boolean(handoffActiveRun(runId, node.node_id, result.port, result.payload));
@@ -2495,6 +3198,22 @@ function _allowedDagTools(node: DAGGraphNode): DagAgentToolName[] | undefined {
   ));
 }
 
+function _requiredDispatchCapabilities(
+  run: ActiveRun,
+  node: DAGGraphNode,
+): string[] | undefined {
+  const required = new Set<string>();
+  for (const capability of node.requires?.capabilities ?? []) {
+    if (typeof capability !== "string") continue;
+    const normalized = capability.trim();
+    if (normalized) required.add(normalized);
+  }
+  if (run.currentRound.ordinal > 1) {
+    required.add(DAG_TRANSPORT_FENCE_CAPABILITY);
+  }
+  return required.size > 0 ? Array.from(required) : undefined;
+}
+
 function _activitySurfaceId(node: DAGGraphNode): string | undefined {
   const value = _agentRuntimeConfig(node).surface_id;
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
@@ -2524,6 +3243,11 @@ function _buildDispatchEnvelope(run: ActiveRun, nodeId: string): DispatchEnvelop
   const actorId = actor.actor_id;
   const generation = actor.generation;
   const surfaceId = actor.surface_id;
+  const roundCommand = listDagActorCommands({
+    run_id: run.runId,
+    actor_id: actorId,
+    round_id: run.currentRound.round_id,
+  }).find((command) => command.status !== "cancelled" && command.status !== "failed");
   const dispatchInputs = nodeSession.resumeInstruction
     ? { ...inputs, checkpoint_resume: [nodeSession.resumeInstruction] }
     : inputs;
@@ -2554,15 +3278,16 @@ function _buildDispatchEnvelope(run: ActiveRun, nodeId: string): DispatchEnvelop
       workspace: run.workspace,
       image: node.image,
       container_group: node.container_group,
-      requiredCapabilities: node.requires?.capabilities,
+      requiredCapabilities: _requiredDispatchCapabilities(run, node),
       advisors: advisorResolution.advisors,
       workspaceAccess: _workspaceAccess(node),
       allowedBuiltinTools: _allowedBuiltinTools(node),
       allowedDagTools: _allowedDagTools(node),
       activity: {
-        roundId: nodeSession.sessionId,
+        roundId: run.currentRound.round_id,
         actorId,
         generation,
+        ...(roundCommand ? { commandId: roundCommand.command_id } : {}),
         ...(surfaceId ? { surfaceId } : {}),
         sequenceStart: getDagActivitySequenceCursor(run.runId, actorId, generation),
       },
@@ -2579,14 +3304,27 @@ export function buildCurrentDispatchEnvelope(
   return _buildDispatchEnvelope(run, nodeId);
 }
 
+function _markRoundCommandsDelivered(run: ActiveRun, nodeId: string): void {
+  const actor = getDagActorByNode(run.runId, nodeId);
+  if (!actor) return;
+  const commands = listDagActorCommands({
+    run_id: run.runId,
+    actor_id: actor.actor_id,
+    round_id: run.currentRound.round_id,
+    status: "pending",
+  });
+  for (const command of commands) markDagActorCommandDelivered(command.command_id);
+}
+
 export function dispatchReadyNodes(
   runId: string,
   dispatcher: DAGDispatcher,
 ): number {
   const run = store.get(runId);
-  if (!run) return 0;
+  if (!run || run.status !== "active") return 0;
 
   let count = 0;
+  let dispatchCounterChanged = false;
   const before = _snapshotNodeStates(run);
   const ready = getReadyNodes(run.dagRun);
   for (const nodeId of ready) {
@@ -2599,6 +3337,7 @@ export function dispatchReadyNodes(
         const message = error instanceof Error ? error.message : String(error);
         failActiveRun(runId, nodeId, `gateway execution failed: ${message}`);
       }
+      if (run.status !== "active") break;
       continue;
     }
 
@@ -2611,11 +3350,13 @@ export function dispatchReadyNodes(
       abortActiveRun(runId, `max_dispatches (${run.limits.max_dispatches}) exceeded`, nodeId);
       break;
     }
-    run.counters.dispatches++;
-
     const envelope = built.envelope;
 
     let result = dispatcher.dispatch(envelope);
+    if (result.status !== "skipped") {
+      run.counters.dispatches++;
+      dispatchCounterChanged = true;
+    }
     if (result.status === "failed") {
       const retryable = result.retryable !== false;
       if (retryable && recordNodeDispatchRetry(runId, nodeId, result.reason)) {
@@ -2623,7 +3364,6 @@ export function dispatchReadyNodes(
           abortActiveRun(runId, `max_dispatches (${run.limits.max_dispatches}) exceeded`, nodeId);
           break;
         }
-        run.counters.dispatches++;
         result = dispatcher.dispatch({
           ...envelope,
           inputs: {
@@ -2633,6 +3373,10 @@ export function dispatchReadyNodes(
             ],
           },
         });
+        if (result.status !== "skipped") {
+          run.counters.dispatches++;
+          dispatchCounterChanged = true;
+        }
       }
       if (result.status === "failed") {
         failActiveRun(runId, nodeId, result.reason);
@@ -2642,11 +3386,14 @@ export function dispatchReadyNodes(
     if (result.status !== "dispatched") continue;
     startNode(run.dagRun, nodeId);
     _markNodeSessionStatus(run, nodeId, "running");
+    _markRoundCommandsDelivered(run, nodeId);
     emit("dag:node_dispatched", { runId, nodeId, agentId: envelope.agentId, sessionId: envelope.sessionId });
     count++;
   }
-  if (count > 0) {
+  if (count > 0 || dispatchCounterChanged) {
     writeRunMetadata(runId, serializeRunMetadata(run));
+  }
+  if (count > 0) {
     _emitNodeStateChanges(run, before);
   }
   return count;
@@ -2667,8 +3414,30 @@ export function markNodeDispatched(
   startNode(run.dagRun, nodeId);
   const nodeSession = _ensureNodeSession(run, nodeId);
   _markNodeSessionStatus(run, nodeId, "running");
+  _markRoundCommandsDelivered(run, nodeId);
   emit("dag:node_dispatched", { runId, nodeId, agentId: node.agent, sessionId: nodeSession.sessionId });
   writeRunMetadata(runId, serializeRunMetadata(run));
   _emitNodeStateChanges(run, before);
+  return true;
+}
+
+export function recordProvisionedNodeDispatchAttempt(
+  runId: string,
+  nodeId: string,
+): boolean {
+  const run = store.get(runId);
+  if (!run || run.status !== "active" || getNodeState(run.dagRun, nodeId) !== "READY") return false;
+  if (run.counters.dispatches >= run.limits.max_dispatches) {
+    abortActiveRun(runId, `max_dispatches (${run.limits.max_dispatches}) exceeded`, nodeId);
+    return false;
+  }
+  const mutableBefore = _snapshotMutableRun(run);
+  try {
+    run.counters.dispatches++;
+    writeRunMetadata(runId, serializeRunMetadata(run));
+  } catch (error) {
+    _restoreMutableRun(run, mutableBefore);
+    throw error;
+  }
   return true;
 }

--- a/homerail_manager/src/runtime/dag-activity-stream.ts
+++ b/homerail_manager/src/runtime/dag-activity-stream.ts
@@ -30,8 +30,8 @@ export function ingestDagActivityStream(
     if (event.actor_id !== actor.actor_id) {
       throw new Error("DAG activity actor identity does not match the logical actor registry");
     }
-    if (typeof event.generation !== "number" || event.generation > actor.generation) {
-      throw new Error("DAG activity generation is ahead of the logical actor registry");
+    if (typeof event.generation !== "number" || event.generation !== actor.generation) {
+      throw new Error("DAG activity generation does not match the logical actor registry");
     }
     if (event.surface_id !== undefined && event.surface_id !== actor.surface_id) {
       throw new Error("DAG activity surface identity does not match the logical actor registry");

--- a/homerail_manager/src/runtime/dag-triggers.ts
+++ b/homerail_manager/src/runtime/dag-triggers.ts
@@ -1,6 +1,6 @@
 import type { ChangeOrchestrator } from "../orchestration/change-orchestrator.js";
 import { emit } from "../events/bus.js";
-import { expireActiveRunApprovals } from "./active-runs.js";
+import { expireActiveRunApprovals, expireWaitingActiveRuns } from "./active-runs.js";
 import {
   claimTriggerDelivery,
   completeTriggerDelivery,
@@ -13,6 +13,16 @@ import {
 import { WorkflowRunAdmissionError } from "../persistence/dag-run-admission.js";
 
 let orchestrator: ChangeOrchestrator | undefined;
+
+function runMaintenance(label: string, task: () => void): void {
+  try {
+    task();
+  } catch (error) {
+    console.error(
+      `[homerail_manager] DAG maintenance ${label} failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
 
 function dispatch(record: DagTriggerRecord, fireKey: string, payload: unknown): { dispatched: boolean; runId?: string; reason?: string } {
   if (!orchestrator) return { dispatched: false, reason: "trigger dispatcher is not initialized" };
@@ -47,7 +57,8 @@ function dispatch(record: DagTriggerRecord, fireKey: string, payload: unknown): 
 export function startDagTriggerScheduler(changeOrchestrator: ChangeOrchestrator, intervalMs = 1_000): () => void {
   orchestrator = changeOrchestrator;
   const tick = () => {
-    expireActiveRunApprovals();
+    runMaintenance("approval expiry", () => { expireActiveRunApprovals(); });
+    runMaintenance("waiting-run expiry", () => { expireWaitingActiveRuns(); });
     for (const record of dueIntervalTriggers()) {
       const fireAt = record.next_fire_at ?? Date.now();
       dispatch(record, `interval:${fireAt}`, { scheduled_at: fireAt });

--- a/homerail_manager/src/runtime/status.ts
+++ b/homerail_manager/src/runtime/status.ts
@@ -1,6 +1,6 @@
 import { getAllWorkers } from "../worker/registry.js";
 import { getAllNodes } from "../node/registry.js";
-import { getActiveRunCount } from "./active-runs.js";
+import { getActiveRunCount, getWaitingRunCount } from "./active-runs.js";
 
 export function runtimeStatusHandler() {
   const workers = getAllWorkers();
@@ -11,6 +11,7 @@ export function runtimeStatusHandler() {
     connected_workers: workers.length,
     connected_nodes: nodes.length,
     active_runs: getActiveRunCount(),
+    waiting_runs: getWaitingRunCount(),
     worker_ids: workers.map((w) => w.worker_id),
     worker_capabilities: Object.fromEntries(
       workers.map((w) => [w.worker_id, w.capabilities]),

--- a/homerail_manager/src/server/mutations.ts
+++ b/homerail_manager/src/server/mutations.ts
@@ -456,6 +456,75 @@ export function mutationRoutesHandler(
     return true;
   }
 
+  // POST /api/runs/:run_id/complete
+  const completeMatch = pathname.match(/^\/api\/runs\/([^/]+)\/complete$/);
+  if (completeMatch && req.method === "POST") {
+    const runId = decodeURIComponent(completeMatch[1]);
+    void _readJsonBody(req).then((raw) => {
+      const body = raw as Record<string, unknown>;
+      const expectedRoundId = typeof body.expected_round_id === "string"
+        ? body.expected_round_id.trim()
+        : "";
+      if (!expectedRoundId) throw new Error("expected_round_id is required");
+      const result = changeOrchestrator.completeRun(runId, expectedRoundId);
+      _ok(res, "Run completed", { completed: result });
+    }).catch((err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message.includes("not found")) _notFound(res, message);
+      else if (message.includes("not waiting") || message.includes("conflict")) {
+        json(res, 409, { success: false, message, error: message });
+      } else _badRequest(res, message);
+    });
+    return true;
+  }
+
+  // POST /api/runs/:run_id/commands
+  const commandsMatch = pathname.match(/^\/api\/runs\/([^/]+)\/commands$/);
+  if (commandsMatch && req.method === "POST") {
+    const runId = decodeURIComponent(commandsMatch[1]);
+    void _readJsonBody(req).then((raw) => {
+      const body = raw as Record<string, unknown>;
+      const expectedRoundId = typeof body.expected_round_id === "string"
+        ? body.expected_round_id.trim()
+        : "";
+      if (!expectedRoundId) throw new Error("expected_round_id is required");
+      if (!Array.isArray(body.commands) || body.commands.length < 1 || body.commands.length > 128) {
+        throw new Error("commands must contain between 1 and 128 entries");
+      }
+      const commands = body.commands.map((rawCommand, index) => {
+        if (!rawCommand || typeof rawCommand !== "object" || Array.isArray(rawCommand)) {
+          throw new Error(`commands[${index}] must be an object`);
+        }
+        const command = rawCommand as Record<string, unknown>;
+        const actorId = typeof command.actor_id === "string" ? command.actor_id.trim() : "";
+        if (!actorId) throw new Error(`commands[${index}].actor_id is required`);
+        if (!("payload" in command)) throw new Error(`commands[${index}].payload is required`);
+        const commandId = typeof command.command_id === "string" ? command.command_id.trim() : undefined;
+        const idempotencyKey = typeof command.idempotency_key === "string"
+          ? command.idempotency_key.trim()
+          : undefined;
+        return {
+          actor_id: actorId,
+          payload: command.payload,
+          ...(commandId ? { command_id: commandId } : {}),
+          ...(idempotencyKey ? { idempotency_key: idempotencyKey } : {}),
+        };
+      });
+      const result = changeOrchestrator.resumeRun(runId, {
+        expected_round_id: expectedRoundId,
+        commands,
+      });
+      _ok(res, "Waiting run resumed", result);
+    }).catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      if (message.includes("not found") || message.includes("Unknown DAG actor")) _notFound(res, message);
+      else if (message.includes("not waiting") || message.includes("conflict")) {
+        json(res, 409, { success: false, message, error: message });
+      } else _badRequest(res, message);
+    });
+    return true;
+  }
+
   const workspaceRetentionMatch = pathname.match(/^\/api\/runs\/([^/]+)\/workspace-retention$/);
   if (workspaceRetentionMatch && req.method === "POST") {
     const runId = decodeURIComponent(workspaceRetentionMatch[1]);

--- a/homerail_manager/src/server/routes.ts
+++ b/homerail_manager/src/server/routes.ts
@@ -11,7 +11,11 @@ import { getDiagnostics } from "../config/diagnostics.js";
 import { runtimeStatusHandler } from "../runtime/status.js";
 import { computeScorecard, renderScorecardJson } from "./scorecard.js";
 import { buildEvalReport, renderEvalJson } from "./eval.js";
-import { computeSuperviseTick } from "./supervise.js";
+import {
+  computeSuperviseTick,
+  isTerminalDagRunEvent,
+  isTerminalDagRunStatus,
+} from "./supervise.js";
 import { buildReplayReport } from "./replay.js";
 import { ingestRunExperience } from "./experience.js";
 import {
@@ -22,6 +26,8 @@ import { listActiveRuns } from "../runtime/active-runs.js";
 import { getDagState, listPendingApprovals } from "../persistence/dag-runtime-primitives.js";
 import { listDagTriggers } from "../persistence/dag-triggers.js";
 import { listDagActivityEvents } from "../persistence/dag-activity-journal.js";
+import { listDagActorCommands, type DagActorCommandStatus } from "../persistence/dag-actors.js";
+import { listDagRunRounds } from "../persistence/dag-run-rounds.js";
 
 interface BaseResponse {
   success: boolean;
@@ -92,7 +98,7 @@ function _buildExecutionStatus(metadata: ReturnType<typeof loadRunMetadata>) {
     .filter(([, state]) => state === "FAILED")
     .map(([id]) => id);
   return {
-    complete: ["completed", "failed"].includes(metadata.status),
+    complete: isTerminalDagRunStatus(metadata.status),
     active_nodes: activeNodes,
     completed_nodes: completedNodes,
     failed_nodes: failedNodes,
@@ -189,9 +195,7 @@ function _streamDagEvents(
     cleanup.push(subscribe(eventType, (payload) => {
       if (closed || _payloadRunId(payload) !== runId) return;
       res.write(_sseEvent(eventType, payload));
-      if (eventType === "dag:run_completed" || eventType === "dag:run_cancelled") {
-        close();
-      }
+      if (isTerminalDagRunEvent(eventType)) close();
     }));
   }
 
@@ -199,7 +203,7 @@ function _streamDagEvents(
   for (const event of snapshot.events) {
     res.write(_sseEvent(event.type, event.payload));
   }
-  if (metadata.status === "completed") {
+  if (isTerminalDagRunStatus(metadata.status)) {
     close();
   }
 }
@@ -377,6 +381,7 @@ export function inspectionRoutesHandler(
         workflowName: m.workflowName,
         nodeCount: m.nodeCount,
         status: m.status,
+        currentRound: m.currentRound,
         createdAt: m.createdAt,
         completedAt: m.completedAt,
       }));
@@ -409,13 +414,14 @@ export function inspectionRoutesHandler(
   // GET /api/runs/active/list
   if (pathname === "/api/runs/active/list" && req.method === "GET") {
     const runs = listActiveRuns()
-      .filter((run) => run.status === "active")
+      .filter((run) => run.status === "active" || run.status === "waiting")
       .map((run) => ({
         runId: run.runId,
         workflowId: run.workflowId,
         workflowName: run.workflowName,
         nodeCount: run.nodeCount,
         status: run.status,
+        currentRound: run.currentRound,
         createdAt: run.createdAt,
       }));
     _ok(res, "Active runs retrieved", { runs, total: runs.length });
@@ -425,13 +431,14 @@ export function inspectionRoutesHandler(
   // GET /api/runs/active/dashboard
   if (pathname === "/api/runs/active/dashboard" && req.method === "GET") {
     const runs = listActiveRuns()
-      .filter((run) => run.status === "active")
+      .filter((run) => run.status === "active" || run.status === "waiting")
       .map((run) => ({
         runId: run.runId,
         workflowId: run.workflowId,
         workflowName: run.workflowName,
         nodeCount: run.nodeCount,
         status: run.status,
+        currentRound: run.currentRound,
         createdAt: run.createdAt,
       }));
     _ok(res, "Active dashboard runs retrieved", { runs, total: runs.length });
@@ -447,6 +454,7 @@ export function inspectionRoutesHandler(
       homerail_home: process.env.HOMERAIL_HOME || null,
       active_runs: runtime.active_runs,
       active_run_ids: activeRunsList.filter((r) => r.status === "active").map((r) => r.runId),
+      waiting_run_ids: activeRunsList.filter((r) => r.status === "waiting").map((r) => r.runId),
       connected_nodes: runtime.connected_nodes,
       connected_workers: runtime.connected_workers,
       directory_import: {
@@ -512,7 +520,9 @@ export function inspectionRoutesHandler(
       run_id: metadata.runId,
       runId: metadata.runId,
       status: metadata.status,
+      terminal: isTerminalDagRunStatus(metadata.status),
       current_phase: metadata.status,
+      current_round: metadata.currentRound,
       created_at: new Date(metadata.createdAt).toISOString(),
       completed_at: metadata.completedAt ? new Date(metadata.completedAt).toISOString() : null,
       node_states: metadata.nodeStates,
@@ -573,8 +583,45 @@ export function inspectionRoutesHandler(
     return true;
   }
 
+  const roundsMatch = pathname.match(/^\/api\/runs\/([^/]+)\/rounds$/);
+  if (roundsMatch && req.method === "GET") {
+    const runId = decodeURIComponent(roundsMatch[1]);
+    if (!loadRunMetadata(runId)) {
+      _notFound(res, `Run not found: ${runId}`);
+      return true;
+    }
+    const rounds = listDagRunRounds(runId);
+    _ok(res, `Found ${rounds.length} round(s)`, { rounds, total: rounds.length });
+    return true;
+  }
+
+  const commandsMatch = pathname.match(/^\/api\/runs\/([^/]+)\/commands$/);
+  if (commandsMatch && req.method === "GET") {
+    const runId = decodeURIComponent(commandsMatch[1]);
+    if (!loadRunMetadata(runId)) {
+      _notFound(res, `Run not found: ${runId}`);
+      return true;
+    }
+    const url = new URL(req.url || "/", "http://localhost");
+    const status = url.searchParams.get("status") || undefined;
+    try {
+      const commands = listDagActorCommands({
+        run_id: runId,
+        actor_id: url.searchParams.get("actor_id") || undefined,
+        round_id: url.searchParams.get("round_id") || undefined,
+        status: status as DagActorCommandStatus | undefined,
+        limit: url.searchParams.get("limit") ? Number(url.searchParams.get("limit")) : undefined,
+      });
+      _ok(res, `Found ${commands.length} command(s)`, { commands, total: commands.length });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      json(res, 400, { success: false, message, error: message });
+    }
+    return true;
+  }
+
   // GET /api/runs/:run_id
-  if (pathname.startsWith("/api/runs/") && !pathname.includes("/activities") && !pathname.includes("/events") && !pathname.includes("/handoffs") && !pathname.includes("/chats") && !pathname.includes("/scorecard") && !pathname.includes("/eval-run") && !pathname.includes("/supervise") && !pathname.includes("/inject") && !pathname.includes("/experience") && !pathname.includes("/status") && !pathname.includes("/audit") && req.method === "GET") {
+  if (pathname.startsWith("/api/runs/") && !pathname.includes("/activities") && !pathname.includes("/events") && !pathname.includes("/handoffs") && !pathname.includes("/chats") && !pathname.includes("/scorecard") && !pathname.includes("/eval-run") && !pathname.includes("/supervise") && !pathname.includes("/inject") && !pathname.includes("/experience") && !pathname.includes("/status") && !pathname.includes("/audit") && !pathname.includes("/rounds") && !pathname.includes("/commands") && !pathname.includes("/complete") && req.method === "GET") {
     const runId = _parseRunId(pathname, "/api/runs/");
     if (!runId) {
       _notFound(res, "Invalid run ID");
@@ -593,6 +640,7 @@ export function inspectionRoutesHandler(
       agents: metadata.agents,
       createdAt: metadata.createdAt,
       status: metadata.status,
+      currentRound: metadata.currentRound,
       completedAt: metadata.completedAt,
       nodeStates: metadata.nodeStates,
       handoffedNodes: metadata.handoffedNodes,

--- a/homerail_manager/src/server/routes.ts
+++ b/homerail_manager/src/server/routes.ts
@@ -94,6 +94,9 @@ function _buildExecutionStatus(metadata: ReturnType<typeof loadRunMetadata>) {
   const activeNodes = Object.entries(metadata.nodeStates)
     .filter(([, state]) => state === "RUNNING")
     .map(([id]) => id);
+  const waitingNodes = Object.entries(metadata.nodeStates)
+    .filter(([, state]) => state === "WAITING_FOR_COMMAND")
+    .map(([id]) => id);
   const failedNodes = Object.entries(metadata.nodeStates)
     .filter(([, state]) => state === "FAILED")
     .map(([id]) => id);
@@ -103,6 +106,7 @@ function _buildExecutionStatus(metadata: ReturnType<typeof loadRunMetadata>) {
     completed_nodes: completedNodes,
     failed_nodes: failedNodes,
     ready_nodes: readyNodes,
+    waiting_nodes: waitingNodes,
     node_count: metadata.nodeCount || Object.keys(metadata.nodeStates).length,
     nodes,
   };

--- a/homerail_manager/src/server/supervise.ts
+++ b/homerail_manager/src/server/supervise.ts
@@ -1,5 +1,21 @@
 import type { PersistedEvent, PersistedRunMetadata } from "../persistence/types.js";
 
+const TERMINAL_DAG_RUN_STATUSES = new Set(["completed", "failed", "cancelled", "expired"]);
+const TERMINAL_DAG_RUN_EVENTS = new Set([
+  "dag:run_completed",
+  "dag:run_failed",
+  "dag:run_cancelled",
+  "dag:run_expired",
+]);
+
+export function isTerminalDagRunStatus(status: string): boolean {
+  return TERMINAL_DAG_RUN_STATUSES.has(status);
+}
+
+export function isTerminalDagRunEvent(eventType: string): boolean {
+  return TERMINAL_DAG_RUN_EVENTS.has(eventType);
+}
+
 export interface SuperviseTickData {
   run_id: string;
   cursor: number;
@@ -45,7 +61,7 @@ export function computeSuperviseTick(
 ): SuperviseTickData {
   const newEvents = events.filter((e) => e.timestamp > cursor);
   const changed = newEvents.length > 0;
-  const terminal = metadata.status === "completed";
+  const terminal = isTerminalDagRunStatus(metadata.status);
 
   const completedNodes = Object.entries(metadata.nodeStates)
     .filter(([, state]) => state === "COMPLETED")

--- a/homerail_manager/src/worker/websocket.ts
+++ b/homerail_manager/src/worker/websocket.ts
@@ -11,7 +11,10 @@ import {
   getWorker,
   type WorkerState,
 } from "./registry.js";
-import { applyResponseHandoff } from "../orchestration/response-bridge.js";
+import {
+  applyResponseHandoff,
+  assessDagTransportFence,
+} from "../orchestration/response-bridge.js";
 import { handleDagMessageResponse } from "../orchestration/dag-message-router.js";
 import { clearByTargetId, isCurrentDispatchTarget } from "../orchestration/dispatch-tracker.js";
 import { emit } from "../events/bus.js";
@@ -20,6 +23,7 @@ import { appendSessionTranscriptEntry } from "../persistence/dag-session-files.j
 import {
   autoHandoffAfterCorrectionExhausted,
   failActiveRun,
+  getActiveRun,
   getCurrentNodeSession,
   recordAdvisorCall,
   requestNodeCorrection,
@@ -68,6 +72,28 @@ function objectData(value: unknown): Record<string, unknown> | undefined {
   return typeof value === "object" && value !== null && !Array.isArray(value)
     ? value as Record<string, unknown>
     : undefined;
+}
+
+function dagActivityRoundContext(data: Record<string, unknown>, runId: string): string {
+  const run = getActiveRun(runId);
+  if (!run) throw new Error(`DAG activity run ${runId} is not active`);
+  const currentRoundId = run.currentRound.round_id;
+  if (data.round_id !== undefined) {
+    if (typeof data.round_id !== "string" || !data.round_id.trim()) {
+      throw new Error("DAG activity transport round is invalid");
+    }
+    if (data.round_id !== currentRoundId) {
+      throw new Error(`DAG activity transport round ${data.round_id} is not current (${currentRoundId})`);
+    }
+    return currentRoundId;
+  }
+
+  const activityRoundId = objectData(data.activity)?.round_id;
+  const sessionId = dataSessionId(data);
+  if (run.currentRound.ordinal === 1 && typeof activityRoundId === "string" && activityRoundId === sessionId) {
+    return activityRoundId;
+  }
+  return currentRoundId;
 }
 
 function shouldIgnoreStaleSession(
@@ -219,9 +245,10 @@ export function setupWorkerWebSocket(
 
       ws.on("message", (raw: Buffer) => {
         let msg: IncomingWorkerMessage | null;
+        let rawMessage: unknown;
         try {
-          const parsed = JSON.parse(raw.toString());
-          msg = parseIncomingMessage(parsed);
+          rawMessage = JSON.parse(raw.toString());
+          msg = parseIncomingMessage(rawMessage);
         } catch {
           msg = null;
         }
@@ -370,18 +397,30 @@ export function setupWorkerWebSocket(
             });
             options.onHandoffApplied?.(result.runId);
           } else {
+            const reason = result.status === "malformed_payload"
+              ? result.reason
+              : result.status === "unknown_run"
+                ? `unknown run ${result.runId}`
+                : result.reason;
             emit("dag:response_handoff_failed", {
               runId: "runId" in result ? (result.runId as string) : undefined,
-              nodeId: result.status === "handoff_failed" ? result.nodeId : undefined,
-              reason:
-                result.status === "malformed_payload"
-                  ? result.reason
-                  : result.status === "unknown_run"
-                    ? `unknown run ${result.runId}`
-                    : result.reason,
+              nodeId: result.status === "handoff_failed" || result.status === "handoff_ignored"
+                ? result.nodeId
+                : undefined,
+              reason,
               source: "worker",
               sourceId: worker_id,
             });
+            if (result.status === "handoff_ignored") {
+              mirrorSessionTranscript(
+                worker_id,
+                `handoff_${result.disposition}_ignored`,
+                result.runId,
+                result.nodeId,
+                responseSessionId,
+                { disposition: result.disposition, reason, payload: msg.data },
+              );
+            }
             if (result.status === "handoff_failed") {
               tryCorrectNode(result.runId, result.nodeId, result.reason);
             }
@@ -401,10 +440,11 @@ export function setupWorkerWebSocket(
                 throw new Error("DAG activity source does not match the current dispatch target");
               }
               if (shouldIgnoreStaleSession(worker_id, "dag_activity", msg.data)) return;
+              const roundId = dagActivityRoundContext(msg.data, runId);
               ingestDagActivityStream(msg.data, {
                 runId,
                 nodeId,
-                roundId: sessionId,
+                roundId,
               });
             } catch (error) {
               console.warn(
@@ -461,16 +501,42 @@ export function setupWorkerWebSocket(
         }
 
         if (msg.type === "node_error") {
+          const rawData = objectData(objectData(rawMessage)?.data) ?? msg.data;
           if (shouldIgnoreStaleSession(worker_id, "node_error", {
             runId: msg.data.runId,
             nodeId: msg.data.nodeId,
             session_id: msg.data.session_id,
           })) return;
+          const assessment = assessDagTransportFence(rawData);
+          if (assessment.status !== "current") {
+            const runId = assessment.status === "malformed_payload" ? msg.data.runId : assessment.runId;
+            const nodeId = assessment.status === "malformed_payload" ? msg.data.nodeId : assessment.nodeId;
+            const disposition = assessment.status === "ignored" ? assessment.disposition : assessment.status;
+            const reason = assessment.status === "unknown_run"
+              ? `unknown run ${assessment.runId}`
+              : assessment.reason;
+            emit("dag:response_handoff_failed", {
+              runId,
+              nodeId,
+              reason: `node_error ${disposition} ignored: ${reason}`,
+              source: "worker",
+              sourceId: worker_id,
+            });
+            mirrorSessionTranscript(
+              worker_id,
+              `node_error_${disposition}_ignored`,
+              runId,
+              nodeId,
+              msg.data.session_id,
+              { disposition, reason, payload: rawData },
+            );
+            return;
+          }
           appendChatEntry(msg.data.runId, msg.data.nodeId, {
             role: "worker",
             type: "response",
             targetId: worker_id,
-            content: msg.data,
+            content: rawData,
             timestamp: Date.now(),
           });
           mirrorSessionTranscript(
@@ -479,7 +545,7 @@ export function setupWorkerWebSocket(
             msg.data.runId,
             msg.data.nodeId,
             msg.data.session_id,
-            msg.data,
+            rawData,
           );
           if (tryCorrectNode(msg.data.runId, msg.data.nodeId, msg.data.message)) {
             return;

--- a/homerail_manager/tests/dag-activity-stream.test.ts
+++ b/homerail_manager/tests/dag-activity-stream.test.ts
@@ -132,7 +132,7 @@ nodes:
       actorId: "research",
       generation: 1,
       sequenceStart: 2,
-      roundId: built.envelope.sessionId,
+      roundId: "round-0001",
     });
   });
 
@@ -187,7 +187,15 @@ nodes:
       runId: "run-actor-activity",
       nodeId: "research",
       roundId: built.envelope.sessionId,
-    })).toThrow("generation is ahead");
+    })).toThrow("generation does not match");
+    expect(() => ingestDagActivityStream({
+      event: "dag_activity",
+      activity: { ...valid, event_id: "stale-generation", generation: 0, sequence: 2 },
+    }, {
+      runId: "run-actor-activity",
+      nodeId: "research",
+      roundId: built.envelope.sessionId,
+    })).toThrow("generation does not match");
     expect(() => ingestDagActivityStream({
       event: "dag_activity",
       activity: { ...valid, event_id: "spoofed-surface", surface_id: "other", sequence: 2 },

--- a/homerail_manager/tests/dag-actors.test.ts
+++ b/homerail_manager/tests/dag-actors.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   acknowledgeDagActorCommand,
   advanceDagActorGeneration,
+  cancelUnclaimedDagActorCommands,
   claimDagActorCommand,
   createDagActorCommand,
   DagActorConflictError,
@@ -14,6 +15,7 @@ import {
   getDagActorCommand,
   listDagActorCommands,
   listDagActors,
+  markDagActorCommandDelivered,
   registerDagActor,
   updateDagActorBinding,
 } from "../src/persistence/dag-actors.js";
@@ -106,9 +108,10 @@ describe("durable DAG logical actors and command inbox", () => {
 
   it("upgrades a v19 database and validates migration v20 on repeated startup", () => {
     getDb().exec(`
+      DROP TABLE dag_run_rounds;
       DROP TABLE dag_actor_commands;
       DROP TABLE dag_actors;
-      DELETE FROM schema_migrations WHERE version = 20;
+      DELETE FROM schema_migrations WHERE version IN (20, 23);
     `);
     closeDb();
 
@@ -354,6 +357,46 @@ nodes:
     expect(listDagActorCommands({ run_id: "run-1" })).toHaveLength(1);
     expect(() => createCommand({ payload: { instruction: "Different work" } }))
       .toThrowError(expect.objectContaining<DagActorConflictError>({ code: "command_identity_conflict" }));
+  });
+
+  it("cancels only pending and delivered commands while preserving audit rows", () => {
+    registerActor();
+    createCommand();
+    createCommand({ command_id: "command-2", idempotency_key: "research-round-1-delivered" });
+    createCommand({ command_id: "command-3", idempotency_key: "research-round-1-claimed" });
+    const delivered = markDagActorCommandDelivered("command-2").command;
+    claimDagActorCommand({
+      command_id: "command-3",
+      run_id: "run-1",
+      actor_id: "researcher",
+      generation: 1,
+    });
+
+    const cancelled = cancelUnclaimedDagActorCommands({
+      run_id: "run-1",
+      completed_at: Date.now() + 1_000,
+      reason: { status: "cancelled", message: "run cancelled" },
+    });
+
+    expect(cancelled.map((command) => [command.command_id, command.status]))
+      .toEqual([
+        ["command-1", "cancelled"],
+        ["command-2", "cancelled"],
+      ]);
+    expect(getDagActorCommand("command-2")).toMatchObject({
+      status: "cancelled",
+      delivered_at: delivered.delivered_at,
+      failure: { status: "cancelled", message: "run cancelled" },
+    });
+    expect(getDagActorCommand("command-3")?.status).toBe("claimed");
+    expect(listDagActorCommands({ run_id: "run-1" })).toHaveLength(3);
+    expect(cancelUnclaimedDagActorCommands("run-1")).toEqual([]);
+    expect(() => claimDagActorCommand({
+      command_id: "command-1",
+      run_id: "run-1",
+      actor_id: "researcher",
+      generation: 1,
+    })).toThrowError(expect.objectContaining<DagActorConflictError>({ code: "command_status_conflict" }));
   });
 
   it("allows only the current generation to claim and complete a command", () => {

--- a/homerail_manager/tests/dag-graph-validator.test.ts
+++ b/homerail_manager/tests/dag-graph-validator.test.ts
@@ -154,6 +154,105 @@ nodes:
     expect(result.warnings).toContain("Dead-end node (no terminal or outgoing edges): middle");
   });
 
+  it("treats await_command as a non-terminal suspension boundary without requiring feedback", () => {
+    const parsed = parseDAGYaml(`
+name: await-command-boundary
+nodes:
+  actor:
+    agent: worker
+    outputs:
+      summary: { to: suspend.in:summary }
+  suspend:
+    type: await_command_gateway
+    gateway_config:
+      primitive_version: 1
+      target_actors: [actor]
+      expires_after_ms: 60000
+      command_port: next_command
+  finisher:
+    agent: worker
+    outputs:
+      done: { to: "" }
+`);
+
+    const result = validateGraph(parsed.graph);
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).not.toContain("Dead-end node (no terminal or outgoing edges): suspend");
+    expect(result.terminal_nodes).toEqual(["finisher"]);
+    expect(parsed.loop_sources).toEqual([]);
+  });
+
+  it.each([
+    ["primitive_version: 2", /requires primitive_version 1/],
+    ["primitive_version: 1\n      expires_after_ms: 999", /expires_after_ms to be an integer of at least 1000/],
+    ["primitive_version: 1\n      command_port: Invalid.Port", /invalid command_port identifier/],
+    ["primitive_version: 1\n      unexpected: true", /unsupported config fields: unexpected/],
+    ["primitive_version: 1\n      target_actors: [actor, actor]", /duplicate target actor: actor/],
+  ])("rejects invalid legacy await_command config: %s", (config, expected) => {
+    expect(() => parseDAGYaml(`
+name: invalid-await-command
+nodes:
+  actor: { agent: worker }
+  suspend:
+    type: await_command_gateway
+    gateway_config:
+      ${config}
+`)).toThrow(expected);
+  });
+
+  it("rejects legacy await_command output routes", () => {
+    expect(() => parseDAGYaml(`
+name: invalid-await-command-output
+nodes:
+  suspend:
+    type: await_command_gateway
+    gateway_config: { primitive_version: 1 }
+    outputs:
+      resumed: { to: "" }
+`)).toThrow(/does not support output routes/);
+  });
+
+  it("rejects legacy downstream dependencies from await_command", () => {
+    expect(() => parseDAGYaml(`
+name: invalid-await-command-dependent
+nodes:
+  actor:
+    agent: worker
+    outputs:
+      summary: { to: suspend.in:summary }
+  suspend:
+    type: await_command_gateway
+    gateway_config:
+      primitive_version: 1
+      target_actors: [actor]
+  after_suspend:
+    agent: worker
+    after: [suspend]
+    outputs:
+      done: { to: "" }
+`)).toThrow(/await_command suspend cannot have outgoing edges or downstream dependents/i);
+  });
+
+  it.each([
+    ["suspend", /cannot target itself/],
+    ["gate", /must reference an agent node/],
+    ["missing", /references unknown target actor: missing/],
+  ])("rejects legacy await_command target actor %s", (targetActor, expected) => {
+    expect(() => parseDAGYaml(`
+name: invalid-await-command-target
+nodes:
+  actor: { agent: worker }
+  gate: { type: command_gateway }
+  suspend:
+    type: await_command_gateway
+    gateway_config:
+      primitive_version: 1
+      target_actors: [${targetActor}]
+`)).toThrow(expected);
+  });
+
   it("warns when high-retry on_failure feedback edges can loop", () => {
     const parsed = parseDAGYaml(`
 name: feedback-risk-warning

--- a/homerail_manager/tests/dag-multiround-api.test.ts
+++ b/homerail_manager/tests/dag-multiround-api.test.ts
@@ -1,0 +1,436 @@
+import * as fs from "node:fs";
+import * as http from "node:http";
+import * as os from "node:os";
+import * as path from "node:path";
+import WebSocket from "ws";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DAG_TRANSPORT_FENCE_CAPABILITY } from "homerail-protocol";
+
+import type { DAGDispatcher, DispatchEnvelope, DispatchResult } from "../src/orchestration/dag-dispatcher.js";
+import { _clearAllDispatches } from "../src/orchestration/dispatch-tracker.js";
+import { parseDAGYaml } from "../src/orchestration/yaml-loader.js";
+import { closeDb } from "../src/persistence/db.js";
+import { listDagActorCommands } from "../src/persistence/dag-actors.js";
+import { _clearAllPersistence, loadRunMetadata } from "../src/persistence/store.js";
+import { _clearNodes } from "../src/node/registry.js";
+import {
+  _clearActiveRuns,
+  createActiveRun,
+  dispatchReadyNodes,
+  getActiveRun,
+  handoffActiveRun,
+} from "../src/runtime/active-runs.js";
+import { createServer } from "../src/server/http.js";
+import { _clearWorkers, getWorker } from "../src/worker/registry.js";
+
+class CapturingDispatcher implements DAGDispatcher {
+  readonly dispatched: DispatchEnvelope[] = [];
+
+  dispatch(envelope: DispatchEnvelope): DispatchResult {
+    this.dispatched.push(structuredClone(envelope));
+    return { status: "dispatched", targetType: "fake", targetId: "worker-hot" };
+  }
+}
+
+function multiRoundDag(options: { maxDispatches?: number } = {}) {
+  return parseDAGYaml(`
+name: multi-round-api
+workflow_id: multi-round-api
+${options.maxDispatches === undefined ? "" : `limits:\n  max_dispatches: ${options.maxDispatches}\n`}
+agents:
+  worker: { agent_type: deterministic }
+nodes:
+  actor:
+    agent: worker
+    extra:
+      agent_runtime:
+        actor_id: researcher
+        surface_id: surface-research
+    outputs:
+      summary: { to: suspend.in:summary }
+  suspend:
+    type: await_command
+    after: [actor]
+    gateway_config:
+      primitive_version: 1
+      target_actors: [actor]
+      command_port: command
+`);
+}
+
+async function listen(server: http.Server): Promise<number> {
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address !== "object") throw new Error("server did not bind");
+  return address.port;
+}
+
+async function closeServer(server: http.Server | undefined): Promise<void> {
+  if (!server?.listening) return;
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+async function jsonResponse(url: string, init?: RequestInit): Promise<{
+  status: number;
+  body: Record<string, unknown>;
+}> {
+  const response = await fetch(url, init);
+  return {
+    status: response.status,
+    body: await response.json() as Record<string, unknown>,
+  };
+}
+
+function jsonPost(body: unknown, token?: string): RequestInit {
+  return {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { "X-Homerail-Dag-Token": token } : {}),
+    },
+    body: JSON.stringify(body),
+  };
+}
+
+function moveToWaiting(
+  runId: string,
+  dispatcher: CapturingDispatcher,
+  dag = multiRoundDag(),
+): DispatchEnvelope {
+  createActiveRun(runId, dag);
+  expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+  const firstEnvelope = dispatcher.dispatched.at(-1)!;
+  handoffActiveRun(runId, "actor", "summary", { result: "round one" });
+  expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+  expect(getActiveRun(runId)?.status).toBe("waiting");
+  return firstEnvelope;
+}
+
+describe("multi-round DAG HTTP API", () => {
+  let tmpHome: string;
+  let oldHome: string | undefined;
+  let oldMutationToken: string | undefined;
+  let server: http.Server | undefined;
+  let workerSocket: WebSocket | undefined;
+  let legacyWorkerSocket: WebSocket | undefined;
+
+  beforeEach(() => {
+    oldHome = process.env.HOMERAIL_HOME;
+    oldMutationToken = process.env.HOMERAIL_DAG_MUTATION_TOKEN;
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-multiround-api-"));
+    process.env.HOMERAIL_HOME = tmpHome;
+    delete process.env.HOMERAIL_DAG_MUTATION_TOKEN;
+    closeDb();
+    _clearActiveRuns();
+    _clearAllPersistence();
+    _clearAllDispatches();
+    _clearWorkers();
+    _clearNodes();
+  });
+
+  afterEach(async () => {
+    workerSocket?.terminate();
+    workerSocket = undefined;
+    legacyWorkerSocket?.terminate();
+    legacyWorkerSocket = undefined;
+    await closeServer(server);
+    _clearActiveRuns();
+    _clearAllPersistence();
+    _clearAllDispatches();
+    _clearWorkers();
+    _clearNodes();
+    closeDb();
+    if (oldHome === undefined) delete process.env.HOMERAIL_HOME;
+    else process.env.HOMERAIL_HOME = oldHome;
+    if (oldMutationToken === undefined) delete process.env.HOMERAIL_DAG_MUTATION_TOKEN;
+    else process.env.HOMERAIL_DAG_MUTATION_TOKEN = oldMutationToken;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("observes, resumes, deduplicates, and explicitly completes a waiting run", async () => {
+    const runId = "multi-round-http";
+    const dispatcher = new CapturingDispatcher();
+    moveToWaiting(runId, dispatcher);
+    server = createServer(0, undefined, dispatcher, false, { autoDetectCodex: false });
+    const baseUrl = `http://127.0.0.1:${await listen(server)}`;
+
+    const status = await jsonResponse(`${baseUrl}/api/runs/${runId}/status`);
+    expect(status).toMatchObject({
+      status: 200,
+      body: {
+        data: {
+          status: "waiting",
+          terminal: false,
+          current_round: { round_id: "round-0001", ordinal: 1, status: "waiting" },
+        },
+      },
+    });
+    expect(await jsonResponse(`${baseUrl}/api/runs/${runId}/supervise`)).toMatchObject({
+      body: { data: { terminal: false } },
+    });
+    expect(await jsonResponse(`${baseUrl}/api/dag-status/${runId}`)).toMatchObject({
+      body: { data: { execution: { complete: false } } },
+    });
+    const rounds = await jsonResponse(`${baseUrl}/api/runs/${runId}/rounds`);
+    expect(rounds.body).toMatchObject({
+      data: { total: 1, rounds: [{ round_id: "round-0001", status: "waiting" }] },
+    });
+    const emptyCommands = await jsonResponse(`${baseUrl}/api/runs/${runId}/commands`);
+    expect(emptyCommands.body).toMatchObject({ data: { total: 0, commands: [] } });
+
+    const stale = await jsonResponse(`${baseUrl}/api/runs/${runId}/commands`, jsonPost({
+      expected_round_id: "stale-round",
+      commands: [{ actor_id: "researcher", payload: "continue" }],
+    }));
+    expect(stale.status).toBe(409);
+
+    const request = {
+      expected_round_id: "round-0001",
+      commands: [{
+        actor_id: "researcher",
+        command_id: "command-http-round-2",
+        idempotency_key: "http-round-2",
+        payload: { task: "continue" },
+      }],
+    };
+    const resumed = await jsonResponse(`${baseUrl}/api/runs/${runId}/commands`, jsonPost(request));
+    expect(resumed).toMatchObject({
+      status: 200,
+      body: {
+        data: {
+          resumed: true,
+          previous_round_id: "round-0001",
+          round_id: "round-0002",
+          command_ids: ["command-http-round-2"],
+          actor_ids: ["researcher"],
+          dispatched: 1,
+        },
+      },
+    });
+    expect(dispatcher.dispatched.at(-1)?.activity).toMatchObject({
+      roundId: "round-0002",
+      actorId: "researcher",
+      generation: 1,
+      commandId: "command-http-round-2",
+    });
+
+    const retry = await jsonResponse(`${baseUrl}/api/runs/${runId}/commands`, jsonPost(request));
+    expect(retry).toMatchObject({ status: 200, body: { data: { deduplicated: true, dispatched: 0 } } });
+    const commandList = await jsonResponse(
+      `${baseUrl}/api/runs/${runId}/commands?round_id=round-0002&status=delivered`,
+    );
+    expect(commandList.body).toMatchObject({
+      data: {
+        total: 1,
+        commands: [{ command_id: "command-http-round-2", status: "delivered" }],
+      },
+    });
+
+    const prematureComplete = await jsonResponse(`${baseUrl}/api/runs/${runId}/complete`, jsonPost({
+      expected_round_id: "round-0002",
+    }));
+    expect(prematureComplete.status).toBe(409);
+
+    handoffActiveRun(runId, "actor", "summary", { result: "round two" }, {
+      transport: true,
+      roundId: "round-0002",
+      actorId: "researcher",
+      generation: 1,
+      commandId: "command-http-round-2",
+    });
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+    expect(getActiveRun(runId)?.status).toBe("waiting");
+    const completed = await jsonResponse(`${baseUrl}/api/runs/${runId}/complete`, jsonPost({
+      expected_round_id: "round-0002",
+    }));
+    expect(completed).toMatchObject({ status: 200, body: { data: { completed: true } } });
+    expect(getActiveRun(runId)?.status).toBe("completed");
+    expect(await jsonResponse(`${baseUrl}/api/runs/${runId}/status`)).toMatchObject({
+      body: { data: { status: "completed", terminal: true } },
+    });
+    expect(await jsonResponse(`${baseUrl}/api/runs/${runId}/supervise`)).toMatchObject({
+      body: { data: { terminal: true } },
+    });
+    expect(await jsonResponse(`${baseUrl}/api/dag-status/${runId}`)).toMatchObject({
+      body: { data: { execution: { complete: true } } },
+    });
+  });
+
+  it("requires the configured DAG mutation token for resume and completion", async () => {
+    const runId = "multi-round-http-auth";
+    const dispatcher = new CapturingDispatcher();
+    moveToWaiting(runId, dispatcher);
+    process.env.HOMERAIL_DAG_MUTATION_TOKEN = "dag-test-token";
+    server = createServer(0, undefined, dispatcher, false, { autoDetectCodex: false });
+    const baseUrl = `http://127.0.0.1:${await listen(server)}`;
+    const request = {
+      expected_round_id: "round-0001",
+      commands: [{ actor_id: "researcher", payload: "continue" }],
+    };
+
+    expect((await jsonResponse(`${baseUrl}/api/runs/${runId}/commands`, jsonPost(request))).status).toBe(403);
+    expect((await jsonResponse(
+      `${baseUrl}/api/runs/${runId}/commands`,
+      jsonPost(request, "dag-test-token"),
+    )).status).toBe(200);
+    expect((await jsonResponse(`${baseUrl}/api/runs/${runId}/complete`, jsonPost({
+      expected_round_id: "round-0002",
+    }))).status).toBe(403);
+  });
+
+  it("keeps an offline resumed command retryable and dispatches it after worker registration", async () => {
+    const runId = "multi-round-http-offline-resume";
+    moveToWaiting(runId, new CapturingDispatcher(), multiRoundDag({ maxDispatches: 1 }));
+    server = createServer(0, undefined, undefined, false, { autoDetectCodex: false });
+    const port = await listen(server);
+    const baseUrl = `http://127.0.0.1:${port}`;
+    const request = {
+      expected_round_id: "round-0001",
+      commands: [{
+        actor_id: "researcher",
+        command_id: "command-offline-round-2",
+        idempotency_key: "offline-round-2",
+        payload: { task: "continue after reconnect" },
+      }],
+    };
+
+    const resumed = await jsonResponse(`${baseUrl}/api/runs/${runId}/commands`, jsonPost(request));
+    expect(resumed).toMatchObject({
+      status: 200,
+      body: { data: { resumed: true, round_id: "round-0002", dispatched: 0 } },
+    });
+    expect(getActiveRun(runId)?.status).toBe("active");
+    expect(getActiveRun(runId)?.dagRun.nodeStates.get("actor")).toBe("READY");
+    expect(getActiveRun(runId)?.limits.max_dispatches).toBe(1);
+    expect(getActiveRun(runId)?.counters.dispatches).toBe(0);
+    expect(loadRunMetadata(runId)).toMatchObject({
+      status: "active",
+      currentRound: { round_id: "round-0002", status: "active" },
+      nodeStates: { actor: "READY" },
+    });
+    expect(listDagActorCommands({ run_id: runId, round_id: "round-0002" })).toMatchObject([
+      { command_id: "command-offline-round-2", status: "pending" },
+    ]);
+
+    workerSocket = new WebSocket(`ws://127.0.0.1:${port}/ws/projects/p1/workers/reconnected-worker`);
+    await new Promise<void>((resolve, reject) => {
+      workerSocket!.once("open", resolve);
+      workerSocket!.once("error", reject);
+    });
+    const prompt = new Promise<{ type: string; envelope: DispatchEnvelope }>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error("timed out waiting for resumed prompt")), 2_000);
+      workerSocket!.on("message", (raw) => {
+        const message = JSON.parse(raw.toString()) as { type?: string; envelope?: DispatchEnvelope };
+        if (message.type !== "prompt" || !message.envelope) return;
+        clearTimeout(timeout);
+        resolve({ type: message.type, envelope: message.envelope });
+      });
+    });
+    workerSocket.send(JSON.stringify({
+      type: "register",
+      worker_id: "reconnected-worker",
+      capabilities: [DAG_TRANSPORT_FENCE_CAPABILITY],
+    }));
+
+    await expect(prompt).resolves.toMatchObject({
+      type: "prompt",
+      envelope: {
+        runId,
+        nodeId: "actor",
+        activity: {
+          roundId: "round-0002",
+          actorId: "researcher",
+          commandId: "command-offline-round-2",
+        },
+      },
+    });
+    expect(getActiveRun(runId)).toMatchObject({
+      status: "active",
+      counters: { dispatches: 1 },
+    });
+    expect(getActiveRun(runId)?.dagRun.nodeStates.get("actor")).toBe("RUNNING");
+    expect(listDagActorCommands({ run_id: runId, round_id: "round-0002" })).toMatchObject([
+      { command_id: "command-offline-round-2", status: "delivered" },
+    ]);
+  });
+
+  it("keeps round two retryable until a transport-fence-compatible worker registers", async () => {
+    const runId = "multi-round-http-incompatible-worker";
+    moveToWaiting(runId, new CapturingDispatcher());
+    server = createServer(0, undefined, undefined, false, { autoDetectCodex: false });
+    const port = await listen(server);
+    const baseUrl = `http://127.0.0.1:${port}`;
+
+    legacyWorkerSocket = new WebSocket(`ws://127.0.0.1:${port}/ws/projects/p1/workers/legacy-worker`);
+    await new Promise<void>((resolve, reject) => {
+      legacyWorkerSocket!.once("open", resolve);
+      legacyWorkerSocket!.once("error", reject);
+    });
+    legacyWorkerSocket.send(JSON.stringify({
+      type: "register",
+      worker_id: "legacy-worker",
+      capabilities: [],
+    }));
+    await vi.waitFor(() => expect(getWorker("legacy-worker")).toBeDefined());
+
+    const request = {
+      expected_round_id: "round-0001",
+      commands: [{
+        actor_id: "researcher",
+        command_id: "command-compatible-round-2",
+        idempotency_key: "compatible-round-2",
+        payload: { task: "wait for a compatible worker" },
+      }],
+    };
+    const resumed = await jsonResponse(`${baseUrl}/api/runs/${runId}/commands`, jsonPost(request));
+    expect(resumed).toMatchObject({
+      status: 200,
+      body: { data: { resumed: true, round_id: "round-0002", dispatched: 0 } },
+    });
+    expect(getActiveRun(runId)).toMatchObject({
+      status: "active",
+      currentRound: { round_id: "round-0002", status: "active" },
+    });
+    expect(getActiveRun(runId)?.dagRun.nodeStates.get("actor")).toBe("READY");
+    expect(listDagActorCommands({ run_id: runId, round_id: "round-0002" })).toMatchObject([
+      { command_id: "command-compatible-round-2", status: "pending" },
+    ]);
+
+    workerSocket = new WebSocket(`ws://127.0.0.1:${port}/ws/projects/p1/workers/compatible-worker`);
+    await new Promise<void>((resolve, reject) => {
+      workerSocket!.once("open", resolve);
+      workerSocket!.once("error", reject);
+    });
+    const prompt = new Promise<{ type: string; envelope: DispatchEnvelope }>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error("timed out waiting for compatible worker prompt")), 3_000);
+      workerSocket!.on("message", (raw) => {
+        const message = JSON.parse(raw.toString()) as { type?: string; envelope?: DispatchEnvelope };
+        if (message.type !== "prompt" || !message.envelope) return;
+        clearTimeout(timeout);
+        resolve({ type: message.type, envelope: message.envelope });
+      });
+    });
+    workerSocket.send(JSON.stringify({
+      type: "register",
+      worker_id: "compatible-worker",
+      capabilities: [DAG_TRANSPORT_FENCE_CAPABILITY],
+    }));
+
+    await expect(prompt).resolves.toMatchObject({
+      type: "prompt",
+      envelope: {
+        runId,
+        nodeId: "actor",
+        activity: {
+          roundId: "round-0002",
+          actorId: "researcher",
+          commandId: "command-compatible-round-2",
+        },
+      },
+    });
+    expect(getActiveRun(runId)?.dagRun.nodeStates.get("actor")).toBe("RUNNING");
+    expect(listDagActorCommands({ run_id: runId, round_id: "round-0002" })).toMatchObject([
+      { command_id: "command-compatible-round-2", status: "delivered" },
+    ]);
+  }, 10_000);
+});

--- a/homerail_manager/tests/dag-multiround-api.test.ts
+++ b/homerail_manager/tests/dag-multiround-api.test.ts
@@ -169,7 +169,15 @@ describe("multi-round DAG HTTP API", () => {
       body: { data: { terminal: false } },
     });
     expect(await jsonResponse(`${baseUrl}/api/dag-status/${runId}`)).toMatchObject({
-      body: { data: { execution: { complete: false } } },
+      body: {
+        data: {
+          execution: {
+            complete: false,
+            waiting_nodes: ["suspend"],
+            nodes: { suspend: { status: "waiting_for_command" } },
+          },
+        },
+      },
     });
     const rounds = await jsonResponse(`${baseUrl}/api/runs/${runId}/rounds`);
     expect(rounds.body).toMatchObject({

--- a/homerail_manager/tests/dag-multiround-runtime.test.ts
+++ b/homerail_manager/tests/dag-multiround-runtime.test.ts
@@ -1,0 +1,795 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DAG_TRANSPORT_FENCE_CAPABILITY } from "homerail-protocol";
+
+import type { DAGDispatcher, DispatchEnvelope, DispatchResult } from "../src/orchestration/dag-dispatcher.js";
+import { ChangeOrchestrator } from "../src/orchestration/change-orchestrator.js";
+import { GraphExecutor } from "../src/orchestration/graph-executor.js";
+import {
+  compileWorkflowSource,
+  projectCanonicalWorkflowToParsedDAG,
+} from "../src/orchestration/workflow-spec-v1.js";
+import { parseDAGYaml } from "../src/orchestration/yaml-loader.js";
+import { listDagActors, listDagActorCommands } from "../src/persistence/dag-actors.js";
+import { closeDb, getDb } from "../src/persistence/db.js";
+import { listDagRunRounds } from "../src/persistence/dag-run-rounds.js";
+import {
+  _clearAllSettings,
+  createSetting,
+  upsertProvider,
+} from "../src/persistence/llm-settings.js";
+import { _clearAllPersistence, loadRunMetadata, loadRunSnapshot } from "../src/persistence/store.js";
+import {
+  _clearActiveRuns,
+  abortActiveRun,
+  cancelActiveRun,
+  completeActiveRun,
+  createActiveRun,
+  dispatchReadyNodes,
+  expireWaitingActiveRuns,
+  getActiveRun,
+  getActiveRunCount,
+  getWaitingRunCount,
+  handoffActiveRun,
+  recoverAllActiveRuns,
+  resumeWaitingActiveRun,
+} from "../src/runtime/active-runs.js";
+
+class RepeatableDispatcher implements DAGDispatcher {
+  readonly dispatched: DispatchEnvelope[] = [];
+
+  dispatch(envelope: DispatchEnvelope): DispatchResult {
+    this.dispatched.push(structuredClone(envelope));
+    return { status: "dispatched", targetType: "fake", targetId: "worker-hot" };
+  }
+}
+
+function multiRoundDag() {
+  return parseDAGYaml(`
+name: multi-round-runtime
+workflow_id: multi-round-runtime
+agents:
+  worker:
+    agent_type: deterministic
+    system: HANDOFF port=summary content=ok
+nodes:
+  actor:
+    agent: worker
+    extra:
+      agent_runtime:
+        actor_id: researcher
+        role: research
+        surface_id: surface-research
+    outputs:
+      summary: { to: suspend.in:summary }
+  suspend:
+    type: await_command
+    after: [actor]
+    gateway_config:
+      primitive_version: 1
+      target_actors: [actor]
+      command_port: command
+`);
+}
+
+function strictV1MultiRoundDag() {
+  const compilation = compileWorkflowSource(`
+api_version: homerail.ai/v1
+kind: Workflow
+metadata:
+  id: strict-multi-round-runtime
+  name: Strict Multi Round Runtime
+spec:
+  agents:
+    worker:
+      system: HANDOFF port=summary content=ok
+  nodes:
+    actor:
+      kind: agent
+      agent: worker
+      outputs:
+        summary: {}
+    suspend:
+      kind: await_command
+      inputs:
+        summary: {}
+      config:
+        primitive_version: 1
+        target_actors: [actor]
+        command_port: command
+  edges:
+    - { from: actor.summary, to: suspend.summary }
+`);
+  if (!compilation.valid || !compilation.canonical) {
+    throw new Error(compilation.diagnostics.map((entry) => entry.message).join("\n"));
+  }
+  return projectCanonicalWorkflowToParsedDAG(compilation.canonical);
+}
+
+function fanInMultiRoundDag() {
+  return parseDAGYaml(`
+name: multi-round-fan-in
+workflow_id: multi-round-fan-in
+agents:
+  worker: { agent_type: deterministic }
+nodes:
+  actor_a:
+    agent: worker
+    outputs:
+      result: { to: join.in:a }
+  actor_b:
+    agent: worker
+    outputs:
+      result: { to: join.in:b }
+  join:
+    type: join_gateway
+    after: [actor_a, actor_b]
+    gateway_config:
+      mode: all
+      field: ok
+      success_values: [true]
+      passed_port: merged
+      failed_port: failed
+    outputs:
+      merged: { to: suspend.in:summary }
+      failed: { to: suspend.in:summary }
+  suspend:
+    type: await_command
+    after: [join]
+    gateway_config:
+      primitive_version: 1
+      target_actors: [actor_a, actor_b]
+      command_port: command
+`);
+}
+
+function expiringMultiRoundDag() {
+  return parseDAGYaml(`
+name: multi-round-expiry
+workflow_id: multi-round-expiry
+agents:
+  worker: { agent_type: deterministic }
+nodes:
+  actor:
+    agent: worker
+    outputs:
+      summary: { to: suspend.in:summary }
+  suspend:
+    type: await_command
+    after: [actor]
+    gateway_config:
+      primitive_version: 1
+      target_actors: [actor]
+      command_port: command
+      expires_after_ms: 1000
+`);
+}
+
+function nonQuiescentMultiRoundDag() {
+  return parseDAGYaml(`
+name: multi-round-non-quiescent
+workflow_id: multi-round-non-quiescent
+agents:
+  worker: { agent_type: deterministic }
+nodes:
+  actor:
+    agent: worker
+    outputs:
+      summary: { to: suspend.in:summary }
+  sibling:
+    agent: worker
+    outputs:
+      done: { to: "" }
+  suspend:
+    type: await_command
+    after: [actor]
+    gateway_config:
+      primitive_version: 1
+      target_actors: [actor]
+      command_port: command
+`);
+}
+
+describe("durable multi-round DAG runtime", () => {
+  let tmpHome: string;
+  let oldHome: string | undefined;
+
+  beforeEach(() => {
+    oldHome = process.env.HOMERAIL_HOME;
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-multiround-"));
+    process.env.HOMERAIL_HOME = tmpHome;
+    closeDb();
+    _clearActiveRuns();
+    _clearAllPersistence();
+    _clearAllSettings();
+  });
+
+  afterEach(() => {
+    _clearActiveRuns();
+    _clearAllPersistence();
+    _clearAllSettings();
+    closeDb();
+    if (oldHome === undefined) delete process.env.HOMERAIL_HOME;
+    else process.env.HOMERAIL_HOME = oldHome;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("executes a strict v1 workflow across rounds without a synthetic terminal branch", () => {
+    const runId = "strict-v1-multi-round";
+    const dispatcher = new RepeatableDispatcher();
+    upsertProvider({
+      id: "strict-test",
+      name: "Strict Test",
+      default_model: "test-model",
+      base_url: "http://127.0.0.1:9/v1",
+      anthropic_base_url: "http://127.0.0.1:9/anthropic",
+    });
+    createSetting({
+      provider_id: "strict-test",
+      endpoint_id: "strict-test-default",
+      endpoint_name: "default",
+      model_name: "test-model",
+      display_name: "Strict Test",
+      api_key: "test-only",
+      protocol: "custom",
+      plan_type: "custom",
+      base_url: "http://127.0.0.1:9/v1",
+      anthropic_base_url: "http://127.0.0.1:9/anthropic",
+      supports_llm: true,
+      is_active: true,
+      is_default: true,
+    });
+    createActiveRun(runId, strictV1MultiRoundDag());
+
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+    const firstEnvelope = dispatcher.dispatched.at(-1)!;
+    expect(firstEnvelope.activity).toMatchObject({
+      roundId: "round-0001",
+      actorId: "actor",
+      generation: 1,
+      surfaceId: "actor:actor",
+    });
+    expect(firstEnvelope.requiredCapabilities).toBeUndefined();
+    handoffActiveRun(runId, "actor", "summary", { result: "round one" });
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+    expect(getActiveRun(runId)).toMatchObject({
+      status: "waiting",
+      currentRound: { round_id: "round-0001", ordinal: 1, status: "waiting" },
+    });
+
+    resumeWaitingActiveRun(runId, {
+      expected_round_id: "round-0001",
+      commands: [{ actor_id: "actor", command_id: "strict-command-2", payload: "continue" }],
+    });
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+    expect(dispatcher.dispatched.at(-1)).toMatchObject({
+      runId,
+      nodeId: "actor",
+      sessionId: firstEnvelope.sessionId,
+      activity: {
+        roundId: "round-0002",
+        actorId: "actor",
+        generation: 1,
+        commandId: "strict-command-2",
+        surfaceId: "actor:actor",
+      },
+      requiredCapabilities: [DAG_TRANSPORT_FENCE_CAPABILITY],
+    });
+  });
+
+  it("rejects strict v1 workflows with more than one await_command", () => {
+    const strict = compileWorkflowSource(`
+api_version: homerail.ai/v1
+kind: Workflow
+metadata:
+  id: multiple-await-command
+  name: Multiple Await Command
+spec:
+  agents:
+    worker: { system: HANDOFF }
+  nodes:
+    actor_a:
+      kind: agent
+      agent: worker
+      outputs: { summary: {} }
+    actor_b:
+      kind: agent
+      agent: worker
+      outputs: { summary: {} }
+    suspend_a:
+      kind: await_command
+      inputs: { summary: {} }
+      config:
+        primitive_version: 1
+        target_actors: [actor_a]
+    suspend_b:
+      kind: await_command
+      inputs: { summary: {} }
+      config:
+        primitive_version: 1
+        target_actors: [actor_b]
+  edges:
+    - { from: actor_a.summary, to: suspend_a.summary }
+    - { from: actor_b.summary, to: suspend_b.summary }
+`);
+    expect(strict.valid).toBe(false);
+    expect(strict.diagnostics).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        severity: "error",
+        message: expect.stringMatching(/at most one await_command/i),
+      }),
+    ]));
+  });
+
+  it("rejects legacy graphs with more than one await_command", () => {
+    expect(() => parseDAGYaml(`
+name: multiple-await-command-graph
+agents:
+  worker: { agent_type: deterministic }
+nodes:
+  actor_a:
+    agent: worker
+    outputs:
+      summary: { to: suspend_a.in:summary }
+  actor_b:
+    agent: worker
+    outputs:
+      summary: { to: suspend_b.in:summary }
+  suspend_a:
+    type: await_command
+    gateway_config:
+      primitive_version: 1
+      target_actors: [actor_a]
+  suspend_b:
+    type: await_command
+    gateway_config:
+      primitive_version: 1
+      target_actors: [actor_b]
+`)).toThrow(/at most one await_command/i);
+  });
+
+  it("runs two fenced rounds under one run and cold-recovers the waiting actor", () => {
+    const runId = "multi-round-cold-recovery";
+    const dispatcher = new RepeatableDispatcher();
+    createActiveRun(runId, multiRoundDag());
+
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+    const firstEnvelope = dispatcher.dispatched.at(-1)!;
+    expect(firstEnvelope.activity).toMatchObject({
+      roundId: "round-0001",
+      actorId: "researcher",
+      generation: 1,
+      surfaceId: "surface-research",
+    });
+    handoffActiveRun(runId, "actor", "summary", { result: "round one" });
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+    expect(getActiveRun(runId)).toMatchObject({
+      status: "waiting",
+      currentRound: { round_id: "round-0001", ordinal: 1, status: "waiting" },
+    });
+    expect(getActiveRunCount()).toBe(0);
+    expect(getWaitingRunCount()).toBe(1);
+
+    const commandRequest = {
+      expected_round_id: "round-0001",
+      commands: [{
+        actor_id: "researcher",
+        command_id: "command-round-2",
+        idempotency_key: "retry-round-2",
+        payload: { task: "continue" },
+      }],
+    };
+    const resumed = resumeWaitingActiveRun(runId, commandRequest);
+    expect(resumed).toMatchObject({
+      previousRoundId: "round-0001",
+      roundId: "round-0002",
+      ordinal: 2,
+      actorIds: ["researcher"],
+      nodeIds: ["actor"],
+      commandIds: ["command-round-2"],
+    });
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+    const secondEnvelope = dispatcher.dispatched.at(-1)!;
+    expect(secondEnvelope).toMatchObject({
+      runId,
+      nodeId: "actor",
+      sessionId: firstEnvelope.sessionId,
+      activity: {
+        roundId: "round-0002",
+        actorId: "researcher",
+        generation: 1,
+        commandId: "command-round-2",
+        surfaceId: "surface-research",
+      },
+      inputs: {
+        command: [{
+          command_id: "command-round-2",
+          round_id: "round-0002",
+          actor_id: "researcher",
+          payload: { task: "continue" },
+        }],
+      },
+    });
+    expect(listDagActorCommands({ run_id: runId })[0]?.status).toBe("delivered");
+
+    expect(() => handoffActiveRun(runId, "actor", "summary", "late", {
+      transport: true,
+      roundId: "round-0001",
+      actorId: "researcher",
+      generation: 1,
+      commandId: "command-round-2",
+    })).toThrow("DAG_HANDOFF_ROUND_CONFLICT");
+    handoffActiveRun(runId, "actor", "summary", { result: "round two" }, {
+      transport: true,
+      roundId: "round-0002",
+      actorId: "researcher",
+      generation: 1,
+      commandId: "command-round-2",
+    });
+    expect(listDagActorCommands({ run_id: runId })[0]?.status).toBe("acknowledged");
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+    expect(getActiveRun(runId)?.status).toBe("waiting");
+
+    expect(resumeWaitingActiveRun(runId, commandRequest)).toMatchObject({
+      roundId: "round-0002",
+      commandIds: ["command-round-2"],
+      deduplicated: true,
+    });
+
+    _clearActiveRuns();
+    closeDb();
+    expect(recoverAllActiveRuns()).toMatchObject({ recovered: [runId] });
+    expect(getActiveRun(runId)).toMatchObject({
+      status: "waiting",
+      currentRound: { round_id: "round-0002", ordinal: 2, status: "waiting" },
+    });
+    expect(listDagActors(runId)).toContainEqual(expect.objectContaining({
+      actor_id: "researcher",
+      generation: 1,
+      session_id: firstEnvelope.sessionId,
+      surface_id: "surface-research",
+    }));
+    expect(loadRunMetadata(runId)?.dagRuntimeState).toBeDefined();
+
+    resumeWaitingActiveRun(runId, {
+      expected_round_id: "round-0002",
+      commands: [{ actor_id: "researcher", command_id: "command-round-3", payload: "one more" }],
+    });
+    cancelActiveRun(runId);
+    expect(getActiveRun(runId)?.status).toBe("cancelled");
+    expect(listDagActorCommands({ run_id: runId }).find((command) => command.command_id === "command-round-3"))
+      .toMatchObject({ status: "cancelled" });
+    expect(listDagRunRounds(runId).map((round) => [round.round_id, round.status])).toEqual([
+      ["round-0001", "completed"],
+      ["round-0002", "completed"],
+      ["round-0003", "cancelled"],
+    ]);
+  });
+
+  it("allows explicit completion only after the run reaches await_command", () => {
+    const runId = "multi-round-explicit-complete";
+    const dispatcher = new RepeatableDispatcher();
+    const orchestrator = new ChangeOrchestrator(new GraphExecutor(dispatcher));
+    createActiveRun(runId, multiRoundDag());
+    expect(() => orchestrator.completeRun(runId, "round-0001"))
+      .toThrow("not waiting for explicit completion");
+
+    const waitingRunId = "multi-round-explicit-complete-waiting";
+    createActiveRun(waitingRunId, multiRoundDag());
+    dispatchReadyNodes(waitingRunId, dispatcher);
+    handoffActiveRun(waitingRunId, "actor", "summary", "done");
+    dispatchReadyNodes(waitingRunId, dispatcher);
+    expect(getActiveRun(waitingRunId)?.status).toBe("waiting");
+    expect(() => orchestrator.completeRun(waitingRunId, "stale-round"))
+      .toThrow("Waiting round conflict");
+    orchestrator.completeRun(waitingRunId, "round-0001");
+    expect(getActiveRun(waitingRunId)?.status).toBe("completed");
+    expect(listDagRunRounds(waitingRunId)).toContainEqual(expect.objectContaining({
+      round_id: "round-0001",
+      status: "completed",
+    }));
+  });
+
+  it("fails a waiting run deterministically when await_command expires", () => {
+    const runId = "multi-round-expired";
+    const dispatcher = new RepeatableDispatcher();
+    createActiveRun(runId, expiringMultiRoundDag());
+    dispatchReadyNodes(runId, dispatcher);
+    handoffActiveRun(runId, "actor", "summary", "done");
+    dispatchReadyNodes(runId, dispatcher);
+    const expiresAt = getActiveRun(runId)?.currentRound.expires_at;
+    expect(expiresAt).toEqual(expect.any(Number));
+
+    expect(expireWaitingActiveRuns((expiresAt ?? 0) + 1)).toEqual([runId]);
+    expect(getActiveRun(runId)).toMatchObject({
+      status: "failed",
+      currentRound: { round_id: "round-0001", status: "failed" },
+    });
+    expect(listDagRunRounds(runId)).toContainEqual(expect.objectContaining({
+      round_id: "round-0001",
+      status: "failed",
+    }));
+  });
+
+  it("replays frozen unselected actor payloads when a selected actor rejoins fan-in", () => {
+    const runId = "multi-round-fan-in-carryover";
+    const dispatcher = new RepeatableDispatcher();
+    createActiveRun(runId, fanInMultiRoundDag());
+
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(2);
+    handoffActiveRun(runId, "actor_a", "result", { ok: true, label: "A1" });
+    handoffActiveRun(runId, "actor_b", "result", { ok: true, label: "B1" });
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+    expect(getActiveRun(runId)?.status).toBe("waiting");
+
+    resumeWaitingActiveRun(runId, {
+      expected_round_id: "round-0001",
+      commands: [{ actor_id: "actor_a", command_id: "command-a2", payload: "refresh A" }],
+    });
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+    handoffActiveRun(runId, "actor_a", "result", { ok: true, label: "A2" }, {
+      transport: true,
+      roundId: "round-0002",
+      actorId: "actor_a",
+      generation: 1,
+      commandId: "command-a2",
+    });
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+
+    const joinHandoff = loadRunSnapshot(runId)?.handoffs.findLast((record) => record.fromNode === "join");
+    expect(joinHandoff?.content).toMatchObject({
+      total: 2,
+      successes: 2,
+      passed: true,
+      values: expect.arrayContaining([
+        { ok: true, label: "A2" },
+        { ok: true, label: "B1" },
+      ]),
+    });
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+    expect(getActiveRun(runId)).toMatchObject({
+      status: "waiting",
+      currentRound: { round_id: "round-0002", status: "waiting" },
+    });
+  });
+
+  it("does not deduplicate a subset retry after accepting commands for two actors", () => {
+    const runId = "multi-round-command-subset-retry";
+    const dispatcher = new RepeatableDispatcher();
+    createActiveRun(runId, fanInMultiRoundDag());
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(2);
+    handoffActiveRun(runId, "actor_a", "result", { ok: true, label: "A1" });
+    handoffActiveRun(runId, "actor_b", "result", { ok: true, label: "B1" });
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+    expect(getActiveRun(runId)?.status).toBe("waiting");
+
+    const commands = [
+      {
+        actor_id: "actor_a",
+        command_id: "subset-command-a2",
+        idempotency_key: "subset-a2",
+        payload: { task: "retry A" },
+      },
+      {
+        actor_id: "actor_b",
+        command_id: "subset-command-b2",
+        idempotency_key: "subset-b2",
+        payload: { task: "retry B" },
+      },
+    ];
+    expect(resumeWaitingActiveRun(runId, {
+      expected_round_id: "round-0001",
+      commands,
+    })).toMatchObject({
+      roundId: "round-0002",
+      actorIds: ["actor_a", "actor_b"],
+      commandIds: ["subset-command-a2", "subset-command-b2"],
+    });
+
+    expect(() => resumeWaitingActiveRun(runId, {
+      expected_round_id: "round-0001",
+      commands: [commands[0]],
+    })).toThrow(`Run ${runId} is not waiting`);
+    expect(() => resumeWaitingActiveRun(runId, {
+      expected_round_id: "round-0001",
+      commands: [commands[0], { ...commands[0] }],
+    })).toThrow("Each actor may receive at most one command per round");
+    expect(listDagActorCommands({ run_id: runId, round_id: "round-0002" })).toHaveLength(2);
+  });
+
+  it("commits command acknowledgement, handoff, and run metadata atomically", () => {
+    const runId = "multi-round-atomic-handoff";
+    const dispatcher = new RepeatableDispatcher();
+    createActiveRun(runId, multiRoundDag());
+    dispatchReadyNodes(runId, dispatcher);
+    handoffActiveRun(runId, "actor", "summary", "round one");
+    dispatchReadyNodes(runId, dispatcher);
+    resumeWaitingActiveRun(runId, {
+      expected_round_id: "round-0001",
+      commands: [{ actor_id: "researcher", command_id: "atomic-command", payload: "continue" }],
+    });
+    dispatchReadyNodes(runId, dispatcher);
+
+    getDb().exec(`
+      CREATE TRIGGER fail_atomic_handoff_metadata
+      BEFORE UPDATE ON dag_runs
+      WHEN NEW.run_id = '${runId}'
+      BEGIN
+        SELECT RAISE(ABORT, 'forced metadata failure');
+      END
+    `);
+    expect(() => handoffActiveRun(runId, "actor", "summary", "round two", {
+      transport: true,
+      roundId: "round-0002",
+      actorId: "researcher",
+      generation: 1,
+      commandId: "atomic-command",
+    })).toThrow("forced metadata failure");
+
+    expect(getActiveRun(runId)?.dagRun.nodeStates.get("actor")).toBe("RUNNING");
+    expect(listDagActorCommands({ run_id: runId })).toContainEqual(expect.objectContaining({
+      command_id: "atomic-command",
+      status: "delivered",
+    }));
+    expect(loadRunSnapshot(runId)?.handoffs.filter((record) => record.roundId === "round-0002")).toEqual([]);
+
+    getDb().exec("DROP TRIGGER fail_atomic_handoff_metadata");
+    handoffActiveRun(runId, "actor", "summary", "round two", {
+      transport: true,
+      roundId: "round-0002",
+      actorId: "researcher",
+      generation: 1,
+      commandId: "atomic-command",
+    });
+    expect(listDagActorCommands({ run_id: runId })).toContainEqual(expect.objectContaining({
+      command_id: "atomic-command",
+      status: "acknowledged",
+    }));
+  });
+
+  it("rolls back in-memory completion and cancellation when persistence fails", () => {
+    const dispatcher = new RepeatableDispatcher();
+    const makeWaiting = (runId: string) => {
+      createActiveRun(runId, multiRoundDag());
+      dispatchReadyNodes(runId, dispatcher);
+      handoffActiveRun(runId, "actor", "summary", "done");
+      dispatchReadyNodes(runId, dispatcher);
+      expect(getActiveRun(runId)?.status).toBe("waiting");
+    };
+
+    makeWaiting("rollback-complete");
+    getDb().exec(`
+      CREATE TRIGGER fail_terminal_metadata
+      BEFORE UPDATE ON dag_runs
+      BEGIN
+        SELECT RAISE(ABORT, 'forced terminal failure');
+      END
+    `);
+    expect(() => completeActiveRun("rollback-complete")).toThrow("forced terminal failure");
+    expect(getActiveRun("rollback-complete")).toMatchObject({
+      status: "waiting",
+      currentRound: { status: "waiting" },
+    });
+    expect(getActiveRun("rollback-complete")?.dagRun.nodeStates.get("suspend")).toBe("WAITING_FOR_COMMAND");
+
+    getDb().exec("DROP TRIGGER fail_terminal_metadata");
+    makeWaiting("rollback-cancel");
+    getDb().exec(`
+      CREATE TRIGGER fail_terminal_metadata
+      BEFORE UPDATE ON dag_runs
+      BEGIN
+        SELECT RAISE(ABORT, 'forced terminal failure');
+      END
+    `);
+    expect(() => cancelActiveRun("rollback-cancel")).toThrow("forced terminal failure");
+    expect(getActiveRun("rollback-cancel")).toMatchObject({
+      status: "waiting",
+      currentRound: { status: "waiting" },
+    });
+    expect(getActiveRun("rollback-cancel")?.dagRun.nodeStates.get("suspend")).toBe("WAITING_FOR_COMMAND");
+    getDb().exec("DROP TRIGGER fail_terminal_metadata");
+  });
+
+  it("restores a waiting run in memory when expiry persistence fails", () => {
+    const runId = "rollback-expiry";
+    const dispatcher = new RepeatableDispatcher();
+    createActiveRun(runId, expiringMultiRoundDag());
+    dispatchReadyNodes(runId, dispatcher);
+    handoffActiveRun(runId, "actor", "summary", "done");
+    dispatchReadyNodes(runId, dispatcher);
+    const beforeRound = structuredClone(getActiveRun(runId)!.currentRound);
+    const expiresAt = beforeRound.expires_at!;
+
+    getDb().exec(`
+      CREATE TRIGGER fail_expiry_metadata
+      BEFORE UPDATE ON dag_runs
+      WHEN NEW.run_id = '${runId}'
+      BEGIN
+        SELECT RAISE(ABORT, 'forced expiry failure');
+      END
+    `);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    try {
+      expect(expireWaitingActiveRuns(expiresAt + 1)).toEqual([]);
+      expect(consoleError).toHaveBeenCalledWith(expect.stringContaining("forced expiry failure"));
+      expect(getActiveRun(runId)).toMatchObject({
+        status: "waiting",
+        completedAt: undefined,
+      });
+      expect(getActiveRun(runId)?.counters.abort_reason).toBeUndefined();
+      expect(getActiveRun(runId)?.currentRound).toEqual(beforeRound);
+      expect(getActiveRun(runId)?.dagRun.nodeStates.get("suspend")).toBe("WAITING_FOR_COMMAND");
+      expect(loadRunMetadata(runId)).toMatchObject({
+        status: "waiting",
+        currentRound: { round_id: "round-0001", status: "waiting" },
+        nodeStates: { suspend: "WAITING_FOR_COMMAND" },
+      });
+    } finally {
+      consoleError.mockRestore();
+      getDb().exec("DROP TRIGGER fail_expiry_metadata");
+    }
+  });
+
+  it("restores an active run in memory when abort persistence fails", () => {
+    const runId = "rollback-abort";
+    const dispatcher = new RepeatableDispatcher();
+    createActiveRun(runId, multiRoundDag());
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+    const beforeRound = structuredClone(getActiveRun(runId)!.currentRound);
+    const beforeCounters = structuredClone(getActiveRun(runId)!.counters);
+
+    getDb().exec(`
+      CREATE TRIGGER fail_abort_metadata
+      BEFORE UPDATE ON dag_runs
+      WHEN NEW.run_id = '${runId}'
+      BEGIN
+        SELECT RAISE(ABORT, 'forced abort failure');
+      END
+    `);
+    try {
+      expect(() => abortActiveRun(runId, "forced abort", "actor")).toThrow("forced abort failure");
+      expect(getActiveRun(runId)).toMatchObject({
+        status: "active",
+        completedAt: undefined,
+      });
+      expect(getActiveRun(runId)?.currentRound).toEqual(beforeRound);
+      expect(getActiveRun(runId)?.counters).toEqual(beforeCounters);
+      expect(getActiveRun(runId)?.dagRun.nodeStates.get("actor")).toBe("RUNNING");
+      expect(getActiveRun(runId)?.dagRun.nodeStates.get("suspend")).toBe("PENDING");
+      expect(loadRunMetadata(runId)).toMatchObject({
+        status: "active",
+        currentRound: { round_id: "round-0001", status: "active" },
+        nodeStates: { actor: "RUNNING", suspend: "PENDING" },
+      });
+    } finally {
+      getDb().exec("DROP TRIGGER fail_abort_metadata");
+    }
+  });
+
+  it("keeps await_command ready until a live sibling completes", () => {
+    const runId = "multi-round-live-sibling";
+    const dispatcher = new RepeatableDispatcher();
+    createActiveRun(runId, nonQuiescentMultiRoundDag());
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(2);
+    handoffActiveRun(runId, "actor", "summary", "ready to wait");
+
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(0);
+    expect(getActiveRun(runId)?.status).toBe("active");
+    expect(getActiveRun(runId)?.dagRun.nodeStates.get("sibling")).toBe("RUNNING");
+    expect(getActiveRun(runId)?.dagRun.nodeStates.get("suspend")).toBe("READY");
+
+    handoffActiveRun(runId, "sibling", "done", "sibling complete");
+    expect(getActiveRun(runId)?.dagRun.nodeStates.get("sibling")).toBe("COMPLETED");
+    expect(getActiveRun(runId)?.dagRun.nodeStates.get("suspend")).toBe("READY");
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+    expect(getActiveRun(runId)).toMatchObject({
+      status: "waiting",
+      currentRound: { round_id: "round-0001", status: "waiting" },
+    });
+    expect(getActiveRun(runId)?.dagRun.nodeStates.get("suspend")).toBe("WAITING_FOR_COMMAND");
+  });
+});

--- a/homerail_manager/tests/dag-run-rounds.test.ts
+++ b/homerail_manager/tests/dag-run-rounds.test.ts
@@ -1,0 +1,395 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  acknowledgeDagActorCommand,
+  claimDagActorCommand,
+  createDagActorCommand,
+  failDagActorCommand,
+  markDagActorCommandDelivered,
+  registerDagActor,
+} from "../src/persistence/dag-actors.js";
+import { closeDb, getDb } from "../src/persistence/db.js";
+import {
+  createInitialDagRunRound,
+  DagRunRoundConflictError,
+  getCurrentDagRunRound,
+  getDagRunRound,
+  listDagRunRounds,
+  openNextDagRunRound,
+  terminalizeCurrentDagRunRound,
+  transitionDagRunRoundToWaiting,
+} from "../src/persistence/dag-run-rounds.js";
+import {
+  appendHandoff,
+  ensureRunDir,
+  loadRunMetadata,
+  loadRunSnapshot,
+  serializeRunMetadata,
+  writeRunMetadata,
+} from "../src/persistence/store.js";
+
+function registerActor(): void {
+  registerDagActor({
+    run_id: "run-1",
+    actor_id: "researcher",
+    node_id: "research",
+    role: "research",
+    surface_id: "surface-research",
+  });
+}
+
+function createCommand(commandId: string): void {
+  createDagActorCommand({
+    command_id: commandId,
+    run_id: "run-1",
+    actor_id: "researcher",
+    round_id: "round-0001",
+    idempotency_key: `key-${commandId}`,
+    payload: { command_id: commandId },
+  });
+}
+
+function downgradeActorCommandsToV20(): void {
+  const db = getDb();
+  db.transaction(() => db.exec(`
+    DROP TABLE dag_run_rounds;
+    ALTER TABLE dag_actor_commands RENAME TO dag_actor_commands_v23_source;
+    CREATE TABLE dag_actor_commands (
+      command_id TEXT PRIMARY KEY,
+      run_id TEXT NOT NULL,
+      actor_id TEXT NOT NULL,
+      round_id TEXT NOT NULL,
+      target_generation INTEGER NOT NULL CHECK(target_generation >= 1),
+      status TEXT NOT NULL CHECK(status IN ('pending', 'delivered', 'claimed', 'acknowledged', 'failed')),
+      idempotency_key TEXT NOT NULL,
+      payload_digest TEXT NOT NULL CHECK(length(payload_digest) = 64),
+      payload_json TEXT NOT NULL,
+      claimed_generation INTEGER CHECK(claimed_generation IS NULL OR claimed_generation >= 1),
+      created_at INTEGER NOT NULL CHECK(created_at >= 0),
+      delivered_at INTEGER CHECK(delivered_at IS NULL OR delivered_at >= created_at),
+      claimed_at INTEGER CHECK(claimed_at IS NULL OR claimed_at >= created_at),
+      completed_at INTEGER CHECK(completed_at IS NULL OR completed_at >= created_at),
+      failure_json TEXT,
+      CHECK(
+        (status = 'pending' AND delivered_at IS NULL AND claimed_generation IS NULL AND claimed_at IS NULL AND completed_at IS NULL AND failure_json IS NULL)
+        OR (status = 'delivered' AND delivered_at IS NOT NULL AND claimed_generation IS NULL AND claimed_at IS NULL AND completed_at IS NULL AND failure_json IS NULL)
+        OR (status = 'claimed' AND claimed_generation IS NOT NULL AND claimed_at IS NOT NULL AND completed_at IS NULL AND failure_json IS NULL)
+        OR (status = 'acknowledged' AND claimed_generation IS NOT NULL AND claimed_at IS NOT NULL AND completed_at IS NOT NULL AND failure_json IS NULL)
+        OR (status = 'failed' AND claimed_generation IS NOT NULL AND claimed_at IS NOT NULL AND completed_at IS NOT NULL AND failure_json IS NOT NULL)
+      ),
+      FOREIGN KEY(run_id, actor_id) REFERENCES dag_actors(run_id, actor_id) ON DELETE CASCADE
+    );
+    INSERT INTO dag_actor_commands SELECT * FROM dag_actor_commands_v23_source;
+    DROP TABLE dag_actor_commands_v23_source;
+    CREATE UNIQUE INDEX idx_dag_actor_commands_idempotency
+      ON dag_actor_commands(run_id, actor_id, idempotency_key);
+    CREATE INDEX idx_dag_actor_commands_actor_status
+      ON dag_actor_commands(run_id, actor_id, status, created_at, command_id);
+    CREATE INDEX idx_dag_actor_commands_round
+      ON dag_actor_commands(run_id, round_id, created_at, command_id);
+    DELETE FROM schema_migrations WHERE version = 23;
+    INSERT OR IGNORE INTO schema_migrations(version, applied_at) VALUES (21, 'parallel-21');
+    INSERT OR IGNORE INTO schema_migrations(version, applied_at) VALUES (22, 'parallel-22');
+  `)).immediate();
+}
+
+describe("DAG run round persistence", () => {
+  let home: string;
+  let oldHome: string | undefined;
+
+  beforeEach(() => {
+    closeDb();
+    oldHome = process.env.HOMERAIL_HOME;
+    home = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-dag-rounds-"));
+    process.env.HOMERAIL_HOME = home;
+    ensureRunDir("run-1");
+  });
+
+  afterEach(() => {
+    closeDb();
+    if (oldHome === undefined) delete process.env.HOMERAIL_HOME;
+    else process.env.HOMERAIL_HOME = oldHome;
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it("migrates v20 actor commands without data loss and tolerates reserved v21/v22 markers", () => {
+    registerActor();
+    for (const commandId of ["pending", "delivered", "claimed", "acknowledged", "failed"]) {
+      createCommand(commandId);
+    }
+    markDagActorCommandDelivered("delivered");
+    claimDagActorCommand({ command_id: "claimed", run_id: "run-1", actor_id: "researcher", generation: 1 });
+    claimDagActorCommand({ command_id: "acknowledged", run_id: "run-1", actor_id: "researcher", generation: 1 });
+    acknowledgeDagActorCommand({ command_id: "acknowledged", generation: 1 });
+    claimDagActorCommand({ command_id: "failed", run_id: "run-1", actor_id: "researcher", generation: 1 });
+    failDagActorCommand({ command_id: "failed", generation: 1, failure: { message: "expected" } });
+
+    const expectedRows = getDb().prepare("SELECT * FROM dag_actor_commands ORDER BY command_id").all();
+    downgradeActorCommandsToV20();
+    closeDb();
+
+    const migrated = getDb();
+    expect(migrated.prepare("SELECT version FROM schema_migrations WHERE version >= 21 ORDER BY version").all())
+      .toEqual([{ version: 21 }, { version: 22 }, { version: 23 }]);
+    expect(migrated.prepare("SELECT * FROM dag_actor_commands ORDER BY command_id").all())
+      .toEqual(expectedRows);
+    expect(migrated.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
+    expect(migrated.prepare("PRAGMA index_list(dag_run_rounds)").all())
+      .toEqual(expect.arrayContaining([
+        expect.objectContaining({ name: "idx_dag_run_rounds_run_ordinal", unique: 1, partial: 0 }),
+        expect.objectContaining({ name: "idx_dag_run_rounds_current", unique: 1, partial: 1 }),
+      ]));
+    expect(migrated.prepare("PRAGMA foreign_key_list(dag_run_rounds)").all())
+      .toEqual(expect.arrayContaining([
+        expect.objectContaining({ table: "dag_runs", from: "run_id", to: "run_id", on_delete: "CASCADE" }),
+      ]));
+    expect(migrated.prepare("PRAGMA index_list(dag_actor_commands)").all())
+      .toEqual(expect.arrayContaining([
+        expect.objectContaining({ name: "idx_dag_actor_commands_idempotency", unique: 1 }),
+        expect.objectContaining({ name: "idx_dag_actor_commands_actor_status", unique: 0 }),
+        expect.objectContaining({ name: "idx_dag_actor_commands_round", unique: 0 }),
+      ]));
+    expect((migrated.prepare(
+      "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'dag_actor_commands'",
+    ).get() as { sql: string }).sql).toContain("'cancelled'");
+
+    migrated.prepare("DELETE FROM schema_migrations WHERE version = 23").run();
+    closeDb();
+    const reapplied = getDb();
+    expect(reapplied.prepare("SELECT COUNT(*) AS count FROM schema_migrations WHERE version = 23").get())
+      .toEqual({ count: 1 });
+    expect(reapplied.prepare("SELECT * FROM dag_actor_commands ORDER BY command_id").all())
+      .toEqual(expectedRows);
+  });
+
+  it("fails closed when the current-round index is not unique and partial", () => {
+    getDb().exec(`
+      DROP INDEX idx_dag_run_rounds_current;
+      CREATE UNIQUE INDEX idx_dag_run_rounds_current ON dag_run_rounds(run_id);
+    `);
+    closeDb();
+
+    expect(() => getDb()).toThrow(
+      "Schema migration 23 is incomplete: index idx_dag_run_rounds_current is missing or invalid",
+    );
+  });
+
+  it("closes an active round to waiting exactly once", () => {
+    const initial = createInitialDagRunRound({
+      run_id: "run-1",
+      round_id: "round-0001",
+      target_actor_ids: ["writer", "researcher", "writer"],
+      opened_at: 100,
+    });
+    expect(initial).toMatchObject({
+      ordinal: 1,
+      status: "active",
+      target_actor_ids: ["researcher", "writer"],
+    });
+
+    const waiting = transitionDagRunRoundToWaiting({
+      run_id: "run-1",
+      round_id: "round-0001",
+      await_node_id: "await-next-command",
+      closed_at: 200,
+      expires_at: 500,
+    });
+    expect(waiting).toMatchObject({
+      status: "waiting",
+      await_node_id: "await-next-command",
+      closed_at: 200,
+      expires_at: 500,
+    });
+    expect(() => transitionDagRunRoundToWaiting({
+      run_id: "run-1",
+      round_id: "round-0001",
+      await_node_id: "await-next-command",
+      closed_at: 200,
+    })).toThrowError(expect.objectContaining<DagRunRoundConflictError>({ code: "round_status_conflict" }));
+  });
+
+  it("enforces one current round and one ordinal per run", () => {
+    createInitialDagRunRound({
+      run_id: "run-1",
+      round_id: "round-0001",
+      target_actor_ids: ["researcher"],
+      opened_at: 100,
+    });
+    expect(() => createInitialDagRunRound({
+      run_id: "run-1",
+      round_id: "round-other",
+      target_actor_ids: ["writer"],
+      opened_at: 100,
+    })).toThrowError(expect.objectContaining<DagRunRoundConflictError>({ code: "initial_round_conflict" }));
+
+    expect(() => getDb().prepare(`
+      INSERT INTO dag_run_rounds(
+        run_id, round_id, ordinal, status, target_actor_ids_json, opened_at
+      ) VALUES (?, ?, ?, 'active', '[]', ?)
+    `).run("run-1", "round-0002", 2, 200)).toThrow(/UNIQUE constraint failed/);
+    expect(() => getDb().prepare(`
+      INSERT INTO dag_run_rounds(
+        run_id, round_id, ordinal, status, target_actor_ids_json, opened_at, closed_at
+      ) VALUES (?, ?, ?, 'completed', '[]', ?, ?)
+    `).run("run-1", "round-same-ordinal", 1, 200, 200)).toThrow(/UNIQUE constraint failed/);
+  });
+
+  it("completes the waiting round and opens monotonically increasing ordinals atomically", () => {
+    createInitialDagRunRound({
+      run_id: "run-1",
+      round_id: "round-0001",
+      target_actor_ids: ["researcher"],
+      opened_at: 100,
+    });
+    transitionDagRunRoundToWaiting({
+      run_id: "run-1",
+      round_id: "round-0001",
+      await_node_id: "await",
+      closed_at: 200,
+    });
+    const second = openNextDagRunRound({
+      run_id: "run-1",
+      expected_round_id: "round-0001",
+      round_id: "round-0002",
+      target_actor_ids: ["writer"],
+      opened_at: 300,
+    });
+    expect(second).toMatchObject({ round_id: "round-0002", ordinal: 2, status: "active" });
+    expect(getDagRunRound("run-1", "round-0001")?.status).toBe("completed");
+    expect(getCurrentDagRunRound("run-1")?.round_id).toBe("round-0002");
+
+    transitionDagRunRoundToWaiting({
+      run_id: "run-1",
+      round_id: "round-0002",
+      await_node_id: "await",
+      closed_at: 400,
+    });
+    const third = openNextDagRunRound({
+      run_id: "run-1",
+      expected_round_id: "round-0002",
+      round_id: "round-0003",
+      target_actor_ids: ["researcher", "writer"],
+      opened_at: 500,
+    });
+    expect(third.ordinal).toBe(3);
+    expect(listDagRunRounds("run-1").map((round) => [round.ordinal, round.status]))
+      .toEqual([[1, "completed"], [2, "completed"], [3, "active"]]);
+  });
+
+  it("terminalizes the expected current round and rejects stale repeats", () => {
+    createInitialDagRunRound({
+      run_id: "run-1",
+      round_id: "round-0001",
+      target_actor_ids: ["researcher"],
+      opened_at: 100,
+    });
+    expect(terminalizeCurrentDagRunRound({
+      run_id: "run-1",
+      round_id: "round-0001",
+      status: "failed",
+      closed_at: 200,
+    })).toMatchObject({ status: "failed", closed_at: 200 });
+    expect(getCurrentDagRunRound("run-1")).toBeUndefined();
+    expect(() => terminalizeCurrentDagRunRound({
+      run_id: "run-1",
+      round_id: "round-0001",
+      status: "failed",
+      closed_at: 200,
+    })).toThrowError(expect.objectContaining<DagRunRoundConflictError>({ code: "current_round_conflict" }));
+  });
+
+  it("serializes round and DAG runtime state deterministically while reading legacy metadata", () => {
+    const metadata = serializeRunMetadata({
+      runId: "run-1",
+      createdAt: 100,
+      status: "waiting",
+      currentRound: {
+        round_id: "round-0001",
+        ordinal: 1,
+        status: "waiting",
+        target_actor_ids: ["writer", "researcher", "writer"],
+        await_node_id: "await",
+        opened_at: 100,
+        closed_at: 200,
+        expires_at: 500,
+      },
+      dagRun: {
+        nodeStates: new Map([["writer", "READY"], ["researcher", "COMPLETED"]]),
+        handoffedNodes: new Set(["writer", "researcher"]),
+        graph: { nodes: [], edges: [] },
+        afterSatisfied: new Map([
+          ["writer", new Set(["researcher", "source"])],
+          ["researcher", new Set()],
+        ]),
+        inputSatisfied: new Map([
+          ["writer", new Set(["source", "researcher"])],
+          ["researcher", new Set()],
+        ]),
+        mailboxes: new Map([
+          ["writer", new Map([["z-port", [{ z: 1 }]], ["a-port", [{ a: 1 }]]])],
+          ["researcher", new Map()],
+        ]),
+        loopSources: new Set(["writer", "researcher"]),
+      },
+    });
+
+    expect(metadata.currentRound).toEqual({
+      round_id: "round-0001",
+      ordinal: 1,
+      status: "waiting",
+      target_actor_ids: ["researcher", "writer"],
+      await_node_id: "await",
+      opened_at: 100,
+      closed_at: 200,
+      expires_at: 500,
+    });
+    expect(metadata.dagRuntimeState).toEqual({
+      after_satisfied: { researcher: [], writer: ["researcher", "source"] },
+      input_satisfied: { researcher: [], writer: ["researcher", "source"] },
+      mailboxes: {
+        researcher: {},
+        writer: { "a-port": [{ a: 1 }], "z-port": [{ z: 1 }] },
+      },
+      loop_sources: ["researcher", "writer"],
+    });
+    expect(Object.keys(metadata.nodeStates)).toEqual(["researcher", "writer"]);
+    expect(metadata.handoffedNodes).toEqual(["researcher", "writer"]);
+
+    writeRunMetadata("run-1", metadata);
+    expect(loadRunMetadata("run-1")).toMatchObject({
+      currentRound: metadata.currentRound,
+      dagRuntimeState: metadata.dagRuntimeState,
+    });
+    appendHandoff("run-1", {
+      runId: "run-1",
+      fromNode: "legacy",
+      port: "done",
+      timestamp: 300,
+    });
+    appendHandoff("run-1", {
+      runId: "run-1",
+      roundId: "round-0001",
+      fromNode: "researcher",
+      port: "done",
+      timestamp: 400,
+    });
+    expect(loadRunSnapshot("run-1")?.handoffs.map((handoff) => handoff.roundId))
+      .toEqual([undefined, "round-0001"]);
+
+    const legacy = serializeRunMetadata({
+      runId: "legacy-run",
+      createdAt: 100,
+      status: "active",
+      dagRun: {
+        nodeStates: new Map(),
+        handoffedNodes: new Set(),
+        graph: { nodes: [], edges: [] },
+      },
+    });
+    expect(legacy).not.toHaveProperty("currentRound");
+    expect(legacy).not.toHaveProperty("dagRuntimeState");
+  });
+});

--- a/homerail_manager/tests/dag-session-websocket.test.ts
+++ b/homerail_manager/tests/dag-session-websocket.test.ts
@@ -239,6 +239,7 @@ describe("worker websocket node session filtering", () => {
     const dispatcher = new CaptureDispatcher();
     expect(dispatchReadyNodes("run-ws-activity", dispatcher)).toBe(1);
     const sessionId = dispatcher.dispatched[0].sessionId!;
+    const roundId = dispatcher.dispatched[0].activity!.roundId;
     recordDispatch("run-ws-activity", "work", "worker", "worker-activity");
 
     const staleEvents: unknown[] = [];
@@ -276,7 +277,10 @@ describe("worker websocket node session filtering", () => {
         activity,
         run_id: "run-ws-activity",
         node_id: "work",
-        session_id: "stale-round",
+        session_id: sessionId,
+        round_id: "stale-round",
+        actor_id: "work",
+        generation: 1,
       },
     });
     ws.send(stream);
@@ -285,13 +289,36 @@ describe("worker websocket node session filtering", () => {
 
     const page = listDagActivityEvents({ run_id: "run-ws-activity" });
     expect(page.events).toHaveLength(0);
-    expect(staleEvents).toHaveLength(2);
+    expect(staleEvents).toHaveLength(0);
     const genericEvidence = JSON.stringify({
       chats: loadRunSnapshot("run-ws-activity")?.chats,
       transcript: loadSessionTranscript(sessionId),
     });
     expect(genericEvidence).not.toContain("durable finding");
     expect(genericEvidence).not.toContain("raw-worker-secret");
+
+    ws.send(JSON.stringify({
+      type: "stream",
+      data: {
+        type: "dag_activity",
+        event: "dag_activity",
+        activity: {
+          ...activity,
+          event_id: "ws-activity-current",
+          round_id: roundId,
+          payload: { message: "current round finding" },
+        },
+        run_id: "run-ws-activity",
+        node_id: "work",
+        session_id: sessionId,
+        round_id: roundId,
+        actor_id: "work",
+        generation: 1,
+      },
+    }));
+    await delay(20);
+    expect(listDagActivityEvents({ run_id: "run-ws-activity" }).events)
+      .toMatchObject([{ event: { event_id: "ws-activity-current", round_id: roundId } }]);
     ws.close();
   });
 
@@ -300,6 +327,7 @@ describe("worker websocket node session filtering", () => {
     const dispatcher = new CaptureDispatcher();
     expect(dispatchReadyNodes("run-ws-source-bound", dispatcher)).toBe(1);
     const sessionId = dispatcher.dispatched[0].sessionId!;
+    const roundId = dispatcher.dispatched[0].activity!.roundId;
     recordDispatch("run-ws-source-bound", "work", "worker", "worker-owner");
 
     server = http.createServer();
@@ -317,11 +345,14 @@ describe("worker websocket node session filtering", () => {
         run_id: "run-ws-source-bound",
         node_id: "work",
         session_id: sessionId,
+        round_id: roundId,
+        actor_id: "work",
+        generation: 1,
         activity: {
           schema_version: 1,
           event_id: "spoofed-source-activity",
           run_id: "run-ws-source-bound",
-          round_id: sessionId,
+          round_id: roundId,
           node_id: "work",
           actor_id: "work",
           generation: 1,
@@ -335,6 +366,51 @@ describe("worker websocket node session filtering", () => {
     await delay(30);
 
     expect(listDagActivityEvents({ run_id: "run-ws-source-bound" }).events).toEqual([]);
+    ws.close();
+  });
+
+  it("accepts legacy session-based activity during the first round", async () => {
+    createActiveRun("run-ws-legacy-activity", simpleDag());
+    const dispatcher = new CaptureDispatcher();
+    expect(dispatchReadyNodes("run-ws-legacy-activity", dispatcher)).toBe(1);
+    const sessionId = dispatcher.dispatched[0].sessionId!;
+    recordDispatch("run-ws-legacy-activity", "work", "worker", "worker-legacy-activity");
+
+    server = http.createServer();
+    setupWorkerWebSocket(server, { registrationTimeoutMs: 500, pingIntervalMs: 5_000 });
+    const port = await listen(server);
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws/projects/default/workers/worker-legacy-activity`);
+    await new Promise<void>((resolve) => ws.once("open", () => resolve()));
+    ws.send(JSON.stringify({ type: "register", worker_id: "worker-legacy-activity" }));
+    await delay(20);
+
+    ws.send(JSON.stringify({
+      type: "stream",
+      data: {
+        type: "dag_activity",
+        event: "dag_activity",
+        run_id: "run-ws-legacy-activity",
+        node_id: "work",
+        session_id: sessionId,
+        activity: {
+          schema_version: 1,
+          event_id: "legacy-first-round-activity",
+          run_id: "run-ws-legacy-activity",
+          round_id: sessionId,
+          node_id: "work",
+          actor_id: "work",
+          generation: 1,
+          sequence: 1,
+          timestamp: Date.now(),
+          type: "finding",
+          payload: { message: "legacy accepted" },
+        },
+      },
+    }));
+    await delay(20);
+
+    expect(listDagActivityEvents({ run_id: "run-ws-legacy-activity" }).events)
+      .toMatchObject([{ event: { event_id: "legacy-first-round-activity", round_id: sessionId } }]);
     ws.close();
   });
 

--- a/homerail_manager/tests/dag-workflow-revisions.test.ts
+++ b/homerail_manager/tests/dag-workflow-revisions.test.ts
@@ -92,7 +92,7 @@ describe("DAG workflow revisions", () => {
     expect(workflow).toMatchObject({
       head_revision: 1,
       api_version: "legacy/v0",
-      compiler_version: "4",
+      compiler_version: "5",
     });
     expect(workflow?.canonical_hash).toMatch(/^[a-f0-9]{64}$/);
     expect(listDagWorkflowRevisions("revision-test")).toEqual([
@@ -135,7 +135,7 @@ spec:
       workflow_id: "v1-revision",
       head_revision: 1,
       api_version: "homerail.ai/v1",
-      compiler_version: "4",
+      compiler_version: "5",
       node_ids: ["execute"],
       agent_ids: ["worker"],
     });

--- a/homerail_manager/tests/dag-workflows.test.ts
+++ b/homerail_manager/tests/dag-workflows.test.ts
@@ -106,14 +106,14 @@ default:
     expect(result).toMatchObject({
       workflowRevision: 1,
       canonicalHash: synced.workflow.canonical_hash,
-      compilerVersion: "4",
+      compilerVersion: "5",
       sourceApiVersion: "legacy/v0",
     });
     expect(loadRunMetadata(result.runId)).toMatchObject({
       workflowId: "db-workflow",
       workflowRevision: 1,
       canonicalHash: synced.workflow.canonical_hash,
-      compilerVersion: "4",
+      compilerVersion: "5",
       sourceApiVersion: "legacy/v0",
     });
 

--- a/homerail_manager/tests/dispatch-capabilities.test.ts
+++ b/homerail_manager/tests/dispatch-capabilities.test.ts
@@ -3,14 +3,16 @@ import * as os from "node:os";
 import * as path from "node:path";
 import WebSocket from "ws";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DAG_TRANSPORT_FENCE_CAPABILITY } from "homerail-protocol";
 
 import type { DispatchEnvelope } from "../src/orchestration/dag-dispatcher.js";
-import { _clearAllDispatches, recordProvisioning } from "../src/orchestration/dispatch-tracker.js";
+import { _clearAllDispatches, recordDispatch, recordProvisioning } from "../src/orchestration/dispatch-tracker.js";
 import { normalizeAgentBackend, WsDispatchAdapter } from "../src/orchestration/ws-dispatch-adapter.js";
 import { parseDAGYaml } from "../src/orchestration/yaml-loader.js";
-import { _clearListeners } from "../src/events/bus.js";
+import { _clearListeners, subscribe } from "../src/events/bus.js";
 import { registerNode, _clearNodes } from "../src/node/registry.js";
 import { createSetting, upsertProvider } from "../src/persistence/llm-settings.js";
+import { listDagActorCommands } from "../src/persistence/dag-actors.js";
 import { appendSessionTranscriptForTest, loadSessionTranscript } from "../src/persistence/dag-session-files.js";
 import { _clearAllPersistence } from "../src/persistence/store.js";
 import { closeDb } from "../src/persistence/db.js";
@@ -21,6 +23,8 @@ import {
   dispatchReadyNodes,
   getActiveRun,
   getCurrentNodeSession,
+  handoffActiveRun,
+  resumeWaitingActiveRun,
 } from "../src/runtime/active-runs.js";
 import { registerWorker, _clearWorkers } from "../src/worker/registry.js";
 
@@ -44,6 +48,16 @@ function makeEnvelope(overrides: Partial<DispatchEnvelope> = {}): DispatchEnvelo
     image: "homerail-worker:latest",
     ...overrides,
   };
+}
+
+function waitForProvisioningCompleted(runId: string): Promise<void> {
+  return new Promise((resolve) => {
+    const unsubscribe = subscribe("dag:provisioning_completed", (payload) => {
+      if ((payload as { runId?: string }).runId !== runId) return;
+      unsubscribe();
+      resolve();
+    });
+  });
 }
 
 describe("DAG node capability requirements", () => {
@@ -144,6 +158,42 @@ nodes:
     expect(hostSocket.send).toHaveBeenCalledTimes(1);
   });
 
+  it("reuses the previous online worker for a hot multi-round actor", () => {
+    const otherSocket = makeSocket();
+    const hotSocket = makeSocket();
+    registerWorker({
+      worker_id: "other-worker",
+      project_id: "p1",
+      socket: otherSocket,
+      status: "idle",
+      capabilities: ["browser"],
+      registered_at: Date.now(),
+      last_heartbeat: Date.now(),
+    });
+    registerWorker({
+      worker_id: "hot-worker",
+      project_id: "p1",
+      socket: hotSocket,
+      status: "idle",
+      capabilities: ["browser"],
+      registered_at: Date.now(),
+      last_heartbeat: Date.now(),
+    });
+    recordDispatch("run-capabilities", "diagnose", "worker", "hot-worker");
+
+    const result = new WsDispatchAdapter({ provisioner: false }).dispatch(
+      makeEnvelope({ requiredCapabilities: ["browser"] }),
+    );
+
+    expect(result).toMatchObject({
+      status: "dispatched",
+      targetType: "worker",
+      targetId: "hot-worker",
+    });
+    expect(hotSocket.send).toHaveBeenCalledTimes(1);
+    expect(otherSocket.send).not.toHaveBeenCalled();
+  });
+
   it("mirrors dispatched prompts into the manager-side session store", () => {
     const socket = makeSocket();
     registerWorker({
@@ -193,7 +243,7 @@ nodes:
     });
   });
 
-  it("does not fall back to a node when required worker capabilities are missing", () => {
+  it("keeps a required-capability node READY instead of falling back to a Node", () => {
     const nodeSocket = makeSocket();
     registerNode({
       node_id: "docker-node",
@@ -205,16 +255,154 @@ nodes:
       last_heartbeat: Date.now(),
       pending_requests: new Map(),
     });
+    createActiveRun("run-required-capability", parseDAGYaml(`
+name: required-capability
+agents:
+  worker: { agent_type: deterministic }
+nodes:
+  diagnose:
+    agent: worker
+    requires:
+      capabilities: [browser]
+    outputs: { done: { to: "" } }
+`));
+    const adapter = new WsDispatchAdapter({ provisioner: false });
+    const dispatch = vi.spyOn(adapter, "dispatch");
 
-    const result = new WsDispatchAdapter({ provisioner: false }).dispatch(
-      makeEnvelope({ requiredCapabilities: ["browser"] }),
-    );
+    expect(dispatchReadyNodes("run-required-capability", adapter)).toBe(0);
 
-    expect(result).toMatchObject({
-      status: "failed",
-      reason: "no available worker satisfies required capabilities: browser",
+    expect(dispatch).toHaveReturnedWith(expect.objectContaining({
+      status: "skipped",
+    }));
+    expect(getActiveRun("run-required-capability")).toMatchObject({
+      status: "active",
     });
+    expect(getActiveRun("run-required-capability")?.dagRun.nodeStates.get("diagnose")).toBe("READY");
     expect(nodeSocket.send).not.toHaveBeenCalled();
+  });
+
+  it("keeps an offline node READY and retries after a node registers", async () => {
+    createActiveRun("run-offline-node-reconnect", parseDAGYaml(`
+name: offline-node-reconnect
+workflow_id: offline-node-reconnect
+agents:
+  worker: { agent_type: deterministic }
+nodes:
+  diagnose:
+    agent: worker
+    outputs: { done: { to: "" } }
+`));
+    const adapter = new WsDispatchAdapter({ provisioner: false });
+
+    expect(dispatchReadyNodes("run-offline-node-reconnect", adapter)).toBe(0);
+    expect(getActiveRun("run-offline-node-reconnect")).toMatchObject({ status: "active" });
+    expect(getActiveRun("run-offline-node-reconnect")?.dagRun.nodeStates.get("diagnose")).toBe("READY");
+
+    const nodeSocket = makeSocket();
+    registerNode({
+      node_id: "late-node",
+      project_id: "p1",
+      socket: nodeSocket,
+      status: "connected",
+      capabilities: [],
+      registered_at: Date.now(),
+      last_heartbeat: Date.now(),
+      pending_requests: new Map(),
+    });
+
+    await vi.waitFor(
+      () => expect(nodeSocket.send).toHaveBeenCalledTimes(1),
+      { timeout: 2_500 },
+    );
+    expect(getActiveRun("run-offline-node-reconnect")?.dagRun.nodeStates.get("diagnose")).toBe("RUNNING");
+    expect(JSON.parse(String(nodeSocket.send.mock.calls[0]?.[0]))).toMatchObject({
+      type: "prompt",
+      envelope: { runId: "run-offline-node-reconnect", nodeId: "diagnose" },
+    });
+  });
+
+  it("contains an offline retry timer dispatch error and recovers after another target change", async () => {
+    const runId = "run-offline-retry-error";
+    createActiveRun(runId, parseDAGYaml(`
+name: offline-retry-error
+agents:
+  worker: { agent_type: deterministic }
+nodes:
+  diagnose:
+    agent: worker
+    outputs: { done: { to: "" } }
+`));
+    const adapter = new WsDispatchAdapter({ provisioner: false });
+    const originalDispatch = adapter.dispatch.bind(adapter);
+    let throwOnNextDispatch = false;
+    const dispatch = vi.spyOn(adapter, "dispatch").mockImplementation((envelope) => {
+      if (throwOnNextDispatch) {
+        throwOnNextDispatch = false;
+        throw new Error("forced offline retry dispatch failure");
+      }
+      return originalDispatch(envelope);
+    });
+
+    expect(dispatchReadyNodes(runId, adapter)).toBe(0);
+    expect(getActiveRun(runId)?.dagRun.nodeStates.get("diagnose")).toBe("READY");
+
+    throwOnNextDispatch = true;
+    const firstWorkerSocket = makeSocket();
+    registerWorker({
+      worker_id: "offline-retry-worker-1",
+      project_id: "p1",
+      socket: firstWorkerSocket,
+      status: "idle",
+      capabilities: [],
+      registered_at: Date.now(),
+      last_heartbeat: Date.now(),
+    });
+    await vi.waitFor(
+      () => expect(dispatch).toHaveBeenCalledTimes(2),
+      { timeout: 2_500 },
+    );
+    expect(firstWorkerSocket.send).not.toHaveBeenCalled();
+    expect(getActiveRun(runId)).toMatchObject({ status: "active" });
+    expect(getActiveRun(runId)?.dagRun.nodeStates.get("diagnose")).toBe("READY");
+
+    const secondWorkerSocket = makeSocket();
+    registerWorker({
+      worker_id: "offline-retry-worker-2",
+      project_id: "p1",
+      socket: secondWorkerSocket,
+      status: "idle",
+      capabilities: [],
+      registered_at: Date.now(),
+      last_heartbeat: Date.now(),
+    });
+    await vi.waitFor(
+      () => expect(firstWorkerSocket.send.mock.calls.length + secondWorkerSocket.send.mock.calls.length).toBe(1),
+      { timeout: 3_500 },
+    );
+    expect(dispatch.mock.calls.length).toBeGreaterThanOrEqual(3);
+    expect(getActiveRun(runId)?.dagRun.nodeStates.get("diagnose")).toBe("RUNNING");
+  }, 8_000);
+
+  it("keeps socket send errors on the failed dispatch path", () => {
+    const workerSocket = makeSocket();
+    workerSocket.send.mockImplementation(() => {
+      throw new Error("socket write failed");
+    });
+    registerWorker({
+      worker_id: "broken-worker",
+      project_id: "p1",
+      socket: workerSocket,
+      status: "idle",
+      capabilities: [],
+      registered_at: Date.now(),
+      last_heartbeat: Date.now(),
+    });
+
+    expect(new WsDispatchAdapter({ provisioner: false }).dispatch(makeEnvelope())).toMatchObject({
+      status: "failed",
+      reason: "socket write failed",
+      retryable: true,
+    });
   });
 
   it("provisions a run-scoped worker instead of reusing generic workers for isolated workspaces", async () => {
@@ -291,7 +479,7 @@ nodes:
     });
   });
 
-  it("provisions through a docker-api capable node", async () => {
+  it("provisions through a docker-api Node before waiting for a capability-matched Worker", async () => {
     const nodeSocket = makeSocket();
     const created: Array<{ nodeId: string; workspaceId: string }> = [];
     registerNode({
@@ -317,7 +505,7 @@ nodes:
           worker_ids: ["provisioned-run-capabilities-diagnose"],
         }),
       },
-    }).dispatch(makeEnvelope());
+    }).dispatch(makeEnvelope({ requiredCapabilities: ["browser"] }));
 
     expect(result).toMatchObject({
       status: "skipped",
@@ -331,6 +519,250 @@ nodes:
         },
       ]);
     });
+  });
+
+  it("keeps a node READY when its provisioned Worker lacks required capabilities", async () => {
+    const runId = "run-provisioned-capability-mismatch";
+    const nodeSocket = makeSocket();
+    registerNode({
+      node_id: "provisioning-node",
+      project_id: "p1",
+      socket: nodeSocket,
+      status: "connected",
+      capabilities: ["docker-api"],
+      registered_at: Date.now(),
+      last_heartbeat: Date.now(),
+      pending_requests: new Map(),
+    });
+    createActiveRun(runId, parseDAGYaml(`
+name: provisioned-capability-mismatch
+agents:
+  worker: { agent_type: deterministic }
+nodes:
+  diagnose:
+    agent: worker
+    requires:
+      capabilities: [browser]
+    outputs: { done: { to: "" } }
+`));
+
+    const provisionedWorkerId = "provisioned-run-provisioned-capability-mismatch-diagnose";
+    const incompatibleSocket = makeSocket();
+    const provisioningCompleted = waitForProvisioningCompleted(runId);
+    const adapter = new WsDispatchAdapter({
+      managerBaseUrl: "http://127.0.0.1:19191",
+      provisioner: {
+        createFn: async () => ({ status: "success", resource_data: { id: "container-incompatible" } }),
+        startFn: async () => {
+          registerWorker({
+            worker_id: provisionedWorkerId,
+            project_id: "p1",
+            socket: incompatibleSocket,
+            status: "idle",
+            capabilities: [],
+            registered_at: Date.now(),
+            last_heartbeat: Date.now(),
+          });
+          return { status: "success" };
+        },
+        runtimeStatusFn: async () => ({ worker_ids: [provisionedWorkerId] }),
+      },
+    });
+
+    expect(dispatchReadyNodes(runId, adapter)).toBe(0);
+    await provisioningCompleted;
+    expect(incompatibleSocket.send).not.toHaveBeenCalled();
+    expect(getActiveRun(runId)).toMatchObject({
+      status: "active",
+      counters: { dispatches: 0 },
+    });
+    expect(getActiveRun(runId)?.dagRun.nodeStates.get("diagnose")).toBe("READY");
+
+    const compatibleSocket = makeSocket();
+    registerWorker({
+      worker_id: "compatible-browser-worker",
+      project_id: "p1",
+      socket: compatibleSocket,
+      status: "idle",
+      capabilities: ["browser"],
+      registered_at: Date.now(),
+      last_heartbeat: Date.now(),
+    });
+    await vi.waitFor(
+      () => expect(compatibleSocket.send).toHaveBeenCalledTimes(1),
+      { timeout: 2_500 },
+    );
+    expect(incompatibleSocket.send).not.toHaveBeenCalled();
+    expect(getActiveRun(runId)).toMatchObject({
+      status: "active",
+      counters: { dispatches: 1 },
+    });
+    expect(getActiveRun(runId)?.dagRun.nodeStates.get("diagnose")).toBe("RUNNING");
+  }, 6_000);
+
+  it("counts a successful provisioning send against max_dispatches", async () => {
+    const runId = "run-provisioning-dispatch-budget";
+    const nodeSocket = makeSocket();
+    registerNode({
+      node_id: "budget-provisioning-node",
+      project_id: "p1",
+      socket: nodeSocket,
+      status: "connected",
+      capabilities: ["docker-api"],
+      registered_at: Date.now(),
+      last_heartbeat: Date.now(),
+      pending_requests: new Map(),
+    });
+    createActiveRun(runId, parseDAGYaml(`
+name: provisioning-dispatch-budget
+limits:
+  max_dispatches: 1
+agents:
+  worker: { agent_type: deterministic }
+nodes:
+  diagnose:
+    agent: worker
+    outputs: { done: { to: "" } }
+`));
+
+    const workerId = "provisioned-run-provisioning-dispatch-budget-diagnose";
+    const workerSocket = makeSocket();
+    const provisioningCompleted = waitForProvisioningCompleted(runId);
+    const adapter = new WsDispatchAdapter({
+      managerBaseUrl: "http://127.0.0.1:19191",
+      provisioner: {
+        createFn: async () => ({ status: "success", resource_data: { id: "container-budget" } }),
+        startFn: async () => {
+          registerWorker({
+            worker_id: workerId,
+            project_id: "p1",
+            socket: workerSocket,
+            status: "idle",
+            capabilities: [],
+            registered_at: Date.now(),
+            last_heartbeat: Date.now(),
+          });
+          return { status: "success" };
+        },
+        runtimeStatusFn: async () => ({ worker_ids: [workerId] }),
+      },
+    });
+
+    expect(dispatchReadyNodes(runId, adapter)).toBe(0);
+    await provisioningCompleted;
+    expect(workerSocket.send).toHaveBeenCalledTimes(1);
+    expect(getActiveRun(runId)).toMatchObject({
+      status: "active",
+      limits: { max_dispatches: 1 },
+      counters: { dispatches: 1 },
+    });
+    expect(getActiveRun(runId)?.dagRun.nodeStates.get("diagnose")).toBe("RUNNING");
+
+    expect(checkpointResumeActiveRun(runId, "diagnose", {
+      instruction: "retry after the provisioning send",
+    })).toMatchObject({ status: "scheduled" });
+    expect(dispatchReadyNodes(runId, adapter)).toBe(0);
+    expect(workerSocket.send).toHaveBeenCalledTimes(1);
+    expect(getActiveRun(runId)).toMatchObject({
+      status: "failed",
+      counters: { abort_reason: "max_dispatches (1) exceeded" },
+    });
+  });
+
+  it("marks a round-two actor command delivered after async provisioned dispatch", async () => {
+    const runId = "run-provisioned-round-two-delivery";
+    const initialDispatcher = {
+      dispatch: vi.fn(() => ({ status: "dispatched" as const })),
+    };
+    createActiveRun(runId, parseDAGYaml(`
+name: provisioned-round-two-delivery
+workflow_id: provisioned-round-two-delivery
+agents:
+  worker: { agent_type: deterministic }
+nodes:
+  actor:
+    agent: worker
+    extra:
+      agent_runtime:
+        actor_id: researcher
+    outputs:
+      summary: { to: suspend.in:summary }
+  suspend:
+    type: await_command
+    after: [actor]
+    gateway_config:
+      primitive_version: 1
+      target_actors: [actor]
+      command_port: command
+`));
+    expect(dispatchReadyNodes(runId, initialDispatcher)).toBe(1);
+    handoffActiveRun(runId, "actor", "summary", { result: "round one" });
+    expect(dispatchReadyNodes(runId, initialDispatcher)).toBe(1);
+    expect(getActiveRun(runId)?.status).toBe("waiting");
+
+    const commandId = "provisioned-round-two-command";
+    resumeWaitingActiveRun(runId, {
+      expected_round_id: "round-0001",
+      commands: [{
+        actor_id: "researcher",
+        command_id: commandId,
+        payload: { task: "continue through provisioning" },
+      }],
+    });
+    expect(getActiveRun(runId)?.dagRun.nodeStates.get("actor")).toBe("READY");
+    expect(listDagActorCommands({ run_id: runId, round_id: "round-0002" })).toMatchObject([
+      { command_id: commandId, status: "pending" },
+    ]);
+
+    const nodeSocket = makeSocket();
+    registerNode({
+      node_id: "round-two-provisioning-node",
+      project_id: "p1",
+      socket: nodeSocket,
+      status: "connected",
+      capabilities: ["docker-api"],
+      registered_at: Date.now(),
+      last_heartbeat: Date.now(),
+      pending_requests: new Map(),
+    });
+    const workerId = "provisioned-run-provisioned-round-two-delivery-actor";
+    const workerSocket = makeSocket();
+    const provisioningCompleted = waitForProvisioningCompleted(runId);
+    const adapter = new WsDispatchAdapter({
+      managerBaseUrl: "http://127.0.0.1:19191",
+      provisioner: {
+        createFn: async () => ({ status: "success", resource_data: { id: "container-round-two" } }),
+        startFn: async () => {
+          registerWorker({
+            worker_id: workerId,
+            project_id: "p1",
+            socket: workerSocket,
+            status: "idle",
+            capabilities: [DAG_TRANSPORT_FENCE_CAPABILITY],
+            registered_at: Date.now(),
+            last_heartbeat: Date.now(),
+          });
+          return { status: "success" };
+        },
+        runtimeStatusFn: async () => ({ worker_ids: [workerId] }),
+      },
+    });
+
+    expect(dispatchReadyNodes(runId, adapter)).toBe(0);
+    expect(listDagActorCommands({ run_id: runId, round_id: "round-0002" })).toMatchObject([
+      { command_id: commandId, status: "pending" },
+    ]);
+    await provisioningCompleted;
+
+    expect(workerSocket.send).toHaveBeenCalledTimes(1);
+    expect(getActiveRun(runId)).toMatchObject({
+      status: "active",
+      currentRound: { round_id: "round-0002", status: "active" },
+    });
+    expect(getActiveRun(runId)?.dagRun.nodeStates.get("actor")).toBe("RUNNING");
+    expect(listDagActorCommands({ run_id: runId, round_id: "round-0002" })).toMatchObject([
+      { command_id: commandId, status: "delivered" },
+    ]);
   });
 
   it("does not dispatch a node while its provisioned worker is still being finalized", () => {
@@ -452,7 +884,7 @@ nodes:
     });
   });
 
-  it("does not dispatch a node to another node's run-scoped worker", () => {
+  it("keeps dispatch retryable when only another node's run-scoped worker exists", () => {
     const otherNodeWorkerSocket = makeSocket();
     registerWorker({
       worker_id: "provisioned-run-capabilities-other-node",
@@ -469,7 +901,7 @@ nodes:
     );
 
     expect(result).toMatchObject({
-      status: "failed",
+      status: "skipped",
       reason: "no available worker or node",
     });
     expect(otherNodeWorkerSocket.send).not.toHaveBeenCalled();

--- a/homerail_manager/tests/dynamic-node-append.test.ts
+++ b/homerail_manager/tests/dynamic-node-append.test.ts
@@ -4,6 +4,7 @@ import { ChangeOrchestrator } from "../src/orchestration/change-orchestrator.js"
 import { FakeDAGDispatcher } from "../src/orchestration/dag-dispatcher.js";
 import { GraphExecutor } from "../src/orchestration/graph-executor.js";
 import type { ParsedDAG } from "../src/orchestration/graph.js";
+import { _clearAllPersistence } from "../src/persistence/store.js";
 import { _clearActiveRuns } from "../src/runtime/active-runs.js";
 
 function parsedDag(): ParsedDAG {
@@ -35,6 +36,7 @@ function parsedDag(): ParsedDAG {
 describe("dynamic node append", () => {
   afterEach(() => {
     _clearActiveRuns();
+    _clearAllPersistence();
   });
 
   it("requires explicit agent configuration", () => {

--- a/homerail_manager/tests/generative-ui-persistent-document-service.test.ts
+++ b/homerail_manager/tests/generative-ui-persistent-document-service.test.ts
@@ -187,7 +187,10 @@ describe("PersistentGenerativeUiDocumentService", () => {
     legacy.close();
 
     expect(getDb().prepare("SELECT version FROM schema_migrations ORDER BY version").all())
-      .toEqual(Array.from({ length: 20 }, (_, index) => ({ version: index + 1 })));
+      .toEqual([
+        ...Array.from({ length: 20 }, (_, index) => ({ version: index + 1 })),
+        { version: 23 },
+      ]);
     expect(getDb().prepare("SELECT data FROM voice_agent_sessions WHERE session_id = ?").get("legacy-v2"))
       .toEqual({ data: legacyPayload });
     expect(getDb().prepare(`
@@ -269,7 +272,10 @@ describe("PersistentGenerativeUiDocumentService", () => {
     mainDb.close();
 
     expect(getDb().prepare("SELECT version FROM schema_migrations ORDER BY version").all())
-      .toEqual(Array.from({ length: 20 }, (_, index) => ({ version: index + 1 })));
+      .toEqual([
+        ...Array.from({ length: 20 }, (_, index) => ({ version: index + 1 })),
+        { version: 23 },
+      ]);
     expect(getDb().prepare(`
       SELECT name FROM sqlite_master
       WHERE type = 'table' AND name IN ('generative_ui_documents', 'generative_ui_user_overrides')

--- a/homerail_manager/tests/persistence-contracts.test.ts
+++ b/homerail_manager/tests/persistence-contracts.test.ts
@@ -53,6 +53,16 @@ describe("SQLite persistence contracts", () => {
       nodeStates: {},
       handoffedNodes: [],
     } as never)).toThrow(/Invalid dag_run status/);
+
+    writeRunMetadata("run-waiting", {
+      runId: "run-waiting",
+      createdAt: Date.now(),
+      status: "waiting",
+      nodeStates: { await: "WAITING_FOR_COMMAND" },
+      handoffedNodes: [],
+    });
+    expect(getDb().prepare("SELECT status FROM dag_runs WHERE run_id = ?").get("run-waiting"))
+      .toEqual({ status: "waiting" });
   });
 
   it("uses explicit timestamp helpers for ISO and epoch-ms domains", () => {

--- a/homerail_manager/tests/plugin-distribution.test.ts
+++ b/homerail_manager/tests/plugin-distribution.test.ts
@@ -149,6 +149,6 @@ describe("plugin publisher trust persistence", () => {
     expect(listPluginPublisherTrustEvents()).toHaveLength(1);
     expect(getDb().prepare(
       "SELECT MAX(version) AS version FROM schema_migrations",
-    ).get()).toEqual({ version: 20 });
+    ).get()).toEqual({ version: 23 });
   });
 });

--- a/homerail_manager/tests/plugin-package-lifecycle.test.ts
+++ b/homerail_manager/tests/plugin-package-lifecycle.test.ts
@@ -260,7 +260,7 @@ describe("external plugin package lifecycle", () => {
       expect.objectContaining({ plugin_version: "1.1.0", active: false, enabled: false }),
       expect.objectContaining({ plugin_version: "1.2.0", active: false, enabled: false }),
     ]));
-    expect(getDb().prepare("SELECT MAX(version) AS version FROM schema_migrations").get()).toEqual({ version: 20 });
+    expect(getDb().prepare("SELECT MAX(version) AS version FROM schema_migrations").get()).toEqual({ version: 23 });
     expect(inspectInstalledPlugin("com.example.release-notes")).toMatchObject({ healthy: true, issues: [] });
   });
 
@@ -455,7 +455,7 @@ describe("external plugin package lifecycle", () => {
 
     expect(getPluginRegistryState().revision).toBe(101);
     expect(getDb().prepare("SELECT MAX(version) AS version FROM schema_migrations").get())
-      .toEqual({ version: 20 });
+      .toEqual({ version: 23 });
   });
 
   it("rejects a stale uninstall when an inactive version was installed concurrently", () => {

--- a/homerail_manager/tests/plugin-remote-registry.test.ts
+++ b/homerail_manager/tests/plugin-remote-registry.test.ts
@@ -236,7 +236,7 @@ describe("signed remote plugin registry", () => {
     expect(listPluginRegistryUpdateAttempts("stable.example").filter((attempt) => attempt.status === "failed"))
       .toHaveLength(3);
     expect(getDb().prepare("SELECT MAX(version) AS version FROM schema_migrations").get())
-      .toEqual({ version: 20 });
+      .toEqual({ version: 23 });
   });
 
   it("rejects signed catalog releases whose payload or publisher digest disagrees with the HRP", () => {

--- a/homerail_manager/tests/response-bridge.test.ts
+++ b/homerail_manager/tests/response-bridge.test.ts
@@ -1,0 +1,236 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  handoffActiveRun: vi.fn(),
+  getActiveRun: vi.fn(),
+  getDagActorByNode: vi.fn(),
+  getDagActorCommand: vi.fn(),
+}));
+
+vi.mock("../src/runtime/active-runs.js", () => ({
+  handoffActiveRun: mocks.handoffActiveRun,
+  getActiveRun: mocks.getActiveRun,
+}));
+
+vi.mock("../src/persistence/dag-actors.js", () => ({
+  getDagActorByNode: mocks.getDagActorByNode,
+  getDagActorCommand: mocks.getDagActorCommand,
+}));
+
+import { applyResponseHandoff } from "../src/orchestration/response-bridge.js";
+
+describe("response bridge transport fence", () => {
+  beforeEach(() => {
+    mocks.handoffActiveRun.mockReset();
+    mocks.handoffActiveRun.mockReturnValue({});
+    mocks.getActiveRun.mockReset();
+    mocks.getActiveRun.mockReturnValue({
+      status: "active",
+      currentRound: { round_id: "round-0002", ordinal: 2 },
+      dagRun: { handoffedNodes: new Set<string>() },
+    });
+    mocks.getDagActorByNode.mockReset();
+    mocks.getDagActorByNode.mockReturnValue({
+      run_id: "run-2",
+      node_id: "actor-node",
+      actor_id: "actor-1",
+      generation: 3,
+    });
+    mocks.getDagActorCommand.mockReset();
+    mocks.getDagActorCommand.mockReturnValue({
+      command_id: "command-2",
+      run_id: "run-2",
+      actor_id: "actor-1",
+      round_id: "round-0002",
+      target_generation: 3,
+      status: "delivered",
+    });
+  });
+
+  it("passes authoritative round metadata to handoffActiveRun", () => {
+    const payload = {
+      runId: "run-2",
+      nodeId: "actor-node",
+      port: "done",
+      content: { ok: true },
+      round_id: "round-0002",
+      actor_id: "actor-1",
+      generation: 3,
+      command_id: "command-2",
+    };
+
+    expect(applyResponseHandoff(payload)).toEqual({
+      status: "handoff_applied",
+      runId: "run-2",
+      nodeId: "actor-node",
+      port: "done",
+    });
+    expect(mocks.handoffActiveRun).toHaveBeenCalledWith(
+      "run-2",
+      "actor-node",
+      "done",
+      { ok: true },
+      {
+        transport: true,
+        roundId: "round-0002",
+        actorId: "actor-1",
+        generation: 3,
+        commandId: "command-2",
+      },
+    );
+  });
+
+  it("keeps legacy first-round payloads transport-marked but unfenced", () => {
+    mocks.getActiveRun.mockReturnValue({
+      status: "active",
+      currentRound: { round_id: "round-0001", ordinal: 1 },
+      dagRun: { handoffedNodes: new Set<string>() },
+    });
+    mocks.getDagActorByNode.mockReturnValue({
+      run_id: "run-1",
+      node_id: "legacy-node",
+      actor_id: "legacy-node",
+      generation: 1,
+    });
+
+    applyResponseHandoff({
+      runId: "run-1",
+      nodeId: "legacy-node",
+      port: "done",
+      content: "legacy",
+    });
+
+    expect(mocks.handoffActiveRun).toHaveBeenCalledWith(
+      "run-1",
+      "legacy-node",
+      "done",
+      "legacy",
+      { transport: true },
+    );
+  });
+
+  it("rejects malformed transport metadata before applying a handoff", () => {
+    expect(applyResponseHandoff({
+      runId: "run-2",
+      nodeId: "actor-node",
+      port: "done",
+      content: null,
+      round_id: "round-0002",
+      generation: 1.5,
+    })).toEqual({
+      status: "malformed_payload",
+      reason: "generation must be a positive safe integer",
+    });
+    expect(mocks.handoffActiveRun).not.toHaveBeenCalled();
+  });
+
+  it("ignores a legacy unfenced response once the run reaches round two", () => {
+    expect(applyResponseHandoff({
+      runId: "run-2",
+      nodeId: "actor-node",
+      port: "done",
+      content: "late round one",
+    })).toMatchObject({
+      status: "handoff_ignored",
+      disposition: "stale",
+      runId: "run-2",
+      nodeId: "actor-node",
+      reason: expect.stringContaining("DAG_TRANSPORT_ROUND_FENCE_MISSING"),
+    });
+    expect(mocks.handoffActiveRun).not.toHaveBeenCalled();
+  });
+
+  it("ignores old rounds and old actor generations before handoff mutation", () => {
+    expect(applyResponseHandoff({
+      runId: "run-2",
+      nodeId: "actor-node",
+      port: "done",
+      content: "late round",
+      round_id: "round-0001",
+      actor_id: "actor-1",
+      generation: 3,
+      command_id: "command-2",
+    })).toMatchObject({ status: "handoff_ignored", disposition: "stale" });
+
+    expect(applyResponseHandoff({
+      runId: "run-2",
+      nodeId: "actor-node",
+      port: "done",
+      content: "late generation",
+      round_id: "round-0002",
+      actor_id: "actor-1",
+      generation: 2,
+      command_id: "command-2",
+    })).toMatchObject({
+      status: "handoff_ignored",
+      disposition: "stale",
+      reason: expect.stringContaining("DAG_TRANSPORT_GENERATION_STALE"),
+    });
+    expect(mocks.handoffActiveRun).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates acknowledged commands and completed handoffs", () => {
+    mocks.getDagActorCommand.mockReturnValue({
+      command_id: "command-2",
+      run_id: "run-2",
+      actor_id: "actor-1",
+      round_id: "round-0002",
+      target_generation: 3,
+      status: "acknowledged",
+    });
+    expect(applyResponseHandoff({
+      runId: "run-2",
+      nodeId: "actor-node",
+      port: "done",
+      content: "duplicate",
+      round_id: "round-0002",
+      actor_id: "actor-1",
+      generation: 3,
+      command_id: "command-2",
+    })).toMatchObject({
+      status: "handoff_ignored",
+      disposition: "duplicate",
+      reason: expect.stringContaining("DAG_TRANSPORT_COMMAND_DUPLICATE"),
+    });
+
+    mocks.getActiveRun.mockReturnValue({
+      status: "active",
+      currentRound: { round_id: "round-0001", ordinal: 1 },
+      dagRun: { handoffedNodes: new Set(["actor-node"]) },
+    });
+    expect(applyResponseHandoff({
+      runId: "run-2",
+      nodeId: "actor-node",
+      port: "done",
+      content: "legacy duplicate",
+    })).toMatchObject({
+      status: "handoff_ignored",
+      disposition: "duplicate",
+      reason: expect.stringContaining("DAG_TRANSPORT_HANDOFF_DUPLICATE"),
+    });
+    expect(mocks.handoffActiveRun).not.toHaveBeenCalled();
+  });
+
+  it("keeps current fenced contract failures eligible for correction", () => {
+    mocks.handoffActiveRun.mockImplementation(() => {
+      throw new Error("DAG_HANDOFF_CONTRACT_VIOLATION actor-node.done");
+    });
+
+    expect(applyResponseHandoff({
+      runId: "run-2",
+      nodeId: "actor-node",
+      port: "done",
+      content: { invalid: true },
+      round_id: "round-0002",
+      actor_id: "actor-1",
+      generation: 3,
+      command_id: "command-2",
+    })).toEqual({
+      status: "handoff_failed",
+      runId: "run-2",
+      nodeId: "actor-node",
+      reason: "DAG_HANDOFF_CONTRACT_VIOLATION actor-node.done",
+    });
+    expect(mocks.handoffActiveRun).toHaveBeenCalledTimes(1);
+  });
+});

--- a/homerail_manager/tests/supervise.test.ts
+++ b/homerail_manager/tests/supervise.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import type { PersistedRunMetadata } from "../src/persistence/types.js";
+import {
+  computeSuperviseTick,
+  isTerminalDagRunEvent,
+  isTerminalDagRunStatus,
+} from "../src/server/supervise.js";
+
+function metadata(status: string): PersistedRunMetadata {
+  return {
+    runId: `run-${status}`,
+    createdAt: 1,
+    status: status as PersistedRunMetadata["status"],
+    nodeStates: { work: status === "completed" ? "COMPLETED" : "READY" },
+    handoffedNodes: [],
+  };
+}
+
+describe("DAG supervise terminal boundaries", () => {
+  it.each(["completed", "failed", "cancelled", "expired"])(
+    "treats %s as terminal everywhere",
+    (status) => {
+      expect(isTerminalDagRunStatus(status)).toBe(true);
+      expect(computeSuperviseTick(`run-${status}`, metadata(status), [], 0).terminal).toBe(true);
+    },
+  );
+
+  it.each(["active", "waiting"])("keeps %s non-terminal", (status) => {
+    expect(isTerminalDagRunStatus(status)).toBe(false);
+    expect(computeSuperviseTick(`run-${status}`, metadata(status), [], 0).terminal).toBe(false);
+  });
+
+  it.each([
+    "dag:run_completed",
+    "dag:run_failed",
+    "dag:run_cancelled",
+    "dag:run_expired",
+  ])("closes SSE on %s", (eventType) => {
+    expect(isTerminalDagRunEvent(eventType)).toBe(true);
+  });
+
+  it("does not close SSE when a run starts waiting", () => {
+    expect(isTerminalDagRunEvent("dag:run_waiting")).toBe(false);
+  });
+});

--- a/homerail_manager/tests/transport-fence-websocket.test.ts
+++ b/homerail_manager/tests/transport-fence-websocket.test.ts
@@ -3,16 +3,17 @@ import * as http from "node:http";
 import * as os from "node:os";
 import * as path from "node:path";
 import WebSocket from "ws";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { DAG_TRANSPORT_FENCE_CAPABILITY } from "homerail-protocol";
 import type { DAGDispatcher, DispatchEnvelope, DispatchResult } from "../src/orchestration/dag-dispatcher.js";
-import { _clearAllDispatches } from "../src/orchestration/dispatch-tracker.js";
+import { _clearAllDispatches, recordDispatch } from "../src/orchestration/dispatch-tracker.js";
 import { _clearDagMessageRouter } from "../src/orchestration/dag-message-router.js";
 import { parseDAGYaml } from "../src/orchestration/yaml-loader.js";
 import { _clearListeners, subscribe } from "../src/events/bus.js";
 import { _clearNodes } from "../src/node/registry.js";
 import { setupNodeWebSocket } from "../src/node/websocket.js";
+import { listDagActivityEvents } from "../src/persistence/dag-activity-journal.js";
 import { listDagActorCommands } from "../src/persistence/dag-actors.js";
 import { closeDb } from "../src/persistence/db.js";
 import { loadSessionTranscript } from "../src/persistence/dag-session-files.js";
@@ -293,4 +294,51 @@ describe("round-aware terminal websocket transport", () => {
       await closeServer(server);
     }
   });
+
+  it.each(["worker", "node"] as const)(
+    "rejects stale %s activity when only the nested round fence is present",
+    async (sourceType) => {
+      const runId = `run-${sourceType}-nested-activity-fence`;
+      const envelope = startRoundTwo(runId);
+      const { server, ws, sourceId } = await openTransport(sourceType, runId, () => undefined);
+      recordDispatch(runId, "actor", sourceType, sourceId);
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+      try {
+        ws.send(JSON.stringify({
+          type: "stream",
+          data: {
+            type: "dag_activity",
+            event: "dag_activity",
+            run_id: runId,
+            node_id: "actor",
+            session_id: envelope.sessionId,
+            activity: {
+              schema_version: 1,
+              event_id: `${runId}-late-activity`,
+              run_id: runId,
+              round_id: "round-0001",
+              node_id: "actor",
+              actor_id: "researcher",
+              generation: 1,
+              sequence: 1,
+              timestamp: Date.now(),
+              type: "finding",
+              payload: { message: "late round-one evidence" },
+            },
+          },
+        }));
+        await delay(30);
+
+        expect(listDagActivityEvents({ run_id: runId }).events).toEqual([]);
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining(
+          "DAG activity identity does not match the transport stream context",
+        ));
+      } finally {
+        warn.mockRestore();
+        ws.terminate();
+        await closeServer(server);
+      }
+    },
+  );
 });

--- a/homerail_manager/tests/transport-fence-websocket.test.ts
+++ b/homerail_manager/tests/transport-fence-websocket.test.ts
@@ -1,0 +1,296 @@
+import * as fs from "node:fs";
+import * as http from "node:http";
+import * as os from "node:os";
+import * as path from "node:path";
+import WebSocket from "ws";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { DAG_TRANSPORT_FENCE_CAPABILITY } from "homerail-protocol";
+import type { DAGDispatcher, DispatchEnvelope, DispatchResult } from "../src/orchestration/dag-dispatcher.js";
+import { _clearAllDispatches } from "../src/orchestration/dispatch-tracker.js";
+import { _clearDagMessageRouter } from "../src/orchestration/dag-message-router.js";
+import { parseDAGYaml } from "../src/orchestration/yaml-loader.js";
+import { _clearListeners, subscribe } from "../src/events/bus.js";
+import { _clearNodes } from "../src/node/registry.js";
+import { setupNodeWebSocket } from "../src/node/websocket.js";
+import { listDagActorCommands } from "../src/persistence/dag-actors.js";
+import { closeDb } from "../src/persistence/db.js";
+import { loadSessionTranscript } from "../src/persistence/dag-session-files.js";
+import { _clearAllPersistence } from "../src/persistence/store.js";
+import {
+  _clearActiveRuns,
+  createActiveRun,
+  dispatchReadyNodes,
+  getActiveRun,
+  handoffActiveRun,
+  resumeWaitingActiveRun,
+} from "../src/runtime/active-runs.js";
+import { _clearWorkers } from "../src/worker/registry.js";
+import { setupWorkerWebSocket } from "../src/worker/websocket.js";
+
+type SourceType = "worker" | "node";
+
+class RepeatableDispatcher implements DAGDispatcher {
+  readonly dispatched: DispatchEnvelope[] = [];
+
+  dispatch(envelope: DispatchEnvelope): DispatchResult {
+    this.dispatched.push(structuredClone(envelope));
+    return { status: "dispatched", targetType: "fake", targetId: "fake" };
+  }
+}
+
+function multiRoundDag() {
+  return parseDAGYaml(`
+name: websocket-transport-fence
+workflow_id: websocket-transport-fence
+agents:
+  worker: { agent_type: deterministic }
+nodes:
+  actor:
+    agent: worker
+    extra:
+      agent_runtime:
+        actor_id: researcher
+        role: research
+        surface_id: surface-research
+    outputs:
+      summary: { to: suspend.in:summary }
+  suspend:
+    type: await_command
+    after: [actor]
+    gateway_config:
+      primitive_version: 1
+      target_actors: [actor]
+      command_port: command
+`);
+}
+
+function listen(server: http.Server): Promise<number> {
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address !== "object") throw new Error("server did not bind");
+      resolve(address.port);
+    });
+  });
+}
+
+function closeServer(server: http.Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function startRoundTwo(runId: string): DispatchEnvelope {
+  const dispatcher = new RepeatableDispatcher();
+  createActiveRun(runId, multiRoundDag());
+  expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+  handoffActiveRun(runId, "actor", "summary", { result: "round one" });
+  expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+  expect(getActiveRun(runId)?.status).toBe("waiting");
+  resumeWaitingActiveRun(runId, {
+    expected_round_id: "round-0001",
+    commands: [{ actor_id: "researcher", command_id: `${runId}-command-2`, payload: "continue" }],
+  });
+  expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+  return dispatcher.dispatched.at(-1)!;
+}
+
+async function openTransport(
+  sourceType: SourceType,
+  runId: string,
+  onHandoffApplied: () => void,
+): Promise<{ server: http.Server; ws: WebSocket; sourceId: string }> {
+  const sourceId = `${sourceType}-${runId}`;
+  const server = http.createServer();
+  if (sourceType === "worker") {
+    setupWorkerWebSocket(server, {
+      registrationTimeoutMs: 500,
+      pingIntervalMs: 5_000,
+      onHandoffApplied,
+    });
+  } else {
+    setupNodeWebSocket(server, {
+      registrationTimeoutMs: 500,
+      pingIntervalMs: 5_000,
+      onHandoffApplied,
+    });
+  }
+  const port = await listen(server);
+  const ws = new WebSocket(
+    `ws://127.0.0.1:${port}/ws/projects/default/${sourceType === "worker" ? "workers" : "nodes"}/${sourceId}`,
+  );
+  await new Promise<void>((resolve, reject) => {
+    ws.once("open", resolve);
+    ws.once("error", reject);
+  });
+  ws.send(JSON.stringify(sourceType === "worker"
+    ? {
+        type: "register",
+        worker_id: sourceId,
+        capabilities: [DAG_TRANSPORT_FENCE_CAPABILITY],
+      }
+    : { type: "register", node_id: sourceId }));
+  await delay(20);
+  return { server, ws, sourceId };
+}
+
+describe("round-aware terminal websocket transport", () => {
+  let tmpHome: string;
+  let oldHome: string | undefined;
+
+  beforeEach(() => {
+    oldHome = process.env.HOMERAIL_HOME;
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-transport-fence-ws-"));
+    process.env.HOMERAIL_HOME = tmpHome;
+    closeDb();
+    _clearActiveRuns();
+    _clearAllPersistence();
+    _clearAllDispatches();
+    _clearDagMessageRouter();
+    _clearWorkers();
+    _clearNodes();
+    _clearListeners();
+  });
+
+  afterEach(() => {
+    _clearActiveRuns();
+    _clearAllPersistence();
+    _clearAllDispatches();
+    _clearDagMessageRouter();
+    _clearWorkers();
+    _clearNodes();
+    _clearListeners();
+    closeDb();
+    if (oldHome === undefined) delete process.env.HOMERAIL_HOME;
+    else process.env.HOMERAIL_HOME = oldHome;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it.each(["worker", "node"] as const)(
+    "audits and ignores stale or duplicate %s terminal messages",
+    async (sourceType) => {
+      const runId = `run-${sourceType}-transport-fence`;
+      const envelope = startRoundTwo(runId);
+      const sessionId = envelope.sessionId!;
+      const commandId = `${runId}-command-2`;
+      const correctionEvents: unknown[] = [];
+      const auditEvents: unknown[] = [];
+      subscribe("dag:node_correction_requested", (payload) => correctionEvents.push(payload));
+      subscribe("dag:response_handoff_failed", (payload) => auditEvents.push(payload));
+      let applied = 0;
+      const { server, ws } = await openTransport(sourceType, runId, () => {
+        applied += 1;
+      });
+
+      const response = (roundId: string, content: string) => ({
+        type: "response",
+        session_id: sessionId,
+        data: {
+          type: "node_handoff",
+          runId,
+          nodeId: "actor",
+          port: "summary",
+          from_node: "actor",
+          from_port: "summary",
+          session_id: sessionId,
+          round_id: roundId,
+          actor_id: "researcher",
+          generation: 1,
+          command_id: commandId,
+          content,
+          summary: content,
+        },
+      });
+      const nodeError = (roundId: string, message: string) => ({
+        type: "node_error",
+        data: {
+          runId,
+          nodeId: "actor",
+          message,
+          session_id: sessionId,
+          round_id: roundId,
+          actor_id: "researcher",
+          generation: 1,
+          command_id: commandId,
+        },
+      });
+
+      try {
+        ws.send(JSON.stringify(response("round-0001", "late handoff")));
+        ws.send(JSON.stringify(nodeError("round-0001", "late error")));
+        await delay(30);
+
+        expect(correctionEvents).toEqual([]);
+        expect(applied).toBe(0);
+        expect(getActiveRun(runId)?.dagRun.nodeStates.get("actor")).toBe("RUNNING");
+        expect(listDagActorCommands({ run_id: runId })).toContainEqual(expect.objectContaining({
+          command_id: commandId,
+          status: "delivered",
+        }));
+
+        ws.send(JSON.stringify(response("round-0002", "current handoff")));
+        await delay(30);
+        expect(applied).toBe(1);
+        expect(getActiveRun(runId)?.dagRun.nodeStates.get("actor")).toBe("COMPLETED");
+        expect(listDagActorCommands({ run_id: runId })).toContainEqual(expect.objectContaining({
+          command_id: commandId,
+          status: "acknowledged",
+        }));
+
+        ws.send(JSON.stringify(response("round-0002", "duplicate handoff")));
+        await delay(30);
+        expect(correctionEvents).toEqual([]);
+        expect(applied).toBe(1);
+        expect(auditEvents).toHaveLength(3);
+        expect(JSON.stringify(auditEvents)).toContain("DAG_TRANSPORT_ROUND_STALE");
+        expect(JSON.stringify(auditEvents)).toContain("DAG_TRANSPORT_COMMAND_DUPLICATE");
+
+        const transcript = JSON.stringify(loadSessionTranscript(sessionId));
+        expect(transcript).toContain("handoff_stale_ignored");
+        expect(transcript).toContain("node_error_stale_ignored");
+        expect(transcript).toContain("handoff_duplicate_ignored");
+      } finally {
+        ws.terminate();
+        await closeServer(server);
+      }
+    },
+  );
+
+  it.each(["worker", "node"] as const)("allows current fenced %s errors to request correction", async (sourceType) => {
+    const runId = `run-${sourceType}-current-error`;
+    const envelope = startRoundTwo(runId);
+    const correctionEvents: unknown[] = [];
+    subscribe("dag:node_correction_requested", (payload) => correctionEvents.push(payload));
+    let applied = 0;
+    const { server, ws } = await openTransport(sourceType, runId, () => {
+      applied += 1;
+    });
+
+    try {
+      ws.send(JSON.stringify({
+        type: "node_error",
+        data: {
+          runId,
+          nodeId: "actor",
+          message: "current round failed",
+          session_id: envelope.sessionId,
+          round_id: "round-0002",
+          actor_id: "researcher",
+          generation: 1,
+          command_id: `${runId}-command-2`,
+        },
+      }));
+      await delay(30);
+
+      expect(correctionEvents).toHaveLength(1);
+      expect(applied).toBe(1);
+      expect(getActiveRun(runId)?.dagRun.nodeStates.get("actor")).toBe("READY");
+    } finally {
+      ws.terminate();
+      await closeServer(server);
+    }
+  });
+});

--- a/homerail_manager/tests/workflow-concurrency.test.ts
+++ b/homerail_manager/tests/workflow-concurrency.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ChangeOrchestrator } from "../src/orchestration/change-orchestrator.js";
 import { FakeDAGDispatcher } from "../src/orchestration/dag-dispatcher.js";
 import { GraphExecutor } from "../src/orchestration/graph-executor.js";
+import { parseDAGYaml } from "../src/orchestration/yaml-loader.js";
 import { closeDb, getDb } from "../src/persistence/db.js";
 import {
   deriveWorkflowConcurrencyPolicy,
@@ -15,7 +16,13 @@ import {
   reserveWorkflowRun,
 } from "../src/persistence/dag-run-admission.js";
 import { upsertDagWorkflowFromYaml } from "../src/persistence/dag-workflows.js";
-import { _clearActiveRuns, getActiveRun } from "../src/runtime/active-runs.js";
+import {
+  _clearActiveRuns,
+  createActiveRun,
+  dispatchReadyNodes,
+  getActiveRun,
+  handoffActiveRun,
+} from "../src/runtime/active-runs.js";
 import { fireDagEventTrigger, startDagTriggerScheduler } from "../src/runtime/dag-triggers.js";
 import { createServer } from "../src/server/http.js";
 
@@ -69,6 +76,57 @@ ${triggerBlock}  agents: {}
     - { from: review.approved, to: done.result }
     - { from: review.rejected, to: rejected.result, condition: on_failure }
 `;
+}
+
+function multiRoundWorkflow(id: string): string {
+  return `
+api_version: homerail.ai/v1
+kind: Workflow
+metadata: { id: ${id}, name: ${id} }
+spec:
+  triggers:
+    push:
+      type: event
+      event: repo.push
+      overlap: allow
+      max_concurrency: 1
+  agents:
+    worker: { system: "HANDOFF port=summary content=ok" }
+  nodes:
+    actor:
+      kind: agent
+      agent: worker
+      outputs: { summary: {} }
+    suspend:
+      kind: await_command
+      inputs: { summary: {} }
+      config:
+        primitive_version: 1
+        target_actors: [actor]
+        command_port: command
+  edges:
+    - { from: actor.summary, to: suspend.summary }
+`;
+}
+
+function multiRoundRuntimeDag(id: string) {
+  return parseDAGYaml(`
+name: ${id}
+workflow_id: ${id}
+agents:
+  worker: { agent_type: deterministic }
+nodes:
+  actor:
+    agent: worker
+    outputs: { summary: { to: suspend.in:summary } }
+  suspend:
+    type: await_command
+    after: [actor]
+    gateway_config:
+      primitive_version: 1
+      target_actors: [actor]
+      command_port: command
+`);
 }
 
 describe("workflow-level run admission", () => {
@@ -156,6 +214,16 @@ describe("workflow-level run admission", () => {
       "SELECT COUNT(*) AS count FROM dag_run_admissions WHERE run_id = ?",
     ).get("crash-window-run")).toEqual({ count: 0 });
 
+    getDb().prepare("UPDATE dag_runs SET status = 'waiting', updated_at = ? WHERE run_id = ?")
+      .run(Date.now(), "crash-window-run");
+    expect(reserveWorkflowRun({
+      runId: "while-waiting-run",
+      workflowId: "restart-workflow",
+      source: "test:while-waiting",
+      policy,
+    })).toMatchObject({ reserved: true });
+    releaseWorkflowRunReservation("while-waiting-run");
+
     getDb().prepare("UPDATE dag_runs SET status = 'completed', updated_at = ? WHERE run_id = ?")
       .run(Date.now(), "crash-window-run");
     expect(reserveWorkflowRun({
@@ -164,6 +232,37 @@ describe("workflow-level run admission", () => {
       source: "test:after-terminal",
       policy,
     })).toMatchObject({ reserved: true });
+  });
+
+  it("cleans a crash-window resume reservation as soon as the real run becomes active", () => {
+    const workflowId = "resume-restart-workflow";
+    const runId = "resume-restart-run";
+    const reservationId = `resume:${runId}`;
+    const policy = { overlap: "allow", max_concurrency: 2, trigger_ids: ["push"] } as const;
+    const now = Date.now();
+    getDb().prepare(`
+      INSERT INTO dag_runs(run_id, status, created_at, updated_at, workflow_id, metadata)
+      VALUES (?, 'waiting', ?, ?, ?, '{}')
+    `).run(runId, now, now, workflowId);
+    expect(reserveWorkflowRun({
+      runId: reservationId,
+      workflowId,
+      source: "resume:command",
+      policy,
+    })).toMatchObject({ reserved: true });
+
+    getDb().prepare("UPDATE dag_runs SET status = 'active', updated_at = ? WHERE run_id = ?")
+      .run(Date.now(), runId);
+    expect(reserveWorkflowRun({
+      runId: "resume-restart-competing",
+      workflowId,
+      source: "test:competing",
+      policy,
+    })).toMatchObject({ reserved: true });
+    expect(getDb().prepare(
+      "SELECT COUNT(*) AS count FROM dag_run_admissions WHERE run_id = ?",
+    ).get(reservationId)).toEqual({ count: 0 });
+    releaseWorkflowRunReservation("resume-restart-competing");
   });
 
   it("expires orphaned reservations that never created a run row", () => {
@@ -215,6 +314,110 @@ timer:
     } finally {
       stop();
     }
+  });
+
+  it("rejects waiting-run resume when another run holds the workflow slot", async () => {
+    upsertDagWorkflowFromYaml({ yaml_text: multiRoundWorkflow("resume-admission") });
+    const dispatcher = new FakeDAGDispatcher();
+    const orchestrator = new ChangeOrchestrator(new GraphExecutor(dispatcher));
+    createActiveRun("waiting-resume-run", multiRoundRuntimeDag("resume-admission"));
+    expect(dispatchReadyNodes("waiting-resume-run", dispatcher)).toBe(1);
+    handoffActiveRun("waiting-resume-run", "actor", "summary", { result: "round one" });
+    expect(dispatchReadyNodes("waiting-resume-run", dispatcher)).toBe(1);
+    const waitingBefore = structuredClone(getActiveRun("waiting-resume-run")!.currentRound);
+    expect(getActiveRun("waiting-resume-run")).toMatchObject({ status: "waiting" });
+
+    expect(orchestrator.createRun({
+      workflowId: "resume-admission",
+      runId: "competing-active-run",
+    }).status).toBe("active");
+
+    const server = createServer(0, undefined, dispatcher, false);
+    const baseUrl = `http://127.0.0.1:${await listen(server)}`;
+    try {
+      const response = await fetch(`${baseUrl}/api/runs/waiting-resume-run/commands`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          expected_round_id: "round-0001",
+          commands: [{ actor_id: "actor", payload: { task: "continue" } }],
+        }),
+      });
+      const body = await response.json() as { error: string };
+
+      expect(response.status).toBe(409);
+      expect(body.error).toContain("max_concurrency");
+      expect(getActiveRun("waiting-resume-run")?.status).toBe("waiting");
+      expect(getActiveRun("waiting-resume-run")?.currentRound).toEqual(waitingBefore);
+      expect(getActiveRun("waiting-resume-run")?.dagRun.nodeStates.get("suspend")).toBe("WAITING_FOR_COMMAND");
+      expect(getDb().prepare(
+        "SELECT COUNT(*) AS count FROM dag_actor_commands WHERE run_id = ?",
+      ).get("waiting-resume-run")).toEqual({ count: 0 });
+      expect(getActiveRun("competing-active-run")?.status).toBe("active");
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it("deduplicates an accepted resume retry even after workflow admission becomes blocked", () => {
+    const workflowId = "resume-retry-admission";
+    const runId = "resume-retry-waiting-run";
+    upsertDagWorkflowFromYaml({ yaml_text: multiRoundWorkflow(workflowId) });
+    const dispatcher = new FakeDAGDispatcher();
+    const orchestrator = new ChangeOrchestrator(new GraphExecutor(dispatcher));
+    createActiveRun(runId, multiRoundRuntimeDag(workflowId));
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+    handoffActiveRun(runId, "actor", "summary", { result: "round one" });
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+    expect(getActiveRun(runId)?.status).toBe("waiting");
+
+    const request = {
+      expected_round_id: "round-0001",
+      commands: [{
+        actor_id: "actor",
+        command_id: "resume-retry-command",
+        idempotency_key: "resume-retry-key",
+        payload: { task: "continue" },
+      }],
+    };
+    dispatcher.reset();
+    const firstResume = orchestrator.resumeRun(runId, request);
+    expect(firstResume).toMatchObject({
+      resumed: true,
+      round_id: "round-0002",
+      dispatched: 1,
+    });
+    expect(firstResume.deduplicated).toBeUndefined();
+    handoffActiveRun(runId, "actor", "summary", { result: "round two" }, {
+      transport: true,
+      roundId: "round-0002",
+      actorId: "actor",
+      generation: 1,
+      commandId: "resume-retry-command",
+    });
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+    expect(getActiveRun(runId)).toMatchObject({
+      status: "waiting",
+      currentRound: { round_id: "round-0002", status: "waiting" },
+    });
+
+    expect(orchestrator.createRun({
+      workflowId,
+      runId: "resume-retry-competing-run",
+    }).status).toBe("active");
+    expect(() => reserveWorkflowRun({
+      runId: "resume-retry-admission-probe",
+      workflowId,
+      source: "test:probe",
+      policy: { overlap: "allow", max_concurrency: 1, trigger_ids: ["push"] },
+    })).toThrowError(expect.objectContaining({ reason: "max_concurrency" }));
+
+    expect(orchestrator.resumeRun(runId, request)).toMatchObject({
+      resumed: true,
+      round_id: "round-0002",
+      deduplicated: true,
+      dispatched: 0,
+    });
   });
 
   it("makes a skip policy global even when another trigger allows overlap", () => {

--- a/homerail_manager/tests/workflow-spec-v1-parity.test.ts
+++ b/homerail_manager/tests/workflow-spec-v1-parity.test.ts
@@ -88,6 +88,53 @@ describe("WorkflowSpec v1 legacy runtime parity", () => {
     expect(() => assertRuntimeGraphParity(file, legacy, v1)).not.toThrow();
   });
 
+  it("recognizes legacy await_command gateways and preserves their runtime config", () => {
+    const source = `
+name: legacy-await-command
+agents:
+  worker: { system: Work. }
+nodes:
+  actor:
+    agent: worker
+    outputs:
+      summary: { to: suspend.in:summary }
+  suspend:
+    type: gateway
+    after: [actor]
+    gateway_config:
+      kind: await_command
+      primitive_version: 1
+      target_actors: [actor]
+      expires_after_ms: 60000
+      command_port: next_command
+  finisher:
+    agent: worker
+    outputs:
+      done: { to: "" }
+`;
+    const compilation = compileWorkflowSource(source);
+    expect(compilation.valid, compilation.diagnostics.map((entry) => entry.message).join("\n")).toBe(true);
+    expect(compilation.canonical?.nodes.find((node) => node.id === "suspend")).toMatchObject({
+      kind: "await_command",
+      config: {
+        primitive_version: 1,
+        target_actors: ["actor"],
+        expires_after_ms: 60_000,
+        command_port: "next_command",
+      },
+    });
+
+    const authoring = canonicalWorkflowToV1Document(compilation.canonical!);
+    expect((authoring.spec as any).nodes.suspend.config).toEqual({
+      command_port: "next_command",
+      expires_after_ms: 60_000,
+      primitive_version: 1,
+      target_actors: ["actor"],
+    });
+    const { legacy, v1 } = convertLegacySource(source);
+    expect(() => assertRuntimeGraphParity("legacy-await-command", legacy, v1)).not.toThrow();
+  });
+
   it("preserves quorum branch selection and skipped descendants", () => {
     const { legacy, v1 } = loadLegacyAndV1("pattern-quorum-offline.yaml");
     createActiveRun("quorum-legacy", legacy);

--- a/homerail_manager/tests/workflow-spec-v1.test.ts
+++ b/homerail_manager/tests/workflow-spec-v1.test.ts
@@ -3,7 +3,12 @@ import YAML from "yaml";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { Value } from "@sinclair/typebox/value";
-import { compileWorkflowSource, parseWorkflowSourceFile } from "../src/orchestration/workflow-spec-v1.js";
+import {
+  canonicalWorkflowToV1Document,
+  compileWorkflowSource,
+  parseWorkflowSourceFile,
+  projectCanonicalWorkflowToParsedDAG,
+} from "../src/orchestration/workflow-spec-v1.js";
 import { WorkflowSpecV1Schema } from "../src/orchestration/workflow-spec-v1-schema.js";
 
 const PUBLIC_V1_ASSETS = [
@@ -63,6 +68,37 @@ const MINIMAL_WORKFLOW = {
     ],
   },
 } as const;
+
+function awaitCommandWorkflow(): any {
+  return {
+    api_version: "homerail.ai/v1",
+    kind: "Workflow",
+    metadata: { id: "multi-round", name: "Multi Round" },
+    spec: {
+      agents: { worker: { system: "Work." } },
+      nodes: {
+        actor: {
+          kind: "agent",
+          agent: "worker",
+          outputs: { summary: {} },
+        },
+        suspend: {
+          kind: "await_command",
+          inputs: { summary: {} },
+          config: {
+            primitive_version: 1,
+            target_actors: ["actor"],
+            expires_after_ms: 60_000,
+            command_port: "next_command",
+          },
+        },
+      },
+      edges: [
+        { from: "actor.summary", to: "suspend.summary" },
+      ],
+    },
+  };
+}
 
 describe("WorkflowSpec v1", () => {
   it("canonicalizes strict per-agent built-in tool allowlists", () => {
@@ -179,6 +215,11 @@ describe("WorkflowSpec v1", () => {
               max_iterations: 3,
             },
           },
+          suspend: {
+            kind: "await_command",
+            inputs: { summary: { contract: "Data" } },
+            config: { primitive_version: 1, target_actors: ["worker"], command_port: "command" },
+          },
           terminal: {
             kind: "terminal",
             outcome: "success",
@@ -236,7 +277,7 @@ describe("WorkflowSpec v1", () => {
     const result = compileWorkflowSource(YAML.stringify(workflow));
 
     expect(result.valid, result.diagnostics.map((item) => item.message).join("\n")).toBe(true);
-    expect(result.canonical?.compiler_version).toBe("4");
+    expect(result.canonical?.compiler_version).toBe("5");
     expect(result.canonical?.artifacts).toEqual([
       {
         name: "evidence.tar.gz",
@@ -429,6 +470,122 @@ spec:
         path: "/spec/nodes/approve/config/authorized_actors",
       }),
     ]));
+  });
+
+  it("compiles await_command as an outputless persistent runtime gateway", () => {
+    const result = compileWorkflowSource(YAML.stringify(awaitCommandWorkflow()));
+
+    expect(result.valid, result.diagnostics.map((item) => item.message).join("\n")).toBe(true);
+    expect(result.diagnostics.map((item) => item.code)).not.toContain("DAG_SEMANTIC_NO_TERMINAL_PATH");
+    expect(result.canonical?.compiler_version).toBe("5");
+    expect(result.canonical?.feedback_edges).toEqual([]);
+    expect(result.canonical?.nodes.find((node) => node.id === "suspend")).toMatchObject({
+      kind: "await_command",
+      outputs: [],
+      config: {
+        primitive_version: 1,
+        target_actors: ["actor"],
+        expires_after_ms: 60_000,
+        command_port: "next_command",
+      },
+    });
+
+    const runtime = projectCanonicalWorkflowToParsedDAG(result.canonical!);
+    expect(runtime.graph.nodes.find((node) => node.node_id === "suspend")).toMatchObject({
+      node_type: "await_command_gateway",
+      agent: "__gateway__",
+      outputs: {},
+      gateway_config: {
+        type: "await_command",
+        primitive_version: 1,
+        target_actors: ["actor"],
+        expires_after_ms: 60_000,
+        command_port: "next_command",
+      },
+    });
+  });
+
+  it("accepts await_command as the persistent workflow boundary", () => {
+    const workflow = awaitCommandWorkflow();
+
+    const result = compileWorkflowSource(YAML.stringify(workflow));
+
+    expect(result.valid, result.diagnostics.map((entry) => entry.message).join("\n")).toBe(true);
+    expect(result.diagnostics.map((entry) => entry.code)).not.toContain("DAG_SEMANTIC_TERMINAL_REQUIRED");
+  });
+
+  it("rejects strict downstream dependencies from await_command", () => {
+    const workflow = awaitCommandWorkflow();
+    workflow.spec.nodes.after_suspend = {
+      kind: "terminal",
+      outcome: "success",
+      depends_on: ["suspend"],
+    };
+
+    const result = compileWorkflowSource(YAML.stringify(workflow));
+
+    expect(result.valid).toBe(false);
+    expect(result.diagnostics).toContainEqual(expect.objectContaining({
+      code: "DAG_SEMANTIC_AWAIT_COMMAND_DOWNSTREAM",
+      path: "/spec/nodes/after_suspend/depends_on",
+      message: expect.stringMatching(/await_command .* cannot have downstream dependents/i),
+    }));
+  });
+
+  it.each([0, 2, 1.5, "1"])("rejects await_command primitive_version %j", (primitiveVersion) => {
+    const workflow = awaitCommandWorkflow();
+    workflow.spec.nodes.suspend.config.primitive_version = primitiveVersion;
+
+    const result = compileWorkflowSource(YAML.stringify(workflow));
+
+    expect(result.valid).toBe(false);
+    expect(result.diagnostics).toContainEqual(expect.objectContaining({
+      code: "DAG_SCHEMA_INVALID_FIELD",
+      path: "/spec/nodes/suspend",
+    }));
+  });
+
+  it.each([
+    ["itself", "suspend", "DAG_SEMANTIC_INVALID_TARGET_ACTOR"],
+    ["another gateway", "other_suspend", "DAG_SEMANTIC_INVALID_TARGET_ACTOR"],
+    ["an unknown node", "missing_actor", "DAG_SEMANTIC_UNKNOWN_NODE"],
+  ])("rejects await_command target_actors that reference %s", (_label, targetActor, code) => {
+    const workflow = awaitCommandWorkflow();
+    workflow.spec.nodes.other_suspend = {
+      kind: "await_command",
+      config: { primitive_version: 1, target_actors: ["actor"] },
+    };
+    workflow.spec.nodes.suspend.config.target_actors = [targetActor];
+
+    const result = compileWorkflowSource(YAML.stringify(workflow));
+
+    expect(result.valid).toBe(false);
+    expect(result.diagnostics).toContainEqual(expect.objectContaining({
+      code,
+      path: "/spec/nodes/suspend/config/target_actors/0",
+    }));
+  });
+
+  it("preserves await_command config through canonical and authoring round trips", () => {
+    const first = compileWorkflowSource(YAML.stringify(awaitCommandWorkflow()));
+    expect(first.valid).toBe(true);
+
+    const authoring = canonicalWorkflowToV1Document(first.canonical!);
+    expect((authoring.spec as any).nodes.suspend).toEqual({
+      kind: "await_command",
+      inputs: { summary: {} },
+      config: {
+        command_port: "next_command",
+        expires_after_ms: 60_000,
+        primitive_version: 1,
+        target_actors: ["actor"],
+      },
+    });
+
+    const second = compileWorkflowSource(YAML.stringify(authoring));
+    expect(second.valid, second.diagnostics.map((item) => item.message).join("\n")).toBe(true);
+    expect(second.canonical?.nodes.find((node) => node.id === "suspend")?.config)
+      .toEqual(first.canonical?.nodes.find((node) => node.id === "suspend")?.config);
   });
 
   it("requires explicit terminals and rejects normal cycles", () => {

--- a/homerail_manager/tests/yaml-loader.test.ts
+++ b/homerail_manager/tests/yaml-loader.test.ts
@@ -36,4 +36,30 @@ nodes:
 
     expect(parsed.graph.nodes[0]?.image).toBe("homerail-worker:custom");
   });
+
+  it("classifies all supported runtime gateway types without agent image defaults", () => {
+    const parsed = parseDAGYaml(`
+name: gateway-types
+image: homerail-worker:custom
+nodes:
+  actor: { agent: worker }
+  command: { type: command_gateway }
+  approval: { type: approval_gateway }
+  state: { type: state_gateway }
+  fanout: { type: fanout_gateway }
+  suspend:
+    type: await_command
+    gateway_config:
+      primitive_version: 1
+      target_actors: [actor]
+`);
+    const nodes = Object.fromEntries(parsed.graph.nodes.map((node) => [node.node_id, node]));
+
+    expect(nodes.actor).toMatchObject({ node_type: "agent", agent: "worker", image: "homerail-worker:custom" });
+    for (const nodeId of ["command", "approval", "state", "fanout", "suspend"]) {
+      expect(nodes[nodeId]?.agent).toBe("__gateway__");
+      expect(nodes[nodeId]?.image).toBeUndefined();
+    }
+    expect(nodes.suspend?.node_type).toBe("await_command_gateway");
+  });
 });

--- a/homerail_plugin_sdk/tests/project.test.ts
+++ b/homerail_plugin_sdk/tests/project.test.ts
@@ -451,13 +451,13 @@ describe("HomeRail plugin project SDK", () => {
     expect(() => generatePluginTypes(root, { check: true })).toThrow(/output parent must not be a symbolic link/);
     expect(fs.readdirSync(outside)).toEqual([]);
 
-    fs.rmSync(path.join(root, ".homerail"));
+    fs.unlinkSync(path.join(root, ".homerail"));
     fs.mkdirSync(path.join(root, ".homerail"));
     fs.symlinkSync(outside, path.join(root, ".homerail", "generated"), "dir");
     expect(() => generatePluginTypes(root)).toThrow(/output parent must not be a symbolic link/);
     expect(fs.readdirSync(outside)).toEqual([]);
 
-    fs.rmSync(path.join(root, ".homerail", "generated"));
+    fs.unlinkSync(path.join(root, ".homerail", "generated"));
     fs.writeFileSync(path.join(root, ".homerail", "generated"), "not a directory");
     expect(() => generatePluginTypes(root)).toThrow(/output parent must be a directory/);
   });
@@ -508,7 +508,7 @@ describe("HomeRail plugin project SDK", () => {
     fs.symlinkSync(path.join(outside, "schemas"), path.join(root, "schemas"), "dir");
     expect(() => scanPluginSource(root)).toThrow(/traverses a symlink/);
 
-    fs.rmSync(path.join(root, "schemas"));
+    fs.unlinkSync(path.join(root, "schemas"));
     fs.renameSync(path.join(outside, "schemas"), path.join(root, "schemas"));
     fs.renameSync(path.join(root, "homerail.plugin.json"), path.join(outside, "manifest.json"));
     fs.symlinkSync(path.join(outside, "manifest.json"), path.join(root, "homerail.plugin.json"), "file");

--- a/homerail_protocol/src/schemas.ts
+++ b/homerail_protocol/src/schemas.ts
@@ -8,6 +8,11 @@ import {
 } from "./generative-ui/schemas.js";
 import { homerailPluginSchemas } from "./plugins/schemas.js";
 import { dagActivityEventV1Schema } from "./dag-activity.js";
+import {
+  DAG_NODE_ERROR_SCHEMA_ID,
+  DAG_TRANSPORT_FENCE_SCHEMA_ID,
+  DAG_TRANSPORT_FENCE_PROTOCOL_VERSION,
+} from "./types.js";
 
 // ── DAG Tool Schemas ─────────────────────────────────────────────
 
@@ -202,10 +207,49 @@ export const dagNodeConfigSchema = {
     round_id: { type: "string", minLength: 1, maxLength: 256 },
     actor_id: { type: "string", minLength: 1, maxLength: 256 },
     generation: { type: "integer", minimum: 1, maximum: Number.MAX_SAFE_INTEGER },
+    command_id: { type: "string", minLength: 1, maxLength: 256 },
     surface_id: { type: "string", minLength: 1, maxLength: 256 },
     activity_sequence_start: { type: "integer", minimum: 0, maximum: Number.MAX_SAFE_INTEGER },
   },
   required: ["node_id", "agent_type", "model", "outgoing_edges", "incoming_edges", "graph_nodes"],
+  additionalProperties: true,
+};
+
+const dagTransportFenceProperties = {
+  round_id: { type: "string", minLength: 1, maxLength: 256 },
+  actor_id: { type: "string", minLength: 1, maxLength: 256 },
+  generation: { type: "integer", minimum: 1, maximum: Number.MAX_SAFE_INTEGER },
+  command_id: { type: "string", minLength: 1, maxLength: 256 },
+};
+
+export const dagTransportFenceV1Schema = {
+  $id: DAG_TRANSPORT_FENCE_SCHEMA_ID,
+  type: "object",
+  properties: dagTransportFenceProperties,
+  required: ["round_id", "actor_id", "generation", "command_id"],
+  additionalProperties: false,
+  version: DAG_TRANSPORT_FENCE_PROTOCOL_VERSION,
+};
+
+export const dagNodeErrorSchema = {
+  $id: DAG_NODE_ERROR_SCHEMA_ID,
+  type: "object",
+  properties: {
+    type: { const: "node_error" },
+    data: {
+      type: "object",
+      properties: {
+        runId: { type: "string", minLength: 1 },
+        nodeId: { type: "string", minLength: 1 },
+        message: { type: "string" },
+        session_id: { type: "string", minLength: 1 },
+        ...dagTransportFenceProperties,
+      },
+      required: ["runId", "nodeId", "message"],
+      additionalProperties: true,
+    },
+  },
+  required: ["type", "data"],
   additionalProperties: true,
 };
 
@@ -398,6 +442,8 @@ export const allSchemas: Record<string, Record<string, unknown>> = {
   ...generativeUiSchemas,
   ...homerailPluginSchemas,
   "dag-activity-event-v1": dagActivityEventV1Schema as Record<string, unknown>,
+  [DAG_TRANSPORT_FENCE_SCHEMA_ID]: dagTransportFenceV1Schema as Record<string, unknown>,
+  [DAG_NODE_ERROR_SCHEMA_ID]: dagNodeErrorSchema as Record<string, unknown>,
   "handoff-request": handoffRequestSchema as Record<string, unknown>,
   "handoff-response": handoffResponseSchema as Record<string, unknown>,
   "tool-call": toolCallSchema as Record<string, unknown>,

--- a/homerail_protocol/src/types.ts
+++ b/homerail_protocol/src/types.ts
@@ -456,6 +456,39 @@ export const DAG_AGENT_TOOL_NAMES = [
 
 export type DagAgentToolName = (typeof DAG_AGENT_TOOL_NAMES)[number];
 
+/** Versioned Worker capability for round-aware terminal transport. @version 0.1.0 */
+export const DAG_TRANSPORT_FENCE_PROTOCOL_VERSION = 1 as const;
+export const DAG_TRANSPORT_FENCE_CAPABILITY = "dag-transport-fence-v1" as const;
+export const DAG_TRANSPORT_FENCE_SCHEMA_ID = "dag-transport-fence-v1" as const;
+export const DAG_NODE_ERROR_SCHEMA_ID = "dag-node-error" as const;
+
+/** Optional on round-one wire messages; required by Manager for later rounds. */
+export interface DagTransportFenceMetadata {
+  round_id?: string;
+  actor_id?: string;
+  generation?: number;
+  command_id?: string;
+}
+
+export interface DagTransportFenceV1 {
+  round_id: string;
+  actor_id: string;
+  generation: number;
+  command_id: string;
+}
+
+export interface DagNodeErrorData extends DagTransportFenceMetadata {
+  runId: string;
+  nodeId: string;
+  message: string;
+  session_id?: string;
+}
+
+export interface DagNodeErrorMessage {
+  type: "node_error";
+  data: DagNodeErrorData;
+}
+
 /** @version 0.1.0 */
 export interface Edge {
   from_node?: string;
@@ -473,10 +506,11 @@ export interface DagNodeConfig {
   incoming_edges: Edge[];
   graph_nodes: string[];
   session_id?: string;
-  /** Activity routing metadata. Defaults are assigned by the Worker when omitted. */
+  /** Dispatch routing metadata. It may be omitted only for legacy first-round work. */
   round_id?: string;
   actor_id?: string;
   generation?: number;
+  command_id?: string;
   surface_id?: string;
   /** Last persisted activity sequence; the next emitted event starts after this value. */
   activity_sequence_start?: number;
@@ -513,7 +547,7 @@ export interface DagWorkspaceAccess {
 // ── Event Emitter Wire Types ─────────────────────────────────────
 
 /** @version 0.1.0 */
-export interface HandoffEvent {
+export interface HandoffEvent extends DagTransportFenceMetadata {
   type: "node_handoff";
   from_node: string;
   from_port: string;

--- a/homerail_protocol/tests/dag-activity.test.ts
+++ b/homerail_protocol/tests/dag-activity.test.ts
@@ -4,7 +4,12 @@ import {
   DAG_ACTIVITY_EVENT_V1_SCHEMA_ID,
   DAG_ACTIVITY_TYPES,
   DAG_AGENT_TOOL_NAMES,
+  DAG_NODE_ERROR_SCHEMA_ID,
+  DAG_TRANSPORT_FENCE_CAPABILITY,
+  DAG_TRANSPORT_FENCE_PROTOCOL_VERSION,
+  DAG_TRANSPORT_FENCE_SCHEMA_ID,
   type DagActivityEventV1,
+  type DagNodeErrorMessage,
   validateDagActivityEventV1,
 } from "../src/index.js";
 import { allSchemas } from "../src/schemas.js";
@@ -106,6 +111,7 @@ describe("DAG activity routing metadata", () => {
     round_id: "round-02",
     actor_id: "researcher",
     generation: 2,
+    command_id: "command-02",
     surface_id: "surface-news",
     activity_sequence_start: 41,
   };
@@ -119,11 +125,62 @@ describe("DAG activity routing metadata", () => {
     ["round_id", ""],
     ["actor_id", ""],
     ["generation", 0],
+    ["command_id", ""],
     ["surface_id", ""],
     ["activity_sequence_start", -1],
     ["activity_sequence_start", 1.5],
     ["activity_sequence_start", Number.MAX_SAFE_INTEGER + 1],
   ])("rejects invalid %s metadata", (key, value) => {
     expect(validateMessage({ ...config, [key]: value }, "dag-node-config").valid).toBe(false);
+  });
+});
+
+describe("DAG terminal transport fence", () => {
+  const fencedError: DagNodeErrorMessage = {
+    type: "node_error",
+    data: {
+      runId: "run-02",
+      nodeId: "worker-01",
+      message: "agent failed",
+      session_id: "session-01",
+      round_id: "round-02",
+      actor_id: "researcher",
+      generation: 2,
+      command_id: "command-02",
+    },
+  };
+
+  it("exports an explicit versioned Worker capability", () => {
+    expect(DAG_TRANSPORT_FENCE_PROTOCOL_VERSION).toBe(1);
+    expect(DAG_TRANSPORT_FENCE_CAPABILITY).toBe("dag-transport-fence-v1");
+    expect(DAG_TRANSPORT_FENCE_SCHEMA_ID).toBe(DAG_TRANSPORT_FENCE_CAPABILITY);
+    expect(allSchemas[DAG_TRANSPORT_FENCE_SCHEMA_ID]).toBeDefined();
+    expect(allSchemas[DAG_NODE_ERROR_SCHEMA_ID]).toBeDefined();
+  });
+
+  it("validates a complete v1 fence and fenced node_error", () => {
+    expect(validateMessage({
+      round_id: "round-02",
+      actor_id: "researcher",
+      generation: 2,
+      command_id: "command-02",
+    }, DAG_TRANSPORT_FENCE_SCHEMA_ID).valid).toBe(true);
+    expect(validateMessage(fencedError, DAG_NODE_ERROR_SCHEMA_ID).valid).toBe(true);
+  });
+
+  it("keeps legacy round-one node_error compatible while rejecting malformed metadata", () => {
+    expect(validateMessage({
+      type: "node_error",
+      data: { runId: "run-01", nodeId: "worker-01", message: "legacy failure" },
+    }, DAG_NODE_ERROR_SCHEMA_ID).valid).toBe(true);
+    expect(validateMessage({
+      ...fencedError,
+      data: { ...fencedError.data, generation: 0 },
+    }, DAG_NODE_ERROR_SCHEMA_ID).valid).toBe(false);
+    expect(validateMessage({
+      round_id: "round-02",
+      actor_id: "researcher",
+      generation: 2,
+    }, DAG_TRANSPORT_FENCE_SCHEMA_ID).valid).toBe(false);
   });
 });

--- a/homerail_worker/src/__tests__/dag-tools.test.ts
+++ b/homerail_worker/src/__tests__/dag-tools.test.ts
@@ -79,7 +79,27 @@ describe("DAG tools", () => {
         session_id: "run-1",
         content: "test content",
       });
+      expect(state.handoffData).not.toHaveProperty("round_id");
       expect(state.yielded).toBe(true);
+    });
+
+    it("stages the dispatch transport fence in the authoritative handoff", async () => {
+      state = createDagToolsState(makeConfig({
+        round_id: "round-0002",
+        actor_id: "actor-coder",
+        generation: 2,
+        command_id: "command-2",
+      }), "run-1", wsSend);
+      const handoffTool = createDagTools(state).find((tool) => tool.name === "handoff")!;
+
+      await handoffTool.handler({ port: "done", content: { ok: true } });
+
+      expect(state.handoffData).toMatchObject({
+        round_id: "round-0002",
+        actor_id: "actor-coder",
+        generation: 2,
+        command_id: "command-2",
+      });
     });
 
     it("uses the DAG node session id on handoff when provided", async () => {

--- a/homerail_worker/src/__tests__/prompt-runner.test.ts
+++ b/homerail_worker/src/__tests__/prompt-runner.test.ts
@@ -249,6 +249,53 @@ describe("prompt runner", () => {
     }]);
   });
 
+  it("binds node_error to the same round transport fence as handoff", async () => {
+    const mockAgent: AgentClient = {
+      run() {
+        return (async function* () {
+          yield { type: "error" as const, message: "round two failed" };
+          yield { type: "done" as const };
+        })();
+      },
+    };
+    registerAgentBackend("test-fenced-node-error", () => mockAgent);
+
+    const terminalMessages: string[] = [];
+    await runPrompt(
+      {
+        task: "test",
+        sender: "test",
+        runId: "run-fenced-node-error",
+        dagConfig: makeConfigWith({
+          session_id: "session-fenced",
+          round_id: "round-0002",
+          actor_id: "actor-coder",
+          generation: 3,
+          command_id: "command-2",
+        }),
+      },
+      {
+        wsSend: () => {},
+        onTerminalMessage: (data) => terminalMessages.push(data),
+        agentBackend: "test-fenced-node-error",
+      },
+    );
+
+    expect(terminalMessages.map((message) => JSON.parse(message))).toEqual([{
+      type: "node_error",
+      data: {
+        runId: "run-fenced-node-error",
+        nodeId: "coder",
+        message: "round two failed",
+        session_id: "session-fenced",
+        round_id: "round-0002",
+        actor_id: "actor-coder",
+        generation: 3,
+        command_id: "command-2",
+      },
+    }]);
+  });
+
   it("fails claude-sdk before execution when the protocol is missing", async () => {
     const sent: string[] = [];
     await runPrompt(
@@ -689,6 +736,10 @@ describe("prompt runner", () => {
           agent_type: "deterministic",
           graph_nodes: ["live_node"],
           outgoing_edges: [{ from_port: "done", to_node: "", to_port: "" }],
+          round_id: "round-0002",
+          actor_id: "actor-live",
+          generation: 4,
+          command_id: "command-live-2",
         },
         systemPrompt: "  HANDOFF port=done content=Source Issue: #847\n\nArtifact: ok",
       },
@@ -707,10 +758,24 @@ describe("prompt runner", () => {
       runId: "run-det",
       nodeId: "live_node",
       port: "done",
+      round_id: "round-0002",
+      actor_id: "actor-live",
+      generation: 4,
+      command_id: "command-live-2",
       content: "Source Issue: #847\n\nArtifact: ok",
     });
-    const activities = parsed
-      .filter((message) => message.type === "stream" && message.data?.event === "dag_activity")
+    const activityStreams = parsed
+      .filter((message) => message.type === "stream" && message.data?.event === "dag_activity");
+    expect(activityStreams).not.toHaveLength(0);
+    for (const message of activityStreams) {
+      expect(message.data).toMatchObject({
+        round_id: "round-0002",
+        actor_id: "actor-live",
+        generation: 4,
+        command_id: "command-live-2",
+      });
+    }
+    const activities = activityStreams
       .map((message) => message.data.activity);
     expect(activities.map((activity) => activity.type)).toEqual([
       "started",

--- a/homerail_worker/src/dag-tools/handoff.ts
+++ b/homerail_worker/src/dag-tools/handoff.ts
@@ -98,6 +98,10 @@ export function createHandoffTool(state: DagToolsState): DagToolDefinition {
         from_node: state.nodeId,
         from_port: port,
         session_id: state.sessionId,
+        ...(state.roundId !== undefined ? { round_id: state.roundId } : {}),
+        ...(state.actorId !== undefined ? { actor_id: state.actorId } : {}),
+        ...(state.generation !== undefined ? { generation: state.generation } : {}),
+        ...(state.commandId !== undefined ? { command_id: state.commandId } : {}),
         content,
         summary,
       };

--- a/homerail_worker/src/dag-tools/index.ts
+++ b/homerail_worker/src/dag-tools/index.ts
@@ -32,6 +32,10 @@ export interface DagToolsState {
   nodeId: string;
   runId: string;
   sessionId: string;
+  roundId?: string;
+  actorId?: string;
+  generation?: number;
+  commandId?: string;
   graphNodes: string[];
   availablePorts: string[];
   outgoingEdges: Edge[];
@@ -85,6 +89,10 @@ export function createDagToolsState(
     nodeId: config.node_id,
     runId,
     sessionId: config.session_id || runId,
+    roundId: config.round_id,
+    actorId: config.actor_id,
+    generation: config.generation,
+    commandId: config.command_id,
     graphNodes: config.graph_nodes,
     availablePorts: [...ports].sort(),
     outgoingEdges: config.outgoing_edges,

--- a/homerail_worker/src/index.ts
+++ b/homerail_worker/src/index.ts
@@ -7,7 +7,14 @@
 import { WsClient } from "./ws-client.js";
 import { runPrompt } from "./prompt-runner.js";
 import type { PromptJob } from "./prompt-runner.js";
-import type { AgentBuiltinToolName, DagAdvisorConfig, DagAgentToolName, DagNodeConfig, DagWorkspaceAccess } from "homerail-protocol";
+import {
+  DAG_TRANSPORT_FENCE_CAPABILITY,
+  type AgentBuiltinToolName,
+  type DagAdvisorConfig,
+  type DagAgentToolName,
+  type DagNodeConfig,
+  type DagWorkspaceAccess,
+} from "homerail-protocol";
 import { startManagerAgentServer } from "./manager-agent/server.js";
 import { resolveWorkerAgentBackend } from "./agent/backend-selection.js";
 import { envelopeInputsToTaskText } from "./envelope-task.js";
@@ -24,10 +31,14 @@ const MANAGER_WS_URL =
   `${DEFAULT_MANAGER_WS_BASE}/ws/projects/default/workers/${encodeURIComponent(WORKER_ID)}`;
 const TOKEN = process.env.HOMERAIL_WORKER_TOKEN ?? "";
 const ALLOW_INSECURE_REMOTE_WS = process.env.HOMERAIL_ALLOW_INSECURE_REMOTE_WS === "1";
-const CAPABILITIES = (process.env.HOMERAIL_WORKER_CAPABILITIES ?? "")
+const CONFIGURED_CAPABILITIES = (process.env.HOMERAIL_WORKER_CAPABILITIES ?? "")
   .split(",")
   .map((capability) => capability.trim())
   .filter((capability) => capability.length > 0);
+const CAPABILITIES = Array.from(new Set([
+  ...CONFIGURED_CAPABILITIES,
+  DAG_TRANSPORT_FENCE_CAPABILITY,
+]));
 
 if (process.env.MANAGER_AGENT_MODE === "1") {
   startManagerAgentServer();
@@ -139,9 +150,10 @@ client.on("task", async (msg) => {
         incoming_edges: [],
         graph_nodes: [nodeId],
         session_id: sessionId,
-        round_id: typeof activity?.roundId === "string" ? activity.roundId : sessionId,
-        actor_id: typeof activity?.actorId === "string" ? activity.actorId : nodeId,
-        generation: typeof activity?.generation === "number" ? activity.generation : 1,
+        round_id: typeof activity?.roundId === "string" ? activity.roundId : undefined,
+        actor_id: typeof activity?.actorId === "string" ? activity.actorId : undefined,
+        generation: typeof activity?.generation === "number" ? activity.generation : undefined,
+        command_id: typeof activity?.commandId === "string" ? activity.commandId : undefined,
         surface_id: typeof activity?.surfaceId === "string" ? activity.surfaceId : undefined,
         activity_sequence_start: typeof activity?.sequenceStart === "number" ? activity.sequenceStart : 0,
         advisors: Array.isArray(envelope.advisors) ? envelope.advisors as DagAdvisorConfig[] : undefined,

--- a/homerail_worker/src/prompt-runner.ts
+++ b/homerail_worker/src/prompt-runner.ts
@@ -274,6 +274,10 @@ export async function runPrompt(
           run_id: job.runId,
           node_id: job.dagConfig.node_id,
           session_id: job.dagConfig.session_id ?? job.runId,
+          ...(job.dagConfig.round_id !== undefined ? { round_id: job.dagConfig.round_id } : {}),
+          ...(job.dagConfig.actor_id !== undefined ? { actor_id: job.dagConfig.actor_id } : {}),
+          ...(job.dagConfig.generation !== undefined ? { generation: job.dagConfig.generation } : {}),
+          ...(job.dagConfig.command_id !== undefined ? { command_id: job.dagConfig.command_id } : {}),
         },
       }),
     );
@@ -552,6 +556,10 @@ export async function runPrompt(
       nodeId: job.dagConfig.node_id,
       message: redactedMessage,
       session_id: job.dagConfig.session_id ?? job.runId,
+      ...(job.dagConfig.round_id !== undefined ? { round_id: job.dagConfig.round_id } : {}),
+      ...(job.dagConfig.actor_id !== undefined ? { actor_id: job.dagConfig.actor_id } : {}),
+      ...(job.dagConfig.generation !== undefined ? { generation: job.dagConfig.generation } : {}),
+      ...(job.dagConfig.command_id !== undefined ? { command_id: job.dagConfig.command_id } : {}),
     };
     sendTerminalMessage(JSON.stringify({ type: "node_error", data }));
   }


### PR DESCRIPTION
Parent epic: #36

Implements: #39

## Why

A fan-in should close one round, not terminate a durable DAG. The run must wait without consuming active concurrency and accept later commands for the same logical Actors.

## What changed

- adds the non-terminal `waiting` run state and explicit terminal transitions
- adds versioned `await_command` runtime behavior and durable `round_id`
- persists round open, close, wake, cancel, resume, and recovery state
- wakes only selected Actors when a new durable command arrives
- supports direct hot-Worker command injection while preserving Inbox-first ordering
- excludes waiting runs from active workflow concurrency
- restores waiting runs after Manager restart
- surfaces waiting runs distinctly in the dashboard, run list, graph, and node detail UI
- updates trigger, cancellation, monitoring, CLI watch/supervise, WorkflowSpec, YAML, and protocol contracts

## Invariants

- `waiting` is not `completed`
- fan-in does not destroy logical Actors
- the same round cannot close twice
- only explicit complete, cancel, fail, or expiry reaches a terminal state
- a second round reuses the same `actor_id` and `surface_id`
- stale activity from an earlier round cannot enter the current activity journal

## Migrations

Migration 23 adds durable run-round state, cancelled command support, constraints, indexes, upgrade validation, and repeat-start coverage.

## Verification

- rebased onto `main@fa0802e` after PR #48 merged
- full local `npm run ci` passed
- Protocol: 245 passed
- Plugin SDK: 34 passed
- Manager: 807 passed, 2 skipped
- Node: 187 passed, 2 skipped
- Worker: 214 passed, 1 skipped
- CLI: 241 passed
- Agent UI: 290 passed
- live-validator: 13 passed
- Manager also passed 807/2 with `VITEST_MAX_WORKERS=2`
- dedicated two-round, waiting admission, Manager restart wakeup, cancellation, WebSocket fence, persistence rollback, API authorization, and CLI tests included

## Review hardening

- distinguishes waiting runs from actively executing runs in the UI
- exposes `waiting_nodes` through the DAG status API
- adds worker and node regressions for stale nested activity fences
- uses explicit symlink unlinking in Plugin SDK fixtures for Node 24 compatibility
- bounds Windows Vitest workers without extending test or hook timeouts

## Out of scope

- releasing and recreating physical Workers: #40
- A2UI projection: #41
- Manager Supervisor tools and commentary: #43
