### PR TITLE
Add durable DAG worker leases and cold recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,21 +172,17 @@ jobs:
   live-dag-patterns:
     name: Live DAG patterns (self-hosted Qwen3.6)
     if: >-
-      (github.event_name == 'workflow_dispatch' &&
-       inputs.live_patterns &&
-       github.actor == 'xiaotianfotos') ||
-      (github.event_name == 'pull_request' &&
-       github.event.pull_request.draft == false &&
-       github.actor == 'xiaotianfotos' &&
-       github.event.pull_request.head.repo.full_name == github.repository)
+      github.event_name == 'workflow_dispatch' &&
+      inputs.live_patterns &&
+      github.actor == 'xiaotianfotos'
     runs-on: [self-hosted, Linux, X64, homerail-live]
     timeout-minutes: 90
     env:
       HOMERAIL_RUNNER_BASE: ${{ secrets.HOMERAIL_LIVE_RUNNER_BASE }}
       HOMERAIL_MANAGER_PORT: ${{ secrets.HOMERAIL_LIVE_MANAGER_PORT }}
       HOMERAIL_LIVE_WORKER_IMAGE_PREFIX: homerail-worker:dag-live
-      HOMERAIL_WAKE_MODEL: ${{ github.event_name == 'pull_request' && '1' || inputs.wake_model && '1' || '0' }}
-      HOMERAIL_LIVE_PATTERNS: ${{ github.event_name == 'workflow_dispatch' && inputs.patterns || '' }}
+      HOMERAIL_WAKE_MODEL: ${{ inputs.wake_model && '1' || '0' }}
+      HOMERAIL_LIVE_PATTERNS: ${{ inputs.patterns || '' }}
       HOMERAIL_LIVE_RUN_KEY: ${{ github.run_id }}-${{ github.run_attempt }}
       HOMERAIL_LIVE_REPORT_PATH: ${{ github.workspace }}/artifacts/dag-patterns-live.json
       HOMERAIL_PATTERN_MODEL: qwen3.6
@@ -197,7 +193,7 @@ jobs:
       - name: Check out target revision
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.target_ref || github.ref }}
+          ref: ${{ inputs.target_ref || github.ref }}
           persist-credentials: false
 
       - name: Set up Node.js

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -66,31 +66,22 @@ jobs:
       - name: Resolve immutable review input
         id: input
         env:
-          EVENT_NAME: ${{ github.event_name }}
           EVENT_REPO: ${{ github.repository }}
-          EVENT_PR: ${{ github.event.pull_request.number }}
-          EVENT_BASE: ${{ github.event.pull_request.base.sha }}
-          EVENT_HEAD: ${{ github.event.pull_request.head.sha }}
-          EVENT_TITLE: ${{ github.event.pull_request.title }}
-          EVENT_AUTHOR: ${{ github.event.pull_request.user.login }}
-          MANUAL_REPO: ${{ inputs.repo }}
-          MANUAL_PR: ${{ inputs.pr }}
-          MANUAL_BASE: ${{ inputs.base }}
-          MANUAL_HEAD: ${{ inputs.head }}
+          INPUT_REPO: ${{ inputs.repo }}
+          INPUT_PR: ${{ inputs.pr }}
+          INPUT_BASE: ${{ inputs.base }}
+          INPUT_HEAD: ${{ inputs.head }}
         run: |
           node --input-type=module <<'NODE'
           import fs from 'node:fs'
-          const manual = process.env.EVENT_NAME === 'workflow_dispatch'
           const input = {
-            repo: (manual && process.env.MANUAL_REPO) || process.env.EVENT_REPO,
-            pr: Number((manual && process.env.MANUAL_PR) || process.env.EVENT_PR),
+            repo: process.env.INPUT_REPO || process.env.EVENT_REPO,
+            pr: Number(process.env.INPUT_PR),
           }
-          const base = (manual && process.env.MANUAL_BASE) || process.env.EVENT_BASE
-          const head = (manual && process.env.MANUAL_HEAD) || process.env.EVENT_HEAD
+          const base = process.env.INPUT_BASE
+          const head = process.env.INPUT_HEAD
           if (base) input.base = base
           if (head) input.head = head
-          if (!manual && process.env.EVENT_TITLE) input.title = process.env.EVENT_TITLE
-          if (!manual && process.env.EVENT_AUTHOR) input.author = process.env.EVENT_AUTHOR
           fs.appendFileSync(process.env.GITHUB_OUTPUT, `json=${JSON.stringify(input)}\n`)
           NODE
 

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,8 +1,6 @@
 name: HomeRail PR Review
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     inputs:
       repo:
@@ -26,17 +24,13 @@ permissions:
   contents: read
 
 concurrency:
-  group: homerail-pr-review-${{ github.event.pull_request.number || inputs.pr }}
+  group: homerail-pr-review-${{ inputs.pr }}
   cancel-in-progress: true
 
 jobs:
   review:
     name: HomeRail PR Review
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.pull_request.draft == false &&
-       github.event.pull_request.head.repo.full_name == github.repository &&
-       github.actor == 'xiaotianfotos')
+    if: github.event_name == 'workflow_dispatch'
     runs-on: [self-hosted, Linux, X64, homerail-pr-review]
     timeout-minutes: 90
     env:
@@ -130,7 +124,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: pr-review-${{ github.event.pull_request.number || inputs.pr }}-${{ github.run_id }}
+          name: pr-review-${{ inputs.pr }}-${{ github.run_id }}
           path: artifacts/pr-review/
           if-no-files-found: warn
           retention-days: 14

--- a/homerail_manager/src/config/dag-actor-lease-settings.ts
+++ b/homerail_manager/src/config/dag-actor-lease-settings.ts
@@ -1,0 +1,62 @@
+export const DEFAULT_DAG_WORKER_IDLE_TTL_MS = 5 * 60_000;
+export const DEFAULT_DAG_ACTOR_RETENTION_TTL_MS = 7 * 24 * 60 * 60_000;
+
+export const MIN_DAG_ACTOR_TTL_MS = 1;
+export const MAX_DAG_WORKER_IDLE_TTL_MS = 7 * 24 * 60 * 60_000;
+export const MAX_DAG_ACTOR_RETENTION_TTL_MS = 3_650 * 24 * 60 * 60_000;
+
+export interface DagActorLeaseSettings {
+  worker_idle_ttl_ms: number;
+  actor_retention_ttl_ms: number;
+}
+
+function validateTtl(value: number, name: string, maximum: number): number {
+  if (!Number.isSafeInteger(value) || value < MIN_DAG_ACTOR_TTL_MS || value > maximum) {
+    throw new Error(
+      `${name} must be a safe integer between ${MIN_DAG_ACTOR_TTL_MS} and ${maximum} milliseconds`,
+    );
+  }
+  return value;
+}
+
+function parseEnvironmentTtl(
+  env: NodeJS.ProcessEnv,
+  name: string,
+  fallback: number,
+  maximum: number,
+): number {
+  const raw = env[name];
+  if (raw === undefined) return fallback;
+  const normalized = raw.trim();
+  if (!/^\d+$/.test(normalized)) {
+    throw new Error(`${name} must be a base-10 integer number of milliseconds`);
+  }
+  return validateTtl(Number(normalized), name, maximum);
+}
+
+export function validateDagWorkerIdleTtlMs(value: number): number {
+  return validateTtl(value, "worker_idle_ttl_ms", MAX_DAG_WORKER_IDLE_TTL_MS);
+}
+
+export function validateDagActorRetentionTtlMs(value: number): number {
+  return validateTtl(value, "actor_retention_ttl_ms", MAX_DAG_ACTOR_RETENTION_TTL_MS);
+}
+
+export function loadDagActorLeaseSettings(
+  env: NodeJS.ProcessEnv = process.env,
+): DagActorLeaseSettings {
+  return {
+    worker_idle_ttl_ms: parseEnvironmentTtl(
+      env,
+      "HOMERAIL_DAG_WORKER_IDLE_TTL_MS",
+      DEFAULT_DAG_WORKER_IDLE_TTL_MS,
+      MAX_DAG_WORKER_IDLE_TTL_MS,
+    ),
+    actor_retention_ttl_ms: parseEnvironmentTtl(
+      env,
+      "HOMERAIL_DAG_ACTOR_RETENTION_TTL_MS",
+      DEFAULT_DAG_ACTOR_RETENTION_TTL_MS,
+      MAX_DAG_ACTOR_RETENTION_TTL_MS,
+    ),
+  };
+}

--- a/homerail_manager/src/events/bus.ts
+++ b/homerail_manager/src/events/bus.ts
@@ -10,6 +10,10 @@ export type DAGEventType =
   | "dag:node_dispatch_retry"
   | "dag:checkpoint_resume"
   | "dag:stale_session_ignored"
+  | "dag:stale_lease_ignored"
+  | "dag:actor_lease_acquired"
+  | "dag:actor_lease_released"
+  | "dag:actor_checkpoint_saved"
   | "dag:gateway_executed"
   | "dag:worker_manager_command_requested"
   | "dag:manager_command_received"
@@ -78,6 +82,10 @@ export const DAG_EVENT_TYPES: DAGEventType[] = [
   "dag:node_dispatch_retry",
   "dag:checkpoint_resume",
   "dag:stale_session_ignored",
+  "dag:stale_lease_ignored",
+  "dag:actor_lease_acquired",
+  "dag:actor_lease_released",
+  "dag:actor_checkpoint_saved",
   "dag:gateway_executed",
   "dag:worker_manager_command_requested",
   "dag:manager_command_received",

--- a/homerail_manager/src/node/types.ts
+++ b/homerail_manager/src/node/types.ts
@@ -41,6 +41,11 @@ export interface ContentMessage {
     run_id?: string;
     node_id?: string;
     session_id?: string;
+    round_id?: string;
+    actor_id?: string;
+    generation?: number;
+    lease_generation?: number;
+    command_id?: string;
   };
 }
 
@@ -55,6 +60,11 @@ export interface NodeErrorMessage {
     nodeId: string;
     message: string;
     session_id?: string;
+    round_id?: string;
+    actor_id?: string;
+    generation?: number;
+    lease_generation?: number;
+    command_id?: string;
   };
 }
 
@@ -164,6 +174,11 @@ export function parseIncomingNodeMessage(raw: unknown): IncomingNodeMessage | nu
           run_id: typeof data.run_id === "string" ? data.run_id : undefined,
           node_id: typeof data.node_id === "string" ? data.node_id : undefined,
           session_id: typeof data.session_id === "string" ? data.session_id : undefined,
+          round_id: typeof data.round_id === "string" ? data.round_id : undefined,
+          actor_id: typeof data.actor_id === "string" ? data.actor_id : undefined,
+          generation: typeof data.generation === "number" ? data.generation : undefined,
+          lease_generation: typeof data.lease_generation === "number" ? data.lease_generation : undefined,
+          command_id: typeof data.command_id === "string" ? data.command_id : undefined,
         },
       };
     }
@@ -180,6 +195,11 @@ export function parseIncomingNodeMessage(raw: unknown): IncomingNodeMessage | nu
           nodeId: data.nodeId,
           message: data.message,
           session_id: typeof data.session_id === "string" ? data.session_id : undefined,
+          round_id: typeof data.round_id === "string" ? data.round_id : undefined,
+          actor_id: typeof data.actor_id === "string" ? data.actor_id : undefined,
+          generation: typeof data.generation === "number" ? data.generation : undefined,
+          lease_generation: typeof data.lease_generation === "number" ? data.lease_generation : undefined,
+          command_id: typeof data.command_id === "string" ? data.command_id : undefined,
         },
       };
     }

--- a/homerail_manager/src/node/websocket.ts
+++ b/homerail_manager/src/node/websocket.ts
@@ -84,6 +84,16 @@ function objectData(value: unknown): Record<string, unknown> | undefined {
     : undefined;
 }
 
+function transportPayload(data: Record<string, unknown>): Record<string, unknown> {
+  const runId = streamRunId(data);
+  const nodeId = streamNodeId(data);
+  return {
+    ...data,
+    ...(runId === undefined ? {} : { runId }),
+    ...(nodeId === undefined ? {} : { nodeId }),
+  };
+}
+
 function dagActivityRoundContext(data: Record<string, unknown>, runId: string): string {
   const run = getActiveRun(runId);
   if (!run) throw new Error(`DAG activity run ${runId} is not active`);
@@ -151,6 +161,50 @@ function mirrorSessionTranscript(
   } catch {
     // Best-effort mirror; websocket handling and DB chat remain authoritative.
   }
+}
+
+function isCurrentDagTransport(
+  sourceId: string,
+  messageType: string,
+  data: Record<string, unknown>,
+  explicitSessionId?: string,
+): boolean {
+  const payload = transportPayload(data);
+  const assessment = assessDagTransportFence(payload, {
+    targetType: "node",
+    targetId: sourceId,
+  });
+  if (assessment.status === "current") return true;
+
+  const runId = assessment.status === "malformed_payload" ? streamRunId(data) : assessment.runId;
+  const nodeId = assessment.status === "malformed_payload" ? streamNodeId(data) : assessment.nodeId;
+  const disposition = assessment.status === "ignored" ? assessment.disposition : assessment.status;
+  const reason = assessment.status === "unknown_run"
+    ? `unknown run ${assessment.runId}`
+    : assessment.reason;
+  const sessionId = explicitSessionId ?? dataSessionId(data);
+  emit("dag:stale_lease_ignored", {
+    runId,
+    nodeId,
+    source: "node",
+    sourceId,
+    messageType,
+    disposition,
+    reason,
+  });
+  mirrorSessionTranscript(
+    sourceId,
+    `stale_lease_${messageType}_ignored`,
+    runId,
+    nodeId,
+    sessionId,
+    {
+      disposition,
+      reason,
+      lease_generation: typeof data.lease_generation === "number" ? data.lease_generation : undefined,
+    },
+  );
+  return false;
 }
 
 export interface NodeWebSocketOptions {
@@ -319,6 +373,7 @@ export function setupNodeWebSocket(
         }
 
         if (msg.type === "content") {
+          if (!isCurrentDagTransport(node_id, "content", msg.data)) return;
           if (shouldIgnoreStaleSession(node_id, "content", msg.data)) return;
           const runId = streamRunId(msg.data);
           const nodeId = streamNodeId(msg.data);
@@ -337,6 +392,7 @@ export function setupNodeWebSocket(
 
         if (msg.type === "response") {
           const responseData = objectData(msg.data);
+          if (responseData && !isCurrentDagTransport(node_id, "response", responseData, msg.session_id)) return;
           if (responseData && shouldIgnoreStaleSession(node_id, "response", responseData, msg.session_id)) return;
           const responseSessionId = msg.session_id ?? dataSessionId(responseData);
 
@@ -370,7 +426,7 @@ export function setupNodeWebSocket(
             return;
           }
 
-          const result = applyResponseHandoff(msg.data);
+          const result = applyResponseHandoff(msg.data, { targetType: "node", targetId: node_id });
           if (result.status === "handoff_applied") {
             appendChatEntry(result.runId, result.nodeId, {
               role: "node",
@@ -396,6 +452,29 @@ export function setupNodeWebSocket(
             });
             options.onHandoffApplied?.(result.runId);
           } else {
+            if (
+              result.status === "handoff_ignored"
+              && result.reason.startsWith("DAG_TRANSPORT_LEASE_")
+            ) {
+              emit("dag:stale_lease_ignored", {
+                runId: result.runId,
+                nodeId: result.nodeId,
+                source: "node",
+                sourceId: node_id,
+                messageType: "response",
+                disposition: result.disposition,
+                reason: result.reason,
+              });
+              mirrorSessionTranscript(
+                node_id,
+                "stale_lease_response_ignored",
+                result.runId,
+                result.nodeId,
+                responseSessionId,
+                { disposition: result.disposition, reason: result.reason },
+              );
+              return;
+            }
             const reason = result.status === "malformed_payload"
               ? result.reason
               : result.status === "unknown_run"
@@ -430,6 +509,14 @@ export function setupNodeWebSocket(
         if (msg.type === "stream") {
           const runId = streamRunId(msg.data);
           const nodeId = streamNodeId(msg.data);
+          const messageType = msg.data.event === "dag_activity"
+            ? "dag_activity"
+            : msg.data.event === "usage"
+              ? "usage"
+              : "stream";
+          if (!isCurrentDagTransport(node_id, messageType, msg.data)) {
+            return;
+          }
           if (msg.data.event === "dag_activity") {
             try {
               if (!runId || !nodeId) throw new Error("DAG activity transport identity is missing");
@@ -479,36 +566,12 @@ export function setupNodeWebSocket(
 
         if (msg.type === "node_error") {
           const rawData = objectData(objectData(rawMessage)?.data) ?? msg.data;
+          if (!isCurrentDagTransport(node_id, "node_error", rawData, msg.data.session_id)) return;
           if (shouldIgnoreStaleSession(node_id, "node_error", {
             runId: msg.data.runId,
             nodeId: msg.data.nodeId,
             session_id: msg.data.session_id,
           })) return;
-          const assessment = assessDagTransportFence(rawData);
-          if (assessment.status !== "current") {
-            const runId = assessment.status === "malformed_payload" ? msg.data.runId : assessment.runId;
-            const dagNodeId = assessment.status === "malformed_payload" ? msg.data.nodeId : assessment.nodeId;
-            const disposition = assessment.status === "ignored" ? assessment.disposition : assessment.status;
-            const reason = assessment.status === "unknown_run"
-              ? `unknown run ${assessment.runId}`
-              : assessment.reason;
-            emit("dag:response_handoff_failed", {
-              runId,
-              nodeId: dagNodeId,
-              reason: `node_error ${disposition} ignored: ${reason}`,
-              source: "node",
-              sourceId: node_id,
-            });
-            mirrorSessionTranscript(
-              node_id,
-              `node_error_${disposition}_ignored`,
-              runId,
-              dagNodeId,
-              msg.data.session_id,
-              { disposition, reason, payload: rawData },
-            );
-            return;
-          }
           appendChatEntry(msg.data.runId, msg.data.nodeId, {
             role: "node",
             type: "response",

--- a/homerail_manager/src/orchestration/dag-dispatcher.ts
+++ b/homerail_manager/src/orchestration/dag-dispatcher.ts
@@ -1,5 +1,11 @@
 import type { DAGAgentConfig, DAGEdge } from "./graph.js";
-import type { AgentBuiltinToolName, DagAdvisorConfig, DagAgentToolName, DagWorkspaceAccess } from "homerail-protocol";
+import type {
+  AgentBuiltinToolName,
+  DagActorCheckpointV1,
+  DagAdvisorConfig,
+  DagAgentToolName,
+  DagWorkspaceAccess,
+} from "homerail-protocol";
 
 export interface DispatchEnvelope {
   runId: string;
@@ -15,6 +21,8 @@ export interface DispatchEnvelope {
     instruction: string;
     attempt: number;
   };
+  /** Durable provider-neutral context used when the physical Worker changes. */
+  actorCheckpoint?: DagActorCheckpointV1;
   workflowId?: string;
   workflowName?: string;
   workspace?: Record<string, unknown>;
@@ -29,6 +37,8 @@ export interface DispatchEnvelope {
     roundId: string;
     actorId: string;
     generation: number;
+    /** Physical Worker binding generation, assigned by the dispatch adapter. */
+    leaseGeneration?: number;
     commandId?: string;
     surfaceId?: string;
     sequenceStart: number;

--- a/homerail_manager/src/orchestration/dag-engine.ts
+++ b/homerail_manager/src/orchestration/dag-engine.ts
@@ -275,6 +275,7 @@ function _wakeLoopSource(run: DAGRun, nodeId: string): void {
         mailbox.set(port, [values[values.length - 1]]);
       }
     }
+    run.handoffedNodes.delete(nodeId);
     run.nodeStates.set(nodeId, "READY");
   }
 }
@@ -332,6 +333,7 @@ function _wakeLoopGatewayReceiver(run: DAGRun, fromNode: string, nodeId: string)
       }
     }
     if (state !== "READY") {
+      run.handoffedNodes.delete(nodeId);
       run.nodeStates.set(nodeId, "READY");
     }
   }

--- a/homerail_manager/src/orchestration/provisioned-cleanup.ts
+++ b/homerail_manager/src/orchestration/provisioned-cleanup.ts
@@ -1,18 +1,12 @@
-/**
- * provisioned worker cleanup registry.
- *
- * Tracks `(runId, nodeId) -> (workerId, containerId, dockerNodeId)` tuples
- * that were created by the async worker provisioner () and provides
- * a `deprovisionProvisionedForRun` that iterates the entries, calls
- * `deprovisionWorkerContainer` for each, and emits the
- * `dag:cleanup_requested` / `dag:cleanup_completed` / `dag:cleanup_failed`
- * events.
- *
- * Concurrency: a per-run `Set<string>` guard prevents re-entry if
- * `completeActiveRun` and `cancelActiveRun` race for the same runId.
- */
-
 import { emit } from "../events/bus.js";
+import {
+  getDagActorLease,
+  listDagProvisionedWorkers,
+  registerDagProvisionedWorker,
+  transitionDagProvisionedWorker,
+  type DagProvisionedWorkerRecord,
+} from "../persistence/dag-actor-leases.js";
+import { getDagActorByNode } from "../persistence/dag-actors.js";
 import {
   deprovisionWorkerContainer,
   type ProvisionerOptions,
@@ -21,41 +15,88 @@ import {
 export interface ProvisionedWorkerEntry {
   runId: string;
   nodeId: string;
+  actorId: string;
+  leaseGeneration: number;
   workerId: string;
   containerId: string;
   dockerNodeId: string;
   provisionedAt: number;
 }
 
-const registry = new Map<string, ProvisionedWorkerEntry[]>();
+export interface RegisterProvisionedWorkerInput {
+  runId: string;
+  nodeId: string;
+  workerId: string;
+  containerId: string;
+  dockerNodeId: string;
+  actorId?: string;
+  leaseGeneration?: number;
+}
+
 const inflightCleanups = new Set<string>();
+const inflightWorkers = new Set<string>();
 
-export function registerProvisionedWorker(
-  entry: Omit<ProvisionedWorkerEntry, "provisionedAt">,
-): ProvisionedWorkerEntry {
-  const full: ProvisionedWorkerEntry = {
-    ...entry,
-    provisionedAt: Date.now(),
+function workerKey(entry: Pick<ProvisionedWorkerEntry, "runId" | "actorId" | "leaseGeneration" | "workerId">): string {
+  return `${entry.runId}\u0000${entry.actorId}\u0000${entry.leaseGeneration}\u0000${entry.workerId}`;
+}
+
+function entryFromRecord(record: DagProvisionedWorkerRecord): ProvisionedWorkerEntry {
+  return {
+    runId: record.run_id,
+    nodeId: record.node_id,
+    actorId: record.actor_id,
+    leaseGeneration: record.lease_generation,
+    workerId: record.worker_id,
+    containerId: record.container_id,
+    dockerNodeId: record.docker_node_id,
+    provisionedAt: record.registered_at,
   };
-  const existing = registry.get(entry.runId) ?? [];
-  existing.push(full);
-  registry.set(entry.runId, existing);
-  return full;
 }
 
-export function listProvisionedForRun(
-  runId: string,
-): ProvisionedWorkerEntry[] {
-  return [...(registry.get(runId) ?? [])];
+function resolveRegistration(input: RegisterProvisionedWorkerInput): Required<RegisterProvisionedWorkerInput> {
+  if (input.actorId !== undefined || input.leaseGeneration !== undefined) {
+    if (!input.actorId || input.leaseGeneration === undefined) {
+      throw new Error("actorId and leaseGeneration must be provided together for a provisioned worker");
+    }
+    return input as Required<RegisterProvisionedWorkerInput>;
+  }
+
+  // Compatibility for callers that predate lease-aware provisioning. Production
+  // dispatches provide actorId and leaseGeneration explicitly.
+  const actor = getDagActorByNode(input.runId, input.nodeId);
+  if (!actor) throw new Error(`No logical actor for provisioned worker ${input.runId}/${input.nodeId}`);
+  const lease = getDagActorLease({ run_id: input.runId, actor_id: actor.actor_id });
+  if (!lease || lease.state !== "leased" || lease.target_id !== input.workerId) {
+    throw new Error(`No current lease for provisioned worker ${input.runId}/${input.nodeId}/${input.workerId}`);
+  }
+  return { ...input, actorId: actor.actor_id, leaseGeneration: lease.lease_generation };
 }
 
-export function clearProvisionedForRun(runId: string): void {
-  registry.delete(runId);
+export function registerProvisionedWorker(input: RegisterProvisionedWorkerInput): ProvisionedWorkerEntry {
+  const resolved = resolveRegistration(input);
+  return entryFromRecord(registerDagProvisionedWorker({
+    run_id: resolved.runId,
+    node_id: resolved.nodeId,
+    actor_id: resolved.actorId,
+    lease_generation: resolved.leaseGeneration,
+    worker_id: resolved.workerId,
+    container_id: resolved.containerId,
+    docker_node_id: resolved.dockerNodeId,
+  }));
+}
+
+export function listProvisionedForRun(runId: string): ProvisionedWorkerEntry[] {
+  return listDagProvisionedWorkers({ run_id: runId }).map(entryFromRecord);
+}
+
+/** @deprecated Durable rows are retained until actor retention expiry. */
+export function clearProvisionedForRun(_runId: string): void {
+  // Intentionally no-op: clearing durable failures would make restart retry impossible.
 }
 
 export function _clearAllProvisionedWorkers(): void {
-  registry.clear();
   inflightCleanups.clear();
+  inflightWorkers.clear();
 }
 
 export function _isCleanupInflight(runId: string): boolean {
@@ -64,64 +105,129 @@ export function _isCleanupInflight(runId: string): boolean {
 
 export interface DeprovisionOptions {
   deprovisionerOpts?: ProvisionerOptions;
-  /** Test-only: override deprovisionWorkerContainer */
   deprovisionFn?: typeof deprovisionWorkerContainer;
 }
 
+async function transitionToReleasing(entry: ProvisionedWorkerEntry): Promise<DagProvisionedWorkerRecord | undefined> {
+  const current = listDagProvisionedWorkers({
+    run_id: entry.runId,
+    actor_id: entry.actorId,
+    lease_generation: entry.leaseGeneration,
+  }).find((record) => record.worker_id === entry.workerId);
+  if (!current || current.status === "released") return undefined;
+  if (current.status === "releasing") return current;
+  return transitionDagProvisionedWorker({
+    run_id: current.run_id,
+    actor_id: current.actor_id,
+    lease_generation: current.lease_generation,
+    worker_id: current.worker_id,
+    expected_status: current.status,
+    status: "releasing",
+    expected_version: current.version,
+  });
+}
+
+export async function deprovisionProvisionedWorker(
+  entry: ProvisionedWorkerEntry,
+  options: DeprovisionOptions = {},
+  emitRequested = true,
+): Promise<boolean> {
+  const key = workerKey(entry);
+  if (inflightWorkers.has(key)) return false;
+  inflightWorkers.add(key);
+  if (emitRequested) emit("dag:cleanup_requested", { runId: entry.runId, workerCount: 1 });
+
+  try {
+    const releasing = await transitionToReleasing(entry);
+    if (!releasing) return false;
+    const deprovisionFn = options.deprovisionFn ?? deprovisionWorkerContainer;
+    try {
+      const result = await deprovisionFn(
+        releasing.docker_node_id,
+        releasing.container_id,
+        options.deprovisionerOpts,
+      );
+      if (!result.removed && !result.dockerCleanupVerified) {
+        throw new Error(
+          `Provisioned worker ${releasing.worker_id} cleanup did not confirm container removal`,
+        );
+      }
+      transitionDagProvisionedWorker({
+        run_id: releasing.run_id,
+        actor_id: releasing.actor_id,
+        lease_generation: releasing.lease_generation,
+        worker_id: releasing.worker_id,
+        expected_status: "releasing",
+        status: "released",
+        expected_version: releasing.version,
+      });
+      emit("dag:cleanup_completed", {
+        runId: releasing.run_id,
+        workerId: releasing.worker_id,
+        nodeId: releasing.node_id,
+        containerId: releasing.container_id,
+        stopped: result.stopped,
+        removed: result.removed,
+      });
+      return true;
+    } catch (error) {
+      const failure = error instanceof Error ? error.message : String(error);
+      const current = listDagProvisionedWorkers({
+        run_id: releasing.run_id,
+        actor_id: releasing.actor_id,
+        lease_generation: releasing.lease_generation,
+      }).find((record) => record.worker_id === releasing.worker_id);
+      if (current?.status === "releasing") {
+        transitionDagProvisionedWorker({
+          run_id: current.run_id,
+          actor_id: current.actor_id,
+          lease_generation: current.lease_generation,
+          worker_id: current.worker_id,
+          expected_status: "releasing",
+          status: "failed",
+          expected_version: current.version,
+          failure: { message: failure },
+        });
+      }
+      emit("dag:cleanup_failed", {
+        runId: releasing.run_id,
+        workerId: releasing.worker_id,
+        nodeId: releasing.node_id,
+        containerId: releasing.container_id,
+        reason: failure,
+      });
+      return false;
+    }
+  } catch {
+    // A concurrent transition changed the durable row. Re-read on the next
+    // scheduler pass rather than leaving a fire-and-forget rejection behind.
+    return false;
+  } finally {
+    inflightWorkers.delete(key);
+  }
+}
+
 /**
- * Trigger async deprovisioning of all registered workers for a runId.
- * Returns immediately; the actual stop/remove is fire-and-forget.
- * Subsequent calls for the same runId while a cleanup is in-flight are
- * no-ops (returns `false`).
+ * Trigger async cleanup for every non-terminal durable provisioned worker in a run.
+ * The boolean return remains compatible with the former fire-and-forget API.
  */
 export function deprovisionProvisionedForRun(
   runId: string,
   options: DeprovisionOptions = {},
 ): boolean {
   if (inflightCleanups.has(runId)) return false;
-  const entries = listProvisionedForRun(runId);
-  if (entries.length === 0) {
-    return false;
-  }
+  const entries = listDagProvisionedForCleanup(runId);
+  if (entries.length === 0) return false;
   inflightCleanups.add(runId);
-  const deprovisionFn = options.deprovisionFn ?? deprovisionWorkerContainer;
-  emit("dag:cleanup_requested", {
-    runId,
-    workerCount: entries.length,
-  });
-
-  void (async () => {
-    try {
-      for (const entry of entries) {
-        try {
-          const result = await deprovisionFn(
-            entry.dockerNodeId,
-            entry.containerId,
-            options.deprovisionerOpts,
-          );
-          emit("dag:cleanup_completed", {
-            runId,
-            workerId: entry.workerId,
-            nodeId: entry.nodeId,
-            containerId: entry.containerId,
-            stopped: result.stopped,
-            removed: result.removed,
-          });
-        } catch (err) {
-          emit("dag:cleanup_failed", {
-            runId,
-            workerId: entry.workerId,
-            nodeId: entry.nodeId,
-            containerId: entry.containerId,
-            reason: err instanceof Error ? err.message : String(err),
-          });
-        }
-      }
-    } finally {
-      clearProvisionedForRun(runId);
-      inflightCleanups.delete(runId);
-    }
-  })();
-
+  emit("dag:cleanup_requested", { runId, workerCount: entries.length });
+  void Promise.all(entries.map((entry) => deprovisionProvisionedWorker(entry, options, false)))
+    .finally(() => inflightCleanups.delete(runId));
   return true;
+}
+
+export function listDagProvisionedForCleanup(runId: string): ProvisionedWorkerEntry[] {
+  return listDagProvisionedWorkers({
+    run_id: runId,
+    statuses: ["active", "releasing", "failed"],
+  }).map(entryFromRecord);
 }

--- a/homerail_manager/src/orchestration/response-bridge.ts
+++ b/homerail_manager/src/orchestration/response-bridge.ts
@@ -1,5 +1,6 @@
 import type { DagTransportFenceMetadata } from "homerail-protocol";
 import { getDagActorByNode, getDagActorCommand } from "../persistence/dag-actors.js";
+import { acquireDagActorLease, assessDagActorLease } from "../persistence/dag-actor-leases.js";
 import { getActiveRun, handoffActiveRun } from "../runtime/active-runs.js";
 
 export type TransportFenceDisposition = "stale" | "duplicate" | "invalid";
@@ -15,6 +16,11 @@ export type TransportFenceAssessment =
       reason: string;
     }
   | { status: "malformed_payload"; reason: string };
+
+export interface DagTransportFenceSource {
+  targetType: "worker" | "node";
+  targetId: string;
+}
 
 export type ResponseBridgeResult =
   | { status: "handoff_applied"; runId: string; nodeId: string; port: string }
@@ -43,6 +49,13 @@ function transportMetadataError(obj: Record<string, unknown>): string | undefine
   )) {
     return "generation must be a positive safe integer";
   }
+  if (
+    typeof obj.lease_generation !== "number"
+    || !Number.isSafeInteger(obj.lease_generation)
+    || obj.lease_generation < 1
+  ) {
+    return "lease_generation must be a positive safe integer";
+  }
   return undefined;
 }
 
@@ -59,7 +72,10 @@ function ignored(
  * Resolve terminal transport identity without mutating the active run. Fence
  * conflicts are ignored here so they can never enter correction/failure paths.
  */
-export function assessDagTransportFence(payload: unknown): TransportFenceAssessment {
+export function assessDagTransportFence(
+  payload: unknown,
+  source: DagTransportFenceSource,
+): TransportFenceAssessment {
   if (typeof payload !== "object" || payload === null || Array.isArray(payload)) {
     return { status: "malformed_payload", reason: "payload is not an object" };
   }
@@ -85,26 +101,52 @@ export function assessDagTransportFence(payload: unknown): TransportFenceAssessm
   const roundId = typeof obj.round_id === "string" ? obj.round_id : undefined;
   const actorId = typeof obj.actor_id === "string" ? obj.actor_id : undefined;
   const generation = typeof obj.generation === "number" ? obj.generation : undefined;
+  const leaseGeneration = obj.lease_generation as number;
   const commandId = typeof obj.command_id === "string" ? obj.command_id : undefined;
   const currentRoundId = run.currentRound.round_id;
   const requiresDurableFence = run.currentRound.ordinal > 1;
 
+  const leaseInput = {
+    run_id: runId,
+    actor_id: actor.actor_id,
+    lease_generation: leaseGeneration,
+    target_type: source.targetType,
+    target_id: source.targetId,
+  };
+  let lease = assessDagActorLease(leaseInput);
+  if (!lease.current && lease.reason === "expired" && run.status === "active" && lease.lease) {
+    try {
+      acquireDagActorLease({
+        run_id: runId,
+        actor_id: actor.actor_id,
+        target_type: source.targetType,
+        target_id: source.targetId,
+        expected_version: lease.lease.version,
+      });
+      lease = assessDagActorLease(leaseInput);
+    } catch {
+      // A concurrent renewal, reassignment, or release owns the current lease.
+      // The authoritative re-assessment below remains fail-closed.
+      lease = assessDagActorLease(leaseInput);
+    }
+  }
+  if (!lease.current) {
+    const disposition = lease.reason === "target_mismatch" ? "invalid" : "stale";
+    return ignored(
+      disposition,
+      runId,
+      nodeId,
+      `DAG_TRANSPORT_LEASE_${lease.reason.toUpperCase()} ${runId}/${nodeId}`,
+    );
+  }
+
   if (!roundId) {
-    if (requiresDurableFence) {
-      return ignored(
-        "stale",
-        runId,
-        nodeId,
-        `DAG_TRANSPORT_ROUND_FENCE_MISSING ${runId}/${nodeId}: current ${currentRoundId}`,
-      );
-    }
-    if (run.dagRun.handoffedNodes.has(nodeId)) {
-      return ignored("duplicate", runId, nodeId, `DAG_TRANSPORT_HANDOFF_DUPLICATE ${runId}/${nodeId}`);
-    }
-    if (run.status !== "active") {
-      return ignored("stale", runId, nodeId, `DAG_TRANSPORT_RUN_NOT_ACTIVE ${runId}: ${run.status}`);
-    }
-    return { status: "current", runId, nodeId };
+    return ignored(
+      "invalid",
+      runId,
+      nodeId,
+      `DAG_TRANSPORT_ROUND_FENCE_MISSING ${runId}/${nodeId}: current ${currentRoundId}`,
+    );
   }
 
   if (roundId !== currentRoundId) {
@@ -158,8 +200,15 @@ export function assessDagTransportFence(payload: unknown): TransportFenceAssessm
   if (run.status !== "active") {
     return ignored("stale", runId, nodeId, `DAG_TRANSPORT_RUN_NOT_ACTIVE ${runId}: ${run.status}`);
   }
-  if (requiresDurableFence && (!actorId || generation === undefined || !commandId)) {
-    return ignored("invalid", runId, nodeId, `DAG_TRANSPORT_COMMAND_FENCE_MISSING ${runId}/${nodeId}`);
+  if (!actorId || generation === undefined || (requiresDurableFence && !commandId)) {
+    return ignored(
+      "invalid",
+      runId,
+      nodeId,
+      requiresDurableFence
+        ? `DAG_TRANSPORT_COMMAND_FENCE_MISSING ${runId}/${nodeId}`
+        : `DAG_TRANSPORT_FENCE_MISSING ${runId}/${nodeId}`,
+    );
   }
 
   return {
@@ -169,11 +218,15 @@ export function assessDagTransportFence(payload: unknown): TransportFenceAssessm
     round_id: roundId,
     ...(actorId === undefined ? {} : { actor_id: actorId }),
     ...(generation === undefined ? {} : { generation }),
+    lease_generation: leaseGeneration,
     ...(commandId === undefined ? {} : { command_id: commandId }),
   };
 }
 
-export function applyResponseHandoff(payload: unknown): ResponseBridgeResult {
+export function applyResponseHandoff(
+  payload: unknown,
+  source: DagTransportFenceSource,
+): ResponseBridgeResult {
   if (typeof payload !== "object" || payload === null) {
     return {
       status: "malformed_payload",
@@ -204,7 +257,7 @@ export function applyResponseHandoff(payload: unknown): ResponseBridgeResult {
     };
   }
 
-  const assessment = assessDagTransportFence(obj);
+  const assessment = assessDagTransportFence(obj, source);
   if (assessment.status === "malformed_payload") return assessment;
   if (assessment.status === "unknown_run") {
     return { status: "unknown_run", runId: assessment.runId };
@@ -226,6 +279,7 @@ export function applyResponseHandoff(payload: unknown): ResponseBridgeResult {
       ...(typeof obj.round_id === "string" ? { roundId: obj.round_id } : {}),
       ...(typeof obj.actor_id === "string" ? { actorId: obj.actor_id } : {}),
       ...(typeof obj.generation === "number" ? { generation: obj.generation } : {}),
+      ...(typeof obj.lease_generation === "number" ? { leaseGeneration: obj.lease_generation } : {}),
       ...(typeof obj.command_id === "string" ? { commandId: obj.command_id } : {}),
     });
   } catch (error) {

--- a/homerail_manager/src/orchestration/ws-dispatch-adapter.ts
+++ b/homerail_manager/src/orchestration/ws-dispatch-adapter.ts
@@ -39,6 +39,8 @@ import {
 } from "./provisioned-cleanup.js";
 import {
   acquireDagActorLease,
+  getDagActorLease,
+  listDagProvisionedWorkers,
   releaseDagActorLease,
   type DagActorLeaseRecord,
 } from "../persistence/dag-actor-leases.js";
@@ -368,7 +370,7 @@ export class WsDispatchAdapter implements DAGDispatcher {
     const previousTarget = findDispatchTarget(envelope.runId, envelope.nodeId);
     if (previousTarget?.state === "dispatched" && previousTarget.targetType === "worker") {
       const hotWorker = workers.find((worker) => worker.worker_id === previousTarget.targetId);
-      if (hotWorker) return hotWorker;
+      if (hotWorker && this._hasCurrentProvisionedOwnership(envelope, hotWorker.worker_id)) return hotWorker;
     }
 
     const runScopedPrefix = `provisioned-${sanitizeProvisionedWorkerToken(envelope.runId)}-`;
@@ -376,7 +378,10 @@ export class WsDispatchAdapter implements DAGDispatcher {
       `provisioned-${envelope.runId}-${envelope.nodeId}`,
     );
     const exactRunScopedWorker = workers.find((w) => w.worker_id === exactRunScopedWorkerId);
-    if (exactRunScopedWorker) return exactRunScopedWorker;
+    if (
+      exactRunScopedWorker
+      && this._hasCurrentProvisionedOwnership(envelope, exactRunScopedWorker.worker_id)
+    ) return exactRunScopedWorker;
 
     if (requiresIsolatedWorkspace(envelope)) return undefined;
 
@@ -389,6 +394,29 @@ export class WsDispatchAdapter implements DAGDispatcher {
     const worker = genericWorkers[this.nextWorkerIndex % genericWorkers.length];
     this.nextWorkerIndex = (this.nextWorkerIndex + 1) % genericWorkers.length;
     return worker;
+  }
+
+  private _hasCurrentProvisionedOwnership(
+    envelope: DispatchEnvelope,
+    workerId: string,
+  ): boolean {
+    if (!workerId.startsWith("provisioned-")) return true;
+    const actorId = envelope.activity?.actorId;
+    if (!actorId) return false;
+    const lease = getDagActorLease({ run_id: envelope.runId, actor_id: actorId });
+    if (
+      !lease
+      || lease.state !== "leased"
+      || (lease.target_type !== "worker" && lease.target_type !== "provisioned_worker")
+      || lease.target_id !== workerId
+    ) return false;
+    return listDagProvisionedWorkers({
+      run_id: envelope.runId,
+      actor_id: actorId,
+      lease_generation: lease.lease_generation,
+      statuses: ["active"],
+      limit: 1,
+    }).some((worker) => worker.worker_id === workerId);
   }
 
   private _dispatchToNode(
@@ -420,6 +448,12 @@ export class WsDispatchAdapter implements DAGDispatcher {
       && envelope.activity?.leaseGeneration !== preboundLease.lease_generation
     ) {
       throw new Error(`DAG dispatch ${envelope.runId}/${envelope.nodeId} has a mismatched prebound lease`);
+    }
+    if (!this._hasCurrentProvisionedOwnership(bound.envelope, workerId)) {
+      this._releaseFailedDispatchLease(bound.lease);
+      throw new Error(
+        `Provisioned worker ${workerId} is not durably active for DAG actor ${bound.envelope.activity?.actorId ?? "unknown"}`,
+      );
     }
     try {
       socket.send(JSON.stringify({ type: "prompt", envelope: bound.envelope }));

--- a/homerail_manager/src/orchestration/ws-dispatch-adapter.ts
+++ b/homerail_manager/src/orchestration/ws-dispatch-adapter.ts
@@ -3,6 +3,7 @@ import type {
   DispatchEnvelope,
   DispatchResult,
 } from "./dag-dispatcher.js";
+import { randomUUID } from "node:crypto";
 import { getAllWorkers } from "../worker/registry.js";
 import { getAllNodes, isDockerCapableNode } from "../node/registry.js";
 import { emit } from "../events/bus.js";
@@ -17,6 +18,7 @@ import {
   isProvisioning,
 } from "./dispatch-tracker.js";
 import {
+  deprovisionWorkerContainer,
   provisionWorkerContainer,
   type ProvisionerOptions,
 } from "../node/worker-provisioner.js";
@@ -30,7 +32,16 @@ import {
   recordNodeDispatchRetry,
 } from "../runtime/active-runs.js";
 import { getPort } from "../config/env.js";
-import { registerProvisionedWorker } from "./provisioned-cleanup.js";
+import {
+  deprovisionProvisionedWorker,
+  registerProvisionedWorker,
+  type ProvisionedWorkerEntry,
+} from "./provisioned-cleanup.js";
+import {
+  acquireDagActorLease,
+  releaseDagActorLease,
+  type DagActorLeaseRecord,
+} from "../persistence/dag-actor-leases.js";
 import { normalizeManagerAgentRuntimeAgentType, redactTelemetry } from "homerail-protocol";
 import WebSocket from "ws";
 
@@ -385,47 +396,137 @@ export class WsDispatchAdapter implements DAGDispatcher {
     nodeId: string,
     socket: WebSocket,
   ): void {
-    const message = JSON.stringify({ type: "prompt", envelope });
-    socket.send(message);
-    emit("dag:ws_dispatched", {
-      runId: envelope.runId,
-      nodeId: envelope.nodeId,
-      targetType: "node",
-      targetId: nodeId,
-    });
-    appendChatEntry(envelope.runId, envelope.nodeId, {
-      role: "manager",
-      type: "prompt",
-      targetId: nodeId,
-      content: redactDispatchEnvelope(envelope),
-      timestamp: Date.now(),
-    });
-    mirrorDispatchPrompt(envelope, "node", nodeId);
-    recordDispatch(envelope.runId, envelope.nodeId, "node", nodeId);
+    const bound = this._bindEnvelopeToTarget(envelope, "node", nodeId);
+    try {
+      socket.send(JSON.stringify({ type: "prompt", envelope: bound.envelope }));
+    } catch (error) {
+      this._releaseFailedDispatchLease(bound.lease);
+      throw error;
+    }
+    this._recordPostSend(bound.envelope, "node", nodeId);
   }
 
   private _dispatchToWorker(
     envelope: DispatchEnvelope,
     workerId: string,
     socket: WebSocket,
+    preboundLease?: DagActorLeaseRecord,
+  ): DispatchEnvelope {
+    const bound = preboundLease
+      ? { envelope, lease: preboundLease }
+      : this._bindEnvelopeToTarget(envelope, "worker", workerId);
+    if (
+      preboundLease
+      && envelope.activity?.leaseGeneration !== preboundLease.lease_generation
+    ) {
+      throw new Error(`DAG dispatch ${envelope.runId}/${envelope.nodeId} has a mismatched prebound lease`);
+    }
+    try {
+      socket.send(JSON.stringify({ type: "prompt", envelope: bound.envelope }));
+    } catch (error) {
+      this._releaseFailedDispatchLease(bound.lease);
+      throw error;
+    }
+    this._recordPostSend(bound.envelope, "worker", workerId);
+    return bound.envelope;
+  }
+
+  private _recordPostSend(
+    envelope: DispatchEnvelope,
+    targetType: "worker" | "node",
+    targetId: string,
   ): void {
-    const message = JSON.stringify({ type: "prompt", envelope });
-    socket.send(message);
-    emit("dag:ws_dispatched", {
+    try {
+      emit("dag:ws_dispatched", {
+        runId: envelope.runId,
+        nodeId: envelope.nodeId,
+        targetType,
+        targetId,
+      });
+    } catch (error) {
+      this._warnPostSendFailure(envelope, "event emission", error);
+    }
+    try {
+      appendChatEntry(envelope.runId, envelope.nodeId, {
+        role: "manager",
+        type: "prompt",
+        targetId,
+        content: redactDispatchEnvelope(envelope),
+        timestamp: Date.now(),
+      });
+    } catch (error) {
+      this._warnPostSendFailure(envelope, "chat persistence", error);
+    }
+    mirrorDispatchPrompt(envelope, targetType, targetId);
+    try {
+      recordDispatch(envelope.runId, envelope.nodeId, targetType, targetId);
+    } catch (error) {
+      this._warnPostSendFailure(envelope, "dispatch tracking", error);
+    }
+  }
+
+  private _warnPostSendFailure(envelope: DispatchEnvelope, operation: string, error: unknown): void {
+    console.warn(
+      `[homerail_manager] DAG prompt was sent but ${operation} failed for ${envelope.runId}/${envelope.nodeId}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  private _bindEnvelopeToTarget(
+    envelope: DispatchEnvelope,
+    targetType: "worker" | "node",
+    targetId: string,
+  ): { envelope: DispatchEnvelope; lease: DagActorLeaseRecord } {
+    if (!envelope.activity) {
+      throw new Error(`DAG dispatch ${envelope.runId}/${envelope.nodeId} is missing actor activity identity`);
+    }
+    const lease = acquireDagActorLease({
+      run_id: envelope.runId,
+      actor_id: envelope.activity.actorId,
+      target_type: targetType,
+      target_id: targetId,
+    });
+    const boundEnvelope: DispatchEnvelope = {
+      ...envelope,
+      activity: {
+        ...envelope.activity,
+        leaseGeneration: lease.lease_generation,
+      },
+    };
+    emit("dag:actor_lease_acquired", {
       runId: envelope.runId,
       nodeId: envelope.nodeId,
-      targetType: "worker",
-      targetId: workerId,
+      actorId: envelope.activity.actorId,
+      leaseGeneration: lease.lease_generation,
+      targetType,
+      targetId,
+      idleDeadline: lease.idle_deadline,
     });
-    appendChatEntry(envelope.runId, envelope.nodeId, {
-      role: "manager",
-      type: "prompt",
-      targetId: workerId,
-      content: redactDispatchEnvelope(envelope),
-      timestamp: Date.now(),
-    });
-    mirrorDispatchPrompt(envelope, "worker", workerId);
-    recordDispatch(envelope.runId, envelope.nodeId, "worker", workerId);
+    return { envelope: boundEnvelope, lease };
+  }
+
+  private _releaseFailedDispatchLease(lease: DagActorLeaseRecord): void {
+    if (lease.state !== "leased") return;
+    try {
+      const released = releaseDagActorLease({
+        run_id: lease.run_id,
+        actor_id: lease.actor_id,
+        lease_generation: lease.lease_generation,
+        target_type: lease.target_type!,
+        target_id: lease.target_id!,
+        expected_version: lease.version,
+      });
+      emit("dag:actor_lease_released", {
+        runId: lease.run_id,
+        actorId: lease.actor_id,
+        leaseGeneration: lease.lease_generation,
+        reason: "dispatch_send_failed",
+        retainedUntil: released.retained_until,
+      });
+    } catch (error) {
+      console.warn(
+        `[homerail_manager] failed to release DAG actor lease after dispatch send failure: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
   }
 
   private _startProvisioning(
@@ -442,7 +543,9 @@ export class WsDispatchAdapter implements DAGDispatcher {
     });
 
     const workspaceId = envelope.runId;
-    const workerId = sanitizeProvisionedWorkerToken(`provisioned-${envelope.runId}-${envelope.nodeId}`);
+    const workerId = sanitizeProvisionedWorkerToken(
+      `provisioned-${envelope.runId}-${envelope.nodeId}-${randomUUID()}`,
+    );
     const agentBackend = normalizeAgentBackend(envelope.agentConfig.agent_type);
     const provisionerOpts: ProvisionerOptions = {
       ...this.provisionerOpts,
@@ -492,13 +595,36 @@ export class WsDispatchAdapter implements DAGDispatcher {
     containerId: string,
     dockerNodeId: string,
   ): void {
-    registerProvisionedWorker({
-      runId: envelope.runId,
-      nodeId: envelope.nodeId,
-      workerId,
-      containerId,
-      dockerNodeId,
-    });
+    const currentEnvelope = buildCurrentDispatchEnvelope(envelope.runId, envelope.nodeId);
+    if (!currentEnvelope.ok) {
+      recordDispatchFailed(envelope.runId, envelope.nodeId);
+      this._cleanupUnregisteredProvisionedContainer(envelope, workerId, containerId, dockerNodeId);
+      this._failProvisioning(envelope, currentEnvelope.reason);
+      return;
+    }
+    let leasedEnvelope: DispatchEnvelope;
+    let lease: DagActorLeaseRecord | undefined;
+    let provisionedEntry: ProvisionedWorkerEntry | undefined;
+    try {
+      const bound = this._bindEnvelopeToTarget(currentEnvelope.envelope, "worker", workerId);
+      leasedEnvelope = bound.envelope;
+      lease = bound.lease;
+      provisionedEntry = registerProvisionedWorker({
+        runId: envelope.runId,
+        nodeId: envelope.nodeId,
+        actorId: bound.envelope.activity!.actorId,
+        leaseGeneration: bound.lease.lease_generation,
+        workerId,
+        containerId,
+        dockerNodeId,
+      });
+    } catch (error) {
+      recordDispatchFailed(envelope.runId, envelope.nodeId);
+      if (lease) this._releaseFailedDispatchLease(lease);
+      this._cleanupUnregisteredProvisionedContainer(envelope, workerId, containerId, dockerNodeId);
+      this._failProvisioning(envelope, error instanceof Error ? error.message : String(error));
+      return;
+    }
     emit("dag:provisioning_completed", {
       runId: envelope.runId,
       nodeId: envelope.nodeId,
@@ -506,44 +632,78 @@ export class WsDispatchAdapter implements DAGDispatcher {
       containerId,
     });
 
-    const currentEnvelope = buildCurrentDispatchEnvelope(envelope.runId, envelope.nodeId);
-    if (!currentEnvelope.ok) {
-      recordDispatchFailed(envelope.runId, envelope.nodeId);
-      this._failProvisioning(envelope, currentEnvelope.reason);
-      return;
-    }
-
     // Find the newly registered worker and dispatch
     const workers = getAllWorkers();
     const newWorker = workers.find(
       (w) => w.worker_id === workerId && w.socket.readyState === WebSocket.OPEN,
     );
     if (newWorker) {
-      if (!hasCapabilities(newWorker.capabilities, currentEnvelope.envelope.requiredCapabilities)) {
-        clearDispatchTarget(currentEnvelope.envelope.runId, currentEnvelope.envelope.nodeId);
+      if (!hasCapabilities(newWorker.capabilities, leasedEnvelope.requiredCapabilities)) {
+        clearDispatchTarget(leasedEnvelope.runId, leasedEnvelope.nodeId);
+        if (provisionedEntry) void deprovisionProvisionedWorker(provisionedEntry);
+        if (lease) this._releaseFailedDispatchLease(lease);
         this._deferOfflineDispatch(
-          currentEnvelope.envelope,
-          `provisioned worker ${workerId} does not satisfy required capabilities: ${requiredCapabilitiesText(currentEnvelope.envelope.requiredCapabilities)}`,
+          leasedEnvelope,
+          `provisioned worker ${workerId} does not satisfy required capabilities: ${requiredCapabilitiesText(leasedEnvelope.requiredCapabilities)}`,
         );
         return;
       }
       if (!recordProvisionedNodeDispatchAttempt(
-        currentEnvelope.envelope.runId,
-        currentEnvelope.envelope.nodeId,
+        leasedEnvelope.runId,
+        leasedEnvelope.nodeId,
       )) {
+        if (provisionedEntry) void deprovisionProvisionedWorker(provisionedEntry);
+        if (lease) this._releaseFailedDispatchLease(lease);
         return;
       }
-      this._dispatchToWorker(currentEnvelope.envelope, workerId, newWorker.socket);
-      if (!markNodeDispatched(currentEnvelope.envelope.runId, currentEnvelope.envelope.nodeId)) {
-        recordDispatchFailed(currentEnvelope.envelope.runId, currentEnvelope.envelope.nodeId);
-        this._failProvisioning(currentEnvelope.envelope, `node ${currentEnvelope.envelope.nodeId} was not READY after worker provisioning`);
+      try {
+        this._dispatchToWorker(leasedEnvelope, workerId, newWorker.socket, lease);
+      } catch (error) {
+        if (provisionedEntry) void deprovisionProvisionedWorker(provisionedEntry);
+        this._failProvisioning(leasedEnvelope, error instanceof Error ? error.message : String(error));
+        return;
+      }
+      if (!markNodeDispatched(leasedEnvelope.runId, leasedEnvelope.nodeId)) {
+        recordDispatchFailed(leasedEnvelope.runId, leasedEnvelope.nodeId);
+        this._failProvisioning(leasedEnvelope, `node ${leasedEnvelope.nodeId} was not READY after worker provisioning`);
         return;
       }
     } else {
       // Worker registered but socket not ready — mark failed
       recordDispatchFailed(envelope.runId, envelope.nodeId);
+      if (provisionedEntry) void deprovisionProvisionedWorker(provisionedEntry);
+      if (lease) this._releaseFailedDispatchLease(lease);
       this._failProvisioning(envelope, `worker ${workerId} registered but socket not open`);
     }
+  }
+
+  private _cleanupUnregisteredProvisionedContainer(
+    envelope: DispatchEnvelope,
+    workerId: string,
+    containerId: string,
+    dockerNodeId: string,
+  ): void {
+    emit("dag:cleanup_requested", { runId: envelope.runId, workerCount: 1 });
+    void deprovisionWorkerContainer(dockerNodeId, containerId, this.provisionerOpts)
+      .then((result) => {
+        emit("dag:cleanup_completed", {
+          runId: envelope.runId,
+          workerId,
+          nodeId: envelope.nodeId,
+          containerId,
+          stopped: result.stopped,
+          removed: result.removed,
+        });
+      })
+      .catch((error) => {
+        emit("dag:cleanup_failed", {
+          runId: envelope.runId,
+          workerId,
+          nodeId: envelope.nodeId,
+          containerId,
+          reason: error instanceof Error ? error.message : String(error),
+        });
+      });
   }
 
   private _onProvisioningFailure(

--- a/homerail_manager/src/persistence/dag-actor-leases.ts
+++ b/homerail_manager/src/persistence/dag-actor-leases.ts
@@ -1,0 +1,1340 @@
+import { createHash } from "node:crypto";
+import { redactTelemetry, type DagActorCheckpointV1 } from "homerail-protocol";
+
+import {
+  loadDagActorLeaseSettings,
+  validateDagActorRetentionTtlMs,
+  validateDagWorkerIdleTtlMs,
+} from "../config/dag-actor-lease-settings.js";
+import { getDb, parseJsonRow } from "./db.js";
+
+export type { DagActorCheckpointV1 } from "homerail-protocol";
+
+export const MAX_DAG_ACTOR_CHECKPOINT_BYTES = 256 * 1024;
+export const MAX_DAG_ACTOR_CHECKPOINT_ITEMS = 128;
+export const DEFAULT_DAG_ACTOR_LEASE_LIST_LIMIT = 100;
+export const MAX_DAG_ACTOR_LEASE_LIST_LIMIT = 1_000;
+export const MAX_DAG_PROVISIONED_WORKER_FAILURE_BYTES = 64 * 1024;
+
+export type DagActorLeaseState = "leased" | "dormant" | "retired";
+export type DagProvisionedWorkerStatus = "active" | "releasing" | "released" | "failed";
+
+const LEASE_STATES: ReadonlySet<string> = new Set(["leased", "dormant", "retired"]);
+const PROVISIONED_WORKER_STATUSES: ReadonlySet<string> = new Set([
+  "active",
+  "releasing",
+  "released",
+  "failed",
+]);
+
+export interface DagActorLeaseRecord {
+  run_id: string;
+  actor_id: string;
+  state: DagActorLeaseState;
+  lease_generation: number;
+  target_type?: string;
+  target_id?: string;
+  idle_deadline?: number;
+  pinned: boolean;
+  retained_until?: number;
+  state_changed_at: number;
+  created_at: number;
+  updated_at: number;
+  version: number;
+}
+
+export type DagActorLeaseAssessment =
+  | { current: true; lease: DagActorLeaseRecord }
+  | {
+      current: false;
+      reason: "missing" | "not_leased" | "generation_mismatch" | "target_mismatch" | "expired";
+      lease?: DagActorLeaseRecord;
+    };
+
+export interface DagActorCheckpointRecord {
+  run_id: string;
+  actor_id: string;
+  checkpoint_version: number;
+  checkpoint_sha256: string;
+  checkpoint: DagActorCheckpointV1;
+  created_at: number;
+}
+
+export interface DagProvisionedWorkerRecord {
+  run_id: string;
+  node_id: string;
+  actor_id: string;
+  lease_generation: number;
+  worker_id: string;
+  container_id: string;
+  docker_node_id: string;
+  status: DagProvisionedWorkerStatus;
+  registered_at: number;
+  updated_at: number;
+  release_requested_at?: number;
+  terminal_at?: number;
+  failure?: unknown;
+  version: number;
+}
+
+export class DagActorLeaseConflictError extends Error {
+  constructor(
+    public readonly code:
+      | "actor_not_found"
+      | "lease_not_found"
+      | "lease_retired"
+      | "lease_version_conflict"
+      | "lease_state_conflict"
+      | "lease_generation_conflict"
+      | "lease_target_conflict"
+      | "lease_expired"
+      | "checkpoint_version_conflict"
+      | "checkpoint_generation_conflict"
+      | "provisioned_worker_identity_conflict"
+      | "provisioned_worker_version_conflict"
+      | "provisioned_worker_status_conflict",
+    message: string,
+  ) {
+    super(message);
+    this.name = "DagActorLeaseConflictError";
+  }
+}
+
+interface DagActorLeaseRow {
+  run_id: string;
+  actor_id: string;
+  state: string;
+  lease_generation: number;
+  target_type: string | null;
+  target_id: string | null;
+  idle_deadline: number | null;
+  pinned: number;
+  retained_until: number | null;
+  state_changed_at: number;
+  created_at: number;
+  updated_at: number;
+  version: number;
+}
+
+interface DagActorCheckpointRow {
+  run_id: string;
+  actor_id: string;
+  checkpoint_version: number;
+  schema_version: number;
+  actor_generation: number;
+  round_id: string;
+  captured_at: number;
+  checkpoint_sha256: string;
+  checkpoint_json: string;
+  created_at: number;
+}
+
+interface DagProvisionedWorkerRow {
+  run_id: string;
+  actor_id: string;
+  lease_generation: number;
+  worker_id: string;
+  node_id: string;
+  container_id: string;
+  docker_node_id: string;
+  status: string;
+  registered_at: number;
+  updated_at: number;
+  release_requested_at: number | null;
+  terminal_at: number | null;
+  failure_json: string | null;
+  version: number;
+}
+
+function assertBoundedString(value: unknown, label: string, maximum: number): string {
+  if (typeof value !== "string") throw new Error(`${label} must be a string`);
+  const normalized = value.trim();
+  if (!normalized || normalized.length > maximum) {
+    throw new Error(`${label} must be between 1 and ${maximum} characters`);
+  }
+  return normalized;
+}
+
+function assertContentString(value: unknown, label: string, maximum: number): string {
+  if (typeof value !== "string" || !value.trim() || value.length > maximum) {
+    throw new Error(`${label} must be a non-empty string of at most ${maximum} characters`);
+  }
+  return value;
+}
+
+function assertNonNegativeSafeInteger(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${label} must be a non-negative safe integer`);
+  }
+  return value;
+}
+
+function assertPositiveSafeInteger(value: unknown, label: string): number {
+  const normalized = assertNonNegativeSafeInteger(value, label);
+  if (normalized < 1) throw new Error(`${label} must be a positive safe integer`);
+  return normalized;
+}
+
+function assertOptionalExpectedVersion(value: number | undefined): number | undefined {
+  return value === undefined ? undefined : assertPositiveSafeInteger(value, "expected_version");
+}
+
+function assertIncrementableVersion(value: number, label: string): void {
+  assertPositiveSafeInteger(value + 1, label);
+}
+
+function assertNow(value: number | undefined): number {
+  return assertNonNegativeSafeInteger(value ?? Date.now(), "now");
+}
+
+function assertMutationTime(now: number, updatedAt: number): void {
+  if (now < updatedAt) throw new Error("now must not precede the persisted update timestamp");
+}
+
+function checkedDeadline(now: number, ttlMs: number, label: string): number {
+  const deadline = now + ttlMs;
+  if (!Number.isSafeInteger(deadline)) throw new Error(`${label} exceeds the safe timestamp range`);
+  return deadline;
+}
+
+function idleTtl(value: number | undefined): number {
+  return value === undefined
+    ? loadDagActorLeaseSettings().worker_idle_ttl_ms
+    : validateDagWorkerIdleTtlMs(value);
+}
+
+function retentionTtl(value: number | undefined): number {
+  return value === undefined
+    ? loadDagActorLeaseSettings().actor_retention_ttl_ms
+    : validateDagActorRetentionTtlMs(value);
+}
+
+function normalizeListLimit(value: number | undefined): number {
+  const limit = value ?? DEFAULT_DAG_ACTOR_LEASE_LIST_LIMIT;
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > MAX_DAG_ACTOR_LEASE_LIST_LIMIT) {
+    throw new Error(`limit must be an integer between 1 and ${MAX_DAG_ACTOR_LEASE_LIST_LIMIT}`);
+  }
+  return limit;
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object") {
+    const result: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      const nested = (value as Record<string, unknown>)[key];
+      if (nested !== undefined) result[key] = canonicalize(nested);
+    }
+    return result;
+  }
+  return value;
+}
+
+function encodeCanonicalJson(value: unknown, label: string, maximumBytes: number): string {
+  let raw: string | undefined;
+  try {
+    raw = JSON.stringify(value);
+  } catch {
+    throw new Error(`${label} must be JSON serializable`);
+  }
+  if (raw === undefined) throw new Error(`${label} must be JSON serializable`);
+  if (Buffer.byteLength(raw, "utf8") > maximumBytes) {
+    throw new Error(`${label} exceeds ${maximumBytes} bytes`);
+  }
+  const canonical = JSON.stringify(canonicalize(value));
+  if (Buffer.byteLength(canonical, "utf8") > maximumBytes) {
+    throw new Error(`${label} exceeds ${maximumBytes} bytes`);
+  }
+  return canonical;
+}
+
+function getLeaseRow(runId: string, actorId: string): DagActorLeaseRow | undefined {
+  return getDb().prepare("SELECT * FROM dag_actor_runtimes WHERE run_id = ? AND actor_id = ?")
+    .get(runId, actorId) as DagActorLeaseRow | undefined;
+}
+
+function leaseFromRow(row: DagActorLeaseRow): DagActorLeaseRecord {
+  if (!LEASE_STATES.has(row.state)) {
+    throw new Error(`DAG actor lease ${row.run_id}/${row.actor_id} has invalid state ${row.state}`);
+  }
+  const state = row.state as DagActorLeaseState;
+  const leaseGeneration = assertNonNegativeSafeInteger(row.lease_generation, "persisted lease_generation");
+  const createdAt = assertNonNegativeSafeInteger(row.created_at, "persisted created_at");
+  const updatedAt = assertNonNegativeSafeInteger(row.updated_at, "persisted updated_at");
+  const stateChangedAt = assertNonNegativeSafeInteger(row.state_changed_at, "persisted state_changed_at");
+  const version = assertPositiveSafeInteger(row.version, "persisted version");
+  if ((row.pinned !== 0 && row.pinned !== 1) || updatedAt < createdAt || stateChangedAt < createdAt || stateChangedAt > updatedAt) {
+    throw new Error(`DAG actor lease ${row.run_id}/${row.actor_id} has invalid persisted metadata`);
+  }
+  if (state === "leased") {
+    if (
+      leaseGeneration < 1
+      || row.target_type === null
+      || row.target_id === null
+      || row.idle_deadline === null
+      || row.retained_until !== null
+    ) {
+      throw new Error(`DAG actor lease ${row.run_id}/${row.actor_id} has invalid leased state`);
+    }
+    const targetType = assertBoundedString(row.target_type, "persisted target_type", 64);
+    const targetId = assertBoundedString(row.target_id, "persisted target_id", 512);
+    const idleDeadline = assertNonNegativeSafeInteger(row.idle_deadline, "persisted idle_deadline");
+    if (idleDeadline < stateChangedAt) {
+      throw new Error(`DAG actor lease ${row.run_id}/${row.actor_id} has an invalid idle deadline`);
+    }
+    return {
+      run_id: row.run_id,
+      actor_id: row.actor_id,
+      state,
+      lease_generation: leaseGeneration,
+      target_type: targetType,
+      target_id: targetId,
+      idle_deadline: idleDeadline,
+      pinned: row.pinned === 1,
+      state_changed_at: stateChangedAt,
+      created_at: createdAt,
+      updated_at: updatedAt,
+      version,
+    };
+  }
+  if (row.target_type !== null || row.target_id !== null || row.idle_deadline !== null || row.retained_until === null) {
+    throw new Error(`DAG actor lease ${row.run_id}/${row.actor_id} has invalid ${state} state`);
+  }
+  const retainedUntil = assertNonNegativeSafeInteger(row.retained_until, "persisted retained_until");
+  if (retainedUntil < updatedAt) {
+    throw new Error(`DAG actor lease ${row.run_id}/${row.actor_id} has an invalid retention deadline`);
+  }
+  return {
+    run_id: row.run_id,
+    actor_id: row.actor_id,
+    state,
+    lease_generation: leaseGeneration,
+    pinned: row.pinned === 1,
+    retained_until: retainedUntil,
+    state_changed_at: stateChangedAt,
+    created_at: createdAt,
+    updated_at: updatedAt,
+    version,
+  };
+}
+
+function requireLease(runId: string, actorId: string): DagActorLeaseRecord {
+  const row = getLeaseRow(runId, actorId);
+  if (!row) {
+    throw new DagActorLeaseConflictError("lease_not_found", `Unknown DAG actor lease: ${runId}/${actorId}`);
+  }
+  return leaseFromRow(row);
+}
+
+function assertExpectedVersion(lease: DagActorLeaseRecord, expectedVersion: number | undefined): void {
+  if (expectedVersion !== undefined && lease.version !== expectedVersion) {
+    throw new DagActorLeaseConflictError(
+      "lease_version_conflict",
+      `DAG actor lease ${lease.run_id}/${lease.actor_id} version is ${lease.version}, expected ${expectedVersion}`,
+    );
+  }
+}
+
+function assertExactLease(
+  lease: DagActorLeaseRecord,
+  input: { lease_generation: number; target_type: string; target_id: string },
+): void {
+  if (lease.state !== "leased") {
+    throw new DagActorLeaseConflictError(
+      "lease_state_conflict",
+      `DAG actor lease ${lease.run_id}/${lease.actor_id} is ${lease.state}, not leased`,
+    );
+  }
+  if (lease.lease_generation !== input.lease_generation) {
+    throw new DagActorLeaseConflictError(
+      "lease_generation_conflict",
+      `DAG actor lease ${lease.run_id}/${lease.actor_id} generation is ${lease.lease_generation}, expected ${input.lease_generation}`,
+    );
+  }
+  if (lease.target_type !== input.target_type || lease.target_id !== input.target_id) {
+    throw new DagActorLeaseConflictError(
+      "lease_target_conflict",
+      `DAG actor lease ${lease.run_id}/${lease.actor_id} belongs to another target`,
+    );
+  }
+}
+
+function ensureLeaseRow(input: {
+  run_id: string;
+  actor_id: string;
+  pinned: boolean;
+  now: number;
+  retention_ttl_ms: number;
+}): DagActorLeaseRecord {
+  const existing = getLeaseRow(input.run_id, input.actor_id);
+  if (existing) return leaseFromRow(existing);
+  const db = getDb();
+  if (!db.prepare("SELECT 1 FROM dag_actors WHERE run_id = ? AND actor_id = ?").get(input.run_id, input.actor_id)) {
+    throw new DagActorLeaseConflictError(
+      "actor_not_found",
+      `Unknown DAG actor: ${input.run_id}/${input.actor_id}`,
+    );
+  }
+  const retainedUntil = checkedDeadline(input.now, input.retention_ttl_ms, "retained_until");
+  db.prepare(`
+    INSERT INTO dag_actor_runtimes(
+      run_id, actor_id, state, lease_generation, target_type, target_id,
+      idle_deadline, pinned, retained_until, state_changed_at, created_at,
+      updated_at, version
+    ) VALUES (?, ?, 'dormant', 0, NULL, NULL, NULL, ?, ?, ?, ?, ?, 1)
+  `).run(
+    input.run_id,
+    input.actor_id,
+    input.pinned ? 1 : 0,
+    retainedUntil,
+    input.now,
+    input.now,
+    input.now,
+  );
+  return requireLease(input.run_id, input.actor_id);
+}
+
+export function ensureDagActorLease(input: {
+  run_id: string;
+  actor_id: string;
+  pinned?: boolean;
+  retention_ttl_ms?: number;
+  now?: number;
+}): DagActorLeaseRecord {
+  const runId = assertBoundedString(input.run_id, "run_id", 256);
+  const actorId = assertBoundedString(input.actor_id, "actor_id", 256);
+  const now = assertNow(input.now);
+  const actorRetentionTtl = retentionTtl(input.retention_ttl_ms);
+  const db = getDb();
+  return db.transaction(() => ensureLeaseRow({
+    run_id: runId,
+    actor_id: actorId,
+    pinned: input.pinned ?? false,
+    now,
+    retention_ttl_ms: actorRetentionTtl,
+  })).immediate();
+}
+
+export function getDagActorLease(input: {
+  run_id: string;
+  actor_id: string;
+}): DagActorLeaseRecord | undefined {
+  const runId = assertBoundedString(input.run_id, "run_id", 256);
+  const actorId = assertBoundedString(input.actor_id, "actor_id", 256);
+  const row = getLeaseRow(runId, actorId);
+  return row ? leaseFromRow(row) : undefined;
+}
+
+export function acquireDagActorLease(input: {
+  run_id: string;
+  actor_id: string;
+  target_type: string;
+  target_id: string;
+  expected_version?: number;
+  idle_ttl_ms?: number;
+  retention_ttl_ms?: number;
+  now?: number;
+}): DagActorLeaseRecord {
+  const runId = assertBoundedString(input.run_id, "run_id", 256);
+  const actorId = assertBoundedString(input.actor_id, "actor_id", 256);
+  const targetType = assertBoundedString(input.target_type, "target_type", 64);
+  const targetId = assertBoundedString(input.target_id, "target_id", 512);
+  const expectedVersion = assertOptionalExpectedVersion(input.expected_version);
+  const now = assertNow(input.now);
+  const workerIdleTtl = idleTtl(input.idle_ttl_ms);
+  const actorRetentionTtl = retentionTtl(input.retention_ttl_ms);
+  const requestedDeadline = checkedDeadline(now, workerIdleTtl, "idle_deadline");
+  const db = getDb();
+
+  return db.transaction(() => {
+    const current = ensureLeaseRow({
+      run_id: runId,
+      actor_id: actorId,
+      pinned: false,
+      now,
+      retention_ttl_ms: actorRetentionTtl,
+    });
+    if (current.state === "retired") {
+      throw new DagActorLeaseConflictError("lease_retired", `DAG actor lease ${runId}/${actorId} is retired`);
+    }
+    assertExpectedVersion(current, expectedVersion);
+    assertMutationTime(now, current.updated_at);
+    assertIncrementableVersion(current.version, "lease version");
+    const sameTarget = current.state === "leased"
+      && current.target_type === targetType
+      && current.target_id === targetId;
+    const leaseGeneration = sameTarget
+      ? current.lease_generation
+      : assertPositiveSafeInteger(current.lease_generation + 1, "lease_generation");
+    const deadline = sameTarget
+      ? Math.max(current.idle_deadline ?? 0, requestedDeadline)
+      : requestedDeadline;
+    const changed = db.prepare(`
+      UPDATE dag_actor_runtimes SET
+        state = 'leased',
+        lease_generation = ?,
+        target_type = ?,
+        target_id = ?,
+        idle_deadline = ?,
+        retained_until = NULL,
+        state_changed_at = CASE WHEN ? THEN state_changed_at ELSE ? END,
+        updated_at = ?,
+        version = version + 1
+      WHERE run_id = ? AND actor_id = ? AND version = ?
+    `).run(
+      leaseGeneration,
+      targetType,
+      targetId,
+      deadline,
+      sameTarget ? 1 : 0,
+      now,
+      now,
+      runId,
+      actorId,
+      current.version,
+    );
+    if (changed.changes !== 1) {
+      throw new DagActorLeaseConflictError("lease_version_conflict", `DAG actor lease ${runId}/${actorId} changed concurrently`);
+    }
+    return requireLease(runId, actorId);
+  }).immediate();
+}
+
+export function renewDagActorLease(input: {
+  run_id: string;
+  actor_id: string;
+  lease_generation: number;
+  target_type: string;
+  target_id: string;
+  expected_version?: number;
+  idle_ttl_ms?: number;
+  now?: number;
+}): DagActorLeaseRecord {
+  const runId = assertBoundedString(input.run_id, "run_id", 256);
+  const actorId = assertBoundedString(input.actor_id, "actor_id", 256);
+  const leaseGeneration = assertPositiveSafeInteger(input.lease_generation, "lease_generation");
+  const targetType = assertBoundedString(input.target_type, "target_type", 64);
+  const targetId = assertBoundedString(input.target_id, "target_id", 512);
+  const expectedVersion = assertOptionalExpectedVersion(input.expected_version);
+  const now = assertNow(input.now);
+  const deadline = checkedDeadline(now, idleTtl(input.idle_ttl_ms), "idle_deadline");
+  const db = getDb();
+
+  return db.transaction(() => {
+    const current = requireLease(runId, actorId);
+    assertExpectedVersion(current, expectedVersion);
+    assertMutationTime(now, current.updated_at);
+    assertIncrementableVersion(current.version, "lease version");
+    assertExactLease(current, {
+      lease_generation: leaseGeneration,
+      target_type: targetType,
+      target_id: targetId,
+    });
+    if (!current.pinned && now >= current.idle_deadline!) {
+      throw new DagActorLeaseConflictError("lease_expired", `DAG actor lease ${runId}/${actorId} has expired`);
+    }
+    const changed = db.prepare(`
+      UPDATE dag_actor_runtimes SET idle_deadline = ?, updated_at = ?, version = version + 1
+      WHERE run_id = ? AND actor_id = ? AND state = 'leased'
+        AND lease_generation = ? AND target_type = ? AND target_id = ? AND version = ?
+    `).run(
+      Math.max(current.idle_deadline!, deadline),
+      now,
+      runId,
+      actorId,
+      leaseGeneration,
+      targetType,
+      targetId,
+      current.version,
+    );
+    if (changed.changes !== 1) {
+      throw new DagActorLeaseConflictError("lease_version_conflict", `DAG actor lease ${runId}/${actorId} changed concurrently`);
+    }
+    return requireLease(runId, actorId);
+  }).immediate();
+}
+
+export function releaseDagActorLease(input: {
+  run_id: string;
+  actor_id: string;
+  lease_generation: number;
+  target_type: string;
+  target_id: string;
+  expected_version?: number;
+  retention_ttl_ms?: number;
+  now?: number;
+}): DagActorLeaseRecord {
+  const runId = assertBoundedString(input.run_id, "run_id", 256);
+  const actorId = assertBoundedString(input.actor_id, "actor_id", 256);
+  const leaseGeneration = assertPositiveSafeInteger(input.lease_generation, "lease_generation");
+  const targetType = assertBoundedString(input.target_type, "target_type", 64);
+  const targetId = assertBoundedString(input.target_id, "target_id", 512);
+  const expectedVersion = assertOptionalExpectedVersion(input.expected_version);
+  const now = assertNow(input.now);
+  const retainedUntil = checkedDeadline(now, retentionTtl(input.retention_ttl_ms), "retained_until");
+  const db = getDb();
+
+  return db.transaction(() => {
+    const current = requireLease(runId, actorId);
+    assertExpectedVersion(current, expectedVersion);
+    assertMutationTime(now, current.updated_at);
+    assertIncrementableVersion(current.version, "lease version");
+    assertExactLease(current, {
+      lease_generation: leaseGeneration,
+      target_type: targetType,
+      target_id: targetId,
+    });
+    const changed = db.prepare(`
+      UPDATE dag_actor_runtimes SET
+        state = 'dormant', target_type = NULL, target_id = NULL,
+        idle_deadline = NULL, retained_until = ?, state_changed_at = ?,
+        updated_at = ?, version = version + 1
+      WHERE run_id = ? AND actor_id = ? AND state = 'leased'
+        AND lease_generation = ? AND target_type = ? AND target_id = ? AND version = ?
+    `).run(
+      retainedUntil,
+      now,
+      now,
+      runId,
+      actorId,
+      leaseGeneration,
+      targetType,
+      targetId,
+      current.version,
+    );
+    if (changed.changes !== 1) {
+      throw new DagActorLeaseConflictError("lease_version_conflict", `DAG actor lease ${runId}/${actorId} changed concurrently`);
+    }
+    return requireLease(runId, actorId);
+  }).immediate();
+}
+
+export function setDagActorLeasePinned(input: {
+  run_id: string;
+  actor_id: string;
+  pinned: boolean;
+  expected_version?: number;
+  retention_ttl_ms?: number;
+  now?: number;
+}): DagActorLeaseRecord {
+  const runId = assertBoundedString(input.run_id, "run_id", 256);
+  const actorId = assertBoundedString(input.actor_id, "actor_id", 256);
+  if (typeof input.pinned !== "boolean") throw new Error("pinned must be a boolean");
+  const expectedVersion = assertOptionalExpectedVersion(input.expected_version);
+  const now = assertNow(input.now);
+  const actorRetentionTtl = retentionTtl(input.retention_ttl_ms);
+  const db = getDb();
+
+  return db.transaction(() => {
+    const current = requireLease(runId, actorId);
+    assertExpectedVersion(current, expectedVersion);
+    if (current.pinned === input.pinned) return current;
+    assertMutationTime(now, current.updated_at);
+    assertIncrementableVersion(current.version, "lease version");
+    if (input.pinned && current.state === "leased" && now >= current.idle_deadline!) {
+      throw new DagActorLeaseConflictError("lease_expired", `DAG actor lease ${runId}/${actorId} has expired`);
+    }
+    if (input.pinned && current.state !== "leased" && now >= current.retained_until!) {
+      throw new DagActorLeaseConflictError(
+        "lease_expired",
+        `DAG actor lease ${runId}/${actorId} has exceeded its retention deadline`,
+      );
+    }
+    const retainedUntil = current.state === "leased"
+      ? null
+      : input.pinned
+        ? current.retained_until!
+        : checkedDeadline(now, actorRetentionTtl, "retained_until");
+    const changed = db.prepare(`
+      UPDATE dag_actor_runtimes SET
+        pinned = ?, retained_until = ?, updated_at = ?, version = version + 1
+      WHERE run_id = ? AND actor_id = ? AND version = ?
+    `).run(input.pinned ? 1 : 0, retainedUntil, now, runId, actorId, current.version);
+    if (changed.changes !== 1) {
+      throw new DagActorLeaseConflictError("lease_version_conflict", `DAG actor lease ${runId}/${actorId} changed concurrently`);
+    }
+    return requireLease(runId, actorId);
+  }).immediate();
+}
+
+export function retireDagActorLease(input: {
+  run_id: string;
+  actor_id: string;
+  expected_version?: number;
+  lease_generation?: number;
+  target_type?: string;
+  target_id?: string;
+  retention_ttl_ms?: number;
+  now?: number;
+}): DagActorLeaseRecord {
+  const runId = assertBoundedString(input.run_id, "run_id", 256);
+  const actorId = assertBoundedString(input.actor_id, "actor_id", 256);
+  const expectedVersion = assertOptionalExpectedVersion(input.expected_version);
+  const leaseGeneration = input.lease_generation === undefined
+    ? undefined
+    : assertPositiveSafeInteger(input.lease_generation, "lease_generation");
+  const targetType = input.target_type === undefined
+    ? undefined
+    : assertBoundedString(input.target_type, "target_type", 64);
+  const targetId = input.target_id === undefined
+    ? undefined
+    : assertBoundedString(input.target_id, "target_id", 512);
+  const now = assertNow(input.now);
+  const retainedUntil = checkedDeadline(now, retentionTtl(input.retention_ttl_ms), "retained_until");
+  const db = getDb();
+
+  return db.transaction(() => {
+    const current = requireLease(runId, actorId);
+    assertExpectedVersion(current, expectedVersion);
+    if (current.state === "retired") return current;
+    assertMutationTime(now, current.updated_at);
+    assertIncrementableVersion(current.version, "lease version");
+    if (current.state === "leased") {
+      if (leaseGeneration === undefined || targetType === undefined || targetId === undefined) {
+        throw new DagActorLeaseConflictError(
+          "lease_target_conflict",
+          "Retiring a leased actor requires the exact lease generation and target",
+        );
+      }
+      assertExactLease(current, {
+        lease_generation: leaseGeneration,
+        target_type: targetType,
+        target_id: targetId,
+      });
+    } else if (leaseGeneration !== undefined || targetType !== undefined || targetId !== undefined) {
+      throw new DagActorLeaseConflictError(
+        "lease_state_conflict",
+        `DAG actor lease ${runId}/${actorId} is ${current.state} and has no current target`,
+      );
+    }
+    const changed = db.prepare(`
+      UPDATE dag_actor_runtimes SET
+        state = 'retired', target_type = NULL, target_id = NULL,
+        idle_deadline = NULL, retained_until = ?, state_changed_at = ?,
+        updated_at = ?, version = version + 1
+      WHERE run_id = ? AND actor_id = ? AND version = ? AND state != 'retired'
+    `).run(retainedUntil, now, now, runId, actorId, current.version);
+    if (changed.changes !== 1) {
+      throw new DagActorLeaseConflictError("lease_version_conflict", `DAG actor lease ${runId}/${actorId} changed concurrently`);
+    }
+    return requireLease(runId, actorId);
+  }).immediate();
+}
+
+export function assessDagActorLease(input: {
+  run_id: string;
+  actor_id: string;
+  lease_generation: number;
+  target_type: string;
+  target_id: string;
+  now?: number;
+}): DagActorLeaseAssessment {
+  const runId = assertBoundedString(input.run_id, "run_id", 256);
+  const actorId = assertBoundedString(input.actor_id, "actor_id", 256);
+  const leaseGeneration = assertPositiveSafeInteger(input.lease_generation, "lease_generation");
+  const targetType = assertBoundedString(input.target_type, "target_type", 64);
+  const targetId = assertBoundedString(input.target_id, "target_id", 512);
+  const now = assertNow(input.now);
+  const lease = getDagActorLease({ run_id: runId, actor_id: actorId });
+  if (!lease) return { current: false, reason: "missing" };
+  if (lease.state !== "leased") return { current: false, reason: "not_leased", lease };
+  if (lease.lease_generation !== leaseGeneration) {
+    return { current: false, reason: "generation_mismatch", lease };
+  }
+  if (lease.target_type !== targetType || lease.target_id !== targetId) {
+    return { current: false, reason: "target_mismatch", lease };
+  }
+  if (!lease.pinned && now >= lease.idle_deadline!) {
+    return { current: false, reason: "expired", lease };
+  }
+  return { current: true, lease };
+}
+
+export function listExpiredDagActorLeases(input: {
+  now?: number;
+  limit?: number;
+} = {}): DagActorLeaseRecord[] {
+  const now = assertNow(input.now);
+  const limit = normalizeListLimit(input.limit);
+  return (getDb().prepare(`
+    SELECT * FROM dag_actor_runtimes
+    WHERE state = 'leased' AND pinned = 0 AND idle_deadline <= ?
+    ORDER BY idle_deadline, run_id, actor_id
+    LIMIT ?
+  `).all(now, limit) as DagActorLeaseRow[]).map(leaseFromRow);
+}
+
+function normalizeCheckpointStringArray(value: unknown, label: string): string[] {
+  if (!Array.isArray(value) || value.length > MAX_DAG_ACTOR_CHECKPOINT_ITEMS) {
+    throw new Error(`${label} must contain at most ${MAX_DAG_ACTOR_CHECKPOINT_ITEMS} strings`);
+  }
+  return value.map((entry, index) => assertContentString(entry, `${label}[${index}]`, 8_192));
+}
+
+function normalizeCheckpoint(value: unknown): DagActorCheckpointV1 {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("checkpoint must be an object");
+  }
+  const raw = value as Record<string, unknown>;
+  const allowed = new Set([
+    "schema_version",
+    "objective",
+    "confirmed_conclusions",
+    "unresolved_items",
+    "key_event_refs",
+    "artifact_refs",
+    "workspace_ref",
+    "surface_binding",
+    "context_summary",
+    "round_id",
+    "actor_generation",
+    "captured_at",
+  ]);
+  const unknownKeys = Object.keys(raw).filter((key) => !allowed.has(key));
+  if (unknownKeys.length > 0) throw new Error(`checkpoint has unknown fields: ${unknownKeys.sort().join(", ")}`);
+  if (raw.schema_version !== 1) throw new Error("checkpoint.schema_version must equal 1");
+  return {
+    schema_version: 1,
+    objective: assertContentString(raw.objective, "checkpoint.objective", 16_384),
+    confirmed_conclusions: normalizeCheckpointStringArray(
+      raw.confirmed_conclusions,
+      "checkpoint.confirmed_conclusions",
+    ),
+    unresolved_items: normalizeCheckpointStringArray(raw.unresolved_items, "checkpoint.unresolved_items"),
+    key_event_refs: normalizeCheckpointStringArray(raw.key_event_refs, "checkpoint.key_event_refs"),
+    artifact_refs: normalizeCheckpointStringArray(raw.artifact_refs, "checkpoint.artifact_refs"),
+    ...(raw.workspace_ref === undefined
+      ? {}
+      : { workspace_ref: assertBoundedString(raw.workspace_ref, "checkpoint.workspace_ref", 2_048) }),
+    surface_binding: assertBoundedString(raw.surface_binding, "checkpoint.surface_binding", 2_048),
+    context_summary: assertContentString(raw.context_summary, "checkpoint.context_summary", 65_536),
+    round_id: assertBoundedString(raw.round_id, "checkpoint.round_id", 256),
+    actor_generation: assertPositiveSafeInteger(raw.actor_generation, "checkpoint.actor_generation"),
+    captured_at: assertNonNegativeSafeInteger(raw.captured_at, "checkpoint.captured_at"),
+  };
+}
+
+function encodeCheckpoint(value: DagActorCheckpointV1): {
+  checkpoint: DagActorCheckpointV1;
+  json: string;
+  sha256: string;
+} {
+  const raw = encodeCanonicalJson(value, "checkpoint", MAX_DAG_ACTOR_CHECKPOINT_BYTES);
+  const redacted = redactTelemetry(parseJsonRow<unknown>(raw));
+  const checkpoint = normalizeCheckpoint(redacted);
+  const json = encodeCanonicalJson(checkpoint, "checkpoint", MAX_DAG_ACTOR_CHECKPOINT_BYTES);
+  return {
+    checkpoint,
+    json,
+    sha256: createHash("sha256").update(json).digest("hex"),
+  };
+}
+
+function checkpointFromRow(row: DagActorCheckpointRow): DagActorCheckpointRecord {
+  const checkpointVersion = assertPositiveSafeInteger(row.checkpoint_version, "persisted checkpoint_version");
+  const createdAt = assertNonNegativeSafeInteger(row.created_at, "persisted checkpoint created_at");
+  const parsed = parseJsonRow<unknown>(row.checkpoint_json);
+  const checkpoint = normalizeCheckpoint(parsed);
+  const canonicalJson = encodeCanonicalJson(checkpoint, "persisted checkpoint", MAX_DAG_ACTOR_CHECKPOINT_BYTES);
+  const sha256 = createHash("sha256").update(canonicalJson).digest("hex");
+  if (canonicalJson !== row.checkpoint_json || sha256 !== row.checkpoint_sha256) {
+    throw new Error(`DAG actor checkpoint ${row.run_id}/${row.actor_id}/${checkpointVersion} failed integrity validation`);
+  }
+  if (
+    row.schema_version !== checkpoint.schema_version
+    || row.actor_generation !== checkpoint.actor_generation
+    || row.round_id !== checkpoint.round_id
+    || row.captured_at !== checkpoint.captured_at
+  ) {
+    throw new Error(`DAG actor checkpoint ${row.run_id}/${row.actor_id}/${checkpointVersion} metadata is inconsistent`);
+  }
+  return {
+    run_id: row.run_id,
+    actor_id: row.actor_id,
+    checkpoint_version: checkpointVersion,
+    checkpoint_sha256: row.checkpoint_sha256,
+    checkpoint,
+    created_at: createdAt,
+  };
+}
+
+export function writeDagActorCheckpoint(input: {
+  run_id: string;
+  actor_id: string;
+  checkpoint: DagActorCheckpointV1;
+  expected_checkpoint_version?: number;
+  now?: number;
+}): DagActorCheckpointRecord {
+  const runId = assertBoundedString(input.run_id, "run_id", 256);
+  const actorId = assertBoundedString(input.actor_id, "actor_id", 256);
+  const expectedCheckpointVersion = input.expected_checkpoint_version === undefined
+    ? undefined
+    : assertNonNegativeSafeInteger(input.expected_checkpoint_version, "expected_checkpoint_version");
+  const now = assertNow(input.now);
+  const encoded = encodeCheckpoint(input.checkpoint);
+  if (encoded.checkpoint.captured_at > now) {
+    throw new Error("checkpoint.captured_at must not be in the future");
+  }
+  const db = getDb();
+
+  return db.transaction(() => {
+    const actor = db.prepare("SELECT generation FROM dag_actors WHERE run_id = ? AND actor_id = ?")
+      .get(runId, actorId) as { generation: number } | undefined;
+    if (!actor) {
+      throw new DagActorLeaseConflictError("actor_not_found", `Unknown DAG actor: ${runId}/${actorId}`);
+    }
+    const actorGeneration = assertPositiveSafeInteger(actor.generation, "persisted actor generation");
+    if (actorGeneration !== encoded.checkpoint.actor_generation) {
+      throw new DagActorLeaseConflictError(
+        "checkpoint_generation_conflict",
+        `Checkpoint generation ${encoded.checkpoint.actor_generation} does not match actor generation ${actorGeneration}`,
+      );
+    }
+    const latest = db.prepare(`
+      SELECT checkpoint_version, captured_at, created_at
+      FROM dag_actor_checkpoints
+      WHERE run_id = ? AND actor_id = ?
+      ORDER BY checkpoint_version DESC
+      LIMIT 1
+    `).get(runId, actorId) as {
+      checkpoint_version: number;
+      captured_at: number;
+      created_at: number;
+    } | undefined;
+    const currentVersion = latest === undefined
+      ? 0
+      : assertPositiveSafeInteger(latest.checkpoint_version, "persisted checkpoint_version");
+    if (latest !== undefined) {
+      const latestCapturedAt = assertNonNegativeSafeInteger(latest.captured_at, "persisted captured_at");
+      const latestCreatedAt = assertNonNegativeSafeInteger(latest.created_at, "persisted checkpoint created_at");
+      if (encoded.checkpoint.captured_at < latestCapturedAt) {
+        throw new Error("checkpoint.captured_at must not precede the latest checkpoint");
+      }
+      if (now < latestCreatedAt) throw new Error("now must not precede the latest checkpoint write");
+    }
+    if (expectedCheckpointVersion !== undefined && currentVersion !== expectedCheckpointVersion) {
+      throw new DagActorLeaseConflictError(
+        "checkpoint_version_conflict",
+        `Latest checkpoint version is ${currentVersion}, expected ${expectedCheckpointVersion}`,
+      );
+    }
+    const checkpointVersion = assertPositiveSafeInteger(currentVersion + 1, "checkpoint_version");
+    db.prepare(`
+      INSERT INTO dag_actor_checkpoints(
+        run_id, actor_id, checkpoint_version, schema_version, actor_generation,
+        round_id, captured_at, checkpoint_sha256, checkpoint_json, created_at
+      ) VALUES (?, ?, ?, 1, ?, ?, ?, ?, ?, ?)
+    `).run(
+      runId,
+      actorId,
+      checkpointVersion,
+      encoded.checkpoint.actor_generation,
+      encoded.checkpoint.round_id,
+      encoded.checkpoint.captured_at,
+      encoded.sha256,
+      encoded.json,
+      now,
+    );
+    const row = db.prepare(`
+      SELECT * FROM dag_actor_checkpoints
+      WHERE run_id = ? AND actor_id = ? AND checkpoint_version = ?
+    `).get(runId, actorId, checkpointVersion) as DagActorCheckpointRow;
+    return checkpointFromRow(row);
+  }).immediate();
+}
+
+export function getLatestDagActorCheckpoint(input: {
+  run_id: string;
+  actor_id: string;
+}): DagActorCheckpointRecord | undefined {
+  const runId = assertBoundedString(input.run_id, "run_id", 256);
+  const actorId = assertBoundedString(input.actor_id, "actor_id", 256);
+  const row = getDb().prepare(`
+    SELECT * FROM dag_actor_checkpoints
+    WHERE run_id = ? AND actor_id = ?
+    ORDER BY checkpoint_version DESC
+    LIMIT 1
+  `).get(runId, actorId) as DagActorCheckpointRow | undefined;
+  return row ? checkpointFromRow(row) : undefined;
+}
+
+export function deleteExpiredDagActorRuntime(input: {
+  run_id: string;
+  actor_id: string;
+  now?: number;
+}): {
+  deleted: boolean;
+  deleted_checkpoints: number;
+  reason?: "missing" | "leased" | "pinned" | "retained" | "worker_cleanup_pending";
+} {
+  const runId = assertBoundedString(input.run_id, "run_id", 256);
+  const actorId = assertBoundedString(input.actor_id, "actor_id", 256);
+  const now = assertNow(input.now);
+  const db = getDb();
+
+  return db.transaction(() => {
+    const current = getDagActorLease({ run_id: runId, actor_id: actorId });
+    if (!current) return { deleted: false, deleted_checkpoints: 0, reason: "missing" as const };
+    if (current.state === "leased") return { deleted: false, deleted_checkpoints: 0, reason: "leased" as const };
+    if (current.pinned) return { deleted: false, deleted_checkpoints: 0, reason: "pinned" as const };
+    if (current.retained_until! > now) {
+      return { deleted: false, deleted_checkpoints: 0, reason: "retained" as const };
+    }
+    const pendingWorker = db.prepare(`
+      SELECT 1 FROM dag_actor_provisioned_workers
+      WHERE run_id = ? AND actor_id = ? AND status != 'released'
+      LIMIT 1
+    `).get(runId, actorId);
+    if (pendingWorker) {
+      return { deleted: false, deleted_checkpoints: 0, reason: "worker_cleanup_pending" as const };
+    }
+    const checkpointCount = Number((db.prepare(`
+      SELECT COUNT(*) AS count FROM dag_actor_checkpoints WHERE run_id = ? AND actor_id = ?
+    `).get(runId, actorId) as { count: number }).count);
+    const deleted = db.prepare(`
+      DELETE FROM dag_actors
+      WHERE run_id = ? AND actor_id = ?
+        AND EXISTS (
+          SELECT 1 FROM dag_actor_runtimes runtime
+          WHERE runtime.run_id = dag_actors.run_id
+            AND runtime.actor_id = dag_actors.actor_id
+            AND runtime.state IN ('dormant', 'retired')
+            AND runtime.pinned = 0
+            AND runtime.retained_until <= ?
+            AND runtime.version = ?
+        )
+        AND NOT EXISTS (
+          SELECT 1 FROM dag_actor_provisioned_workers worker
+          WHERE worker.run_id = dag_actors.run_id
+            AND worker.actor_id = dag_actors.actor_id
+            AND worker.status != 'released'
+        )
+    `).run(runId, actorId, now, current.version);
+    if (deleted.changes !== 1) {
+      throw new DagActorLeaseConflictError("lease_version_conflict", `DAG actor lease ${runId}/${actorId} changed concurrently`);
+    }
+    return { deleted: true, deleted_checkpoints: checkpointCount };
+  }).immediate();
+}
+
+function getProvisionedWorkerRow(input: {
+  run_id: string;
+  actor_id: string;
+  lease_generation: number;
+  worker_id: string;
+}): DagProvisionedWorkerRow | undefined {
+  return getDb().prepare(`
+    SELECT * FROM dag_actor_provisioned_workers
+    WHERE run_id = ? AND actor_id = ? AND lease_generation = ? AND worker_id = ?
+  `).get(input.run_id, input.actor_id, input.lease_generation, input.worker_id) as
+    | DagProvisionedWorkerRow
+    | undefined;
+}
+
+function provisionedWorkerFromRow(row: DagProvisionedWorkerRow): DagProvisionedWorkerRecord {
+  if (!PROVISIONED_WORKER_STATUSES.has(row.status)) {
+    throw new Error(`Provisioned worker ${row.worker_id} has invalid status ${row.status}`);
+  }
+  const status = row.status as DagProvisionedWorkerStatus;
+  const leaseGeneration = assertPositiveSafeInteger(row.lease_generation, "persisted lease_generation");
+  const registeredAt = assertNonNegativeSafeInteger(row.registered_at, "persisted registered_at");
+  const updatedAt = assertNonNegativeSafeInteger(row.updated_at, "persisted updated_at");
+  const version = assertPositiveSafeInteger(row.version, "persisted version");
+  if (updatedAt < registeredAt) throw new Error(`Provisioned worker ${row.worker_id} has invalid timestamps`);
+  const releaseRequestedAt = row.release_requested_at === null
+    ? undefined
+    : assertNonNegativeSafeInteger(row.release_requested_at, "persisted release_requested_at");
+  const terminalAt = row.terminal_at === null
+    ? undefined
+    : assertNonNegativeSafeInteger(row.terminal_at, "persisted terminal_at");
+  const failure = row.failure_json === null ? undefined : parseJsonRow<unknown>(row.failure_json);
+  if (row.failure_json !== null) {
+    if (failure === null) throw new Error(`Provisioned worker ${row.worker_id} has invalid failure data`);
+    const canonicalFailure = encodeCanonicalJson(
+      failure,
+      "persisted provisioned worker failure",
+      MAX_DAG_PROVISIONED_WORKER_FAILURE_BYTES,
+    );
+    if (canonicalFailure !== row.failure_json) {
+      throw new Error(`Provisioned worker ${row.worker_id} has non-canonical failure data`);
+    }
+  }
+  const coherent =
+    (status === "active" && releaseRequestedAt === undefined && terminalAt === undefined && failure === undefined)
+    || (status === "releasing" && releaseRequestedAt !== undefined && terminalAt === undefined && failure === undefined)
+    || (status === "released" && releaseRequestedAt !== undefined && terminalAt !== undefined && failure === undefined)
+    || (status === "failed" && terminalAt !== undefined && failure !== undefined);
+  if (!coherent) throw new Error(`Provisioned worker ${row.worker_id} has incoherent lifecycle data`);
+  return {
+    run_id: row.run_id,
+    node_id: assertBoundedString(row.node_id, "persisted node_id", 256),
+    actor_id: row.actor_id,
+    lease_generation: leaseGeneration,
+    worker_id: assertBoundedString(row.worker_id, "persisted worker_id", 256),
+    container_id: assertBoundedString(row.container_id, "persisted container_id", 512),
+    docker_node_id: assertBoundedString(row.docker_node_id, "persisted docker_node_id", 256),
+    status,
+    registered_at: registeredAt,
+    updated_at: updatedAt,
+    ...(releaseRequestedAt === undefined ? {} : { release_requested_at: releaseRequestedAt }),
+    ...(terminalAt === undefined ? {} : { terminal_at: terminalAt }),
+    ...(failure === undefined ? {} : { failure }),
+    version,
+  };
+}
+
+export function registerDagProvisionedWorker(input: {
+  run_id: string;
+  node_id: string;
+  actor_id: string;
+  lease_generation: number;
+  worker_id: string;
+  container_id: string;
+  docker_node_id: string;
+  now?: number;
+}): DagProvisionedWorkerRecord {
+  const runId = assertBoundedString(input.run_id, "run_id", 256);
+  const nodeId = assertBoundedString(input.node_id, "node_id", 256);
+  const actorId = assertBoundedString(input.actor_id, "actor_id", 256);
+  const leaseGeneration = assertPositiveSafeInteger(input.lease_generation, "lease_generation");
+  const workerId = assertBoundedString(input.worker_id, "worker_id", 256);
+  const containerId = assertBoundedString(input.container_id, "container_id", 512);
+  const dockerNodeId = assertBoundedString(input.docker_node_id, "docker_node_id", 256);
+  const now = assertNow(input.now);
+  const db = getDb();
+
+  return db.transaction(() => {
+    const actor = db.prepare("SELECT node_id FROM dag_actors WHERE run_id = ? AND actor_id = ?")
+      .get(runId, actorId) as { node_id: string } | undefined;
+    if (!actor) {
+      throw new DagActorLeaseConflictError("actor_not_found", `Unknown DAG actor: ${runId}/${actorId}`);
+    }
+    if (actor.node_id !== nodeId) {
+      throw new DagActorLeaseConflictError(
+        "provisioned_worker_identity_conflict",
+        `DAG actor ${runId}/${actorId} belongs to node ${actor.node_id}, not ${nodeId}`,
+      );
+    }
+    const lease = requireLease(runId, actorId);
+    assertMutationTime(now, lease.updated_at);
+    if (lease.state !== "leased") {
+      throw new DagActorLeaseConflictError("lease_state_conflict", `DAG actor lease ${runId}/${actorId} is not leased`);
+    }
+    if (lease.lease_generation !== leaseGeneration) {
+      throw new DagActorLeaseConflictError(
+        "lease_generation_conflict",
+        `DAG actor lease ${runId}/${actorId} generation is ${lease.lease_generation}, expected ${leaseGeneration}`,
+      );
+    }
+    if (lease.target_id !== workerId) {
+      throw new DagActorLeaseConflictError(
+        "lease_target_conflict",
+        `DAG actor lease ${runId}/${actorId} targets ${lease.target_id}, not worker ${workerId}`,
+      );
+    }
+    if (!lease.pinned && now >= lease.idle_deadline!) {
+      throw new DagActorLeaseConflictError("lease_expired", `DAG actor lease ${runId}/${actorId} has expired`);
+    }
+    const existing = getProvisionedWorkerRow({
+      run_id: runId,
+      actor_id: actorId,
+      lease_generation: leaseGeneration,
+      worker_id: workerId,
+    });
+    if (existing) {
+      if (
+        existing.node_id !== nodeId
+        || existing.container_id !== containerId
+        || existing.docker_node_id !== dockerNodeId
+      ) {
+        throw new DagActorLeaseConflictError(
+          "provisioned_worker_identity_conflict",
+          `Provisioned worker ${workerId} is already registered with different ownership`,
+        );
+      }
+      return provisionedWorkerFromRow(existing);
+    }
+    try {
+      db.prepare(`
+        INSERT INTO dag_actor_provisioned_workers(
+          run_id, actor_id, lease_generation, worker_id, node_id, container_id,
+          docker_node_id, status, registered_at, updated_at, version
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, 1)
+      `).run(
+        runId,
+        actorId,
+        leaseGeneration,
+        workerId,
+        nodeId,
+        containerId,
+        dockerNodeId,
+        now,
+        now,
+      );
+    } catch (cause) {
+      if (!(cause instanceof Error) || !cause.message.includes("UNIQUE constraint failed")) throw cause;
+      throw new DagActorLeaseConflictError(
+        "provisioned_worker_identity_conflict",
+        `Provisioned worker ${workerId} conflicts with existing ownership: ${cause instanceof Error ? cause.message : String(cause)}`,
+      );
+    }
+    return provisionedWorkerFromRow(getProvisionedWorkerRow({
+      run_id: runId,
+      actor_id: actorId,
+      lease_generation: leaseGeneration,
+      worker_id: workerId,
+    })!);
+  }).immediate();
+}
+
+export function listDagProvisionedWorkers(input: {
+  run_id?: string;
+  actor_id?: string;
+  lease_generation?: number;
+  statuses?: readonly DagProvisionedWorkerStatus[];
+  limit?: number;
+} = {}): DagProvisionedWorkerRecord[] {
+  const conditions: string[] = [];
+  const params: Array<string | number> = [];
+  if (input.run_id !== undefined) {
+    conditions.push("run_id = ?");
+    params.push(assertBoundedString(input.run_id, "run_id", 256));
+  }
+  if (input.actor_id !== undefined) {
+    conditions.push("actor_id = ?");
+    params.push(assertBoundedString(input.actor_id, "actor_id", 256));
+  }
+  if (input.lease_generation !== undefined) {
+    conditions.push("lease_generation = ?");
+    params.push(assertPositiveSafeInteger(input.lease_generation, "lease_generation"));
+  }
+  if (input.statuses !== undefined) {
+    const statuses = Array.from(new Set(input.statuses));
+    if (statuses.length < 1 || statuses.some((status) => !PROVISIONED_WORKER_STATUSES.has(status))) {
+      throw new Error("statuses must contain one or more valid provisioned worker statuses");
+    }
+    conditions.push(`status IN (${statuses.map(() => "?").join(", ")})`);
+    params.push(...statuses);
+  }
+  params.push(normalizeListLimit(input.limit));
+  const where = conditions.length === 0 ? "" : `WHERE ${conditions.join(" AND ")}`;
+  return (getDb().prepare(`
+    SELECT * FROM dag_actor_provisioned_workers
+    ${where}
+    ORDER BY registered_at, run_id, actor_id, lease_generation, worker_id
+    LIMIT ?
+  `).all(...params) as DagProvisionedWorkerRow[]).map(provisionedWorkerFromRow);
+}
+
+export function transitionDagProvisionedWorker(input: {
+  run_id: string;
+  actor_id: string;
+  lease_generation: number;
+  worker_id: string;
+  expected_status: DagProvisionedWorkerStatus;
+  status: DagProvisionedWorkerStatus;
+  expected_version?: number;
+  failure?: unknown;
+  now?: number;
+}): DagProvisionedWorkerRecord {
+  const runId = assertBoundedString(input.run_id, "run_id", 256);
+  const actorId = assertBoundedString(input.actor_id, "actor_id", 256);
+  const leaseGeneration = assertPositiveSafeInteger(input.lease_generation, "lease_generation");
+  const workerId = assertBoundedString(input.worker_id, "worker_id", 256);
+  if (!PROVISIONED_WORKER_STATUSES.has(input.expected_status)) throw new Error("expected_status is invalid");
+  if (!PROVISIONED_WORKER_STATUSES.has(input.status)) throw new Error("status is invalid");
+  const expectedVersion = assertOptionalExpectedVersion(input.expected_version);
+  const now = assertNow(input.now);
+  const allowed = new Set([
+    "active:releasing",
+    "active:failed",
+    "releasing:released",
+    "releasing:failed",
+    "failed:releasing",
+  ]);
+  if (!allowed.has(`${input.expected_status}:${input.status}`)) {
+    throw new DagActorLeaseConflictError(
+      "provisioned_worker_status_conflict",
+      `Invalid provisioned worker transition ${input.expected_status} -> ${input.status}`,
+    );
+  }
+  if (input.status === "failed" && (input.failure === undefined || input.failure === null)) {
+    throw new Error("failure is required when transitioning a provisioned worker to failed");
+  }
+  if (input.status !== "failed" && input.failure !== undefined) {
+    throw new Error("failure is only valid when transitioning a provisioned worker to failed");
+  }
+  const failureJson = input.status === "failed"
+    ? encodeCanonicalJson(
+        redactTelemetry(input.failure),
+        "provisioned worker failure",
+        MAX_DAG_PROVISIONED_WORKER_FAILURE_BYTES,
+      )
+    : null;
+  const db = getDb();
+
+  return db.transaction(() => {
+    const row = getProvisionedWorkerRow({
+      run_id: runId,
+      actor_id: actorId,
+      lease_generation: leaseGeneration,
+      worker_id: workerId,
+    });
+    if (!row) {
+      throw new DagActorLeaseConflictError(
+        "provisioned_worker_identity_conflict",
+        `Unknown provisioned worker: ${runId}/${actorId}/${leaseGeneration}/${workerId}`,
+      );
+    }
+    const current = provisionedWorkerFromRow(row);
+    if (current.status !== input.expected_status) {
+      throw new DagActorLeaseConflictError(
+        "provisioned_worker_status_conflict",
+        `Provisioned worker ${workerId} is ${current.status}, expected ${input.expected_status}`,
+      );
+    }
+    if (expectedVersion !== undefined && current.version !== expectedVersion) {
+      throw new DagActorLeaseConflictError(
+        "provisioned_worker_version_conflict",
+        `Provisioned worker ${workerId} version is ${current.version}, expected ${expectedVersion}`,
+      );
+    }
+    assertMutationTime(now, current.updated_at);
+    assertIncrementableVersion(current.version, "provisioned worker version");
+    const releaseRequestedAt = input.status === "releasing"
+      ? now
+      : current.release_requested_at ?? null;
+    const terminalAt = input.status === "released" || input.status === "failed" ? now : null;
+    const changed = db.prepare(`
+      UPDATE dag_actor_provisioned_workers SET
+        status = ?, release_requested_at = ?, terminal_at = ?, failure_json = ?,
+        updated_at = ?, version = version + 1
+      WHERE run_id = ? AND actor_id = ? AND lease_generation = ?
+        AND worker_id = ? AND status = ? AND version = ?
+    `).run(
+      input.status,
+      releaseRequestedAt,
+      terminalAt,
+      failureJson,
+      now,
+      runId,
+      actorId,
+      leaseGeneration,
+      workerId,
+      input.expected_status,
+      current.version,
+    );
+    if (changed.changes !== 1) {
+      throw new DagActorLeaseConflictError(
+        "provisioned_worker_status_conflict",
+        `Provisioned worker ${workerId} changed concurrently`,
+      );
+    }
+    return provisionedWorkerFromRow(getProvisionedWorkerRow({
+      run_id: runId,
+      actor_id: actorId,
+      lease_generation: leaseGeneration,
+      worker_id: workerId,
+    })!);
+  }).immediate();
+}

--- a/homerail_manager/src/persistence/db.ts
+++ b/homerail_manager/src/persistence/db.ts
@@ -35,6 +35,9 @@ const CLEARABLE_TABLES = new Set([
   "dag_handoffs",
   "dag_artifacts",
   "dag_run_rounds",
+  "dag_actor_provisioned_workers",
+  "dag_actor_checkpoints",
+  "dag_actor_runtimes",
   "dag_actor_commands",
   "dag_actors",
   "dag_activity_events",
@@ -668,7 +671,7 @@ function validateDagActorSchemaV20(db: SqliteDatabase): void {
   }
 }
 
-function compactSchemaSql(db: SqliteDatabase, type: "table" | "index", name: string): string {
+function compactSchemaSql(db: SqliteDatabase, type: "table" | "index" | "trigger", name: string): string {
   const row = db.prepare("SELECT sql FROM sqlite_master WHERE type = ? AND name = ?")
     .get(type, name) as { sql: string | null } | undefined;
   return row?.sql?.toLowerCase().replace(/\s+/g, "") ?? "";
@@ -839,6 +842,204 @@ function validateDagRunRoundSchemaV23(db: SqliteDatabase): void {
   validateDagActorSchemaV20(db);
   if (!dagActorCommandsSupportsCancelled(db)) {
     throw new Error("Schema migration 23 is incomplete: dag_actor_commands does not support cancelled commands");
+  }
+}
+
+function validateDagActorLeaseSchemaV24(db: SqliteDatabase): void {
+  const expectedTables = {
+    dag_actor_runtimes: [
+      ["run_id", "TEXT", 1, 1, null],
+      ["actor_id", "TEXT", 1, 2, null],
+      ["state", "TEXT", 1, 0, null],
+      ["lease_generation", "INTEGER", 1, 0, "0"],
+      ["target_type", "TEXT", 0, 0, null],
+      ["target_id", "TEXT", 0, 0, null],
+      ["idle_deadline", "INTEGER", 0, 0, null],
+      ["pinned", "INTEGER", 1, 0, "0"],
+      ["retained_until", "INTEGER", 0, 0, null],
+      ["state_changed_at", "INTEGER", 1, 0, null],
+      ["created_at", "INTEGER", 1, 0, null],
+      ["updated_at", "INTEGER", 1, 0, null],
+      ["version", "INTEGER", 1, 0, "1"],
+    ],
+    dag_actor_checkpoints: [
+      ["run_id", "TEXT", 1, 1, null],
+      ["actor_id", "TEXT", 1, 2, null],
+      ["checkpoint_version", "INTEGER", 1, 3, null],
+      ["schema_version", "INTEGER", 1, 0, null],
+      ["actor_generation", "INTEGER", 1, 0, null],
+      ["round_id", "TEXT", 1, 0, null],
+      ["captured_at", "INTEGER", 1, 0, null],
+      ["checkpoint_sha256", "TEXT", 1, 0, null],
+      ["checkpoint_json", "TEXT", 1, 0, null],
+      ["created_at", "INTEGER", 1, 0, null],
+    ],
+    dag_actor_provisioned_workers: [
+      ["run_id", "TEXT", 1, 1, null],
+      ["actor_id", "TEXT", 1, 2, null],
+      ["lease_generation", "INTEGER", 1, 3, null],
+      ["worker_id", "TEXT", 1, 4, null],
+      ["node_id", "TEXT", 1, 0, null],
+      ["container_id", "TEXT", 1, 0, null],
+      ["docker_node_id", "TEXT", 1, 0, null],
+      ["status", "TEXT", 1, 0, null],
+      ["registered_at", "INTEGER", 1, 0, null],
+      ["updated_at", "INTEGER", 1, 0, null],
+      ["release_requested_at", "INTEGER", 0, 0, null],
+      ["terminal_at", "INTEGER", 0, 0, null],
+      ["failure_json", "TEXT", 0, 0, null],
+      ["version", "INTEGER", 1, 0, "1"],
+    ],
+  } as const;
+
+  for (const [table, expectedColumns] of Object.entries(expectedTables)) {
+    if (!hasTable(db, table)) {
+      throw new Error(`Schema migration 24 is incomplete: missing table ${table}`);
+    }
+    const columns = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{
+      name: string;
+      type: string;
+      notnull: number;
+      dflt_value: string | number | null;
+      pk: number;
+    }>;
+    if (columns.length !== expectedColumns.length) {
+      throw new Error(`Schema migration 24 is incomplete: ${table} has invalid columns`);
+    }
+    for (const [position, [name, type, notnull, pk, defaultValue]] of expectedColumns.entries()) {
+      const column = columns[position];
+      if (
+        column.name !== name
+        || column.type.toUpperCase() !== type
+        || column.notnull !== notnull
+        || column.pk !== pk
+        || (column.dflt_value === null ? null : String(column.dflt_value)) !== defaultValue
+      ) {
+        throw new Error(`Schema migration 24 is incomplete: ${table} column ${name} is invalid`);
+      }
+    }
+  }
+
+  const tableFragments: Record<string, readonly string[]> = {
+    dag_actor_runtimes: [
+      "statein('leased','dormant','retired')",
+      "check(lease_generation>=0)",
+      "check(pinnedin(0,1))",
+      "check(version>=1)",
+      "updated_at>=created_at",
+      "state_changed_at>=created_at",
+      "state_changed_at<=updated_at",
+      "state='leased'andlease_generation>=1",
+      "target_typeisnotnull",
+      "target_idisnotnull",
+      "idle_deadlineisnotnull",
+      "idle_deadline>=state_changed_at",
+      "retained_untilisnull",
+      "statein('dormant','retired')",
+      "target_typeisnull",
+      "target_idisnull",
+      "idle_deadlineisnull",
+      "retained_untilisnotnull",
+      "retained_until>=updated_at",
+    ],
+    dag_actor_checkpoints: [
+      "check(checkpoint_version>=1)",
+      "check(schema_version=1)",
+      "check(actor_generation>=1)",
+      "check(captured_at>=0)",
+      "length(checkpoint_sha256)=64",
+      "checkpoint_sha256notglob'*[^0-9a-f]*'",
+      "length(checkpoint_json)between2and262144",
+      "check(created_at>=0)",
+    ],
+    dag_actor_provisioned_workers: [
+      "check(lease_generation>=1)",
+      "statusin('active','releasing','released','failed')",
+      "check(version>=1)",
+      "updated_at>=registered_at",
+      "release_requested_atisnullorrelease_requested_at>=registered_at",
+      "terminal_atisnullorterminal_at>=registered_at",
+      "status='active'andrelease_requested_atisnullandterminal_atisnullandfailure_jsonisnull",
+      "status='releasing'andrelease_requested_atisnotnullandterminal_atisnullandfailure_jsonisnull",
+      "status='released'andrelease_requested_atisnotnullandterminal_atisnotnullandfailure_jsonisnull",
+      "status='failed'andterminal_atisnotnullandfailure_jsonisnotnull",
+    ],
+  };
+  for (const [table, fragments] of Object.entries(tableFragments)) {
+    const sql = compactSchemaSql(db, "table", table);
+    if (fragments.some((fragment) => !sql.includes(fragment))) {
+      throw new Error(`Schema migration 24 is incomplete: ${table} constraints are invalid`);
+    }
+  }
+
+  const expectedIndexes = [
+    ["dag_actor_runtimes", "idx_dag_actor_runtimes_expired", 0, 1, ["idle_deadline", "run_id", "actor_id"]],
+    ["dag_actor_runtimes", "idx_dag_actor_runtimes_retention", 0, 1, ["retained_until", "run_id", "actor_id"]],
+    ["dag_actor_checkpoints", "idx_dag_actor_checkpoints_generation", 0, 0, ["run_id", "actor_id", "actor_generation", "checkpoint_version"]],
+    ["dag_actor_provisioned_workers", "idx_dag_actor_provisioned_workers_container", 1, 0, ["container_id"]],
+    ["dag_actor_provisioned_workers", "idx_dag_actor_provisioned_workers_restart", 0, 0, ["status", "docker_node_id", "updated_at", "run_id", "actor_id"]],
+    ["dag_actor_provisioned_workers", "idx_dag_actor_provisioned_workers_current", 1, 1, ["run_id", "actor_id", "lease_generation"]],
+  ] as const;
+  for (const [table, name, unique, partial, expectedColumns] of expectedIndexes) {
+    const index = (db.prepare(`PRAGMA index_list(${table})`).all() as Array<{
+      name: string;
+      unique: number;
+      partial: number;
+    }>).find((entry) => entry.name === name);
+    if (index?.unique !== unique || index.partial !== partial) {
+      throw new Error(`Schema migration 24 is incomplete: index ${name} is missing or invalid`);
+    }
+    const actualColumns = (db.prepare(`PRAGMA index_info(${name})`).all() as Array<{
+      seqno: number;
+      name: string;
+    }>).sort((left, right) => left.seqno - right.seqno).map((entry) => entry.name);
+    if (
+      actualColumns.length !== expectedColumns.length
+      || actualColumns.some((column, position) => column !== expectedColumns[position])
+    ) {
+      throw new Error(`Schema migration 24 is incomplete: index ${name} has invalid columns`);
+    }
+  }
+  const indexPredicates: Record<string, string> = {
+    idx_dag_actor_runtimes_expired: "wherestate='leased'andpinned=0",
+    idx_dag_actor_runtimes_retention: "wherestatein('dormant','retired')andpinned=0",
+    idx_dag_actor_provisioned_workers_current: "wherestatusin('active','releasing')",
+  };
+  for (const [name, predicate] of Object.entries(indexPredicates)) {
+    if (!compactSchemaSql(db, "index", name).includes(predicate)) {
+      throw new Error(`Schema migration 24 is incomplete: index ${name} predicate is invalid`);
+    }
+  }
+
+  for (const table of Object.keys(expectedTables)) {
+    const foreignKeys = (db.prepare(`PRAGMA foreign_key_list(${table})`).all() as Array<{
+      id: number;
+      seq: number;
+      table: string;
+      from: string;
+      to: string;
+      on_update: string;
+      on_delete: string;
+    }>).sort((left, right) => left.seq - right.seq);
+    if (
+      foreignKeys.length !== 2
+      || foreignKeys[0].id !== foreignKeys[1].id
+      || foreignKeys[0].table !== "dag_actors"
+      || foreignKeys[1].table !== "dag_actors"
+      || foreignKeys[0].from !== "run_id"
+      || foreignKeys[0].to !== "run_id"
+      || foreignKeys[1].from !== "actor_id"
+      || foreignKeys[1].to !== "actor_id"
+      || foreignKeys.some((entry) => entry.on_update.toUpperCase() !== "RESTRICT")
+      || foreignKeys.some((entry) => entry.on_delete.toUpperCase() !== "CASCADE")
+    ) {
+      throw new Error(`Schema migration 24 is incomplete: ${table} actor ownership constraint is invalid`);
+    }
+  }
+
+  const checkpointTrigger = compactSchemaSql(db, "trigger", "trg_dag_actor_checkpoints_no_update");
+  if (!checkpointTrigger.includes("beforeupdateondag_actor_checkpoints") || !checkpointTrigger.includes("raise(abort,'dagactorcheckpointsareappend-only')")) {
+    throw new Error("Schema migration 24 is incomplete: checkpoint append-only trigger is missing or invalid");
   }
 }
 
@@ -2252,6 +2453,119 @@ const SCHEMA_MIGRATIONS: readonly SchemaMigration[] = [
       `);
     },
     validate: validateDagRunRoundSchemaV23,
+  },
+  {
+    version: 24,
+    up: (db) => db.exec(`
+      CREATE TABLE IF NOT EXISTS dag_actor_runtimes (
+        run_id TEXT NOT NULL,
+        actor_id TEXT NOT NULL,
+        state TEXT NOT NULL CHECK(state IN ('leased', 'dormant', 'retired')),
+        lease_generation INTEGER NOT NULL DEFAULT 0 CHECK(lease_generation >= 0),
+        target_type TEXT,
+        target_id TEXT,
+        idle_deadline INTEGER,
+        pinned INTEGER NOT NULL DEFAULT 0 CHECK(pinned IN (0, 1)),
+        retained_until INTEGER,
+        state_changed_at INTEGER NOT NULL CHECK(state_changed_at >= 0),
+        created_at INTEGER NOT NULL CHECK(created_at >= 0),
+        updated_at INTEGER NOT NULL CHECK(updated_at >= created_at),
+        version INTEGER NOT NULL DEFAULT 1 CHECK(version >= 1),
+        PRIMARY KEY(run_id, actor_id),
+        CHECK(state_changed_at >= created_at AND state_changed_at <= updated_at),
+        CHECK(
+          (
+            state = 'leased'
+            AND lease_generation >= 1
+            AND target_type IS NOT NULL
+            AND length(target_type) BETWEEN 1 AND 64
+            AND target_id IS NOT NULL
+            AND length(target_id) BETWEEN 1 AND 512
+            AND idle_deadline IS NOT NULL
+            AND idle_deadline >= state_changed_at
+            AND retained_until IS NULL
+          )
+          OR (
+            state IN ('dormant', 'retired')
+            AND target_type IS NULL
+            AND target_id IS NULL
+            AND idle_deadline IS NULL
+            AND retained_until IS NOT NULL
+            AND retained_until >= updated_at
+          )
+        ),
+        FOREIGN KEY(run_id, actor_id) REFERENCES dag_actors(run_id, actor_id)
+          ON UPDATE RESTRICT ON DELETE CASCADE
+      );
+      CREATE INDEX IF NOT EXISTS idx_dag_actor_runtimes_expired
+        ON dag_actor_runtimes(idle_deadline, run_id, actor_id)
+        WHERE state = 'leased' AND pinned = 0;
+      CREATE INDEX IF NOT EXISTS idx_dag_actor_runtimes_retention
+        ON dag_actor_runtimes(retained_until, run_id, actor_id)
+        WHERE state IN ('dormant', 'retired') AND pinned = 0;
+
+      CREATE TABLE IF NOT EXISTS dag_actor_checkpoints (
+        run_id TEXT NOT NULL,
+        actor_id TEXT NOT NULL,
+        checkpoint_version INTEGER NOT NULL CHECK(checkpoint_version >= 1),
+        schema_version INTEGER NOT NULL CHECK(schema_version = 1),
+        actor_generation INTEGER NOT NULL CHECK(actor_generation >= 1),
+        round_id TEXT NOT NULL CHECK(length(round_id) BETWEEN 1 AND 256),
+        captured_at INTEGER NOT NULL CHECK(captured_at >= 0),
+        checkpoint_sha256 TEXT NOT NULL CHECK(
+          length(checkpoint_sha256) = 64
+          AND checkpoint_sha256 NOT GLOB '*[^0-9a-f]*'
+        ),
+        checkpoint_json TEXT NOT NULL CHECK(length(checkpoint_json) BETWEEN 2 AND 262144),
+        created_at INTEGER NOT NULL CHECK(created_at >= 0),
+        PRIMARY KEY(run_id, actor_id, checkpoint_version),
+        FOREIGN KEY(run_id, actor_id) REFERENCES dag_actors(run_id, actor_id)
+          ON UPDATE RESTRICT ON DELETE CASCADE
+      );
+      CREATE INDEX IF NOT EXISTS idx_dag_actor_checkpoints_generation
+        ON dag_actor_checkpoints(run_id, actor_id, actor_generation, checkpoint_version);
+      CREATE TRIGGER IF NOT EXISTS trg_dag_actor_checkpoints_no_update
+      BEFORE UPDATE ON dag_actor_checkpoints
+      BEGIN
+        SELECT RAISE(ABORT, 'DAG actor checkpoints are append-only');
+      END;
+
+      CREATE TABLE IF NOT EXISTS dag_actor_provisioned_workers (
+        run_id TEXT NOT NULL,
+        actor_id TEXT NOT NULL,
+        lease_generation INTEGER NOT NULL CHECK(lease_generation >= 1),
+        worker_id TEXT NOT NULL CHECK(length(worker_id) BETWEEN 1 AND 256),
+        node_id TEXT NOT NULL CHECK(length(node_id) BETWEEN 1 AND 256),
+        container_id TEXT NOT NULL CHECK(length(container_id) BETWEEN 1 AND 512),
+        docker_node_id TEXT NOT NULL CHECK(length(docker_node_id) BETWEEN 1 AND 256),
+        status TEXT NOT NULL CHECK(status IN ('active', 'releasing', 'released', 'failed')),
+        registered_at INTEGER NOT NULL CHECK(registered_at >= 0),
+        updated_at INTEGER NOT NULL CHECK(updated_at >= registered_at),
+        release_requested_at INTEGER CHECK(
+          release_requested_at IS NULL OR release_requested_at >= registered_at
+        ),
+        terminal_at INTEGER CHECK(terminal_at IS NULL OR terminal_at >= registered_at),
+        failure_json TEXT CHECK(failure_json IS NULL OR length(failure_json) BETWEEN 2 AND 65536),
+        version INTEGER NOT NULL DEFAULT 1 CHECK(version >= 1),
+        PRIMARY KEY(run_id, actor_id, lease_generation, worker_id),
+        CHECK(
+          (status = 'active' AND release_requested_at IS NULL AND terminal_at IS NULL AND failure_json IS NULL)
+          OR (status = 'releasing' AND release_requested_at IS NOT NULL AND terminal_at IS NULL AND failure_json IS NULL)
+          OR (status = 'released' AND release_requested_at IS NOT NULL AND terminal_at IS NOT NULL AND failure_json IS NULL)
+          OR (status = 'failed' AND terminal_at IS NOT NULL AND failure_json IS NOT NULL)
+        ),
+        FOREIGN KEY(run_id, actor_id) REFERENCES dag_actors(run_id, actor_id)
+          ON UPDATE RESTRICT ON DELETE CASCADE
+      );
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_dag_actor_provisioned_workers_container
+        ON dag_actor_provisioned_workers(container_id);
+      CREATE INDEX IF NOT EXISTS idx_dag_actor_provisioned_workers_restart
+        ON dag_actor_provisioned_workers(status, docker_node_id, updated_at, run_id, actor_id);
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_dag_actor_provisioned_workers_current
+        ON dag_actor_provisioned_workers(run_id, actor_id, lease_generation)
+        WHERE status IN ('active', 'releasing');
+    `),
+    validate: validateDagActorLeaseSchemaV24,
   },
 ];
 

--- a/homerail_manager/src/runtime/active-runs.ts
+++ b/homerail_manager/src/runtime/active-runs.ts
@@ -102,6 +102,15 @@ import {
   updateDagActorBinding,
   type DagActorRecord,
 } from "../persistence/dag-actors.js";
+import {
+  acquireDagActorLease,
+  ensureDagActorLease,
+  getDagActorLease,
+  getLatestDagActorCheckpoint,
+  retireDagActorLease,
+  writeDagActorCheckpoint,
+} from "../persistence/dag-actor-leases.js";
+import { buildRunActorCheckpoints } from "./dag-actor-checkpoint-builder.js";
 
 export interface InjectResult {
   runId: string;
@@ -160,6 +169,7 @@ export interface HandoffTransportFence {
   roundId?: string;
   actorId?: string;
   generation?: number;
+  leaseGeneration?: number;
   commandId?: string;
 }
 
@@ -1347,6 +1357,29 @@ function _persistTerminalRun(
       run_id: run.runId,
       reason: { status, message: `run ${status}` },
     });
+    const leaseRetiredAt = Date.now();
+    for (const actor of listDagActors(run.runId)) {
+      const current = getDagActorLease({ run_id: run.runId, actor_id: actor.actor_id })
+        ?? ensureDagActorLease({
+          run_id: run.runId,
+          actor_id: actor.actor_id,
+          now: leaseRetiredAt,
+        });
+      if (current.state === "retired") continue;
+      retireDagActorLease({
+        run_id: run.runId,
+        actor_id: actor.actor_id,
+        expected_version: current.version,
+        ...(current.state === "leased"
+          ? {
+              lease_generation: current.lease_generation,
+              target_type: current.target_type!,
+              target_id: current.target_id!,
+            }
+          : {}),
+        now: leaseRetiredAt,
+      });
+    }
     writeRunMetadata(run.runId, serializeRunMetadata(run));
   }).immediate();
 }
@@ -1824,25 +1857,41 @@ function _validateHandoffTransportFence(
   if (!actor) throw new Error(`DAG_HANDOFF_ACTOR_FENCE_MISSING ${run.runId}/${fromNode}`);
   const requiresDurableFence = run.currentRound.ordinal > 1;
   if (!fence.roundId) {
-    if (requiresDurableFence) {
-      throw new Error(`DAG_HANDOFF_ROUND_FENCE_MISSING ${run.runId}/${fromNode}`);
-    }
-    return undefined;
+    throw new Error(`DAG_HANDOFF_ROUND_FENCE_MISSING ${run.runId}/${fromNode}`);
   }
   if (fence.roundId !== run.currentRound.round_id) {
     throw new Error(
       `DAG_HANDOFF_ROUND_CONFLICT ${run.runId}/${fromNode}: received ${fence.roundId}, current ${run.currentRound.round_id}`,
     );
   }
-  if (fence.actorId !== undefined && fence.actorId !== actor.actor_id) {
+  if (!fence.actorId) {
+    throw new Error(`DAG_HANDOFF_ACTOR_FENCE_MISSING ${run.runId}/${fromNode}`);
+  }
+  if (fence.actorId !== actor.actor_id) {
     throw new Error(`DAG_HANDOFF_ACTOR_CONFLICT ${run.runId}/${fromNode}`);
   }
-  if (fence.generation !== undefined && fence.generation !== actor.generation) {
+  if (fence.generation === undefined) {
+    throw new Error(`DAG_HANDOFF_GENERATION_FENCE_MISSING ${run.runId}/${fromNode}`);
+  }
+  if (fence.generation !== actor.generation) {
     throw new Error(
       `DAG_HANDOFF_GENERATION_CONFLICT ${run.runId}/${fromNode}: received ${String(fence.generation)}, current ${actor.generation}`,
     );
   }
-  if (requiresDurableFence && (!fence.actorId || fence.generation === undefined || !fence.commandId)) {
+  if (fence.leaseGeneration === undefined) {
+    throw new Error(`DAG_HANDOFF_LEASE_FENCE_MISSING ${run.runId}/${fromNode}`);
+  }
+  const lease = getDagActorLease({ run_id: run.runId, actor_id: actor.actor_id });
+  if (
+    !lease
+    || lease.state !== "leased"
+    || lease.lease_generation !== fence.leaseGeneration
+  ) {
+    throw new Error(
+      `DAG_HANDOFF_LEASE_CONFLICT ${run.runId}/${fromNode}: received ${String(fence.leaseGeneration)}, current ${lease?.state === "leased" ? lease.lease_generation : "none"}`,
+    );
+  }
+  if (requiresDurableFence && !fence.commandId) {
     throw new Error(`DAG_HANDOFF_COMMAND_FENCE_MISSING ${run.runId}/${fromNode}`);
   }
   if (!fence.commandId) return undefined;
@@ -2758,6 +2807,11 @@ function _startAwaitCommand(run: ActiveRun, node: DAGGraphNode): boolean {
   const before = _snapshotNodeStates(run);
   const previousRound = structuredClone(run.currentRound);
   const now = Date.now();
+  const actorCheckpoints = buildRunActorCheckpoints({
+    runId: run.runId,
+    roundId: previousRound.round_id,
+    capturedAt: now,
+  });
   const expiresAt = config.expires_after_ms === undefined
     ? undefined
     : now + Math.max(1_000, Math.floor(config.expires_after_ms));
@@ -2779,6 +2833,32 @@ function _startAwaitCommand(run: ActiveRun, node: DAGGraphNode): boolean {
         closed_at: now,
         expires_at: expiresAt,
       });
+      for (const { actor, checkpoint } of actorCheckpoints) {
+        writeDagActorCheckpoint({
+          run_id: run.runId,
+          actor_id: actor.actor_id,
+          checkpoint,
+          now,
+        });
+        const lease = getDagActorLease({
+          run_id: run.runId,
+          actor_id: actor.actor_id,
+        }) ?? ensureDagActorLease({
+          run_id: run.runId,
+          actor_id: actor.actor_id,
+          now,
+        });
+        if (lease.state === "leased") {
+          acquireDagActorLease({
+            run_id: run.runId,
+            actor_id: actor.actor_id,
+            target_type: lease.target_type!,
+            target_id: lease.target_id!,
+            expected_version: lease.version,
+            now,
+          });
+        }
+      }
       writeRunMetadata(run.runId, serializeRunMetadata(run));
     }).immediate();
   } catch (error) {
@@ -2800,6 +2880,19 @@ function _startAwaitCommand(run: ActiveRun, node: DAGGraphNode): boolean {
     awaitNodeId: node.node_id,
     expiresAt,
   });
+  for (const { actor } of actorCheckpoints) {
+    const checkpoint = getLatestDagActorCheckpoint({
+      run_id: run.runId,
+      actor_id: actor.actor_id,
+    });
+    if (!checkpoint) continue;
+    emit("dag:actor_checkpoint_saved", {
+      runId: run.runId,
+      actorId: actor.actor_id,
+      checkpointVersion: checkpoint.checkpoint_version,
+      checkpointSha256: checkpoint.checkpoint_sha256,
+    });
+  }
   return true;
 }
 
@@ -3208,9 +3301,7 @@ function _requiredDispatchCapabilities(
     const normalized = capability.trim();
     if (normalized) required.add(normalized);
   }
-  if (run.currentRound.ordinal > 1) {
-    required.add(DAG_TRANSPORT_FENCE_CAPABILITY);
-  }
+  required.add(DAG_TRANSPORT_FENCE_CAPABILITY);
   return required.size > 0 ? Array.from(required) : undefined;
 }
 
@@ -3243,6 +3334,10 @@ function _buildDispatchEnvelope(run: ActiveRun, nodeId: string): DispatchEnvelop
   const actorId = actor.actor_id;
   const generation = actor.generation;
   const surfaceId = actor.surface_id;
+  const actorCheckpoint = getLatestDagActorCheckpoint({
+    run_id: run.runId,
+    actor_id: actorId,
+  })?.checkpoint;
   const roundCommand = listDagActorCommands({
     run_id: run.runId,
     actor_id: actorId,
@@ -3273,6 +3368,7 @@ function _buildDispatchEnvelope(run: ActiveRun, nodeId: string): DispatchEnvelop
             attempt: nodeSession.attempt,
           }
         : undefined,
+      ...(actorCheckpoint ? { actorCheckpoint } : {}),
       workflowId: run.workflowId,
       workflowName: run.workflowName,
       workspace: run.workspace,

--- a/homerail_manager/src/runtime/dag-actor-checkpoint-builder.ts
+++ b/homerail_manager/src/runtime/dag-actor-checkpoint-builder.ts
@@ -1,0 +1,172 @@
+import { redactTelemetry, type DagActorCheckpointV1 } from "homerail-protocol";
+import { listDagActors, listDagActorCommands, type DagActorRecord } from "../persistence/dag-actors.js";
+import { listDagActivityEvents } from "../persistence/dag-activity-journal.js";
+import { listRunArtifacts } from "../persistence/run-artifacts.js";
+import { loadRunSnapshot } from "../persistence/store.js";
+
+const MAX_CHECKPOINT_ITEMS = 24;
+const MAX_ITEM_CHARS = 2_000;
+const MAX_CONTEXT_CHARS = 32_000;
+
+function boundedText(value: unknown, maxChars = MAX_ITEM_CHARS): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  let text: string;
+  if (typeof value === "string") {
+    text = value;
+  } else {
+    try {
+      text = JSON.stringify(redactTelemetry(value));
+    } catch {
+      return undefined;
+    }
+  }
+  const normalized = text.replace(/\s+/g, " ").trim();
+  if (!normalized) return undefined;
+  return normalized.length <= maxChars ? normalized : `${normalized.slice(0, maxChars - 3)}...`;
+}
+
+function payloadMessage(payload: unknown): string | undefined {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return boundedText(payload);
+  const record = payload as Record<string, unknown>;
+  return boundedText(record.message ?? record.summary ?? record.result ?? payload);
+}
+
+function uniqueBounded(values: Array<string | undefined>): string[] {
+  return Array.from(new Set(values.filter((value): value is string => Boolean(value))))
+    .slice(-MAX_CHECKPOINT_ITEMS);
+}
+
+function checkpointContext(input: {
+  actor: DagActorRecord;
+  nodeStates: Record<string, string>;
+  handoffs: Array<{ roundId?: string; fromNode: string; port: string; content?: unknown; timestamp: number }>;
+  chats: Array<{ role: string; type: string; content?: unknown; timestamp: number }>;
+  activities: ReturnType<typeof listDagActivityEvents>["events"];
+  commands: ReturnType<typeof listDagActorCommands>;
+}): string {
+  const context = {
+    node_states: input.nodeStates,
+    recent_handoffs: input.handoffs.slice(-12).map((handoff) => ({
+      round_id: handoff.roundId,
+      from_node: handoff.fromNode,
+      port: handoff.port,
+      content: boundedText(handoff.content),
+      timestamp: handoff.timestamp,
+    })),
+    recent_messages: input.chats.slice(-16).map((entry) => ({
+      role: entry.role,
+      type: entry.type,
+      content: boundedText(entry.content),
+      timestamp: entry.timestamp,
+    })),
+    recent_activity: input.activities.slice(-16).map((entry) => ({
+      event_id: entry.event.event_id,
+      type: entry.event.type,
+      payload: payloadMessage(entry.event.payload),
+      timestamp: entry.event.timestamp,
+    })),
+    outstanding_commands: input.commands
+      .filter((command) => !["acknowledged", "failed", "cancelled"].includes(command.status))
+      .slice(-12)
+      .map((command) => ({
+        command_id: command.command_id,
+        round_id: command.round_id,
+        status: command.status,
+        payload: boundedText(command.payload),
+      })),
+  };
+  const encoded = JSON.stringify(redactTelemetry(context));
+  return encoded.length <= MAX_CONTEXT_CHARS
+    ? encoded
+    : JSON.stringify({
+        truncated: true,
+        actor_id: input.actor.actor_id,
+        recent_activity: context.recent_activity.slice(-8),
+        recent_handoffs: context.recent_handoffs.slice(-6),
+        outstanding_commands: context.outstanding_commands,
+      }).slice(0, MAX_CONTEXT_CHARS);
+}
+
+export function buildDagActorCheckpoint(input: {
+  runId: string;
+  actor: DagActorRecord;
+  roundId: string;
+  capturedAt?: number;
+}): DagActorCheckpointV1 {
+  const snapshot = loadRunSnapshot(input.runId);
+  if (!snapshot) throw new Error(`Unknown DAG run: ${input.runId}`);
+  const activities = listDagActivityEvents({
+    run_id: input.runId,
+    actor_id: input.actor.actor_id,
+    limit: 100,
+  }).events;
+  const handoffs = snapshot.handoffs.filter((handoff) => handoff.fromNode === input.actor.node_id);
+  const chats = snapshot.chats[input.actor.node_id] ?? [];
+  const commands = listDagActorCommands({
+    run_id: input.runId,
+    actor_id: input.actor.actor_id,
+  });
+  const completedActivity = activities.filter((entry) => entry.event.type === "finding" || entry.event.type === "completed");
+  const unresolvedActivity = activities.filter((entry) => entry.event.type === "blocked" || entry.event.type === "progress");
+  const objective = boundedText(snapshot.metadata.initialPrompt ?? snapshot.metadata.workflowName ?? input.actor.role, 8_000)
+    ?? input.actor.role;
+
+  return {
+    schema_version: 1,
+    objective,
+    confirmed_conclusions: uniqueBounded([
+      ...handoffs.map((handoff) => boundedText(handoff.content)),
+      ...completedActivity.map((entry) => payloadMessage(entry.event.payload)),
+    ]),
+    unresolved_items: uniqueBounded([
+      ...commands
+        .filter((command) => !["acknowledged", "failed", "cancelled"].includes(command.status))
+        .map((command) => boundedText(command.payload)),
+      ...unresolvedActivity.map((entry) => payloadMessage(entry.event.payload)),
+    ]),
+    key_event_refs: activities.slice(-MAX_CHECKPOINT_ITEMS).map((entry) => entry.event.event_id),
+    artifact_refs: listRunArtifacts(input.runId)
+      .filter((artifact) => artifact.status === "ready")
+      .map((artifact) => `${artifact.name}:${artifact.artifact_id}`)
+      .slice(-MAX_CHECKPOINT_ITEMS),
+    ...(input.actor.workspace_ref ? { workspace_ref: input.actor.workspace_ref } : {}),
+    surface_binding: input.actor.surface_id,
+    context_summary: checkpointContext({
+      actor: input.actor,
+      nodeStates: snapshot.metadata.nodeStates,
+      handoffs,
+      chats,
+      activities,
+      commands,
+    }),
+    round_id: input.roundId,
+    actor_generation: input.actor.generation,
+    captured_at: input.capturedAt ?? Date.now(),
+  };
+}
+
+export function buildRunActorCheckpoints(input: {
+  runId: string;
+  roundId: string;
+  capturedAt?: number;
+}): Array<{ actor: DagActorRecord; checkpoint: DagActorCheckpointV1 }> {
+  return listDagActors(input.runId).map((actor) => ({
+    actor,
+    checkpoint: buildDagActorCheckpoint({
+      runId: input.runId,
+      actor,
+      roundId: input.roundId,
+      capturedAt: input.capturedAt,
+    }),
+  }));
+}
+
+export function renderDagActorCheckpointInstruction(checkpoint: DagActorCheckpointV1): string {
+  return [
+    "## HomeRail portable actor checkpoint",
+    "This checkpoint is authoritative durable context from a previous Worker lease.",
+    "Continue the same objective and logical actor. Do not claim unrecorded conclusions.",
+    "The checkpoint contains no hidden reasoning or provider session state.",
+    JSON.stringify(checkpoint),
+  ].join("\n");
+}

--- a/homerail_manager/src/runtime/dag-actor-lease-reaper.ts
+++ b/homerail_manager/src/runtime/dag-actor-lease-reaper.ts
@@ -1,0 +1,182 @@
+import { emit } from "../events/bus.js";
+import {
+  acquireDagActorLease,
+  deleteExpiredDagActorRuntime,
+  getDagActorLease,
+  listDagProvisionedWorkers,
+  listExpiredDagActorLeases,
+  releaseDagActorLease,
+} from "../persistence/dag-actor-leases.js";
+import { listDagActors } from "../persistence/dag-actors.js";
+import { listPersistedRunIds, loadRunMetadata } from "../persistence/store.js";
+import type { DagRunStatus } from "../persistence/status.js";
+import { loadDagActorLeaseSettings } from "../config/dag-actor-lease-settings.js";
+import {
+  deprovisionProvisionedWorker,
+  type DeprovisionOptions,
+  type ProvisionedWorkerEntry,
+} from "../orchestration/provisioned-cleanup.js";
+
+export const DEFAULT_DAG_ACTOR_LEASE_REAPER_INTERVAL_MS = 1_000;
+
+export interface DagActorLeaseReaperReport {
+  renewed: number;
+  released: number;
+  worker_cleanup_attempted: number;
+  worker_cleanup_failed: number;
+  runtimes_deleted: number;
+}
+
+export interface DagActorLeaseReaperOptions extends DeprovisionOptions {
+  now?: number;
+  limit?: number;
+}
+
+function recordEntry(record: ReturnType<typeof listDagProvisionedWorkers>[number]): ProvisionedWorkerEntry {
+  return {
+    runId: record.run_id,
+    nodeId: record.node_id,
+    actorId: record.actor_id,
+    leaseGeneration: record.lease_generation,
+    workerId: record.worker_id,
+    containerId: record.container_id,
+    dockerNodeId: record.docker_node_id,
+    provisionedAt: record.registered_at,
+  };
+}
+
+function runStatus(runId: string): DagRunStatus | undefined {
+  return loadRunMetadata(runId)?.status;
+}
+
+export async function reapDagActorLeases(
+  options: DagActorLeaseReaperOptions = {},
+): Promise<DagActorLeaseReaperReport> {
+  const now = options.now ?? Date.now();
+  const report: DagActorLeaseReaperReport = {
+    renewed: 0,
+    released: 0,
+    worker_cleanup_attempted: 0,
+    worker_cleanup_failed: 0,
+    runtimes_deleted: 0,
+  };
+
+  const renewalThreshold = Math.floor(loadDagActorLeaseSettings().worker_idle_ttl_ms / 2);
+  for (const runId of listPersistedRunIds()) {
+    if (runStatus(runId) !== "active") continue;
+    for (const actor of listDagActors(runId)) {
+      const lease = getDagActorLease({ run_id: runId, actor_id: actor.actor_id });
+      if (!lease || lease.state !== "leased" || lease.pinned || lease.idle_deadline! - now > renewalThreshold) continue;
+      try {
+        acquireDagActorLease({
+          run_id: lease.run_id,
+          actor_id: lease.actor_id,
+          target_type: lease.target_type!,
+          target_id: lease.target_id!,
+          expected_version: lease.version,
+          now,
+        });
+        report.renewed++;
+      } catch {
+        // A concurrent dispatch or release owns the newer lease state.
+      }
+    }
+  }
+
+  // Retry interrupted cleanup and reclaim any physical Worker that is no
+  // longer owned by the actor's current physical lease generation. This also
+  // closes the crash window between terminal lease retirement and async
+  // container cleanup.
+  const pending = listDagProvisionedWorkers({ statuses: ["active", "releasing", "failed"], limit: options.limit });
+  for (const worker of pending) {
+    if (worker.status === "active") {
+      const lease = getDagActorLease({ run_id: worker.run_id, actor_id: worker.actor_id });
+      const stillOwned = lease?.state === "leased"
+        && lease.lease_generation === worker.lease_generation
+        && (lease.target_type === "worker" || lease.target_type === "provisioned_worker")
+        && lease.target_id === worker.worker_id;
+      if (stillOwned) continue;
+    }
+    report.worker_cleanup_attempted++;
+    if (!await deprovisionProvisionedWorker(recordEntry(worker), options)) report.worker_cleanup_failed++;
+  }
+
+  for (const lease of listExpiredDagActorLeases({ now, limit: options.limit })) {
+    if (runStatus(lease.run_id) === "active") continue;
+    try {
+      // This versioned transition is the physical-generation fence. Once it
+      // commits, late results from the released worker are no longer current.
+      releaseDagActorLease({
+        run_id: lease.run_id,
+        actor_id: lease.actor_id,
+        lease_generation: lease.lease_generation,
+        target_type: lease.target_type!,
+        target_id: lease.target_id!,
+        expected_version: lease.version,
+        now,
+      });
+      report.released++;
+      emit("dag:actor_lease_released", {
+        runId: lease.run_id,
+        actorId: lease.actor_id,
+        leaseGeneration: lease.lease_generation,
+        reason: "idle_ttl_expired",
+      });
+    } catch {
+      // A concurrent renewal or release won the version race. Its current
+      // state is authoritative and must not be overwritten by the reaper.
+      continue;
+    }
+
+    const workers = listDagProvisionedWorkers({
+      run_id: lease.run_id,
+      actor_id: lease.actor_id,
+      lease_generation: lease.lease_generation,
+      statuses: ["active", "releasing", "failed"],
+    });
+    for (const worker of workers) {
+      report.worker_cleanup_attempted++;
+      if (!await deprovisionProvisionedWorker(recordEntry(worker), options)) report.worker_cleanup_failed++;
+    }
+  }
+
+  for (const runId of listPersistedRunIds()) {
+    const status = runStatus(runId);
+    if (status === "active" || status === "waiting") continue;
+    for (const actor of listDagActors(runId)) {
+      const lease = getDagActorLease({ run_id: runId, actor_id: actor.actor_id });
+      if (!lease || lease.state === "leased" || lease.pinned || lease.retained_until! > now) continue;
+      if (deleteExpiredDagActorRuntime({ run_id: runId, actor_id: actor.actor_id, now }).deleted) {
+        report.runtimes_deleted++;
+      }
+    }
+  }
+  return report;
+}
+
+function resolveIntervalMs(env: NodeJS.ProcessEnv): number {
+  const raw = env.HOMERAIL_DAG_ACTOR_LEASE_REAPER_INTERVAL_MS;
+  if (raw === undefined || raw.trim() === "") return DEFAULT_DAG_ACTOR_LEASE_REAPER_INTERVAL_MS;
+  if (!/^\d+$/.test(raw.trim())) return DEFAULT_DAG_ACTOR_LEASE_REAPER_INTERVAL_MS;
+  return Math.max(100, Number(raw));
+}
+
+export function startDagActorLeaseReaper(
+  intervalMs = resolveIntervalMs(process.env),
+): () => void {
+  let running = false;
+  const tick = () => {
+    if (running) return;
+    running = true;
+    void reapDagActorLeases()
+      .catch((error) => {
+        console.error(
+          `[homerail_manager] DAG actor lease reaper failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      })
+      .finally(() => { running = false; });
+  };
+  const timer = setInterval(tick, intervalMs);
+  timer.unref();
+  return () => clearInterval(timer);
+}

--- a/homerail_manager/src/server/http.ts
+++ b/homerail_manager/src/server/http.ts
@@ -47,6 +47,7 @@ import { readOrCreateControlPlaneToken } from "../persistence/control-plane-secr
 import { startWorkspaceCleanupScheduler } from "../runtime/workspace-retention.js";
 import { runArtifactRoutesHandler } from "./run-artifacts.js";
 import { startRunArtifactService } from "../runtime/run-artifact-service.js";
+import { startDagActorLeaseReaper } from "../runtime/dag-actor-lease-reaper.js";
 
 function json(res: http.ServerResponse, status: number, body: unknown) {
   res.writeHead(status, { "Content-Type": "application/json" });
@@ -271,6 +272,7 @@ export function createServer(
   const stopTriggerScheduler = startDagTriggerScheduler(changeOrchestrator);
   const stopWorkspaceCleanupScheduler = startWorkspaceCleanupScheduler();
   const stopRunArtifactService = startRunArtifactService();
+  const stopDagActorLeaseReaper = startDagActorLeaseReaper();
 
   server = http.createServer((req, res) => {
     setCorsHeaders(res);
@@ -399,6 +401,7 @@ export function createServer(
   server.once("close", stopTriggerScheduler);
   server.once("close", stopWorkspaceCleanupScheduler);
   server.once("close", stopRunArtifactService);
+  server.once("close", stopDagActorLeaseReaper);
 
   const workerWebsocketOptions: WorkerWebSocketOptions = {
     ...wsOptions,

--- a/homerail_manager/src/worker/types.ts
+++ b/homerail_manager/src/worker/types.ts
@@ -37,6 +37,11 @@ export interface ContentMessage {
     run_id?: string;
     node_id?: string;
     session_id?: string;
+    round_id?: string;
+    actor_id?: string;
+    generation?: number;
+    lease_generation?: number;
+    command_id?: string;
   };
 }
 
@@ -52,11 +57,30 @@ export interface NodeErrorMessage {
     nodeId: string;
     message: string;
     session_id?: string;
+    round_id?: string;
+    actor_id?: string;
+    generation?: number;
+    lease_generation?: number;
+    command_id?: string;
   };
 }
 
 export interface PongMessage {
   type: "pong";
+}
+
+export interface SessionEndMessage {
+  type: "SESSION_END";
+  data: {
+    run_id: string;
+    node_id: string;
+    session_id: string;
+    round_id?: string;
+    actor_id?: string;
+    generation?: number;
+    lease_generation?: number;
+    command_id?: string;
+  };
 }
 
 export type IncomingWorkerMessage =
@@ -69,6 +93,7 @@ export type IncomingWorkerMessage =
   | ContentMessage
   | ManagerCommandMessage
   | NodeErrorMessage
+  | SessionEndMessage
   | PongMessage;
 
 export interface PingMessage {
@@ -157,6 +182,11 @@ export function parseIncomingMessage(raw: unknown): IncomingWorkerMessage | null
           run_id: typeof data.run_id === "string" ? data.run_id : undefined,
           node_id: typeof data.node_id === "string" ? data.node_id : undefined,
           session_id: typeof data.session_id === "string" ? data.session_id : undefined,
+          round_id: typeof data.round_id === "string" ? data.round_id : undefined,
+          actor_id: typeof data.actor_id === "string" ? data.actor_id : undefined,
+          generation: typeof data.generation === "number" ? data.generation : undefined,
+          lease_generation: typeof data.lease_generation === "number" ? data.lease_generation : undefined,
+          command_id: typeof data.command_id === "string" ? data.command_id : undefined,
         },
       };
     }
@@ -179,6 +209,31 @@ export function parseIncomingMessage(raw: unknown): IncomingWorkerMessage | null
           nodeId: data.nodeId,
           message: data.message,
           session_id: typeof data.session_id === "string" ? data.session_id : undefined,
+          round_id: typeof data.round_id === "string" ? data.round_id : undefined,
+          actor_id: typeof data.actor_id === "string" ? data.actor_id : undefined,
+          generation: typeof data.generation === "number" ? data.generation : undefined,
+          lease_generation: typeof data.lease_generation === "number" ? data.lease_generation : undefined,
+          command_id: typeof data.command_id === "string" ? data.command_id : undefined,
+        },
+      };
+    }
+    case "SESSION_END": {
+      if (typeof obj.data !== "object" || obj.data === null || Array.isArray(obj.data)) return null;
+      const data = obj.data as Record<string, unknown>;
+      if (typeof data.run_id !== "string" || typeof data.node_id !== "string" || typeof data.session_id !== "string") {
+        return null;
+      }
+      return {
+        type: "SESSION_END",
+        data: {
+          run_id: data.run_id,
+          node_id: data.node_id,
+          session_id: data.session_id,
+          round_id: typeof data.round_id === "string" ? data.round_id : undefined,
+          actor_id: typeof data.actor_id === "string" ? data.actor_id : undefined,
+          generation: typeof data.generation === "number" ? data.generation : undefined,
+          lease_generation: typeof data.lease_generation === "number" ? data.lease_generation : undefined,
+          command_id: typeof data.command_id === "string" ? data.command_id : undefined,
         },
       };
     }

--- a/homerail_manager/src/worker/websocket.ts
+++ b/homerail_manager/src/worker/websocket.ts
@@ -74,6 +74,16 @@ function objectData(value: unknown): Record<string, unknown> | undefined {
     : undefined;
 }
 
+function transportPayload(data: Record<string, unknown>): Record<string, unknown> {
+  const runId = streamRunId(data);
+  const nodeId = streamNodeId(data);
+  return {
+    ...data,
+    ...(runId === undefined ? {} : { runId }),
+    ...(nodeId === undefined ? {} : { nodeId }),
+  };
+}
+
 function dagActivityRoundContext(data: Record<string, unknown>, runId: string): string {
   const run = getActiveRun(runId);
   if (!run) throw new Error(`DAG activity run ${runId} is not active`);
@@ -141,6 +151,50 @@ function mirrorSessionTranscript(
   } catch {
     // Best-effort mirror; websocket handling and DB chat remain authoritative.
   }
+}
+
+function isCurrentDagTransport(
+  workerId: string,
+  messageType: string,
+  data: Record<string, unknown>,
+  explicitSessionId?: string,
+): boolean {
+  const payload = transportPayload(data);
+  const assessment = assessDagTransportFence(payload, {
+    targetType: "worker",
+    targetId: workerId,
+  });
+  if (assessment.status === "current") return true;
+
+  const runId = assessment.status === "malformed_payload" ? streamRunId(data) : assessment.runId;
+  const nodeId = assessment.status === "malformed_payload" ? streamNodeId(data) : assessment.nodeId;
+  const disposition = assessment.status === "ignored" ? assessment.disposition : assessment.status;
+  const reason = assessment.status === "unknown_run"
+    ? `unknown run ${assessment.runId}`
+    : assessment.reason;
+  const sessionId = explicitSessionId ?? dataSessionId(data);
+  emit("dag:stale_lease_ignored", {
+    runId,
+    nodeId,
+    source: "worker",
+    sourceId: workerId,
+    messageType,
+    disposition,
+    reason,
+  });
+  mirrorSessionTranscript(
+    workerId,
+    `stale_lease_${messageType}_ignored`,
+    runId,
+    nodeId,
+    sessionId,
+    {
+      disposition,
+      reason,
+      lease_generation: typeof data.lease_generation === "number" ? data.lease_generation : undefined,
+    },
+  );
+  return false;
 }
 
 export interface WorkerWebSocketOptions {
@@ -320,6 +374,7 @@ export function setupWorkerWebSocket(
         }
 
         if (msg.type === "content") {
+          if (!isCurrentDagTransport(worker_id, "content", msg.data)) return;
           if (shouldIgnoreStaleSession(worker_id, "content", msg.data)) return;
           const runId = streamRunId(msg.data);
           const nodeId = streamNodeId(msg.data);
@@ -338,6 +393,7 @@ export function setupWorkerWebSocket(
 
         if (msg.type === "response") {
           const responseData = objectData(msg.data);
+          if (responseData && !isCurrentDagTransport(worker_id, "response", responseData, msg.session_id)) return;
           if (responseData && shouldIgnoreStaleSession(worker_id, "response", responseData, msg.session_id)) return;
           const responseSessionId = msg.session_id ?? dataSessionId(responseData);
 
@@ -371,7 +427,7 @@ export function setupWorkerWebSocket(
             return;
           }
 
-          const result = applyResponseHandoff(msg.data);
+          const result = applyResponseHandoff(msg.data, { targetType: "worker", targetId: worker_id });
           if (result.status === "handoff_applied") {
             appendChatEntry(result.runId, result.nodeId, {
               role: "worker",
@@ -397,6 +453,29 @@ export function setupWorkerWebSocket(
             });
             options.onHandoffApplied?.(result.runId);
           } else {
+            if (
+              result.status === "handoff_ignored"
+              && result.reason.startsWith("DAG_TRANSPORT_LEASE_")
+            ) {
+              emit("dag:stale_lease_ignored", {
+                runId: result.runId,
+                nodeId: result.nodeId,
+                source: "worker",
+                sourceId: worker_id,
+                messageType: "response",
+                disposition: result.disposition,
+                reason: result.reason,
+              });
+              mirrorSessionTranscript(
+                worker_id,
+                "stale_lease_response_ignored",
+                result.runId,
+                result.nodeId,
+                responseSessionId,
+                { disposition: result.disposition, reason: result.reason },
+              );
+              return;
+            }
             const reason = result.status === "malformed_payload"
               ? result.reason
               : result.status === "unknown_run"
@@ -431,6 +510,14 @@ export function setupWorkerWebSocket(
         if (msg.type === "stream") {
           const runId = streamRunId(msg.data);
           const nodeId = streamNodeId(msg.data);
+          const messageType = msg.data.event === "dag_activity"
+            ? "dag_activity"
+            : msg.data.event === "usage"
+              ? "usage"
+              : "stream";
+          if (!isCurrentDagTransport(worker_id, messageType, msg.data)) {
+            return;
+          }
           if (msg.data.event === "dag_activity") {
             try {
               if (!runId || !nodeId) throw new Error("DAG activity transport identity is missing");
@@ -502,36 +589,12 @@ export function setupWorkerWebSocket(
 
         if (msg.type === "node_error") {
           const rawData = objectData(objectData(rawMessage)?.data) ?? msg.data;
+          if (!isCurrentDagTransport(worker_id, "node_error", rawData, msg.data.session_id)) return;
           if (shouldIgnoreStaleSession(worker_id, "node_error", {
             runId: msg.data.runId,
             nodeId: msg.data.nodeId,
             session_id: msg.data.session_id,
           })) return;
-          const assessment = assessDagTransportFence(rawData);
-          if (assessment.status !== "current") {
-            const runId = assessment.status === "malformed_payload" ? msg.data.runId : assessment.runId;
-            const nodeId = assessment.status === "malformed_payload" ? msg.data.nodeId : assessment.nodeId;
-            const disposition = assessment.status === "ignored" ? assessment.disposition : assessment.status;
-            const reason = assessment.status === "unknown_run"
-              ? `unknown run ${assessment.runId}`
-              : assessment.reason;
-            emit("dag:response_handoff_failed", {
-              runId,
-              nodeId,
-              reason: `node_error ${disposition} ignored: ${reason}`,
-              source: "worker",
-              sourceId: worker_id,
-            });
-            mirrorSessionTranscript(
-              worker_id,
-              `node_error_${disposition}_ignored`,
-              runId,
-              nodeId,
-              msg.data.session_id,
-              { disposition, reason, payload: rawData },
-            );
-            return;
-          }
           appendChatEntry(msg.data.runId, msg.data.nodeId, {
             role: "worker",
             type: "response",
@@ -554,6 +617,12 @@ export function setupWorkerWebSocket(
           if (run?.status === "active") {
             options.onHandoffApplied?.(msg.data.runId);
           }
+          return;
+        }
+
+        if (msg.type === "SESSION_END") {
+          if (!isCurrentDagTransport(worker_id, "session_end", msg.data, msg.data.session_id)) return;
+          if (shouldIgnoreStaleSession(worker_id, "session_end", msg.data, msg.data.session_id)) return;
           return;
         }
 

--- a/homerail_manager/tests/dag-actor-lease-reaper.test.ts
+++ b/homerail_manager/tests/dag-actor-lease-reaper.test.ts
@@ -1,0 +1,221 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  acquireDagActorLease,
+  getDagActorLease,
+  getLatestDagActorCheckpoint,
+  listDagProvisionedWorkers,
+  registerDagProvisionedWorker,
+  releaseDagActorLease,
+  retireDagActorLease,
+  setDagActorLeasePinned,
+  writeDagActorCheckpoint,
+} from "../src/persistence/dag-actor-leases.js";
+import { getDagActor, registerDagActor } from "../src/persistence/dag-actors.js";
+import { closeDb } from "../src/persistence/db.js";
+import { ensureRunDir, loadRunMetadata, writeRunMetadata } from "../src/persistence/store.js";
+import { reapDagActorLeases } from "../src/runtime/dag-actor-lease-reaper.js";
+
+describe("DAG actor lease reaper", () => {
+  let home: string;
+  let oldHome: string | undefined;
+  let oldIdleTtl: string | undefined;
+  let now: number;
+
+  beforeEach(() => {
+    closeDb();
+    oldHome = process.env.HOMERAIL_HOME;
+    oldIdleTtl = process.env.HOMERAIL_DAG_WORKER_IDLE_TTL_MS;
+    home = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-dag-lease-reaper-"));
+    process.env.HOMERAIL_HOME = home;
+    now = Date.now();
+    ensureRunDir("run-reaper");
+    registerDagActor({
+      run_id: "run-reaper",
+      actor_id: "actor-1",
+      node_id: "node-1",
+      role: "research",
+      surface_id: "surface-1",
+    });
+  });
+
+  afterEach(() => {
+    closeDb();
+    if (oldHome === undefined) delete process.env.HOMERAIL_HOME;
+    else process.env.HOMERAIL_HOME = oldHome;
+    if (oldIdleTtl === undefined) delete process.env.HOMERAIL_DAG_WORKER_IDLE_TTL_MS;
+    else process.env.HOMERAIL_DAG_WORKER_IDLE_TTL_MS = oldIdleTtl;
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  function setRunStatus(status: "active" | "waiting" | "completed" | "failed" | "cancelled"): void {
+    const metadata = loadRunMetadata("run-reaper")!;
+    writeRunMetadata("run-reaper", {
+      ...metadata,
+      status,
+      ...(status === "active" || status === "waiting" ? {} : { completedAt: now }),
+    });
+  }
+
+  function acquireWorker(workerId = "worker-1"): ReturnType<typeof acquireDagActorLease> {
+    const lease = acquireDagActorLease({
+      run_id: "run-reaper",
+      actor_id: "actor-1",
+      target_type: "worker",
+      target_id: workerId,
+      idle_ttl_ms: 10,
+      retention_ttl_ms: 20,
+      now,
+    });
+    registerDagProvisionedWorker({
+      run_id: "run-reaper",
+      actor_id: "actor-1",
+      node_id: "node-1",
+      lease_generation: lease.lease_generation,
+      worker_id: workerId,
+      container_id: `container-${workerId}`,
+      docker_node_id: "docker-node-1",
+      now,
+    });
+    return lease;
+  }
+
+  it("releases an idle waiting actor before deprovisioning its worker", async () => {
+    setRunStatus("waiting");
+    acquireWorker();
+    const seen: string[] = [];
+    const report = await reapDagActorLeases({
+      now: now + 10,
+      deprovisionFn: async () => {
+        const lease = getDagActorLease({ run_id: "run-reaper", actor_id: "actor-1" });
+        seen.push(lease?.state ?? "missing");
+        return { stopped: true, removed: true, dockerCleanupVerified: true };
+      },
+    });
+
+    expect(report).toMatchObject({ released: 1, worker_cleanup_attempted: 1, worker_cleanup_failed: 0 });
+    expect(seen).toEqual(["dormant"]);
+    expect(getDagActorLease({ run_id: "run-reaper", actor_id: "actor-1" })).toMatchObject({
+      state: "dormant",
+      lease_generation: 1,
+    });
+  });
+
+  it("renews an active long-running lease before it spends its hot TTL", async () => {
+    acquireWorker();
+    process.env.HOMERAIL_DAG_WORKER_IDLE_TTL_MS = "10";
+    expect((await reapDagActorLeases({ now: now + 5 })).renewed).toBe(1);
+    expect(getDagActorLease({ run_id: "run-reaper", actor_id: "actor-1" })).toMatchObject({
+      state: "leased",
+      idle_deadline: now + 15,
+    });
+  });
+
+  it("reclaims an active provisioned worker detached from the current lease generation", async () => {
+    acquireWorker("worker-1");
+    acquireWorker("worker-2");
+    const removed: string[] = [];
+
+    const report = await reapDagActorLeases({
+      now: now + 2,
+      deprovisionFn: async (_dockerNodeId, containerId) => {
+        removed.push(containerId);
+        return { stopped: true, removed: true, dockerCleanupVerified: true };
+      },
+    });
+
+    expect(report).toMatchObject({ worker_cleanup_attempted: 1, worker_cleanup_failed: 0 });
+    expect(removed).toEqual(["container-worker-1"]);
+    expect(listDagProvisionedWorkers({ run_id: "run-reaper" })).toEqual([
+      expect.objectContaining({ worker_id: "worker-1", status: "released" }),
+      expect.objectContaining({ worker_id: "worker-2", status: "active" }),
+    ]);
+  });
+
+  it("reclaims an active provisioned worker left behind after terminal lease retirement", async () => {
+    setRunStatus("completed");
+    const lease = acquireWorker();
+    retireDagActorLease({
+      run_id: "run-reaper",
+      actor_id: "actor-1",
+      lease_generation: lease.lease_generation,
+      target_type: lease.target_type!,
+      target_id: lease.target_id!,
+      expected_version: lease.version,
+      now: now + 1,
+    });
+
+    const report = await reapDagActorLeases({
+      now: now + 2,
+      deprovisionFn: async () => ({ stopped: true, removed: true, dockerCleanupVerified: true }),
+    });
+
+    expect(report).toMatchObject({ worker_cleanup_attempted: 1, worker_cleanup_failed: 0 });
+    expect(listDagProvisionedWorkers({ run_id: "run-reaper" })[0]).toMatchObject({ status: "released" });
+  });
+
+  it("respects explicit pins while a waiting actor is otherwise idle-expired", async () => {
+    acquireWorker();
+    setRunStatus("waiting");
+    const leased = getDagActorLease({ run_id: "run-reaper", actor_id: "actor-1" })!;
+    setDagActorLeasePinned({
+      run_id: "run-reaper",
+      actor_id: "actor-1",
+      pinned: true,
+      expected_version: leased.version,
+      now: now + 1,
+    });
+    expect((await reapDagActorLeases({ now: now + 10 })).released).toBe(0);
+    expect(getDagActorLease({ run_id: "run-reaper", actor_id: "actor-1" })?.state).toBe("leased");
+  });
+
+  it("deletes only terminal, retention-expired dormant runtime and checkpoints", async () => {
+    setRunStatus("completed");
+    const lease = acquireDagActorLease({
+      run_id: "run-reaper",
+      actor_id: "actor-1",
+      target_type: "worker",
+      target_id: "worker-1",
+      idle_ttl_ms: 100,
+      retention_ttl_ms: 10,
+      now,
+    });
+    writeDagActorCheckpoint({
+      run_id: "run-reaper",
+      actor_id: "actor-1",
+      now: now + 1,
+      checkpoint: {
+        schema_version: 1,
+        objective: "Retain this actor until the terminal retention window expires",
+        confirmed_conclusions: [],
+        unresolved_items: [],
+        key_event_refs: [],
+        artifact_refs: [],
+        surface_binding: "surface-1",
+        context_summary: "Checkpoint retained until actor retention expiry.",
+        round_id: "round-1",
+        actor_generation: 1,
+        captured_at: now + 1,
+      },
+    });
+    releaseDagActorLease({
+      run_id: "run-reaper",
+      actor_id: "actor-1",
+      lease_generation: lease.lease_generation,
+      target_type: "worker",
+      target_id: "worker-1",
+      expected_version: lease.version,
+      retention_ttl_ms: 10,
+      now: now + 1,
+    });
+
+    expect((await reapDagActorLeases({ now: now + 10 })).runtimes_deleted).toBe(0);
+    expect(getLatestDagActorCheckpoint({ run_id: "run-reaper", actor_id: "actor-1" })).toBeDefined();
+    expect((await reapDagActorLeases({ now: now + 11 })).runtimes_deleted).toBe(1);
+    expect(getDagActor("run-reaper", "actor-1")).toBeUndefined();
+    expect(getLatestDagActorCheckpoint({ run_id: "run-reaper", actor_id: "actor-1" })).toBeUndefined();
+  });
+});

--- a/homerail_manager/tests/dag-actor-lease-settings.test.ts
+++ b/homerail_manager/tests/dag-actor-lease-settings.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_DAG_ACTOR_RETENTION_TTL_MS,
+  DEFAULT_DAG_WORKER_IDLE_TTL_MS,
+  loadDagActorLeaseSettings,
+  MAX_DAG_ACTOR_RETENTION_TTL_MS,
+  MAX_DAG_WORKER_IDLE_TTL_MS,
+  validateDagActorRetentionTtlMs,
+  validateDagWorkerIdleTtlMs,
+} from "../src/config/dag-actor-lease-settings.js";
+
+const ENV_NAMES = [
+  "HOMERAIL_DAG_WORKER_IDLE_TTL_MS",
+  "HOMERAIL_DAG_ACTOR_RETENTION_TTL_MS",
+] as const;
+const inherited = Object.fromEntries(ENV_NAMES.map((name) => [name, process.env[name]]));
+
+afterEach(() => {
+  for (const name of ENV_NAMES) {
+    const value = inherited[name];
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+});
+
+describe("DAG actor lease settings", () => {
+  it("uses the five-minute idle and seven-day retention defaults", () => {
+    expect(loadDagActorLeaseSettings({})).toEqual({
+      worker_idle_ttl_ms: DEFAULT_DAG_WORKER_IDLE_TTL_MS,
+      actor_retention_ttl_ms: DEFAULT_DAG_ACTOR_RETENTION_TTL_MS,
+    });
+    expect(DEFAULT_DAG_WORKER_IDLE_TTL_MS).toBe(5 * 60_000);
+    expect(DEFAULT_DAG_ACTOR_RETENTION_TTL_MS).toBe(7 * 24 * 60 * 60_000);
+  });
+
+  it("accepts bounded base-10 environment overrides", () => {
+    expect(loadDagActorLeaseSettings({
+      HOMERAIL_DAG_WORKER_IDLE_TTL_MS: "1500",
+      HOMERAIL_DAG_ACTOR_RETENTION_TTL_MS: "900000",
+    })).toEqual({
+      worker_idle_ttl_ms: 1_500,
+      actor_retention_ttl_ms: 900_000,
+    });
+    expect(validateDagWorkerIdleTtlMs(MAX_DAG_WORKER_IDLE_TTL_MS))
+      .toBe(MAX_DAG_WORKER_IDLE_TTL_MS);
+    expect(validateDagActorRetentionTtlMs(MAX_DAG_ACTOR_RETENTION_TTL_MS))
+      .toBe(MAX_DAG_ACTOR_RETENTION_TTL_MS);
+  });
+
+  it.each(["", "0", "-1", "1.5", "1e3", "Infinity", "NaN"])(
+    "rejects an unsafe idle override %j",
+    (value) => {
+      expect(() => loadDagActorLeaseSettings({
+        HOMERAIL_DAG_WORKER_IDLE_TTL_MS: value,
+      })).toThrow(/HOMERAIL_DAG_WORKER_IDLE_TTL_MS/);
+    },
+  );
+
+  it("rejects non-finite, fractional, and out-of-range TTL values", () => {
+    expect(() => validateDagWorkerIdleTtlMs(Number.POSITIVE_INFINITY)).toThrow(/safe integer/);
+    expect(() => validateDagWorkerIdleTtlMs(1.5)).toThrow(/safe integer/);
+    expect(() => validateDagWorkerIdleTtlMs(MAX_DAG_WORKER_IDLE_TTL_MS + 1)).toThrow(/safe integer/);
+    expect(() => validateDagActorRetentionTtlMs(MAX_DAG_ACTOR_RETENTION_TTL_MS + 1))
+      .toThrow(/safe integer/);
+  });
+});

--- a/homerail_manager/tests/dag-actor-leases.test.ts
+++ b/homerail_manager/tests/dag-actor-leases.test.ts
@@ -1,0 +1,649 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  acquireDagActorLease,
+  assessDagActorLease,
+  DagActorLeaseConflictError,
+  deleteExpiredDagActorRuntime,
+  ensureDagActorLease,
+  getDagActorLease,
+  getLatestDagActorCheckpoint,
+  listDagProvisionedWorkers,
+  listExpiredDagActorLeases,
+  registerDagProvisionedWorker,
+  releaseDagActorLease,
+  renewDagActorLease,
+  retireDagActorLease,
+  setDagActorLeasePinned,
+  transitionDagProvisionedWorker,
+  type DagActorCheckpointV1,
+  writeDagActorCheckpoint,
+} from "../src/persistence/dag-actor-leases.js";
+import { getDagActor, registerDagActor } from "../src/persistence/dag-actors.js";
+import { clearTables, closeDb, getDb } from "../src/persistence/db.js";
+import { ensureRunDir } from "../src/persistence/store.js";
+
+function checkpoint(overrides: Partial<DagActorCheckpointV1> = {}): DagActorCheckpointV1 {
+  return {
+    schema_version: 1,
+    objective: "Continue the durable research objective",
+    confirmed_conclusions: ["The primary source confirms the first conclusion"],
+    unresolved_items: ["Verify the second claim"],
+    key_event_refs: ["event-2", "event-1"],
+    artifact_refs: ["report:artifact-1"],
+    workspace_ref: "workspace://run-1",
+    surface_binding: "surface-researcher",
+    context_summary: "Bounded provider-neutral context",
+    round_id: "round-1",
+    actor_generation: 1,
+    captured_at: 90,
+    ...overrides,
+  };
+}
+
+function registerActor(
+  actorId = "researcher",
+  nodeId = actorId,
+  surfaceId = `surface-${actorId}`,
+): void {
+  registerDagActor({
+    run_id: "run-1",
+    actor_id: actorId,
+    node_id: nodeId,
+    role: "research",
+    surface_id: surfaceId,
+  });
+}
+
+describe("DAG actor lease persistence", () => {
+  let home: string;
+  let oldHome: string | undefined;
+
+  beforeEach(() => {
+    closeDb();
+    oldHome = process.env.HOMERAIL_HOME;
+    home = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-dag-actor-leases-"));
+    process.env.HOMERAIL_HOME = home;
+    ensureRunDir("run-1");
+    registerActor();
+  });
+
+  afterEach(() => {
+    closeDb();
+    if (oldHome === undefined) delete process.env.HOMERAIL_HOME;
+    else process.env.HOMERAIL_HOME = oldHome;
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it("creates and revalidates the strict v24 schema on a fresh database", () => {
+    const db = getDb();
+    expect(db.prepare("SELECT MAX(version) AS version FROM schema_migrations").get())
+      .toEqual({ version: 24 });
+    expect(db.prepare(`
+      SELECT name FROM sqlite_master
+      WHERE type = 'table' AND name IN (
+        'dag_actor_runtimes', 'dag_actor_checkpoints', 'dag_actor_provisioned_workers'
+      ) ORDER BY name
+    `).all()).toEqual([
+      { name: "dag_actor_checkpoints" },
+      { name: "dag_actor_provisioned_workers" },
+      { name: "dag_actor_runtimes" },
+    ]);
+    expect(db.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
+    expect(() => db.prepare(`
+      INSERT INTO dag_actor_runtimes(
+        run_id, actor_id, state, lease_generation, target_type, target_id,
+        idle_deadline, pinned, retained_until, state_changed_at, created_at, updated_at
+      ) VALUES ('run-1', 'researcher', 'dormant', 0, 'worker', 'worker-1', NULL, 0, 100, 0, 0, 0)
+    `).run()).toThrow(/CHECK constraint failed/);
+
+    closeDb();
+    expect(getDb().prepare("SELECT COUNT(*) AS count FROM schema_migrations WHERE version = 24").get())
+      .toEqual({ count: 1 });
+  });
+
+  it("migrates a v23 database idempotently without changing existing actors", () => {
+    const actorBefore = getDagActor("run-1", "researcher");
+    const db = getDb();
+    db.exec(`
+      DROP TABLE dag_actor_provisioned_workers;
+      DROP TABLE dag_actor_checkpoints;
+      DROP TABLE dag_actor_runtimes;
+      DELETE FROM schema_migrations WHERE version = 24;
+    `);
+    closeDb();
+
+    const migrated = getDb();
+    expect(migrated.prepare("SELECT version FROM schema_migrations WHERE version = 24").get())
+      .toEqual({ version: 24 });
+    expect(getDagActor("run-1", "researcher")).toEqual(actorBefore);
+    expect(migrated.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
+    expect(migrated.prepare("PRAGMA index_list(dag_actor_runtimes)").all())
+      .toEqual(expect.arrayContaining([
+        expect.objectContaining({ name: "idx_dag_actor_runtimes_expired", unique: 0, partial: 1 }),
+        expect.objectContaining({ name: "idx_dag_actor_runtimes_retention", unique: 0, partial: 1 }),
+      ]));
+    expect(migrated.prepare("PRAGMA index_list(dag_actor_provisioned_workers)").all())
+      .toEqual(expect.arrayContaining([
+        expect.objectContaining({ name: "idx_dag_actor_provisioned_workers_container", unique: 1 }),
+        expect.objectContaining({ name: "idx_dag_actor_provisioned_workers_current", unique: 1, partial: 1 }),
+      ]));
+
+    closeDb();
+    expect(getDb().prepare("SELECT COUNT(*) AS count FROM schema_migrations WHERE version = 24").get())
+      .toEqual({ count: 1 });
+  });
+
+  it("fails closed when a v24 partial uniqueness index is weakened", () => {
+    getDb().exec(`
+      DROP INDEX idx_dag_actor_provisioned_workers_current;
+      CREATE INDEX idx_dag_actor_provisioned_workers_current
+        ON dag_actor_provisioned_workers(run_id, actor_id, lease_generation);
+    `);
+    closeDb();
+
+    expect(() => getDb()).toThrow(
+      "Schema migration 24 is incomplete: index idx_dag_actor_provisioned_workers_current is missing or invalid",
+    );
+  });
+
+  it("acquires, renews, rebinds, releases, and fences stale physical generations", () => {
+    const dormant = ensureDagActorLease({
+      run_id: "run-1",
+      actor_id: "researcher",
+      retention_ttl_ms: 1_000,
+      now: 100,
+    });
+    expect(dormant).toMatchObject({ state: "dormant", lease_generation: 0, version: 1 });
+
+    const acquired = acquireDagActorLease({
+      run_id: "run-1",
+      actor_id: "researcher",
+      target_type: "provisioned_worker",
+      target_id: "worker-1",
+      expected_version: dormant.version,
+      idle_ttl_ms: 100,
+      retention_ttl_ms: 1_000,
+      now: 200,
+    });
+    expect(acquired).toMatchObject({
+      state: "leased",
+      lease_generation: 1,
+      target_id: "worker-1",
+      idle_deadline: 300,
+      version: 2,
+    });
+
+    const sameTarget = acquireDagActorLease({
+      run_id: "run-1",
+      actor_id: "researcher",
+      target_type: "provisioned_worker",
+      target_id: "worker-1",
+      expected_version: acquired.version,
+      idle_ttl_ms: 200,
+      retention_ttl_ms: 1_000,
+      now: 250,
+    });
+    expect(sameTarget).toMatchObject({ lease_generation: 1, idle_deadline: 450, version: 3 });
+
+    const renewed = renewDagActorLease({
+      run_id: "run-1",
+      actor_id: "researcher",
+      lease_generation: 1,
+      target_type: "provisioned_worker",
+      target_id: "worker-1",
+      expected_version: sameTarget.version,
+      idle_ttl_ms: 300,
+      now: 300,
+    });
+    expect(renewed).toMatchObject({ lease_generation: 1, idle_deadline: 600, version: 4 });
+
+    const rebound = acquireDagActorLease({
+      run_id: "run-1",
+      actor_id: "researcher",
+      target_type: "provisioned_worker",
+      target_id: "worker-2",
+      expected_version: renewed.version,
+      idle_ttl_ms: 100,
+      retention_ttl_ms: 1_000,
+      now: 400,
+    });
+    expect(rebound).toMatchObject({ lease_generation: 2, target_id: "worker-2", version: 5 });
+    expect(assessDagActorLease({
+      run_id: "run-1",
+      actor_id: "researcher",
+      lease_generation: 1,
+      target_type: "provisioned_worker",
+      target_id: "worker-1",
+      now: 450,
+    })).toMatchObject({ current: false, reason: "generation_mismatch" });
+    expect(assessDagActorLease({
+      run_id: "run-1",
+      actor_id: "researcher",
+      lease_generation: 2,
+      target_type: "provisioned_worker",
+      target_id: "worker-2",
+      now: 450,
+    })).toMatchObject({ current: true });
+
+    const released = releaseDagActorLease({
+      run_id: "run-1",
+      actor_id: "researcher",
+      lease_generation: 2,
+      target_type: "provisioned_worker",
+      target_id: "worker-2",
+      expected_version: rebound.version,
+      retention_ttl_ms: 1_000,
+      now: 500,
+    });
+    expect(released).toMatchObject({
+      state: "dormant",
+      lease_generation: 2,
+      retained_until: 1_500,
+      version: 6,
+    });
+    expect(released).not.toHaveProperty("target_id");
+    expect(assessDagActorLease({
+      run_id: "run-1",
+      actor_id: "researcher",
+      lease_generation: 2,
+      target_type: "provisioned_worker",
+      target_id: "worker-2",
+      now: 500,
+    })).toMatchObject({ current: false, reason: "not_leased" });
+    expect(() => renewDagActorLease({
+      run_id: "run-1",
+      actor_id: "researcher",
+      lease_generation: 2,
+      target_type: "provisioned_worker",
+      target_id: "worker-2",
+      now: 600,
+    })).toThrowError(expect.objectContaining<DagActorLeaseConflictError>({ code: "lease_state_conflict" }));
+
+    expect(acquireDagActorLease({
+      run_id: "run-1",
+      actor_id: "researcher",
+      target_type: "provisioned_worker",
+      target_id: "worker-3",
+      expected_version: released.version,
+      idle_ttl_ms: 100,
+      retention_ttl_ms: 1_000,
+      now: 600,
+    })).toMatchObject({ lease_generation: 3, target_id: "worker-3" });
+  });
+
+  it("exempts pinned leases from idle expiry and resets retention when unpinned", () => {
+    const acquired = acquireDagActorLease({
+      run_id: "run-1",
+      actor_id: "researcher",
+      target_type: "worker",
+      target_id: "worker-1",
+      idle_ttl_ms: 100,
+      retention_ttl_ms: 1_000,
+      now: 100,
+    });
+    const pinned = setDagActorLeasePinned({
+      run_id: "run-1",
+      actor_id: "researcher",
+      pinned: true,
+      expected_version: acquired.version,
+      retention_ttl_ms: 1_000,
+      now: 150,
+    });
+    expect(listExpiredDagActorLeases({ now: 300 })).toEqual([]);
+    expect(assessDagActorLease({
+      run_id: "run-1",
+      actor_id: "researcher",
+      lease_generation: 1,
+      target_type: "worker",
+      target_id: "worker-1",
+      now: 300,
+    })).toMatchObject({ current: true });
+
+    const unpinned = setDagActorLeasePinned({
+      run_id: "run-1",
+      actor_id: "researcher",
+      pinned: false,
+      expected_version: pinned.version,
+      retention_ttl_ms: 1_000,
+      now: 300,
+    });
+    expect(listExpiredDagActorLeases({ now: 300 }).map((lease) => lease.actor_id))
+      .toEqual(["researcher"]);
+    expect(() => renewDagActorLease({
+      run_id: "run-1",
+      actor_id: "researcher",
+      lease_generation: 1,
+      target_type: "worker",
+      target_id: "worker-1",
+      expected_version: unpinned.version,
+      idle_ttl_ms: 100,
+      now: 300,
+    })).toThrowError(expect.objectContaining<DagActorLeaseConflictError>({ code: "lease_expired" }));
+
+    const dormant = releaseDagActorLease({
+      run_id: "run-1",
+      actor_id: "researcher",
+      lease_generation: 1,
+      target_type: "worker",
+      target_id: "worker-1",
+      expected_version: unpinned.version,
+      retention_ttl_ms: 100,
+      now: 300,
+    });
+    const dormantPinned = setDagActorLeasePinned({
+      run_id: "run-1",
+      actor_id: "researcher",
+      pinned: true,
+      expected_version: dormant.version,
+      retention_ttl_ms: 100,
+      now: 350,
+    });
+    expect(deleteExpiredDagActorRuntime({ run_id: "run-1", actor_id: "researcher", now: 1_000 }))
+      .toMatchObject({ deleted: false, reason: "pinned" });
+    const dormantUnpinned = setDagActorLeasePinned({
+      run_id: "run-1",
+      actor_id: "researcher",
+      pinned: false,
+      expected_version: dormantPinned.version,
+      retention_ttl_ms: 100,
+      now: 1_000,
+    });
+    expect(dormantUnpinned.retained_until).toBe(1_100);
+    expect(deleteExpiredDagActorRuntime({ run_id: "run-1", actor_id: "researcher", now: 1_099 }))
+      .toMatchObject({ deleted: false, reason: "retained" });
+  });
+
+  it("writes append-only canonical checkpoints with monotonic versions and integrity checks", () => {
+    const first = writeDagActorCheckpoint({
+      run_id: "run-1",
+      actor_id: "researcher",
+      checkpoint: checkpoint(),
+      expected_checkpoint_version: 0,
+      now: 100,
+    });
+    expect(first).toMatchObject({ checkpoint_version: 1, created_at: 100 });
+    expect(first.checkpoint_sha256).toMatch(/^[0-9a-f]{64}$/);
+    const raw = getDb().prepare(`
+      SELECT checkpoint_json FROM dag_actor_checkpoints
+      WHERE run_id = 'run-1' AND actor_id = 'researcher' AND checkpoint_version = 1
+    `).get() as { checkpoint_json: string };
+    expect(raw.checkpoint_json).toBe(JSON.stringify({
+      actor_generation: 1,
+      artifact_refs: ["report:artifact-1"],
+      captured_at: 90,
+      confirmed_conclusions: ["The primary source confirms the first conclusion"],
+      context_summary: "Bounded provider-neutral context",
+      key_event_refs: ["event-2", "event-1"],
+      objective: "Continue the durable research objective",
+      round_id: "round-1",
+      schema_version: 1,
+      surface_binding: "surface-researcher",
+      unresolved_items: ["Verify the second claim"],
+      workspace_ref: "workspace://run-1",
+    }));
+
+    const second = writeDagActorCheckpoint({
+      run_id: "run-1",
+      actor_id: "researcher",
+      checkpoint: checkpoint({ captured_at: 190, context_summary: "Second durable snapshot" }),
+      expected_checkpoint_version: 1,
+      now: 200,
+    });
+    expect(second.checkpoint_version).toBe(2);
+    expect(getLatestDagActorCheckpoint({ run_id: "run-1", actor_id: "researcher" }))
+      .toEqual(second);
+    expect(() => writeDagActorCheckpoint({
+      run_id: "run-1",
+      actor_id: "researcher",
+      checkpoint: checkpoint({ captured_at: 200 }),
+      expected_checkpoint_version: 1,
+      now: 200,
+    })).toThrowError(expect.objectContaining<DagActorLeaseConflictError>({ code: "checkpoint_version_conflict" }));
+    expect(() => writeDagActorCheckpoint({
+      run_id: "run-1",
+      actor_id: "researcher",
+      checkpoint: checkpoint({ actor_generation: 2 }),
+      now: 200,
+    })).toThrowError(expect.objectContaining<DagActorLeaseConflictError>({ code: "checkpoint_generation_conflict" }));
+    expect(() => getDb().prepare(`
+      UPDATE dag_actor_checkpoints SET checkpoint_json = '{}' WHERE checkpoint_version = 2
+    `).run()).toThrow(/append-only/);
+
+    getDb().exec("DROP TRIGGER trg_dag_actor_checkpoints_no_update");
+    getDb().prepare(`
+      UPDATE dag_actor_checkpoints SET checkpoint_sha256 = ? WHERE checkpoint_version = 2
+    `).run("0".repeat(64));
+    expect(() => getLatestDagActorCheckpoint({ run_id: "run-1", actor_id: "researcher" }))
+      .toThrow(/failed integrity validation/);
+  });
+
+  it("deletes only retention-expired dormant or retired actors and their checkpoints", () => {
+    registerActor("leased", "leased-node");
+    registerActor("pinned", "pinned-node");
+    registerActor("retired", "retired-node");
+
+    writeDagActorCheckpoint({
+      run_id: "run-1",
+      actor_id: "researcher",
+      checkpoint: checkpoint(),
+      now: 100,
+    });
+    const dormantLease = acquireDagActorLease({
+      run_id: "run-1",
+      actor_id: "researcher",
+      target_type: "worker",
+      target_id: "worker-researcher",
+      idle_ttl_ms: 1_000,
+      retention_ttl_ms: 100,
+      now: 100,
+    });
+    releaseDagActorLease({
+      run_id: "run-1",
+      actor_id: "researcher",
+      lease_generation: dormantLease.lease_generation,
+      target_type: "worker",
+      target_id: "worker-researcher",
+      expected_version: dormantLease.version,
+      retention_ttl_ms: 100,
+      now: 200,
+    });
+
+    acquireDagActorLease({
+      run_id: "run-1",
+      actor_id: "leased",
+      target_type: "worker",
+      target_id: "worker-leased",
+      idle_ttl_ms: 1_000,
+      retention_ttl_ms: 100,
+      now: 100,
+    });
+    ensureDagActorLease({
+      run_id: "run-1",
+      actor_id: "pinned",
+      pinned: true,
+      retention_ttl_ms: 100,
+      now: 100,
+    });
+    const retiring = ensureDagActorLease({
+      run_id: "run-1",
+      actor_id: "retired",
+      retention_ttl_ms: 100,
+      now: 100,
+    });
+    retireDagActorLease({
+      run_id: "run-1",
+      actor_id: "retired",
+      expected_version: retiring.version,
+      retention_ttl_ms: 100,
+      now: 200,
+    });
+
+    expect(deleteExpiredDagActorRuntime({ run_id: "run-1", actor_id: "researcher", now: 299 }))
+      .toMatchObject({ deleted: false, reason: "retained" });
+    expect(deleteExpiredDagActorRuntime({ run_id: "run-1", actor_id: "researcher", now: 300 }))
+      .toEqual({ deleted: true, deleted_checkpoints: 1 });
+    expect(getDagActor("run-1", "researcher")).toBeUndefined();
+    expect(getLatestDagActorCheckpoint({ run_id: "run-1", actor_id: "researcher" })).toBeUndefined();
+    expect(deleteExpiredDagActorRuntime({ run_id: "run-1", actor_id: "leased", now: 10_000 }))
+      .toMatchObject({ deleted: false, reason: "leased" });
+    expect(deleteExpiredDagActorRuntime({ run_id: "run-1", actor_id: "pinned", now: 10_000 }))
+      .toMatchObject({ deleted: false, reason: "pinned" });
+    expect(deleteExpiredDagActorRuntime({ run_id: "run-1", actor_id: "retired", now: 300 }))
+      .toEqual({ deleted: true, deleted_checkpoints: 0 });
+    expect(getDagActor("run-1", "retired")).toBeUndefined();
+  });
+
+  it("persists provisioned ownership through restart and enforces lifecycle transitions", () => {
+    const lease = acquireDagActorLease({
+      run_id: "run-1",
+      actor_id: "researcher",
+      target_type: "provisioned_worker",
+      target_id: "worker-1",
+      idle_ttl_ms: 2_000,
+      retention_ttl_ms: 1_000,
+      now: 100,
+    });
+    const active = registerDagProvisionedWorker({
+      run_id: "run-1",
+      node_id: "researcher",
+      actor_id: "researcher",
+      lease_generation: lease.lease_generation,
+      worker_id: "worker-1",
+      container_id: "container-1",
+      docker_node_id: "docker-node-1",
+      now: 200,
+    });
+    expect(active).toMatchObject({ status: "active", version: 1, registered_at: 200 });
+    expect(registerDagProvisionedWorker({
+      run_id: "run-1",
+      node_id: "researcher",
+      actor_id: "researcher",
+      lease_generation: lease.lease_generation,
+      worker_id: "worker-1",
+      container_id: "container-1",
+      docker_node_id: "docker-node-1",
+      now: 250,
+    })).toEqual(active);
+
+    closeDb();
+    expect(listDagProvisionedWorkers({ statuses: ["active"] })).toEqual([active]);
+    const releasing = transitionDagProvisionedWorker({
+      run_id: "run-1",
+      actor_id: "researcher",
+      lease_generation: 1,
+      worker_id: "worker-1",
+      expected_status: "active",
+      status: "releasing",
+      expected_version: 1,
+      now: 300,
+    });
+    expect(releasing).toMatchObject({ status: "releasing", release_requested_at: 300, version: 2 });
+    const failed = transitionDagProvisionedWorker({
+      run_id: "run-1",
+      actor_id: "researcher",
+      lease_generation: 1,
+      worker_id: "worker-1",
+      expected_status: "releasing",
+      status: "failed",
+      expected_version: releasing.version,
+      failure: { message: "remove failed", authorization: "Bearer secret-token-value" },
+      now: 400,
+    });
+    expect(failed).toMatchObject({
+      status: "failed",
+      terminal_at: 400,
+      failure: { message: "remove failed", authorization: "***REDACTED***" },
+      version: 3,
+    });
+    const retried = transitionDagProvisionedWorker({
+      run_id: "run-1",
+      actor_id: "researcher",
+      lease_generation: 1,
+      worker_id: "worker-1",
+      expected_status: "failed",
+      status: "releasing",
+      expected_version: failed.version,
+      now: 500,
+    });
+    expect(retried).toMatchObject({ status: "releasing", release_requested_at: 500, version: 4 });
+    expect(retried).not.toHaveProperty("failure");
+    const released = transitionDagProvisionedWorker({
+      run_id: "run-1",
+      actor_id: "researcher",
+      lease_generation: 1,
+      worker_id: "worker-1",
+      expected_status: "releasing",
+      status: "released",
+      expected_version: retried.version,
+      now: 600,
+    });
+    expect(released).toMatchObject({ status: "released", terminal_at: 600, version: 5 });
+    expect(() => transitionDagProvisionedWorker({
+      run_id: "run-1",
+      actor_id: "researcher",
+      lease_generation: 1,
+      worker_id: "worker-1",
+      expected_status: "released",
+      status: "active",
+      now: 700,
+    })).toThrowError(expect.objectContaining<DagActorLeaseConflictError>({
+      code: "provisioned_worker_status_conflict",
+    }));
+
+    const currentLease = getDagActorLease({ run_id: "run-1", actor_id: "researcher" })!;
+    const dormant = releaseDagActorLease({
+      run_id: "run-1",
+      actor_id: "researcher",
+      lease_generation: 1,
+      target_type: "provisioned_worker",
+      target_id: "worker-1",
+      expected_version: currentLease.version,
+      retention_ttl_ms: 1_000,
+      now: 700,
+    });
+    const rebound = acquireDagActorLease({
+      run_id: "run-1",
+      actor_id: "researcher",
+      target_type: "provisioned_worker",
+      target_id: "worker-1",
+      expected_version: dormant.version,
+      idle_ttl_ms: 2_000,
+      retention_ttl_ms: 1_000,
+      now: 800,
+    });
+    expect(rebound.lease_generation).toBe(2);
+    expect(() => registerDagProvisionedWorker({
+      run_id: "run-1",
+      node_id: "researcher",
+      actor_id: "researcher",
+      lease_generation: 1,
+      worker_id: "worker-1",
+      container_id: "container-stale",
+      docker_node_id: "docker-node-1",
+      now: 900,
+    })).toThrowError(expect.objectContaining<DagActorLeaseConflictError>({ code: "lease_generation_conflict" }));
+    expect(registerDagProvisionedWorker({
+      run_id: "run-1",
+      node_id: "researcher",
+      actor_id: "researcher",
+      lease_generation: 2,
+      worker_id: "worker-1",
+      container_id: "container-2",
+      docker_node_id: "docker-node-1",
+      now: 900,
+    })).toMatchObject({ lease_generation: 2, status: "active" });
+    expect(listDagProvisionedWorkers({ run_id: "run-1", actor_id: "researcher" }))
+      .toHaveLength(2);
+
+    clearTables([
+      "dag_actor_provisioned_workers",
+      "dag_actor_checkpoints",
+      "dag_actor_runtimes",
+    ]);
+    expect(listDagProvisionedWorkers()).toEqual([]);
+  });
+});

--- a/homerail_manager/tests/dag-multiround-api.test.ts
+++ b/homerail_manager/tests/dag-multiround-api.test.ts
@@ -11,6 +11,7 @@ import { _clearAllDispatches } from "../src/orchestration/dispatch-tracker.js";
 import { parseDAGYaml } from "../src/orchestration/yaml-loader.js";
 import { closeDb } from "../src/persistence/db.js";
 import { listDagActorCommands } from "../src/persistence/dag-actors.js";
+import { acquireDagActorLease } from "../src/persistence/dag-actor-leases.js";
 import { _clearAllPersistence, loadRunMetadata } from "../src/persistence/store.js";
 import { _clearNodes } from "../src/node/registry.js";
 import {
@@ -27,7 +28,20 @@ class CapturingDispatcher implements DAGDispatcher {
   readonly dispatched: DispatchEnvelope[] = [];
 
   dispatch(envelope: DispatchEnvelope): DispatchResult {
-    this.dispatched.push(structuredClone(envelope));
+    if (!envelope.activity) throw new Error("test dispatch is missing actor identity");
+    const lease = acquireDagActorLease({
+      run_id: envelope.runId,
+      actor_id: envelope.activity.actorId,
+      target_type: "worker",
+      target_id: "worker-hot",
+    });
+    this.dispatched.push(structuredClone({
+      ...envelope,
+      activity: {
+        ...envelope.activity,
+        leaseGeneration: lease.lease_generation,
+      },
+    }));
     return { status: "dispatched", targetType: "fake", targetId: "worker-hot" };
   }
 }
@@ -244,6 +258,7 @@ describe("multi-round DAG HTTP API", () => {
       roundId: "round-0002",
       actorId: "researcher",
       generation: 1,
+      leaseGeneration: dispatcher.dispatched.at(-1)!.activity!.leaseGeneration,
       commandId: "command-http-round-2",
     });
     expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);

--- a/homerail_manager/tests/dag-multiround-runtime.test.ts
+++ b/homerail_manager/tests/dag-multiround-runtime.test.ts
@@ -13,6 +13,11 @@ import {
 } from "../src/orchestration/workflow-spec-v1.js";
 import { parseDAGYaml } from "../src/orchestration/yaml-loader.js";
 import { listDagActors, listDagActorCommands } from "../src/persistence/dag-actors.js";
+import {
+  acquireDagActorLease,
+  getDagActorLease,
+  getLatestDagActorCheckpoint,
+} from "../src/persistence/dag-actor-leases.js";
 import { closeDb, getDb } from "../src/persistence/db.js";
 import { listDagRunRounds } from "../src/persistence/dag-run-rounds.js";
 import {
@@ -39,10 +44,24 @@ import {
 
 class RepeatableDispatcher implements DAGDispatcher {
   readonly dispatched: DispatchEnvelope[] = [];
+  targetId = "worker-hot";
 
   dispatch(envelope: DispatchEnvelope): DispatchResult {
-    this.dispatched.push(structuredClone(envelope));
-    return { status: "dispatched", targetType: "fake", targetId: "worker-hot" };
+    if (!envelope.activity) throw new Error("test dispatch is missing actor identity");
+    const lease = acquireDagActorLease({
+      run_id: envelope.runId,
+      actor_id: envelope.activity.actorId,
+      target_type: "worker",
+      target_id: this.targetId,
+    });
+    this.dispatched.push(structuredClone({
+      ...envelope,
+      activity: {
+        ...envelope.activity,
+        leaseGeneration: lease.lease_generation,
+      },
+    }));
+    return { status: "dispatched", targetType: "fake", targetId: this.targetId };
   }
 }
 
@@ -251,7 +270,7 @@ describe("durable multi-round DAG runtime", () => {
       generation: 1,
       surfaceId: "actor:actor",
     });
-    expect(firstEnvelope.requiredCapabilities).toBeUndefined();
+    expect(firstEnvelope.requiredCapabilities).toEqual([DAG_TRANSPORT_FENCE_CAPABILITY]);
     handoffActiveRun(runId, "actor", "summary", { result: "round one" });
     expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
     expect(getActiveRun(runId)).toMatchObject({
@@ -363,6 +382,24 @@ nodes:
       generation: 1,
       surfaceId: "surface-research",
     });
+    expect(() => handoffActiveRun(runId, "actor", "summary", "missing round", {
+      transport: true,
+      actorId: "researcher",
+      generation: 1,
+      leaseGeneration: firstEnvelope.activity!.leaseGeneration,
+    })).toThrow("DAG_HANDOFF_ROUND_FENCE_MISSING");
+    expect(() => handoffActiveRun(runId, "actor", "summary", "missing actor", {
+      transport: true,
+      roundId: "round-0001",
+      generation: 1,
+      leaseGeneration: firstEnvelope.activity!.leaseGeneration,
+    })).toThrow("DAG_HANDOFF_ACTOR_FENCE_MISSING");
+    expect(() => handoffActiveRun(runId, "actor", "summary", "missing generation", {
+      transport: true,
+      roundId: "round-0001",
+      actorId: "researcher",
+      leaseGeneration: firstEnvelope.activity!.leaseGeneration,
+    })).toThrow("DAG_HANDOFF_GENERATION_FENCE_MISSING");
     handoffActiveRun(runId, "actor", "summary", { result: "round one" });
     expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
     expect(getActiveRun(runId)).toMatchObject({
@@ -371,6 +408,16 @@ nodes:
     });
     expect(getActiveRunCount()).toBe(0);
     expect(getWaitingRunCount()).toBe(1);
+    expect(getLatestDagActorCheckpoint({ run_id: runId, actor_id: "researcher" })).toMatchObject({
+      checkpoint_version: 1,
+      checkpoint: {
+        schema_version: 1,
+        round_id: "round-0001",
+        actor_generation: 1,
+        surface_binding: "surface-research",
+        confirmed_conclusions: expect.arrayContaining([expect.stringContaining("round one")]),
+      },
+    });
 
     const commandRequest = {
       expected_round_id: "round-0001",
@@ -381,6 +428,7 @@ nodes:
         payload: { task: "continue" },
       }],
     };
+    dispatcher.targetId = "worker-replacement";
     const resumed = resumeWaitingActiveRun(runId, commandRequest);
     expect(resumed).toMatchObject({
       previousRoundId: "round-0001",
@@ -400,8 +448,15 @@ nodes:
         roundId: "round-0002",
         actorId: "researcher",
         generation: 1,
+        leaseGeneration: 2,
         commandId: "command-round-2",
         surfaceId: "surface-research",
+      },
+      actorCheckpoint: {
+        schema_version: 1,
+        round_id: "round-0001",
+        actor_generation: 1,
+        surface_binding: "surface-research",
       },
       inputs: {
         command: [{
@@ -413,12 +468,27 @@ nodes:
       },
     });
     expect(listDagActorCommands({ run_id: runId })[0]?.status).toBe("delivered");
+    expect(getDagActorLease({ run_id: runId, actor_id: "researcher" })).toMatchObject({
+      state: "leased",
+      lease_generation: 2,
+      target_id: "worker-replacement",
+    });
+
+    expect(() => handoffActiveRun(runId, "actor", "summary", "stale worker", {
+      transport: true,
+      roundId: "round-0002",
+      actorId: "researcher",
+      generation: 1,
+      leaseGeneration: firstEnvelope.activity!.leaseGeneration,
+      commandId: "command-round-2",
+    })).toThrow("DAG_HANDOFF_LEASE_CONFLICT");
 
     expect(() => handoffActiveRun(runId, "actor", "summary", "late", {
       transport: true,
       roundId: "round-0001",
       actorId: "researcher",
       generation: 1,
+      leaseGeneration: secondEnvelope.activity!.leaseGeneration,
       commandId: "command-round-2",
     })).toThrow("DAG_HANDOFF_ROUND_CONFLICT");
     handoffActiveRun(runId, "actor", "summary", { result: "round two" }, {
@@ -426,6 +496,7 @@ nodes:
       roundId: "round-0002",
       actorId: "researcher",
       generation: 1,
+      leaseGeneration: secondEnvelope.activity!.leaseGeneration,
       commandId: "command-round-2",
     });
     expect(listDagActorCommands({ run_id: runId })[0]?.status).toBe("acknowledged");
@@ -457,8 +528,28 @@ nodes:
       expected_round_id: "round-0002",
       commands: [{ actor_id: "researcher", command_id: "command-round-3", payload: "one more" }],
     });
+    dispatcher.targetId = "worker-after-manager-restart";
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+    expect(dispatcher.dispatched.at(-1)).toMatchObject({
+      activity: {
+        roundId: "round-0003",
+        actorId: "researcher",
+        leaseGeneration: 3,
+        commandId: "command-round-3",
+      },
+      actorCheckpoint: {
+        schema_version: 1,
+        round_id: "round-0002",
+        actor_generation: 1,
+        surface_binding: "surface-research",
+      },
+    });
     cancelActiveRun(runId);
     expect(getActiveRun(runId)?.status).toBe("cancelled");
+    expect(getDagActorLease({ run_id: runId, actor_id: "researcher" })).toMatchObject({
+      state: "retired",
+      lease_generation: 3,
+    });
     expect(listDagActorCommands({ run_id: runId }).find((command) => command.command_id === "command-round-3"))
       .toMatchObject({ status: "cancelled" });
     expect(listDagRunRounds(runId).map((round) => [round.round_id, round.status])).toEqual([
@@ -530,11 +621,13 @@ nodes:
       commands: [{ actor_id: "actor_a", command_id: "command-a2", payload: "refresh A" }],
     });
     expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+    const roundTwoEnvelope = dispatcher.dispatched.at(-1)!;
     handoffActiveRun(runId, "actor_a", "result", { ok: true, label: "A2" }, {
       transport: true,
       roundId: "round-0002",
       actorId: "actor_a",
       generation: 1,
+      leaseGeneration: roundTwoEnvelope.activity!.leaseGeneration,
       commandId: "command-a2",
     });
     expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
@@ -613,6 +706,7 @@ nodes:
       commands: [{ actor_id: "researcher", command_id: "atomic-command", payload: "continue" }],
     });
     dispatchReadyNodes(runId, dispatcher);
+    const roundTwoEnvelope = dispatcher.dispatched.at(-1)!;
 
     getDb().exec(`
       CREATE TRIGGER fail_atomic_handoff_metadata
@@ -627,6 +721,7 @@ nodes:
       roundId: "round-0002",
       actorId: "researcher",
       generation: 1,
+      leaseGeneration: roundTwoEnvelope.activity!.leaseGeneration,
       commandId: "atomic-command",
     })).toThrow("forced metadata failure");
 
@@ -643,6 +738,7 @@ nodes:
       roundId: "round-0002",
       actorId: "researcher",
       generation: 1,
+      leaseGeneration: roundTwoEnvelope.activity!.leaseGeneration,
       commandId: "atomic-command",
     });
     expect(listDagActorCommands({ run_id: runId })).toContainEqual(expect.objectContaining({

--- a/homerail_manager/tests/dag-run-rounds.test.ts
+++ b/homerail_manager/tests/dag-run-rounds.test.ts
@@ -133,7 +133,7 @@ describe("DAG run round persistence", () => {
 
     const migrated = getDb();
     expect(migrated.prepare("SELECT version FROM schema_migrations WHERE version >= 21 ORDER BY version").all())
-      .toEqual([{ version: 21 }, { version: 22 }, { version: 23 }]);
+      .toEqual([{ version: 21 }, { version: 22 }, { version: 23 }, { version: 24 }]);
     expect(migrated.prepare("SELECT * FROM dag_actor_commands ORDER BY command_id").all())
       .toEqual(expectedRows);
     expect(migrated.prepare("PRAGMA foreign_key_check").all()).toEqual([]);

--- a/homerail_manager/tests/dag-runtime-primitives.test.ts
+++ b/homerail_manager/tests/dag-runtime-primitives.test.ts
@@ -388,6 +388,7 @@ edges:
     handoffActiveRun("ratchet-runtime-run", "improve", "changed", { measure_command: measureCommand, rollback_command: rollbackCommand });
 
     expect(executor.tick("ratchet-runtime-run")).toBeGreaterThan(0);
+    expect(getActiveRun("ratchet-runtime-run")?.dagRun.handoffedNodes.has("improve")).toBe(false);
     if (getActiveRun("ratchet-runtime-run")?.dagRun.nodeStates.get("improve") === "READY") {
       expect(executor.tick("ratchet-runtime-run")).toBeGreaterThan(0);
     }

--- a/homerail_manager/tests/dag-session-websocket.test.ts
+++ b/homerail_manager/tests/dag-session-websocket.test.ts
@@ -14,6 +14,7 @@ import { _clearDagMessageRouter } from "../src/orchestration/dag-message-router.
 import { _clearListeners, subscribe } from "../src/events/bus.js";
 import { closeDb } from "../src/persistence/db.js";
 import { listDagActivityEvents } from "../src/persistence/dag-activity-journal.js";
+import { acquireDagActorLease } from "../src/persistence/dag-actor-leases.js";
 import { appendSessionTranscriptForTest, loadSessionTranscript } from "../src/persistence/dag-session-files.js";
 import { _clearAllPersistence, loadRunSnapshot } from "../src/persistence/store.js";
 import {
@@ -28,9 +29,24 @@ import {
 class CaptureDispatcher implements DAGDispatcher {
   readonly dispatched: DispatchEnvelope[] = [];
 
+  constructor(private readonly targetId = "worker-a") {}
+
   dispatch(envelope: DispatchEnvelope): DispatchResult {
-    this.dispatched.push(envelope);
-    return { status: "dispatched", targetType: "fake", targetId: "fake" };
+    if (!envelope.activity) throw new Error("test dispatch is missing actor identity");
+    const lease = acquireDagActorLease({
+      run_id: envelope.runId,
+      actor_id: envelope.activity.actorId,
+      target_type: "worker",
+      target_id: this.targetId,
+    });
+    this.dispatched.push({
+      ...envelope,
+      activity: {
+        ...envelope.activity,
+        leaseGeneration: lease.lease_generation,
+      },
+    });
+    return { status: "dispatched", targetType: "worker", targetId: this.targetId };
   }
 }
 
@@ -130,7 +146,8 @@ describe("worker websocket node session filtering", () => {
     createActiveRun("run-ws-stale", simpleDag());
     const dispatcher = new CaptureDispatcher();
     expect(dispatchReadyNodes("run-ws-stale", dispatcher)).toBe(1);
-    const parentSessionId = dispatcher.dispatched[0].sessionId!;
+    const firstEnvelope = dispatcher.dispatched[0];
+    const parentSessionId = firstEnvelope.sessionId!;
     appendSessionTranscriptForTest(parentSessionId, [
       { uuid: "ws-entry-1", type: "text", runId: "run-ws-stale", nodeId: "work", content: "before resume" },
     ]);
@@ -138,7 +155,10 @@ describe("worker websocket node session filtering", () => {
       instruction: "Resume with marker WS_RESUME_MARKER.",
     });
     expect(resume.status).toBe("scheduled");
-    const currentSessionId = getCurrentNodeSession("run-ws-stale", "work")!.sessionId;
+    expect(dispatchReadyNodes("run-ws-stale", dispatcher)).toBe(1);
+    const currentEnvelope = dispatcher.dispatched[1];
+    const currentSessionId = currentEnvelope.sessionId!;
+    const activity = currentEnvelope.activity!;
 
     const staleEvents: unknown[] = [];
     subscribe("dag:stale_session_ignored", (payload) => staleEvents.push(payload));
@@ -169,6 +189,10 @@ describe("worker websocket node session filtering", () => {
         port: "done",
         content,
         session_id: sessionId,
+        round_id: activity.roundId,
+        actor_id: activity.actorId,
+        generation: activity.generation,
+        lease_generation: activity.leaseGeneration,
       },
     });
 
@@ -191,7 +215,9 @@ describe("worker websocket node session filtering", () => {
     createActiveRun("run-ws-exact", exactHandoffDag());
     const dispatcher = new CaptureDispatcher();
     expect(dispatchReadyNodes("run-ws-exact", dispatcher)).toBe(1);
-    const sessionId = dispatcher.dispatched[0].sessionId!;
+    const envelope = dispatcher.dispatched[0];
+    const sessionId = envelope.sessionId!;
+    const activity = envelope.activity!;
     const exact = {
       api_key: "sk-authoritative-secret-123456",
       long: "x".repeat(5000),
@@ -218,6 +244,10 @@ describe("worker websocket node session filtering", () => {
         port: "done",
         content: exact,
         session_id: sessionId,
+        round_id: activity.roundId,
+        actor_id: activity.actorId,
+        generation: activity.generation,
+        lease_generation: activity.leaseGeneration,
       },
     }));
     await delay(20);
@@ -236,10 +266,11 @@ describe("worker websocket node session filtering", () => {
 
   it("rejects stale-round activity before it reaches the journal or chat evidence", async () => {
     createActiveRun("run-ws-activity", simpleDag());
-    const dispatcher = new CaptureDispatcher();
+    const dispatcher = new CaptureDispatcher("worker-activity");
     expect(dispatchReadyNodes("run-ws-activity", dispatcher)).toBe(1);
     const sessionId = dispatcher.dispatched[0].sessionId!;
     const roundId = dispatcher.dispatched[0].activity!.roundId;
+    const leaseGeneration = dispatcher.dispatched[0].activity!.leaseGeneration;
     recordDispatch("run-ws-activity", "work", "worker", "worker-activity");
 
     const staleEvents: unknown[] = [];
@@ -261,6 +292,7 @@ describe("worker websocket node session filtering", () => {
       node_id: "work",
       actor_id: "work",
       generation: 1,
+      lease_generation: leaseGeneration,
       sequence: 1,
       timestamp: Date.now(),
       type: "finding",
@@ -281,6 +313,7 @@ describe("worker websocket node session filtering", () => {
         round_id: "stale-round",
         actor_id: "work",
         generation: 1,
+        lease_generation: leaseGeneration,
       },
     });
     ws.send(stream);
@@ -314,6 +347,7 @@ describe("worker websocket node session filtering", () => {
         round_id: roundId,
         actor_id: "work",
         generation: 1,
+        lease_generation: leaseGeneration,
       },
     }));
     await delay(20);
@@ -324,10 +358,11 @@ describe("worker websocket node session filtering", () => {
 
   it("rejects activity from a worker that does not own the current dispatch", async () => {
     createActiveRun("run-ws-source-bound", simpleDag());
-    const dispatcher = new CaptureDispatcher();
+    const dispatcher = new CaptureDispatcher("worker-owner");
     expect(dispatchReadyNodes("run-ws-source-bound", dispatcher)).toBe(1);
     const sessionId = dispatcher.dispatched[0].sessionId!;
     const roundId = dispatcher.dispatched[0].activity!.roundId;
+    const leaseGeneration = dispatcher.dispatched[0].activity!.leaseGeneration;
     recordDispatch("run-ws-source-bound", "work", "worker", "worker-owner");
 
     server = http.createServer();
@@ -348,6 +383,7 @@ describe("worker websocket node session filtering", () => {
         round_id: roundId,
         actor_id: "work",
         generation: 1,
+        lease_generation: leaseGeneration,
         activity: {
           schema_version: 1,
           event_id: "spoofed-source-activity",
@@ -356,6 +392,7 @@ describe("worker websocket node session filtering", () => {
           node_id: "work",
           actor_id: "work",
           generation: 1,
+          lease_generation: leaseGeneration,
           sequence: 1,
           timestamp: Date.now(),
           type: "finding",
@@ -369,12 +406,14 @@ describe("worker websocket node session filtering", () => {
     ws.close();
   });
 
-  it("accepts legacy session-based activity during the first round", async () => {
+  it("rejects legacy first-round activity without a physical lease fence", async () => {
     createActiveRun("run-ws-legacy-activity", simpleDag());
-    const dispatcher = new CaptureDispatcher();
+    const dispatcher = new CaptureDispatcher("worker-legacy-activity");
     expect(dispatchReadyNodes("run-ws-legacy-activity", dispatcher)).toBe(1);
     const sessionId = dispatcher.dispatched[0].sessionId!;
     recordDispatch("run-ws-legacy-activity", "work", "worker", "worker-legacy-activity");
+    const staleLeaseEvents: unknown[] = [];
+    subscribe("dag:stale_lease_ignored", (payload) => staleLeaseEvents.push(payload));
 
     server = http.createServer();
     setupWorkerWebSocket(server, { registrationTimeoutMs: 500, pingIntervalMs: 5_000 });
@@ -409,8 +448,8 @@ describe("worker websocket node session filtering", () => {
     }));
     await delay(20);
 
-    expect(listDagActivityEvents({ run_id: "run-ws-legacy-activity" }).events)
-      .toMatchObject([{ event: { event_id: "legacy-first-round-activity", round_id: sessionId } }]);
+    expect(listDagActivityEvents({ run_id: "run-ws-legacy-activity" }).events).toEqual([]);
+    expect(staleLeaseEvents).toHaveLength(1);
     ws.close();
   });
 
@@ -418,7 +457,8 @@ describe("worker websocket node session filtering", () => {
     createActiveRun("run-ws-message-stale", simpleDag());
     const dispatcher = new CaptureDispatcher();
     expect(dispatchReadyNodes("run-ws-message-stale", dispatcher)).toBe(1);
-    const parentSessionId = dispatcher.dispatched[0].sessionId!;
+    const firstEnvelope = dispatcher.dispatched[0];
+    const parentSessionId = firstEnvelope.sessionId!;
     appendSessionTranscriptForTest(parentSessionId, [
       { uuid: "ws-message-entry-1", type: "text", runId: "run-ws-message-stale", nodeId: "work", content: "before resume" },
     ]);
@@ -426,7 +466,10 @@ describe("worker websocket node session filtering", () => {
       instruction: "Resume with marker WS_MESSAGE_RESUME_MARKER.",
     });
     expect(resume.status).toBe("scheduled");
-    const currentSessionId = getCurrentNodeSession("run-ws-message-stale", "work")!.sessionId;
+    expect(dispatchReadyNodes("run-ws-message-stale", dispatcher)).toBe(1);
+    const currentEnvelope = dispatcher.dispatched[1];
+    const currentSessionId = currentEnvelope.sessionId!;
+    const activity = currentEnvelope.activity!;
 
     const staleEvents: unknown[] = [];
     const sentEvents: unknown[] = [];
@@ -456,6 +499,10 @@ describe("worker websocket node session filtering", () => {
         to_node: "other",
         content,
         session_id: sessionId,
+        round_id: activity.roundId,
+        actor_id: activity.actorId,
+        generation: activity.generation,
+        lease_generation: activity.leaseGeneration,
       },
     });
     const receiveMessage = (sessionId: string) => ({
@@ -466,6 +513,10 @@ describe("worker websocket node session filtering", () => {
         run_id: "run-ws-message-stale",
         from_node: "work",
         session_id: sessionId,
+        round_id: activity.roundId,
+        actor_id: activity.actorId,
+        generation: activity.generation,
+        lease_generation: activity.leaseGeneration,
       },
     });
 

--- a/homerail_manager/tests/dispatch-capabilities.test.ts
+++ b/homerail_manager/tests/dispatch-capabilities.test.ts
@@ -15,7 +15,8 @@ import { createSetting, upsertProvider } from "../src/persistence/llm-settings.j
 import { listDagActorCommands } from "../src/persistence/dag-actors.js";
 import { appendSessionTranscriptForTest, loadSessionTranscript } from "../src/persistence/dag-session-files.js";
 import { _clearAllPersistence } from "../src/persistence/store.js";
-import { closeDb } from "../src/persistence/db.js";
+import { closeDb, getDb } from "../src/persistence/db.js";
+import { getDagActorLease } from "../src/persistence/dag-actor-leases.js";
 import {
   _clearActiveRuns,
   checkpointResumeActiveRun,
@@ -46,6 +47,12 @@ function makeEnvelope(overrides: Partial<DispatchEnvelope> = {}): DispatchEnvelo
     workflowId: "deployment-diagnosis",
     workflowName: "Deployment Diagnosis",
     image: "homerail-worker:latest",
+    activity: {
+      roundId: "round-0001",
+      actorId: "diagnose",
+      generation: 1,
+      surfaceId: "surface:diagnose",
+    },
     ...overrides,
   };
 }
@@ -75,6 +82,19 @@ describe("DAG node capability requirements", () => {
     _clearWorkers();
     _clearNodes();
     _clearListeners();
+    createActiveRun("run-capabilities", parseDAGYaml(`
+name: dispatch-capabilities-fixture
+agents:
+  worker: { agent_type: deterministic }
+nodes:
+  diagnose:
+    agent: worker
+    outputs:
+      done: { to: "" }
+`));
+    // Direct adapter tests exercise transport without keeping an in-memory run,
+    // while preserving the durable actor identity required by lease binding.
+    _clearActiveRuns();
   });
 
   it("normalizes public Kimi Code backend aliases", () => {
@@ -156,6 +176,52 @@ nodes:
     });
     expect(genericSocket.send).not.toHaveBeenCalled();
     expect(hostSocket.send).toHaveBeenCalledTimes(1);
+    const sent = JSON.parse(String(hostSocket.send.mock.calls[0]?.[0])) as {
+      envelope: DispatchEnvelope;
+    };
+    expect(sent.envelope.activity).toMatchObject({
+      actorId: "diagnose",
+      leaseGeneration: 1,
+    });
+  });
+
+  it("does not retry a prompt that was sent before chat persistence failed", () => {
+    const socket = makeSocket();
+    registerWorker({
+      worker_id: "post-send-worker",
+      project_id: "p1",
+      socket,
+      status: "idle",
+      capabilities: [],
+      registered_at: Date.now(),
+      last_heartbeat: Date.now(),
+    });
+    getDb().exec(`
+      CREATE TRIGGER fail_post_send_chat
+      BEFORE INSERT ON dag_chats
+      BEGIN
+        SELECT RAISE(ABORT, 'forced post-send chat failure');
+      END;
+    `);
+
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(new WsDispatchAdapter({ provisioner: false }).dispatch(makeEnvelope())).toMatchObject({
+        status: "dispatched",
+        targetType: "worker",
+        targetId: "post-send-worker",
+      });
+      expect(socket.send).toHaveBeenCalledTimes(1);
+      expect(getDagActorLease({ run_id: "run-capabilities", actor_id: "diagnose" })).toMatchObject({
+        state: "leased",
+        target_type: "worker",
+        target_id: "post-send-worker",
+      });
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("prompt was sent but chat persistence failed"));
+    } finally {
+      warn.mockRestore();
+      getDb().exec("DROP TRIGGER IF EXISTS fail_post_send_chat");
+    }
   });
 
   it("reuses the previous online worker for a hot multi-round actor", () => {
@@ -281,7 +347,7 @@ nodes:
     expect(nodeSocket.send).not.toHaveBeenCalled();
   });
 
-  it("keeps an offline node READY and retries after a node registers", async () => {
+  it("keeps an offline node READY and retries after a compatible worker registers", async () => {
     createActiveRun("run-offline-node-reconnect", parseDAGYaml(`
 name: offline-node-reconnect
 workflow_id: offline-node-reconnect
@@ -298,24 +364,23 @@ nodes:
     expect(getActiveRun("run-offline-node-reconnect")).toMatchObject({ status: "active" });
     expect(getActiveRun("run-offline-node-reconnect")?.dagRun.nodeStates.get("diagnose")).toBe("READY");
 
-    const nodeSocket = makeSocket();
-    registerNode({
-      node_id: "late-node",
+    const workerSocket = makeSocket();
+    registerWorker({
+      worker_id: "late-worker",
       project_id: "p1",
-      socket: nodeSocket,
-      status: "connected",
-      capabilities: [],
+      socket: workerSocket,
+      status: "idle",
+      capabilities: [DAG_TRANSPORT_FENCE_CAPABILITY],
       registered_at: Date.now(),
       last_heartbeat: Date.now(),
-      pending_requests: new Map(),
     });
 
     await vi.waitFor(
-      () => expect(nodeSocket.send).toHaveBeenCalledTimes(1),
+      () => expect(workerSocket.send).toHaveBeenCalledTimes(1),
       { timeout: 2_500 },
     );
     expect(getActiveRun("run-offline-node-reconnect")?.dagRun.nodeStates.get("diagnose")).toBe("RUNNING");
-    expect(JSON.parse(String(nodeSocket.send.mock.calls[0]?.[0]))).toMatchObject({
+    expect(JSON.parse(String(workerSocket.send.mock.calls[0]?.[0]))).toMatchObject({
       type: "prompt",
       envelope: { runId: "run-offline-node-reconnect", nodeId: "diagnose" },
     });
@@ -353,7 +418,7 @@ nodes:
       project_id: "p1",
       socket: firstWorkerSocket,
       status: "idle",
-      capabilities: [],
+      capabilities: [DAG_TRANSPORT_FENCE_CAPABILITY],
       registered_at: Date.now(),
       last_heartbeat: Date.now(),
     });
@@ -371,7 +436,7 @@ nodes:
       project_id: "p1",
       socket: secondWorkerSocket,
       status: "idle",
-      capabilities: [],
+      capabilities: [DAG_TRANSPORT_FENCE_CAPABILITY],
       registered_at: Date.now(),
       last_heartbeat: Date.now(),
     });
@@ -546,26 +611,30 @@ nodes:
     outputs: { done: { to: "" } }
 `));
 
-    const provisionedWorkerId = "provisioned-run-provisioned-capability-mismatch-diagnose";
+    let provisionedWorkerId: string | undefined;
     const incompatibleSocket = makeSocket();
     const provisioningCompleted = waitForProvisioningCompleted(runId);
     const adapter = new WsDispatchAdapter({
       managerBaseUrl: "http://127.0.0.1:19191",
       provisioner: {
-        createFn: async () => ({ status: "success", resource_data: { id: "container-incompatible" } }),
+        createFn: async (_nodeId, _workspaceId, opts) => {
+          provisionedWorkerId = opts.env?.HOMERAIL_WORKER_ID;
+          return { status: "success", resource_data: { id: "container-incompatible" } };
+        },
         startFn: async () => {
+          if (!provisionedWorkerId) throw new Error("missing provisioned worker id");
           registerWorker({
             worker_id: provisionedWorkerId,
             project_id: "p1",
             socket: incompatibleSocket,
             status: "idle",
-            capabilities: [],
+            capabilities: [DAG_TRANSPORT_FENCE_CAPABILITY],
             registered_at: Date.now(),
             last_heartbeat: Date.now(),
           });
           return { status: "success" };
         },
-        runtimeStatusFn: async () => ({ worker_ids: [provisionedWorkerId] }),
+        runtimeStatusFn: async () => ({ worker_ids: provisionedWorkerId ? [provisionedWorkerId] : [] }),
       },
     });
 
@@ -584,7 +653,7 @@ nodes:
       project_id: "p1",
       socket: compatibleSocket,
       status: "idle",
-      capabilities: ["browser"],
+      capabilities: ["browser", DAG_TRANSPORT_FENCE_CAPABILITY],
       registered_at: Date.now(),
       last_heartbeat: Date.now(),
     });
@@ -625,26 +694,30 @@ nodes:
     outputs: { done: { to: "" } }
 `));
 
-    const workerId = "provisioned-run-provisioning-dispatch-budget-diagnose";
+    let workerId: string | undefined;
     const workerSocket = makeSocket();
     const provisioningCompleted = waitForProvisioningCompleted(runId);
     const adapter = new WsDispatchAdapter({
       managerBaseUrl: "http://127.0.0.1:19191",
       provisioner: {
-        createFn: async () => ({ status: "success", resource_data: { id: "container-budget" } }),
+        createFn: async (_nodeId, _workspaceId, opts) => {
+          workerId = opts.env?.HOMERAIL_WORKER_ID;
+          return { status: "success", resource_data: { id: "container-budget" } };
+        },
         startFn: async () => {
+          if (!workerId) throw new Error("missing provisioned worker id");
           registerWorker({
             worker_id: workerId,
             project_id: "p1",
             socket: workerSocket,
             status: "idle",
-            capabilities: [],
+            capabilities: [DAG_TRANSPORT_FENCE_CAPABILITY],
             registered_at: Date.now(),
             last_heartbeat: Date.now(),
           });
           return { status: "success" };
         },
-        runtimeStatusFn: async () => ({ worker_ids: [workerId] }),
+        runtimeStatusFn: async () => ({ worker_ids: workerId ? [workerId] : [] }),
       },
     });
 
@@ -725,14 +798,18 @@ nodes:
       last_heartbeat: Date.now(),
       pending_requests: new Map(),
     });
-    const workerId = "provisioned-run-provisioned-round-two-delivery-actor";
+    let workerId: string | undefined;
     const workerSocket = makeSocket();
     const provisioningCompleted = waitForProvisioningCompleted(runId);
     const adapter = new WsDispatchAdapter({
       managerBaseUrl: "http://127.0.0.1:19191",
       provisioner: {
-        createFn: async () => ({ status: "success", resource_data: { id: "container-round-two" } }),
+        createFn: async (_nodeId, _workspaceId, opts) => {
+          workerId = opts.env?.HOMERAIL_WORKER_ID;
+          return { status: "success", resource_data: { id: "container-round-two" } };
+        },
         startFn: async () => {
+          if (!workerId) throw new Error("missing provisioned worker id");
           registerWorker({
             worker_id: workerId,
             project_id: "p1",
@@ -744,7 +821,7 @@ nodes:
           });
           return { status: "success" };
         },
-        runtimeStatusFn: async () => ({ worker_ids: [workerId] }),
+        runtimeStatusFn: async () => ({ worker_ids: workerId ? [workerId] : [] }),
       },
     });
 
@@ -816,7 +893,7 @@ nodes:
     });
 
     const workerSocket = makeSocket();
-    const workerId = "provisioned-run-provisioning-resume-diagnose";
+    let workerId: string | undefined;
     let resolveCreate: ((value: { status: "success"; resource_data: { id: string } }) => void) | undefined;
     const createStarted = vi.fn();
     const createPromise = new Promise<{ status: "success"; resource_data: { id: string } }>((resolve) => {
@@ -825,24 +902,26 @@ nodes:
     const adapter = new WsDispatchAdapter({
       managerBaseUrl: "http://127.0.0.1:19191",
       provisioner: {
-        createFn: async () => {
+        createFn: async (_nodeId, _workspaceId, opts) => {
+          workerId = opts.env?.HOMERAIL_WORKER_ID;
           createStarted();
           return createPromise;
         },
         startFn: async () => {
+          if (!workerId) throw new Error("missing provisioned worker id");
           registerWorker({
             worker_id: workerId,
             project_id: "p1",
             socket: workerSocket,
             status: "idle",
-            capabilities: [],
+            capabilities: [DAG_TRANSPORT_FENCE_CAPABILITY],
             registered_at: Date.now(),
             last_heartbeat: Date.now(),
           });
           return { status: "success" };
         },
         runtimeStatusFn: async () => ({
-          worker_ids: [workerId],
+          worker_ids: workerId ? [workerId] : [],
         }),
       },
     });

--- a/homerail_manager/tests/dispatch-capabilities.test.ts
+++ b/homerail_manager/tests/dispatch-capabilities.test.ts
@@ -16,7 +16,13 @@ import { listDagActorCommands } from "../src/persistence/dag-actors.js";
 import { appendSessionTranscriptForTest, loadSessionTranscript } from "../src/persistence/dag-session-files.js";
 import { _clearAllPersistence } from "../src/persistence/store.js";
 import { closeDb, getDb } from "../src/persistence/db.js";
-import { getDagActorLease } from "../src/persistence/dag-actor-leases.js";
+import {
+  acquireDagActorLease,
+  getDagActorLease,
+  registerDagProvisionedWorker,
+  releaseDagActorLease,
+  transitionDagProvisionedWorker,
+} from "../src/persistence/dag-actor-leases.js";
 import {
   _clearActiveRuns,
   checkpointResumeActiveRun,
@@ -864,6 +870,62 @@ nodes:
       reason: "provisioning_in_progress",
     });
     expect(workerSocket.send).not.toHaveBeenCalled();
+  });
+
+  it("does not reuse a provisioned Worker after its lease is released for cleanup", () => {
+    const workerId = "provisioned-run-capabilities-diagnose-stale";
+    const workerSocket = makeSocket();
+    registerWorker({
+      worker_id: workerId,
+      project_id: "p1",
+      socket: workerSocket,
+      status: "idle",
+      capabilities: [DAG_TRANSPORT_FENCE_CAPABILITY],
+      registered_at: Date.now(),
+      last_heartbeat: Date.now(),
+    });
+    const lease = acquireDagActorLease({
+      run_id: "run-capabilities",
+      actor_id: "diagnose",
+      target_type: "worker",
+      target_id: workerId,
+    });
+    const ownership = registerDagProvisionedWorker({
+      run_id: "run-capabilities",
+      node_id: "diagnose",
+      actor_id: "diagnose",
+      lease_generation: lease.lease_generation,
+      worker_id: workerId,
+      container_id: "container-stale",
+      docker_node_id: "docker-node",
+    });
+    recordDispatch("run-capabilities", "diagnose", "worker", workerId);
+    releaseDagActorLease({
+      run_id: "run-capabilities",
+      actor_id: "diagnose",
+      lease_generation: lease.lease_generation,
+      target_type: "worker",
+      target_id: workerId,
+      expected_version: lease.version,
+    });
+    transitionDagProvisionedWorker({
+      run_id: "run-capabilities",
+      actor_id: "diagnose",
+      lease_generation: lease.lease_generation,
+      worker_id: workerId,
+      expected_status: "active",
+      status: "releasing",
+      expected_version: ownership.version,
+    });
+
+    const result = new WsDispatchAdapter({ provisioner: false }).dispatch(
+      makeEnvelope({ workspace: { mode: "isolated" } }),
+    );
+
+    expect(result).toMatchObject({ status: "skipped", reason: "no available worker or node" });
+    expect(workerSocket.send).not.toHaveBeenCalled();
+    expect(getDagActorLease({ run_id: "run-capabilities", actor_id: "diagnose" }))
+      .toMatchObject({ state: "dormant", lease_generation: lease.lease_generation });
   });
 
   it("dispatches the current checkpoint-resume envelope after pending provisioning completes", async () => {

--- a/homerail_manager/tests/generative-ui-persistent-document-service.test.ts
+++ b/homerail_manager/tests/generative-ui-persistent-document-service.test.ts
@@ -190,6 +190,7 @@ describe("PersistentGenerativeUiDocumentService", () => {
       .toEqual([
         ...Array.from({ length: 20 }, (_, index) => ({ version: index + 1 })),
         { version: 23 },
+        { version: 24 },
       ]);
     expect(getDb().prepare("SELECT data FROM voice_agent_sessions WHERE session_id = ?").get("legacy-v2"))
       .toEqual({ data: legacyPayload });
@@ -275,6 +276,7 @@ describe("PersistentGenerativeUiDocumentService", () => {
       .toEqual([
         ...Array.from({ length: 20 }, (_, index) => ({ version: index + 1 })),
         { version: 23 },
+        { version: 24 },
       ]);
     expect(getDb().prepare(`
       SELECT name FROM sqlite_master

--- a/homerail_manager/tests/plugin-distribution.test.ts
+++ b/homerail_manager/tests/plugin-distribution.test.ts
@@ -149,6 +149,6 @@ describe("plugin publisher trust persistence", () => {
     expect(listPluginPublisherTrustEvents()).toHaveLength(1);
     expect(getDb().prepare(
       "SELECT MAX(version) AS version FROM schema_migrations",
-    ).get()).toEqual({ version: 23 });
+    ).get()).toEqual({ version: 24 });
   });
 });

--- a/homerail_manager/tests/plugin-package-lifecycle.test.ts
+++ b/homerail_manager/tests/plugin-package-lifecycle.test.ts
@@ -260,7 +260,7 @@ describe("external plugin package lifecycle", () => {
       expect.objectContaining({ plugin_version: "1.1.0", active: false, enabled: false }),
       expect.objectContaining({ plugin_version: "1.2.0", active: false, enabled: false }),
     ]));
-    expect(getDb().prepare("SELECT MAX(version) AS version FROM schema_migrations").get()).toEqual({ version: 23 });
+    expect(getDb().prepare("SELECT MAX(version) AS version FROM schema_migrations").get()).toEqual({ version: 24 });
     expect(inspectInstalledPlugin("com.example.release-notes")).toMatchObject({ healthy: true, issues: [] });
   });
 
@@ -455,7 +455,7 @@ describe("external plugin package lifecycle", () => {
 
     expect(getPluginRegistryState().revision).toBe(101);
     expect(getDb().prepare("SELECT MAX(version) AS version FROM schema_migrations").get())
-      .toEqual({ version: 23 });
+      .toEqual({ version: 24 });
   });
 
   it("rejects a stale uninstall when an inactive version was installed concurrently", () => {

--- a/homerail_manager/tests/plugin-remote-registry.test.ts
+++ b/homerail_manager/tests/plugin-remote-registry.test.ts
@@ -236,7 +236,7 @@ describe("signed remote plugin registry", () => {
     expect(listPluginRegistryUpdateAttempts("stable.example").filter((attempt) => attempt.status === "failed"))
       .toHaveLength(3);
     expect(getDb().prepare("SELECT MAX(version) AS version FROM schema_migrations").get())
-      .toEqual({ version: 23 });
+      .toEqual({ version: 24 });
   });
 
   it("rejects signed catalog releases whose payload or publisher digest disagrees with the HRP", () => {

--- a/homerail_manager/tests/pr-review-scenario.test.ts
+++ b/homerail_manager/tests/pr-review-scenario.test.ts
@@ -539,15 +539,16 @@ describe("PR Review scenario assets", () => {
     }
   });
 
-  it("keeps the GitHub adapter thin, truthful, and off untrusted fork PRs", () => {
+  it("keeps the manual GitHub adapter thin and truthful", () => {
     const workflow = fs.readFileSync(path.resolve(process.cwd(), "..", ".github", "workflows", "pr-review.yml"), "utf8");
     const runner = fs.readFileSync(path.resolve(process.cwd(), "..", "scripts", "run-dag-patterns-live-runner.sh"), "utf8");
     const reviewRunner = fs.readFileSync(path.resolve(process.cwd(), "..", "scripts", "run-pr-review-live-runner.sh"), "utf8");
     const parsed = parseYaml(workflow) as { jobs: { review: { env: Record<string, string>; steps: Array<{ name: string; env?: Record<string, string> }> } } };
-    expect(workflow).toContain("pull_request:");
     expect(workflow).toContain("workflow_dispatch:");
+    expect(workflow).not.toContain("pull_request:");
     expect(workflow).not.toContain("pull_request_target:");
-    expect(workflow).toContain("github.event.pull_request.head.repo.full_name == github.repository");
+    expect(workflow).not.toContain("github.event.pull_request");
+    expect(workflow).toContain("github.event_name == 'workflow_dispatch'");
     expect(workflow).not.toContain("continue-on-error: true");
     expect(workflow).toContain("bash scripts/run-pr-review-live-runner.sh");
     expect(workflow).toContain("npm run build:packages");

--- a/homerail_manager/tests/provisioned-cleanup.test.ts
+++ b/homerail_manager/tests/provisioned-cleanup.test.ts
@@ -1,56 +1,139 @@
-import { afterEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { _clearListeners, subscribe } from "../src/events/bus.js";
 import {
   _clearAllProvisionedWorkers,
+  deprovisionProvisionedWorker,
   deprovisionProvisionedForRun,
+  listProvisionedForRun,
   registerProvisionedWorker,
 } from "../src/orchestration/provisioned-cleanup.js";
+import {
+  acquireDagActorLease,
+  listDagProvisionedWorkers,
+} from "../src/persistence/dag-actor-leases.js";
+import { registerDagActor } from "../src/persistence/dag-actors.js";
+import { closeDb } from "../src/persistence/db.js";
+import { ensureRunDir, loadRunMetadata, writeRunMetadata } from "../src/persistence/store.js";
 
 describe("provisioned worker cleanup", () => {
+  let home: string;
+  let oldHome: string | undefined;
+
+  beforeEach(() => {
+    closeDb();
+    oldHome = process.env.HOMERAIL_HOME;
+    home = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-provisioned-cleanup-"));
+    process.env.HOMERAIL_HOME = home;
+    ensureRunDir("run-cleanup");
+    registerDagActor({
+      run_id: "run-cleanup",
+      actor_id: "coder-actor",
+      node_id: "coder",
+      role: "coding",
+      surface_id: "surface-coder",
+    });
+  });
+
   afterEach(() => {
     _clearAllProvisionedWorkers();
     _clearListeners();
+    closeDb();
+    if (oldHome === undefined) delete process.env.HOMERAIL_HOME;
+    else process.env.HOMERAIL_HOME = oldHome;
+    fs.rmSync(home, { recursive: true, force: true });
   });
 
-  it("emits cleanup lifecycle events without hard-coded issue identity", async () => {
-    const requested: Record<string, unknown>[] = [];
-    const completedPromise = new Promise<Record<string, unknown>>((resolve) => {
-      subscribe("dag:cleanup_completed", (payload) => resolve(payload as Record<string, unknown>));
+  function registerWorker(workerId = "worker-1") {
+    const lease = acquireDagActorLease({
+      run_id: "run-cleanup",
+      actor_id: "coder-actor",
+      target_type: "provisioned_worker",
+      target_id: workerId,
+      idle_ttl_ms: 60_000,
+      retention_ttl_ms: 60_000,
     });
-    subscribe("dag:cleanup_requested", (payload) => {
-      requested.push(payload as Record<string, unknown>);
-    });
-
-    registerProvisionedWorker({
+    return registerProvisionedWorker({
       runId: "run-cleanup",
       nodeId: "coder",
-      workerId: "worker-1",
-      containerId: "container-1",
+      actorId: "coder-actor",
+      leaseGeneration: lease.lease_generation,
+      workerId,
+      containerId: `container-${workerId}`,
       dockerNodeId: "docker-node-1",
     });
+  }
 
-    const started = deprovisionProvisionedForRun("run-cleanup", {
-      deprovisionFn: async () => ({
-        stopped: true,
-        removed: true,
-        dockerCleanupVerified: true,
-      }),
+  it("keeps a failed durable cleanup row and retries it after a cold restart", async () => {
+    registerWorker();
+    const failed = new Promise<Record<string, unknown>>((resolve) => {
+      subscribe("dag:cleanup_failed", (payload) => resolve(payload as Record<string, unknown>));
     });
-    const completed = await completedPromise;
 
-    expect(started).toBe(true);
-    expect(requested).toHaveLength(1);
-    expect(requested[0]).toMatchObject({ runId: "run-cleanup", workerCount: 1 });
-    expect(requested[0]).not.toHaveProperty("sourceIssue");
-    expect(completed).toMatchObject({
+    expect(deprovisionProvisionedForRun("run-cleanup", {
+      deprovisionFn: async () => { throw new Error("docker unavailable"); },
+    })).toBe(true);
+    await expect(failed).resolves.toMatchObject({ runId: "run-cleanup", workerId: "worker-1" });
+    expect(listDagProvisionedWorkers({ run_id: "run-cleanup" })[0]).toMatchObject({
+      status: "failed",
+      failure: { message: "docker unavailable" },
+    });
+
+    closeDb();
+    expect(listProvisionedForRun("run-cleanup")).toHaveLength(1);
+    const completed = new Promise<Record<string, unknown>>((resolve) => {
+      subscribe("dag:cleanup_completed", (payload) => resolve(payload as Record<string, unknown>));
+    });
+    expect(deprovisionProvisionedForRun("run-cleanup", {
+      deprovisionFn: async () => ({ stopped: true, removed: true, dockerCleanupVerified: true }),
+    })).toBe(true);
+    await expect(completed).resolves.toMatchObject({
       runId: "run-cleanup",
       workerId: "worker-1",
-      nodeId: "coder",
-      containerId: "container-1",
       stopped: true,
       removed: true,
     });
-    expect(completed).not.toHaveProperty("sourceIssue");
+    expect(listDagProvisionedWorkers({ run_id: "run-cleanup" })[0]).toMatchObject({ status: "released" });
+  });
+
+  it("does not mark a worker released unless physical removal is confirmed", async () => {
+    const entry = registerWorker();
+
+    await expect(deprovisionProvisionedWorker(entry, {
+      deprovisionFn: async () => ({ stopped: false, removed: false, dockerCleanupVerified: false }),
+    })).resolves.toBe(false);
+    expect(listDagProvisionedWorkers({ run_id: "run-cleanup" })[0]).toMatchObject({
+      status: "failed",
+      failure: {
+        message: expect.stringContaining("did not confirm container removal"),
+      },
+    });
+
+    await expect(deprovisionProvisionedWorker(entry, {
+      deprovisionFn: async () => ({ stopped: true, removed: true, dockerCleanupVerified: true }),
+    })).resolves.toBe(true);
+    expect(listDagProvisionedWorkers({ run_id: "run-cleanup" })[0]).toMatchObject({ status: "released" });
+  });
+
+  it("uses durable ownership for cancelled and terminal run cleanup", async () => {
+    registerWorker();
+    const metadata = loadRunMetadata("run-cleanup")!;
+    writeRunMetadata("run-cleanup", { ...metadata, status: "cancelled", completedAt: Date.now() });
+    const completed = new Promise<Record<string, unknown>>((resolve) => {
+      subscribe("dag:cleanup_completed", (payload) => resolve(payload as Record<string, unknown>));
+    });
+
+    expect(deprovisionProvisionedForRun("run-cleanup", {
+      deprovisionFn: async () => ({ stopped: true, removed: true, dockerCleanupVerified: true }),
+    })).toBe(true);
+    await completed;
+    expect(listProvisionedForRun("run-cleanup")[0]).toMatchObject({
+      actorId: "coder-actor",
+      leaseGeneration: 1,
+    });
+    expect(listDagProvisionedWorkers({ run_id: "run-cleanup" })[0].status).toBe("released");
   });
 });

--- a/homerail_manager/tests/response-bridge.test.ts
+++ b/homerail_manager/tests/response-bridge.test.ts
@@ -5,6 +5,8 @@ const mocks = vi.hoisted(() => ({
   getActiveRun: vi.fn(),
   getDagActorByNode: vi.fn(),
   getDagActorCommand: vi.fn(),
+  acquireDagActorLease: vi.fn(),
+  assessDagActorLease: vi.fn(),
 }));
 
 vi.mock("../src/runtime/active-runs.js", () => ({
@@ -17,7 +19,14 @@ vi.mock("../src/persistence/dag-actors.js", () => ({
   getDagActorCommand: mocks.getDagActorCommand,
 }));
 
+vi.mock("../src/persistence/dag-actor-leases.js", () => ({
+  acquireDagActorLease: mocks.acquireDagActorLease,
+  assessDagActorLease: mocks.assessDagActorLease,
+}));
+
 import { applyResponseHandoff } from "../src/orchestration/response-bridge.js";
+
+const source = { targetType: "worker", targetId: "worker-1" } as const;
 
 describe("response bridge transport fence", () => {
   beforeEach(() => {
@@ -45,6 +54,9 @@ describe("response bridge transport fence", () => {
       target_generation: 3,
       status: "delivered",
     });
+    mocks.assessDagActorLease.mockReset();
+    mocks.assessDagActorLease.mockReturnValue({ current: true, lease: {} });
+    mocks.acquireDagActorLease.mockReset();
   });
 
   it("passes authoritative round metadata to handoffActiveRun", () => {
@@ -56,10 +68,11 @@ describe("response bridge transport fence", () => {
       round_id: "round-0002",
       actor_id: "actor-1",
       generation: 3,
+      lease_generation: 7,
       command_id: "command-2",
     };
 
-    expect(applyResponseHandoff(payload)).toEqual({
+    expect(applyResponseHandoff(payload, source)).toEqual({
       status: "handoff_applied",
       runId: "run-2",
       nodeId: "actor-node",
@@ -75,12 +88,13 @@ describe("response bridge transport fence", () => {
         roundId: "round-0002",
         actorId: "actor-1",
         generation: 3,
+        leaseGeneration: 7,
         commandId: "command-2",
       },
     );
   });
 
-  it("keeps legacy first-round payloads transport-marked but unfenced", () => {
+  it("accepts a v2 first-round payload without a command id", () => {
     mocks.getActiveRun.mockReturnValue({
       status: "active",
       currentRound: { round_id: "round-0001", ordinal: 1 },
@@ -97,15 +111,25 @@ describe("response bridge transport fence", () => {
       runId: "run-1",
       nodeId: "legacy-node",
       port: "done",
-      content: "legacy",
-    });
+      content: "first round",
+      round_id: "round-0001",
+      actor_id: "legacy-node",
+      generation: 1,
+      lease_generation: 1,
+    }, source);
 
     expect(mocks.handoffActiveRun).toHaveBeenCalledWith(
       "run-1",
       "legacy-node",
       "done",
-      "legacy",
-      { transport: true },
+      "first round",
+      {
+        transport: true,
+        roundId: "round-0001",
+        actorId: "legacy-node",
+        generation: 1,
+        leaseGeneration: 1,
+      },
     );
   });
 
@@ -117,25 +141,27 @@ describe("response bridge transport fence", () => {
       content: null,
       round_id: "round-0002",
       generation: 1.5,
-    })).toEqual({
+      lease_generation: 1,
+    }, source)).toEqual({
       status: "malformed_payload",
       reason: "generation must be a positive safe integer",
     });
     expect(mocks.handoffActiveRun).not.toHaveBeenCalled();
   });
 
-  it("ignores a legacy unfenced response once the run reaches round two", () => {
+  it("rejects a missing v2 lease generation before applying a handoff", () => {
     expect(applyResponseHandoff({
       runId: "run-2",
       nodeId: "actor-node",
       port: "done",
-      content: "late round one",
-    })).toMatchObject({
-      status: "handoff_ignored",
-      disposition: "stale",
-      runId: "run-2",
-      nodeId: "actor-node",
-      reason: expect.stringContaining("DAG_TRANSPORT_ROUND_FENCE_MISSING"),
+      content: "missing lease",
+      round_id: "round-0002",
+      actor_id: "actor-1",
+      generation: 3,
+      command_id: "command-2",
+    }, source)).toMatchObject({
+      status: "malformed_payload",
+      reason: "lease_generation must be a positive safe integer",
     });
     expect(mocks.handoffActiveRun).not.toHaveBeenCalled();
   });
@@ -149,8 +175,9 @@ describe("response bridge transport fence", () => {
       round_id: "round-0001",
       actor_id: "actor-1",
       generation: 3,
+      lease_generation: 7,
       command_id: "command-2",
-    })).toMatchObject({ status: "handoff_ignored", disposition: "stale" });
+    }, source)).toMatchObject({ status: "handoff_ignored", disposition: "stale" });
 
     expect(applyResponseHandoff({
       runId: "run-2",
@@ -160,8 +187,9 @@ describe("response bridge transport fence", () => {
       round_id: "round-0002",
       actor_id: "actor-1",
       generation: 2,
+      lease_generation: 7,
       command_id: "command-2",
-    })).toMatchObject({
+    }, source)).toMatchObject({
       status: "handoff_ignored",
       disposition: "stale",
       reason: expect.stringContaining("DAG_TRANSPORT_GENERATION_STALE"),
@@ -186,8 +214,9 @@ describe("response bridge transport fence", () => {
       round_id: "round-0002",
       actor_id: "actor-1",
       generation: 3,
+      lease_generation: 7,
       command_id: "command-2",
-    })).toMatchObject({
+    }, source)).toMatchObject({
       status: "handoff_ignored",
       disposition: "duplicate",
       reason: expect.stringContaining("DAG_TRANSPORT_COMMAND_DUPLICATE"),
@@ -202,8 +231,12 @@ describe("response bridge transport fence", () => {
       runId: "run-2",
       nodeId: "actor-node",
       port: "done",
-      content: "legacy duplicate",
-    })).toMatchObject({
+      content: "first round duplicate",
+      round_id: "round-0001",
+      actor_id: "actor-1",
+      generation: 3,
+      lease_generation: 7,
+    }, source)).toMatchObject({
       status: "handoff_ignored",
       disposition: "duplicate",
       reason: expect.stringContaining("DAG_TRANSPORT_HANDOFF_DUPLICATE"),
@@ -224,13 +257,100 @@ describe("response bridge transport fence", () => {
       round_id: "round-0002",
       actor_id: "actor-1",
       generation: 3,
+      lease_generation: 7,
       command_id: "command-2",
-    })).toEqual({
+    }, source)).toEqual({
       status: "handoff_failed",
       runId: "run-2",
       nodeId: "actor-node",
       reason: "DAG_HANDOFF_CONTRACT_VIOLATION actor-node.done",
     });
     expect(mocks.handoffActiveRun).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a lease that belongs to a different physical source", () => {
+    mocks.assessDagActorLease.mockReturnValue({ current: false, reason: "target_mismatch" });
+
+    expect(applyResponseHandoff({
+      runId: "run-2",
+      nodeId: "actor-node",
+      port: "done",
+      content: "forged source",
+      round_id: "round-0002",
+      actor_id: "actor-1",
+      generation: 3,
+      lease_generation: 7,
+      command_id: "command-2",
+    }, source)).toMatchObject({
+      status: "handoff_ignored",
+      disposition: "invalid",
+      reason: expect.stringContaining("DAG_TRANSPORT_LEASE_TARGET_MISMATCH"),
+    });
+    expect(mocks.handoffActiveRun).not.toHaveBeenCalled();
+  });
+
+  it("renews an exact expired lease before accepting an active-run result", () => {
+    mocks.assessDagActorLease
+      .mockReturnValueOnce({
+        current: false,
+        reason: "expired",
+        lease: {
+          state: "leased",
+          lease_generation: 7,
+          target_type: "worker",
+          target_id: "worker-1",
+          version: 11,
+        },
+      })
+      .mockReturnValueOnce({ current: true, lease: { version: 12 } });
+
+    expect(applyResponseHandoff({
+      runId: "run-2",
+      nodeId: "actor-node",
+      port: "done",
+      content: "completed after a scheduler pause",
+      round_id: "round-0002",
+      actor_id: "actor-1",
+      generation: 3,
+      lease_generation: 7,
+      command_id: "command-2",
+    }, source)).toMatchObject({ status: "handoff_applied" });
+    expect(mocks.acquireDagActorLease).toHaveBeenCalledWith({
+      run_id: "run-2",
+      actor_id: "actor-1",
+      target_type: "worker",
+      target_id: "worker-1",
+      expected_version: 11,
+    });
+  });
+
+  it("does not revive an expired lease for a waiting run", () => {
+    mocks.getActiveRun.mockReturnValue({
+      status: "waiting",
+      currentRound: { round_id: "round-0002", ordinal: 2 },
+      dagRun: { handoffedNodes: new Set<string>() },
+    });
+    mocks.assessDagActorLease.mockReturnValue({
+      current: false,
+      reason: "expired",
+      lease: { version: 11 },
+    });
+
+    expect(applyResponseHandoff({
+      runId: "run-2",
+      nodeId: "actor-node",
+      port: "done",
+      content: "late waiting result",
+      round_id: "round-0002",
+      actor_id: "actor-1",
+      generation: 3,
+      lease_generation: 7,
+      command_id: "command-2",
+    }, source)).toMatchObject({
+      status: "handoff_ignored",
+      disposition: "stale",
+      reason: expect.stringContaining("DAG_TRANSPORT_LEASE_EXPIRED"),
+    });
+    expect(mocks.acquireDagActorLease).not.toHaveBeenCalled();
   });
 });

--- a/homerail_manager/tests/transport-fence-websocket.test.ts
+++ b/homerail_manager/tests/transport-fence-websocket.test.ts
@@ -13,11 +13,12 @@ import { parseDAGYaml } from "../src/orchestration/yaml-loader.js";
 import { _clearListeners, subscribe } from "../src/events/bus.js";
 import { _clearNodes } from "../src/node/registry.js";
 import { setupNodeWebSocket } from "../src/node/websocket.js";
-import { listDagActivityEvents } from "../src/persistence/dag-activity-journal.js";
 import { listDagActorCommands } from "../src/persistence/dag-actors.js";
-import { closeDb } from "../src/persistence/db.js";
+import { acquireDagActorLease } from "../src/persistence/dag-actor-leases.js";
+import { closeDb, getDb } from "../src/persistence/db.js";
 import { loadSessionTranscript } from "../src/persistence/dag-session-files.js";
-import { _clearAllPersistence } from "../src/persistence/store.js";
+import { _clearAllPersistence, loadNodeUsages } from "../src/persistence/store.js";
+import { listDagActivityEvents } from "../src/persistence/dag-activity-journal.js";
 import {
   _clearActiveRuns,
   createActiveRun,
@@ -180,10 +181,16 @@ describe("round-aware terminal websocket transport", () => {
       const correctionEvents: unknown[] = [];
       const auditEvents: unknown[] = [];
       subscribe("dag:node_correction_requested", (payload) => correctionEvents.push(payload));
-      subscribe("dag:response_handoff_failed", (payload) => auditEvents.push(payload));
+      subscribe("dag:stale_lease_ignored", (payload) => auditEvents.push(payload));
       let applied = 0;
-      const { server, ws } = await openTransport(sourceType, runId, () => {
+      const { server, ws, sourceId } = await openTransport(sourceType, runId, () => {
         applied += 1;
+      });
+      const lease = acquireDagActorLease({
+        run_id: runId,
+        actor_id: "researcher",
+        target_type: sourceType,
+        target_id: sourceId,
       });
 
       const response = (roundId: string, content: string) => ({
@@ -200,6 +207,7 @@ describe("round-aware terminal websocket transport", () => {
           round_id: roundId,
           actor_id: "researcher",
           generation: 1,
+          lease_generation: lease.lease_generation,
           command_id: commandId,
           content,
           summary: content,
@@ -215,6 +223,7 @@ describe("round-aware terminal websocket transport", () => {
           round_id: roundId,
           actor_id: "researcher",
           generation: 1,
+          lease_generation: lease.lease_generation,
           command_id: commandId,
         },
       });
@@ -250,9 +259,8 @@ describe("round-aware terminal websocket transport", () => {
         expect(JSON.stringify(auditEvents)).toContain("DAG_TRANSPORT_COMMAND_DUPLICATE");
 
         const transcript = JSON.stringify(loadSessionTranscript(sessionId));
-        expect(transcript).toContain("handoff_stale_ignored");
-        expect(transcript).toContain("node_error_stale_ignored");
-        expect(transcript).toContain("handoff_duplicate_ignored");
+        expect(transcript).toContain("stale_lease_response_ignored");
+        expect(transcript).toContain("stale_lease_node_error_ignored");
       } finally {
         ws.terminate();
         await closeServer(server);
@@ -266,8 +274,14 @@ describe("round-aware terminal websocket transport", () => {
     const correctionEvents: unknown[] = [];
     subscribe("dag:node_correction_requested", (payload) => correctionEvents.push(payload));
     let applied = 0;
-    const { server, ws } = await openTransport(sourceType, runId, () => {
+    const { server, ws, sourceId } = await openTransport(sourceType, runId, () => {
       applied += 1;
+    });
+    const lease = acquireDagActorLease({
+      run_id: runId,
+      actor_id: "researcher",
+      target_type: sourceType,
+      target_id: sourceId,
     });
 
     try {
@@ -281,6 +295,7 @@ describe("round-aware terminal websocket transport", () => {
           round_id: "round-0002",
           actor_id: "researcher",
           generation: 1,
+          lease_generation: lease.lease_generation,
           command_id: `${runId}-command-2`,
         },
       }));
@@ -341,4 +356,208 @@ describe("round-aware terminal websocket transport", () => {
       }
     },
   );
+
+  it.each(["worker", "node"] as const)(
+    "isolates stale %s content, stream, activity, response, and error reports",
+    async (sourceType) => {
+      const runId = `run-${sourceType}-stale-lease-reports`;
+      const envelope = startRoundTwo(runId);
+      const sessionId = envelope.sessionId!;
+      const auditEvents: unknown[] = [];
+      const correctionEvents: unknown[] = [];
+      let applied = 0;
+      subscribe("dag:stale_lease_ignored", (payload) => auditEvents.push(payload));
+      subscribe("dag:node_correction_requested", (payload) => correctionEvents.push(payload));
+      const { server, ws, sourceId } = await openTransport(sourceType, runId, () => {
+        applied += 1;
+      });
+      const staleLease = acquireDagActorLease({
+        run_id: runId,
+        actor_id: "researcher",
+        target_type: sourceType,
+        target_id: sourceId,
+      });
+      const reboundLease = acquireDagActorLease({
+        run_id: runId,
+        actor_id: "researcher",
+        target_type: sourceType,
+        target_id: `${sourceId}-replacement`,
+      });
+      const fence = {
+        round_id: "round-0002",
+        actor_id: "researcher",
+        generation: 1,
+        lease_generation: staleLease.lease_generation,
+        command_id: `${runId}-command-2`,
+      };
+      const chatsBefore = getDb().prepare("SELECT COUNT(*) AS count FROM dag_chats WHERE run_id = ?")
+        .get(runId) as { count: number };
+
+      try {
+        ws.send(JSON.stringify({
+          type: "content",
+          data: {
+            text: "token=plain-secret-value",
+            run_id: runId,
+            node_id: "actor",
+            session_id: sessionId,
+            ...fence,
+          },
+        }));
+        ws.send(JSON.stringify({
+          type: "stream",
+          data: {
+            event: "tool_call",
+            run_id: runId,
+            node_id: "actor",
+            session_id: sessionId,
+            ...fence,
+          },
+        }));
+        ws.send(JSON.stringify({
+          type: "stream",
+          data: {
+            event: "dag_activity",
+            run_id: runId,
+            node_id: "actor",
+            session_id: sessionId,
+            ...fence,
+            activity: {
+              schema_version: 1,
+              event_id: `${runId}-stale-activity`,
+              run_id: runId,
+              round_id: "round-0002",
+              node_id: "actor",
+              actor_id: "researcher",
+              generation: 1,
+              lease_generation: staleLease.lease_generation,
+              sequence: 1,
+              type: "started",
+              timestamp: Date.now(),
+            },
+          },
+        }));
+        ws.send(JSON.stringify({
+          type: "response",
+          session_id: sessionId,
+          data: {
+            type: "node_handoff",
+            runId,
+            nodeId: "actor",
+            port: "summary",
+            session_id: sessionId,
+            ...fence,
+            content: "late handoff",
+          },
+        }));
+        ws.send(JSON.stringify({
+          type: "node_error",
+          data: {
+            runId,
+            nodeId: "actor",
+            message: "late error",
+            session_id: sessionId,
+            ...fence,
+          },
+        }));
+        // A source that has learned the new generation must still be rejected
+        // when it is no longer the leased physical target.
+        ws.send(JSON.stringify({
+          type: "content",
+          data: {
+            text: "forged source",
+            run_id: runId,
+            node_id: "actor",
+            session_id: sessionId,
+            ...fence,
+            lease_generation: reboundLease.lease_generation,
+          },
+        }));
+        await delay(50);
+
+        expect(getDb().prepare("SELECT COUNT(*) AS count FROM dag_chats WHERE run_id = ?").get(runId))
+          .toEqual(chatsBefore);
+        expect(loadNodeUsages(runId)).toEqual([]);
+        expect(listDagActivityEvents({ run_id: runId })).toMatchObject({ events: [] });
+        expect(getActiveRun(runId)?.dagRun.nodeStates.get("actor")).toBe("RUNNING");
+        expect(correctionEvents).toEqual([]);
+        expect(applied).toBe(0);
+        expect(auditEvents).toHaveLength(6);
+        expect(JSON.stringify(auditEvents)).toContain("DAG_TRANSPORT_LEASE_GENERATION_MISMATCH");
+        expect(JSON.stringify(auditEvents)).toContain("DAG_TRANSPORT_LEASE_TARGET_MISMATCH");
+        const transcript = JSON.stringify(loadSessionTranscript(sessionId));
+        expect(transcript).toContain("stale_lease_content_ignored");
+        expect(transcript).toContain("stale_lease_stream_ignored");
+        expect(transcript).toContain("stale_lease_dag_activity_ignored");
+        expect(transcript).toContain("stale_lease_response_ignored");
+        expect(transcript).toContain("stale_lease_node_error_ignored");
+        expect(transcript).not.toContain("plain-secret-value");
+      } finally {
+        ws.terminate();
+        await closeServer(server);
+      }
+    },
+  );
+
+  it("isolates stale worker usage and session-end reports", async () => {
+    const runId = "run-worker-stale-lease-usage-session-end";
+    const envelope = startRoundTwo(runId);
+    const sessionId = envelope.sessionId!;
+    const auditEvents: unknown[] = [];
+    subscribe("dag:stale_lease_ignored", (payload) => auditEvents.push(payload));
+    const { server, ws, sourceId } = await openTransport("worker", runId, () => undefined);
+    const staleLease = acquireDagActorLease({
+      run_id: runId,
+      actor_id: "researcher",
+      target_type: "worker",
+      target_id: sourceId,
+    });
+    acquireDagActorLease({
+      run_id: runId,
+      actor_id: "researcher",
+      target_type: "worker",
+      target_id: `${sourceId}-replacement`,
+    });
+    const fence = {
+      round_id: "round-0002",
+      actor_id: "researcher",
+      generation: 1,
+      lease_generation: staleLease.lease_generation,
+      command_id: `${runId}-command-2`,
+    };
+
+    try {
+      ws.send(JSON.stringify({
+        type: "stream",
+        data: {
+          event: "usage",
+          run_id: runId,
+          node_id: "actor",
+          session_id: sessionId,
+          usage: { input_tokens: 101, output_tokens: 23 },
+          ...fence,
+        },
+      }));
+      ws.send(JSON.stringify({
+        type: "SESSION_END",
+        data: {
+          run_id: runId,
+          node_id: "actor",
+          session_id: sessionId,
+          ...fence,
+        },
+      }));
+      await delay(50);
+
+      expect(loadNodeUsages(runId)).toEqual([]);
+      expect(getActiveRun(runId)?.dagRun.nodeStates.get("actor")).toBe("RUNNING");
+      expect(auditEvents).toHaveLength(2);
+      const transcript = JSON.stringify(loadSessionTranscript(sessionId));
+      expect(transcript).toContain("stale_lease_usage_ignored");
+      expect(transcript).toContain("stale_lease_session_end_ignored");
+    } finally {
+      ws.terminate();
+      await closeServer(server);
+    }
+  });
 });

--- a/homerail_manager/tests/transport-fence-websocket.test.ts
+++ b/homerail_manager/tests/transport-fence-websocket.test.ts
@@ -317,6 +317,12 @@ describe("round-aware terminal websocket transport", () => {
       const envelope = startRoundTwo(runId);
       const { server, ws, sourceId } = await openTransport(sourceType, runId, () => undefined);
       recordDispatch(runId, "actor", sourceType, sourceId);
+      const lease = acquireDagActorLease({
+        run_id: runId,
+        actor_id: "researcher",
+        target_type: sourceType,
+        target_id: sourceId,
+      });
       const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
 
       try {
@@ -328,6 +334,11 @@ describe("round-aware terminal websocket transport", () => {
             run_id: runId,
             node_id: "actor",
             session_id: envelope.sessionId,
+            round_id: "round-0002",
+            actor_id: "researcher",
+            generation: 1,
+            lease_generation: lease.lease_generation,
+            command_id: `${runId}-command-2`,
             activity: {
               schema_version: 1,
               event_id: `${runId}-late-activity`,

--- a/homerail_manager/tests/workflow-concurrency.test.ts
+++ b/homerail_manager/tests/workflow-concurrency.test.ts
@@ -10,6 +10,7 @@ import { FakeDAGDispatcher } from "../src/orchestration/dag-dispatcher.js";
 import { GraphExecutor } from "../src/orchestration/graph-executor.js";
 import { parseDAGYaml } from "../src/orchestration/yaml-loader.js";
 import { closeDb, getDb } from "../src/persistence/db.js";
+import { acquireDagActorLease } from "../src/persistence/dag-actor-leases.js";
 import {
   deriveWorkflowConcurrencyPolicy,
   releaseWorkflowRunReservation,
@@ -388,11 +389,18 @@ timer:
       dispatched: 1,
     });
     expect(firstResume.deduplicated).toBeUndefined();
+    const lease = acquireDagActorLease({
+      run_id: runId,
+      actor_id: "actor",
+      target_type: "worker",
+      target_id: "fake-dispatcher",
+    });
     handoffActiveRun(runId, "actor", "summary", { result: "round two" }, {
       transport: true,
       roundId: "round-0002",
       actorId: "actor",
       generation: 1,
+      leaseGeneration: lease.lease_generation,
       commandId: "resume-retry-command",
     });
     expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);

--- a/homerail_manager/tests/workspace-retention.test.ts
+++ b/homerail_manager/tests/workspace-retention.test.ts
@@ -9,6 +9,7 @@ import {
   registerProvisionedWorker,
 } from "../src/orchestration/provisioned-cleanup.js";
 import { loadRunMetadata, writeRunMetadata } from "../src/persistence/store.js";
+import { acquireDagActorLease } from "../src/persistence/dag-actor-leases.js";
 import {
   DEFAULT_WORKSPACE_RETENTION_SETTINGS,
   loadWorkspaceRetentionSettings,
@@ -258,10 +259,29 @@ nodes:
   it("protects workspaces while provisioned worker cleanup is pending", async () => {
     const now = Date.now();
     const runId = "worker-cleanup-pending";
+    createActiveRun(runId, parseDAGYaml(`
+name: retention-worker-cleanup-pending
+agents:
+  worker: { agent_type: deterministic }
+nodes:
+  worker-node:
+    agent: worker
+    outputs:
+      done: { to: "" }
+`));
+    const lease = acquireDagActorLease({
+      run_id: runId,
+      actor_id: "worker-node",
+      target_type: "worker",
+      target_id: "worker-1",
+    });
+    _clearActiveRuns();
     const workspace = addRun(runId, "completed", now - 8 * DAY_MS);
     registerProvisionedWorker({
       runId,
       nodeId: "worker-node",
+      actorId: "worker-node",
+      leaseGeneration: lease.lease_generation,
       workerId: "worker-1",
       containerId: "container-1",
       dockerNodeId: "docker-node-1",

--- a/homerail_protocol/src/dag-activity.ts
+++ b/homerail_protocol/src/dag-activity.ts
@@ -37,6 +37,8 @@ export interface DagActivityEventV1 {
   node_id: string;
   actor_id: string;
   generation: number;
+  /** Physical Worker lease generation; required by transport-fence v2. */
+  lease_generation?: number;
   surface_id?: string;
   sequence: number;
   /** Unix epoch milliseconds assigned at the activity source. */
@@ -83,6 +85,7 @@ export const dagActivityEventV1Schema = {
     node_id: identifierSchema,
     actor_id: identifierSchema,
     generation: { type: "integer", minimum: 1, maximum: Number.MAX_SAFE_INTEGER },
+    lease_generation: { type: "integer", minimum: 1, maximum: Number.MAX_SAFE_INTEGER },
     surface_id: identifierSchema,
     sequence: { type: "integer", minimum: 1, maximum: Number.MAX_SAFE_INTEGER },
     timestamp: { type: "integer", minimum: 0, maximum: Number.MAX_SAFE_INTEGER },

--- a/homerail_protocol/src/schemas.ts
+++ b/homerail_protocol/src/schemas.ts
@@ -12,6 +12,8 @@ import {
   DAG_NODE_ERROR_SCHEMA_ID,
   DAG_TRANSPORT_FENCE_SCHEMA_ID,
   DAG_TRANSPORT_FENCE_PROTOCOL_VERSION,
+  DAG_TRANSPORT_FENCE_V1_PROTOCOL_VERSION,
+  DAG_TRANSPORT_FENCE_V1_SCHEMA_ID,
 } from "./types.js";
 
 // ── DAG Tool Schemas ─────────────────────────────────────────────
@@ -207,6 +209,7 @@ export const dagNodeConfigSchema = {
     round_id: { type: "string", minLength: 1, maxLength: 256 },
     actor_id: { type: "string", minLength: 1, maxLength: 256 },
     generation: { type: "integer", minimum: 1, maximum: Number.MAX_SAFE_INTEGER },
+    lease_generation: { type: "integer", minimum: 1, maximum: Number.MAX_SAFE_INTEGER },
     command_id: { type: "string", minLength: 1, maxLength: 256 },
     surface_id: { type: "string", minLength: 1, maxLength: 256 },
     activity_sequence_start: { type: "integer", minimum: 0, maximum: Number.MAX_SAFE_INTEGER },
@@ -219,14 +222,24 @@ const dagTransportFenceProperties = {
   round_id: { type: "string", minLength: 1, maxLength: 256 },
   actor_id: { type: "string", minLength: 1, maxLength: 256 },
   generation: { type: "integer", minimum: 1, maximum: Number.MAX_SAFE_INTEGER },
+  lease_generation: { type: "integer", minimum: 1, maximum: Number.MAX_SAFE_INTEGER },
   command_id: { type: "string", minLength: 1, maxLength: 256 },
 };
 
 export const dagTransportFenceV1Schema = {
-  $id: DAG_TRANSPORT_FENCE_SCHEMA_ID,
+  $id: DAG_TRANSPORT_FENCE_V1_SCHEMA_ID,
   type: "object",
   properties: dagTransportFenceProperties,
   required: ["round_id", "actor_id", "generation", "command_id"],
+  additionalProperties: false,
+  version: DAG_TRANSPORT_FENCE_V1_PROTOCOL_VERSION,
+};
+
+export const dagTransportFenceV2Schema = {
+  $id: DAG_TRANSPORT_FENCE_SCHEMA_ID,
+  type: "object",
+  properties: dagTransportFenceProperties,
+  required: ["round_id", "actor_id", "generation", "lease_generation"],
   additionalProperties: false,
   version: DAG_TRANSPORT_FENCE_PROTOCOL_VERSION,
 };
@@ -442,7 +455,8 @@ export const allSchemas: Record<string, Record<string, unknown>> = {
   ...generativeUiSchemas,
   ...homerailPluginSchemas,
   "dag-activity-event-v1": dagActivityEventV1Schema as Record<string, unknown>,
-  [DAG_TRANSPORT_FENCE_SCHEMA_ID]: dagTransportFenceV1Schema as Record<string, unknown>,
+  [DAG_TRANSPORT_FENCE_V1_SCHEMA_ID]: dagTransportFenceV1Schema as Record<string, unknown>,
+  [DAG_TRANSPORT_FENCE_SCHEMA_ID]: dagTransportFenceV2Schema as Record<string, unknown>,
   [DAG_NODE_ERROR_SCHEMA_ID]: dagNodeErrorSchema as Record<string, unknown>,
   "handoff-request": handoffRequestSchema as Record<string, unknown>,
   "handoff-response": handoffResponseSchema as Record<string, unknown>,

--- a/homerail_protocol/src/types.ts
+++ b/homerail_protocol/src/types.ts
@@ -456,10 +456,15 @@ export const DAG_AGENT_TOOL_NAMES = [
 
 export type DagAgentToolName = (typeof DAG_AGENT_TOOL_NAMES)[number];
 
-/** Versioned Worker capability for round-aware terminal transport. @version 0.1.0 */
-export const DAG_TRANSPORT_FENCE_PROTOCOL_VERSION = 1 as const;
-export const DAG_TRANSPORT_FENCE_CAPABILITY = "dag-transport-fence-v1" as const;
-export const DAG_TRANSPORT_FENCE_SCHEMA_ID = "dag-transport-fence-v1" as const;
+/** Legacy round-aware terminal transport retained for schema compatibility. */
+export const DAG_TRANSPORT_FENCE_V1_PROTOCOL_VERSION = 1 as const;
+export const DAG_TRANSPORT_FENCE_V1_CAPABILITY = "dag-transport-fence-v1" as const;
+export const DAG_TRANSPORT_FENCE_V1_SCHEMA_ID = "dag-transport-fence-v1" as const;
+
+/** Worker transport fence that also binds every report to a physical lease. */
+export const DAG_TRANSPORT_FENCE_PROTOCOL_VERSION = 2 as const;
+export const DAG_TRANSPORT_FENCE_CAPABILITY = "dag-transport-fence-v2" as const;
+export const DAG_TRANSPORT_FENCE_SCHEMA_ID = "dag-transport-fence-v2" as const;
 export const DAG_NODE_ERROR_SCHEMA_ID = "dag-node-error" as const;
 
 /** Optional on round-one wire messages; required by Manager for later rounds. */
@@ -467,6 +472,7 @@ export interface DagTransportFenceMetadata {
   round_id?: string;
   actor_id?: string;
   generation?: number;
+  lease_generation?: number;
   command_id?: string;
 }
 
@@ -475,6 +481,30 @@ export interface DagTransportFenceV1 {
   actor_id: string;
   generation: number;
   command_id: string;
+}
+
+export interface DagTransportFenceV2 {
+  round_id: string;
+  actor_id: string;
+  generation: number;
+  lease_generation: number;
+  command_id?: string;
+}
+
+/** Provider-neutral state used to rebuild an actor on another Worker. */
+export interface DagActorCheckpointV1 {
+  schema_version: 1;
+  objective: string;
+  confirmed_conclusions: string[];
+  unresolved_items: string[];
+  key_event_refs: string[];
+  artifact_refs: string[];
+  workspace_ref?: string;
+  surface_binding: string;
+  context_summary: string;
+  round_id: string;
+  actor_generation: number;
+  captured_at: number;
 }
 
 export interface DagNodeErrorData extends DagTransportFenceMetadata {
@@ -510,6 +540,7 @@ export interface DagNodeConfig {
   round_id?: string;
   actor_id?: string;
   generation?: number;
+  lease_generation?: number;
   command_id?: string;
   surface_id?: string;
   /** Last persisted activity sequence; the next emitted event starts after this value. */

--- a/homerail_protocol/tests/dag-activity.test.ts
+++ b/homerail_protocol/tests/dag-activity.test.ts
@@ -8,6 +8,9 @@ import {
   DAG_TRANSPORT_FENCE_CAPABILITY,
   DAG_TRANSPORT_FENCE_PROTOCOL_VERSION,
   DAG_TRANSPORT_FENCE_SCHEMA_ID,
+  DAG_TRANSPORT_FENCE_V1_CAPABILITY,
+  DAG_TRANSPORT_FENCE_V1_PROTOCOL_VERSION,
+  DAG_TRANSPORT_FENCE_V1_SCHEMA_ID,
   type DagActivityEventV1,
   type DagNodeErrorMessage,
   validateDagActivityEventV1,
@@ -24,6 +27,7 @@ function activity(overrides: Partial<DagActivityEventV1> = {}): DagActivityEvent
     node_id: "worker-01",
     actor_id: "researcher",
     generation: 1,
+    lease_generation: 3,
     surface_id: "surface-news",
     sequence: 1,
     timestamp: 1_784_000_000_000,
@@ -56,6 +60,10 @@ describe("Worker Activity Event V1", () => {
     delete event.surface_id;
 
     expect(validateMessage(event, DAG_ACTIVITY_EVENT_V1_SCHEMA_ID).valid).toBe(true);
+  });
+
+  it("rejects an invalid physical lease generation", () => {
+    expect(validateDagActivityEventV1(activity({ lease_generation: 0 }))).toMatchObject({ valid: false });
   });
 
   it("exposes report_activity as a DAG agent tool", () => {
@@ -111,6 +119,7 @@ describe("DAG activity routing metadata", () => {
     round_id: "round-02",
     actor_id: "researcher",
     generation: 2,
+    lease_generation: 3,
     command_id: "command-02",
     surface_id: "surface-news",
     activity_sequence_start: 41,
@@ -125,6 +134,7 @@ describe("DAG activity routing metadata", () => {
     ["round_id", ""],
     ["actor_id", ""],
     ["generation", 0],
+    ["lease_generation", 0],
     ["command_id", ""],
     ["surface_id", ""],
     ["activity_sequence_start", -1],
@@ -146,23 +156,35 @@ describe("DAG terminal transport fence", () => {
       round_id: "round-02",
       actor_id: "researcher",
       generation: 2,
+      lease_generation: 3,
       command_id: "command-02",
     },
   };
 
   it("exports an explicit versioned Worker capability", () => {
-    expect(DAG_TRANSPORT_FENCE_PROTOCOL_VERSION).toBe(1);
-    expect(DAG_TRANSPORT_FENCE_CAPABILITY).toBe("dag-transport-fence-v1");
+    expect(DAG_TRANSPORT_FENCE_PROTOCOL_VERSION).toBe(2);
+    expect(DAG_TRANSPORT_FENCE_CAPABILITY).toBe("dag-transport-fence-v2");
     expect(DAG_TRANSPORT_FENCE_SCHEMA_ID).toBe(DAG_TRANSPORT_FENCE_CAPABILITY);
+    expect(DAG_TRANSPORT_FENCE_V1_PROTOCOL_VERSION).toBe(1);
+    expect(DAG_TRANSPORT_FENCE_V1_CAPABILITY).toBe("dag-transport-fence-v1");
+    expect(DAG_TRANSPORT_FENCE_V1_SCHEMA_ID).toBe(DAG_TRANSPORT_FENCE_V1_CAPABILITY);
+    expect(allSchemas[DAG_TRANSPORT_FENCE_V1_SCHEMA_ID]).toBeDefined();
     expect(allSchemas[DAG_TRANSPORT_FENCE_SCHEMA_ID]).toBeDefined();
     expect(allSchemas[DAG_NODE_ERROR_SCHEMA_ID]).toBeDefined();
   });
 
-  it("validates a complete v1 fence and fenced node_error", () => {
+  it("validates complete v1 and lease-fenced v2 envelopes", () => {
     expect(validateMessage({
       round_id: "round-02",
       actor_id: "researcher",
       generation: 2,
+      command_id: "command-02",
+    }, DAG_TRANSPORT_FENCE_V1_SCHEMA_ID).valid).toBe(true);
+    expect(validateMessage({
+      round_id: "round-02",
+      actor_id: "researcher",
+      generation: 2,
+      lease_generation: 3,
       command_id: "command-02",
     }, DAG_TRANSPORT_FENCE_SCHEMA_ID).valid).toBe(true);
     expect(validateMessage(fencedError, DAG_NODE_ERROR_SCHEMA_ID).valid).toBe(true);
@@ -181,6 +203,7 @@ describe("DAG terminal transport fence", () => {
       round_id: "round-02",
       actor_id: "researcher",
       generation: 2,
+      lease_generation: 0,
     }, DAG_TRANSPORT_FENCE_SCHEMA_ID).valid).toBe(false);
   });
 });

--- a/homerail_worker/src/__tests__/dag-activity.test.ts
+++ b/homerail_worker/src/__tests__/dag-activity.test.ts
@@ -22,6 +22,7 @@ describe("DAG activity emitter", () => {
       actor_id: "research-actor",
       round_id: "round-2",
       generation: 3,
+      lease_generation: 7,
       surface_id: "surface-news",
       activity_sequence_start: 7,
     }), "run-1", (event) => events.push(event));
@@ -37,6 +38,7 @@ describe("DAG activity emitter", () => {
       node_id: "researcher",
       actor_id: "research-actor",
       generation: 3,
+      lease_generation: 7,
       surface_id: "surface-news",
       sequence: 8,
       type: "started",

--- a/homerail_worker/src/__tests__/prompt-runner.test.ts
+++ b/homerail_worker/src/__tests__/prompt-runner.test.ts
@@ -271,6 +271,7 @@ describe("prompt runner", () => {
           round_id: "round-0002",
           actor_id: "actor-coder",
           generation: 3,
+          lease_generation: 8,
           command_id: "command-2",
         }),
       },
@@ -291,6 +292,7 @@ describe("prompt runner", () => {
         round_id: "round-0002",
         actor_id: "actor-coder",
         generation: 3,
+        lease_generation: 8,
         command_id: "command-2",
       },
     }]);
@@ -616,6 +618,54 @@ describe("prompt runner", () => {
     }
   });
 
+  it.each(["checkpoint-claude-adapter", "checkpoint-codex-adapter"])(
+    "injects the same provider-neutral checkpoint before %s execution",
+    async (backend) => {
+      let observedPrompt = "";
+      const mockAgent: AgentClient = {
+        run(prompt) {
+          observedPrompt = prompt;
+          return (async function* () {
+            yield { type: "done" as const };
+          })();
+        },
+      };
+      registerAgentBackend(backend, () => mockAgent);
+
+      await runPrompt(
+        {
+          task: "Continue with the new command",
+          sender: "test",
+          runId: `run-${backend}`,
+          dagConfig: makeConfig(),
+          actorCheckpoint: {
+            schema_version: 1,
+            objective: "Research the selected topic",
+            confirmed_conclusions: ["Primary source A is current"],
+            unresolved_items: ["Verify source B"],
+            key_event_refs: ["event-7"],
+            artifact_refs: ["brief:artifact-1"],
+            workspace_ref: "project-1",
+            surface_binding: "surface-research",
+            context_summary: "{\"last_step\":\"source A verified\"}",
+            round_id: "round-0001",
+            actor_generation: 1,
+            captured_at: 1_784_000_000_000,
+          },
+        },
+        {
+          wsSend: () => {},
+          agentBackend: backend,
+        },
+      );
+
+      expect(observedPrompt).toContain("HomeRail portable actor checkpoint");
+      expect(observedPrompt).toContain("Primary source A is current");
+      expect(observedPrompt).toContain("Verify source B");
+      expect(observedPrompt).toContain("## Current round input\nContinue with the new command");
+    },
+  );
+
   it("reports a node error when no LLM base URL is configured", async () => {
     delete process.env.LLM_BASE_URL;
     const mockAgent: AgentClient = {
@@ -739,6 +789,7 @@ describe("prompt runner", () => {
           round_id: "round-0002",
           actor_id: "actor-live",
           generation: 4,
+          lease_generation: 9,
           command_id: "command-live-2",
         },
         systemPrompt: "  HANDOFF port=done content=Source Issue: #847\n\nArtifact: ok",
@@ -761,6 +812,7 @@ describe("prompt runner", () => {
       round_id: "round-0002",
       actor_id: "actor-live",
       generation: 4,
+      lease_generation: 9,
       command_id: "command-live-2",
       content: "Source Issue: #847\n\nArtifact: ok",
     });
@@ -772,6 +824,7 @@ describe("prompt runner", () => {
         round_id: "round-0002",
         actor_id: "actor-live",
         generation: 4,
+        lease_generation: 9,
         command_id: "command-live-2",
       });
     }
@@ -784,6 +837,10 @@ describe("prompt runner", () => {
       "completed",
     ]);
     expect(activities.map((activity) => activity.sequence)).toEqual([1, 2, 3, 4]);
+    expect(activities.every((activity) => activity.lease_generation === 9)).toBe(true);
+    expect(parsed.find((message) => message.type === "SESSION_END")?.data).toMatchObject({
+      lease_generation: 9,
+    });
     expect(parsed.map((msg) => msg.type)).toContain("SESSION_END");
   });
 });

--- a/homerail_worker/src/dag-activity.ts
+++ b/homerail_worker/src/dag-activity.ts
@@ -40,6 +40,7 @@ export function createDagActivityEmitter(
         node_id: config.node_id,
         actor_id: actorId,
         generation,
+        ...(config.lease_generation !== undefined ? { lease_generation: config.lease_generation } : {}),
         ...(surfaceId ? { surface_id: surfaceId } : {}),
         sequence,
         timestamp: Date.now(),

--- a/homerail_worker/src/dag-tools/handoff.ts
+++ b/homerail_worker/src/dag-tools/handoff.ts
@@ -101,6 +101,7 @@ export function createHandoffTool(state: DagToolsState): DagToolDefinition {
         ...(state.roundId !== undefined ? { round_id: state.roundId } : {}),
         ...(state.actorId !== undefined ? { actor_id: state.actorId } : {}),
         ...(state.generation !== undefined ? { generation: state.generation } : {}),
+        ...(state.leaseGeneration !== undefined ? { lease_generation: state.leaseGeneration } : {}),
         ...(state.commandId !== undefined ? { command_id: state.commandId } : {}),
         content,
         summary,

--- a/homerail_worker/src/dag-tools/index.ts
+++ b/homerail_worker/src/dag-tools/index.ts
@@ -35,6 +35,7 @@ export interface DagToolsState {
   roundId?: string;
   actorId?: string;
   generation?: number;
+  leaseGeneration?: number;
   commandId?: string;
   graphNodes: string[];
   availablePorts: string[];
@@ -92,6 +93,7 @@ export function createDagToolsState(
     roundId: config.round_id,
     actorId: config.actor_id,
     generation: config.generation,
+    leaseGeneration: config.lease_generation,
     commandId: config.command_id,
     graphNodes: config.graph_nodes,
     availablePorts: [...ports].sort(),

--- a/homerail_worker/src/index.ts
+++ b/homerail_worker/src/index.ts
@@ -9,6 +9,8 @@ import { runPrompt } from "./prompt-runner.js";
 import type { PromptJob } from "./prompt-runner.js";
 import {
   DAG_TRANSPORT_FENCE_CAPABILITY,
+  DAG_TRANSPORT_FENCE_V1_CAPABILITY,
+  type DagActorCheckpointV1,
   type AgentBuiltinToolName,
   type DagAdvisorConfig,
   type DagAgentToolName,
@@ -37,6 +39,7 @@ const CONFIGURED_CAPABILITIES = (process.env.HOMERAIL_WORKER_CAPABILITIES ?? "")
   .filter((capability) => capability.length > 0);
 const CAPABILITIES = Array.from(new Set([
   ...CONFIGURED_CAPABILITIES,
+  DAG_TRANSPORT_FENCE_V1_CAPABILITY,
   DAG_TRANSPORT_FENCE_CAPABILITY,
 ]));
 
@@ -123,6 +126,9 @@ client.on("task", async (msg) => {
     hasManagerEnvelope: Boolean(envelope),
   });
   const checkpointResume = envelope ? parseCheckpointResume(envelope.checkpointResume) : undefined;
+  const actorCheckpoint = envelope?.actorCheckpoint && typeof envelope.actorCheckpoint === "object"
+    ? envelope.actorCheckpoint as DagActorCheckpointV1
+    : undefined;
   const activity = envelope?.activity && typeof envelope.activity === "object"
     ? envelope.activity as Record<string, unknown>
     : undefined;
@@ -153,6 +159,7 @@ client.on("task", async (msg) => {
         round_id: typeof activity?.roundId === "string" ? activity.roundId : undefined,
         actor_id: typeof activity?.actorId === "string" ? activity.actorId : undefined,
         generation: typeof activity?.generation === "number" ? activity.generation : undefined,
+        lease_generation: typeof activity?.leaseGeneration === "number" ? activity.leaseGeneration : undefined,
         command_id: typeof activity?.commandId === "string" ? activity.commandId : undefined,
         surface_id: typeof activity?.surfaceId === "string" ? activity.surfaceId : undefined,
         activity_sequence_start: typeof activity?.sequenceStart === "number" ? activity.sequenceStart : 0,
@@ -192,6 +199,7 @@ client.on("task", async (msg) => {
     llmApiKey: apiKey,
     llmBaseUrl: baseUrl,
     checkpointResume,
+    actorCheckpoint,
   };
 
   const abortController = new AbortController();

--- a/homerail_worker/src/prompt-runner.ts
+++ b/homerail_worker/src/prompt-runner.ts
@@ -4,7 +4,12 @@
  * @version 0.1.0
  */
 
-import { normalizeManagerAgentRuntimeAgentType, type DagAdvisorConfig, type DagNodeConfig } from "homerail-protocol";
+import {
+  normalizeManagerAgentRuntimeAgentType,
+  type DagActorCheckpointV1,
+  type DagAdvisorConfig,
+  type DagNodeConfig,
+} from "homerail-protocol";
 import { createAgentClient } from "./agent/factory.js";
 import type { AgentEvent, AgentRunContext, AgentUsage } from "./agent/types.js";
 import { createDagTools, createDagToolsState, deliverInbox } from "./dag-tools/index.js";
@@ -32,6 +37,7 @@ export interface PromptJob {
     instruction: string;
     attempt: number;
   };
+  actorCheckpoint?: DagActorCheckpointV1;
 }
 
 export interface PromptRunnerDeps {
@@ -135,6 +141,16 @@ export async function runPrompt(
 ): Promise<void> {
   const { wsSend, agentBackend, auditDir } = deps;
   const sessionId = job.dagConfig.session_id ?? job.runId;
+  const effectiveTask = job.actorCheckpoint
+    ? [
+        "## HomeRail portable actor checkpoint",
+        "Continue the same logical actor and objective from this durable checkpoint.",
+        "Treat only recorded conclusions as confirmed. This contains no hidden reasoning or provider session state.",
+        JSON.stringify(job.actorCheckpoint),
+        "## Current round input",
+        job.task,
+      ].join("\n")
+    : job.task;
 
   function appendSessionTranscript(type: string, content?: unknown, metadata?: Record<string, unknown>): void {
     try {
@@ -158,7 +174,7 @@ export async function runPrompt(
       sessionId,
       runId: job.runId,
       nodeId: job.dagConfig.node_id,
-      messages: [{ role: "user", content: job.task }],
+      messages: [{ role: "user", content: effectiveTask }],
       toolCallState: { inFlight: false },
       agentConfig: {
         provider: job.llmProvider,
@@ -243,9 +259,9 @@ export async function runPrompt(
     node_id: job.dagConfig.node_id,
     run_id: job.runId,
     sender: job.sender,
-    task_preview: job.task.slice(0, 500),
+    task_preview: effectiveTask.slice(0, 500),
   });
-  appendSessionTranscript("prompt_start", { task_preview: job.task.slice(0, 500) });
+  appendSessionTranscript("prompt_start", { task_preview: effectiveTask.slice(0, 500) });
 
   // Stream content via WS
   function sendContent(text: string) {
@@ -258,6 +274,11 @@ export async function runPrompt(
           run_id: job.runId,
           node_id: job.dagConfig.node_id,
           session_id: job.dagConfig.session_id ?? job.runId,
+          ...(job.dagConfig.round_id !== undefined ? { round_id: job.dagConfig.round_id } : {}),
+          ...(job.dagConfig.actor_id !== undefined ? { actor_id: job.dagConfig.actor_id } : {}),
+          ...(job.dagConfig.generation !== undefined ? { generation: job.dagConfig.generation } : {}),
+          ...(job.dagConfig.lease_generation !== undefined ? { lease_generation: job.dagConfig.lease_generation } : {}),
+          ...(job.dagConfig.command_id !== undefined ? { command_id: job.dagConfig.command_id } : {}),
         },
       }),
     );
@@ -277,6 +298,7 @@ export async function runPrompt(
           ...(job.dagConfig.round_id !== undefined ? { round_id: job.dagConfig.round_id } : {}),
           ...(job.dagConfig.actor_id !== undefined ? { actor_id: job.dagConfig.actor_id } : {}),
           ...(job.dagConfig.generation !== undefined ? { generation: job.dagConfig.generation } : {}),
+          ...(job.dagConfig.lease_generation !== undefined ? { lease_generation: job.dagConfig.lease_generation } : {}),
           ...(job.dagConfig.command_id !== undefined ? { command_id: job.dagConfig.command_id } : {}),
         },
       }),
@@ -329,7 +351,7 @@ export async function runPrompt(
         sessionId,
         runId: job.runId,
         nodeId: job.dagConfig.node_id,
-        messages: [{ role: "user", content: job.task }],
+        messages: [{ role: "user", content: effectiveTask }],
         toolCallState: { inFlight: false },
         agentConfig: redactAgentContext(context),
         timestamp: Date.now(),
@@ -338,7 +360,7 @@ export async function runPrompt(
       // Best-effort.
     }
     let errorMessage: string | null = null;
-    for await (const event of agent.run(job.task, dagTools, context)) {
+    for await (const event of agent.run(effectiveTask, dagTools, context)) {
       switch (event.type) {
         case "text":
           sendContent(event.text);
@@ -533,6 +555,11 @@ export async function runPrompt(
         session_id: job.dagConfig.session_id ?? job.runId,
         run_id: job.runId,
         node_id: job.dagConfig.node_id,
+        ...(job.dagConfig.round_id !== undefined ? { round_id: job.dagConfig.round_id } : {}),
+        ...(job.dagConfig.actor_id !== undefined ? { actor_id: job.dagConfig.actor_id } : {}),
+        ...(job.dagConfig.generation !== undefined ? { generation: job.dagConfig.generation } : {}),
+        ...(job.dagConfig.lease_generation !== undefined ? { lease_generation: job.dagConfig.lease_generation } : {}),
+        ...(job.dagConfig.command_id !== undefined ? { command_id: job.dagConfig.command_id } : {}),
       },
     }),
   );
@@ -559,6 +586,7 @@ export async function runPrompt(
       ...(job.dagConfig.round_id !== undefined ? { round_id: job.dagConfig.round_id } : {}),
       ...(job.dagConfig.actor_id !== undefined ? { actor_id: job.dagConfig.actor_id } : {}),
       ...(job.dagConfig.generation !== undefined ? { generation: job.dagConfig.generation } : {}),
+      ...(job.dagConfig.lease_generation !== undefined ? { lease_generation: job.dagConfig.lease_generation } : {}),
       ...(job.dagConfig.command_id !== undefined ? { command_id: job.dagConfig.command_id } : {}),
     };
     sendTerminalMessage(JSON.stringify({ type: "node_error", data }));


### PR DESCRIPTION
Parent epic: #36

Implements: #40

## Why

Logical Actors may outlive physical Workers. Idle processes and containers must be released while a provider-neutral checkpoint remains sufficient to continue the same Actor later.

## What changed

- adds configurable hot leases, idle deadlines, Actor retention, pinning, generation fencing, and a periodic reaper
- persists provider-neutral Actor checkpoints for objectives, conclusions, unresolved work, artifacts, workspace, Surface binding, and bounded context
- persists provisioned Worker ownership separately from logical Actor identity
- releases detached or idle provisioned Workers without terminating the Actor
- allocates replacement Workers and rebuilds dispatch context from checkpoints
- rejects stale lease generations across content, stream, usage, activity, response, error, and session-end messages
- prevents released or releasing provisioned Workers from being selected or sent a new task during cleanup
- keeps physical cleanup fail-closed until removal is confirmed

## Invariants

- releasing a Worker does not complete its logical Actor
- dormant Actors consume neither a Worker lease nor active DAG concurrency
- stale generations remain auditable but cannot mutate current output
- checkpoints and Surface bindings survive until Actor retention expiry
- provisioned Workers require matching active durable ownership before dispatch

## Migrations

Migration 24 adds Actor runtime, checkpoint, and provisioned Worker ownership tables with append-only checkpoint protection, constraints, indexes, validation, old-database upgrade, and repeat-start coverage.

## Review fixes

- rebased the true PR delta onto current `main`
- retained the nested round-fence regression while resolving the #49 overlap
- closed a cleanup race where a previous provisioned Worker could be re-leased while its container was already being removed
- added a regression proving a dormant/releasing Worker cannot receive a new isolated-workspace dispatch
- re-arms loop gateways and loop-body nodes before repeated handoffs so a prior traversal cannot reject the next traversal as a duplicate
- makes the model-backed Live DAG and HomeRail PR Review workflows manual-only; ordinary PR checks remain Core, Agent UI coverage, and Docker smoke

## Verification

- HEAD: `ffd6a947ae95ccd406e200bf8e742b768c927abd`
- base: `origin/main@da876e03aed2f4bf70c163d88382a4984f4d6ce7`
- full `npm run ci` passed
- hosted PR CI passed on Linux Node 20/24, Windows Node 24, Agent UI coverage, and Docker smoke; Live DAG was skipped and HomeRail PR Review was not auto-triggered
- Protocol 247; Plugin SDK 34; Manager 841 (2 skipped); Node 187 (2 skipped); Worker 216 (1 skipped); CLI 241; Agent UI 290; live-validator 13
- approximately 2069 passed, 5 skipped, 0 failed
- focused lease, reaper, ownership, response bridge, transport fence, multi-round, loop re-arm, and Worker prompt tests passed
- the pre-fix Live DAG rerun reproduced the ratchet duplicate-handoff stall twice; the fixed head is covered locally and model-backed checks are now manual by policy

## Residual risk

- A Manager crash after physical container creation but before durable ownership registration still leaves no ownership row for the reaper to discover. Closing that gap requires a durable pre-create reservation plus Node-side resource discovery; this PR does not claim it is already recovered.
- An indefinitely waiting Actor remains retained until explicit completion, cancellation, or workflow expiry. A separate maximum waiting-retention policy is still a product decision.
- Migration 24 cannot backfill provisioned containers created by an older Manager because their ownership was never persisted.
- Provider-neutral checkpoint injection is covered through the common Worker runner and two adapter boundaries; real credentialed Codex plus Claude/Kimi recovery remains live validation rather than a unit-test guarantee.

## Out of scope

- Manager Supervisor tools and commentary: #43
- branch intervention: #44
- final real three-Worker scenario: #45