### PR TITLE
Add durable DAG live surface projection

### DIFF
--- a/docs/architecture/dag-live-surface-projector.md
+++ b/docs/architecture/dag-live-surface-projector.md
@@ -1,0 +1,65 @@
+# DAG Live Surface Projector
+
+The Live Surface Projector is the trusted bridge between durable DAG Activity events and native A2UI. Workers report facts; they never submit A2UI components or Canvas mutations. The Manager validates identity, orders the facts, and produces one stable Block for each logical actor.
+
+## Ownership
+
+`dag_actors` remains the only mutable identity authority. A projection records the exact `(run_id, actor_id, node_id, surface_id)` tuple through a composite foreign key, so a row cannot be attached to another actor, node, or surface. The same tuple is present on queue and control records for database-enforced ownership at every write boundary.
+
+All actor Blocks for a run share the active canonical Generative UI document with scope `{ type: "run", id: run_id }`. Each actor owns exactly one node whose id is its stable `surface_id`. The projector rejects an existing node unless its kind, provenance, actor id, run id, and projector marker all agree.
+
+## Ordered Projection
+
+The durable state is split into three tables:
+
+| Table | Responsibility |
+| --- | --- |
+| `dag_surface_projections` | Current actor generation, applied activity sequence, journal cursor, independent Surface revision, activity state, and visibility state. |
+| `dag_surface_projection_queue` | Journal references waiting for a contiguous actor sequence, plus applied, stale, or rejected outcomes. Worker payload is not copied. |
+| `dag_surface_projection_controls` | Idempotent, revision-checked Manager focus and removal commits. |
+
+Activity sequence, not journal arrival order, controls application. If sequence 2 arrives before sequence 1, it remains pending. Adding sequence 1 drains both in order. Events from an older actor generation remain in the Activity Journal but become `stale` and cannot update A2UI. An event ahead of the canonical actor generation fails closed.
+
+Every visual update is one native Generative UI transaction with both:
+
+1. document `base_revision` CAS; and
+2. existing node `if_revision` CAS.
+
+The A2UI transaction, projection cursor, Surface revision, and queue outcome commit in one SQLite transaction. A failure in any part rolls back all of them, leaving the queue entry pending for safe retry.
+
+## Bounded A2UI
+
+The projector owns a fixed Core A2UI component graph. It maps these Activity states:
+
+- `started`
+- `progress`
+- `finding`
+- `blocked`
+- `completed`
+- `failed`
+
+`tool_used` advances the actor sequence without creating noisy visual text. A Worker payload contributes only bounded scalar fields such as title, summary, progress, and recent findings. Unknown fields, component arrays, actions, scripts, and catalog choices are ignored. Content, strings, finding count, and component count are all bounded before the protocol validator runs.
+
+`focused` and `removed` are trusted Manager controls rather than Worker Activity types. They require the exact current Surface revision and an idempotent control id. Focus marks the stable Block as critical and records optional expiry metadata; removal uses a native A2UI remove operation. Animation and layout remain host responsibilities.
+
+## Recovery And Reads
+
+On Manager startup, logical DAG runs and actors recover first. The projector then replays the Activity Journal, recreates missing queue rows, and drains contiguous pending events. Exact transaction ids make replay idempotent, and the persisted document snapshot must remain identical across repeated restarts.
+
+The read endpoint is:
+
+```text
+GET /api/runs/:run_id/live-surfaces
+```
+
+It returns the run-scoped canonical A2UI document and per-actor projection metadata. The live UI consumes this projection, not raw Worker streams.
+
+## Trust Boundary
+
+The data flow is deliberately one way:
+
+```text
+Worker -> Activity validation -> append-only Journal -> ordered Projector -> native A2UI transaction
+```
+
+There is no Worker endpoint for focus, removal, document transactions, or arbitrary Canvas writes. Manager commentary, layout selection, motion, and branch supervision are separate layers implemented by later Epic #36 issues.

--- a/docs/architecture/durable-dag-actors.md
+++ b/docs/architecture/durable-dag-actors.md
@@ -94,7 +94,7 @@ The TypeScript runtime API exposes registration, binding CAS, generation advance
 - **Logical actors and inbox (#38):** this registry and durable command control plane.
 - **Multi-round execution (#39):** create new `round_id` values while continuing the actor-generation sequence.
 - **Lease and cold recovery (#40):** increment `generation` when ownership changes and reject stale writes for live projection while retaining them for audit.
-- **Projector (#41):** consume journal events and produce A2UI transactions. It must not edit journal rows.
+- **Projector (#41):** the [Live Surface Projector](./dag-live-surface-projector.md) consumes journal events, orders them per actor generation, and produces revision-checked native A2UI transactions without editing journal rows.
 - **Live UI (#42):** subscribe to projected state, not raw Worker output.
 - **Supervisor and intervention (#43-#44):** read the same journal and issue commands through the control plane, never by rewriting activity history.
 - **End-to-end proof (#45):** verify multiple actors, live projection, recovery, and release as one scenario.

--- a/homerail_manager/src/generative-ui/dag-live-surface-projector.ts
+++ b/homerail_manager/src/generative-ui/dag-live-surface-projector.ts
@@ -17,10 +17,7 @@ import {
   type GenerativeUiStoredNodeV1,
   type HomerailA2uiSurfaceV1,
 } from "homerail-protocol";
-import {
-  listDagActivityEvents,
-  type DagActivityJournalEntry,
-} from "../persistence/dag-activity-journal.js";
+import type { DagActivityJournalEntry } from "../persistence/dag-activity-journal.js";
 import {
   getDagActor,
   type DagActorRecord,
@@ -34,7 +31,7 @@ const GENERATED_VIEW_KIND = "com.homerail.core/generated_view";
 const GENERATED_VIEW_KIND_VERSION = 2;
 const PROJECTOR_ID = "dag-live-surface-projector";
 const PROJECTOR_DATA_VERSION = 1;
-const MAX_PROJECTED_STRING_LENGTH = 2_048;
+const MAX_PROJECTED_STRING_BYTES = 1_024;
 const MAX_PROJECTED_FINDINGS = 8;
 const MAX_PROJECTED_CONTENT_BYTES = 32 * 1024;
 const MAX_FOCUS_UNTIL = 8_640_000_000_000_000;
@@ -152,6 +149,15 @@ interface QueueRow {
 
 interface QueuedActivityRow extends QueueRow {
   received_at: number;
+  event_json: string;
+}
+
+interface RecoverableActivityRow {
+  seq: number;
+  received_at: number;
+  event_id: string;
+  run_id: string;
+  actor_id: string;
   event_json: string;
 }
 
@@ -403,15 +409,16 @@ function advanceProjectionGeneration(
   if (projection.generation === actor.generation) return projection;
 
   const staleCursor = getDb().prepare(`
-    SELECT COALESCE(MAX(journal_seq), 0) AS cursor
+    SELECT COALESCE(MAX(journal_seq), 0) AS cursor, COALESCE(MAX(queued_at), 0) AS queued_at
     FROM dag_surface_projection_queue
     WHERE run_id = ? AND actor_id = ? AND status = 'pending' AND generation < ?
-  `).get(actor.run_id, actor.actor_id, actor.generation) as { cursor: number };
+  `).get(actor.run_id, actor.actor_id, actor.generation) as { cursor: number; queued_at: number };
+  const transitionAt = Math.max(timestamp, Number(staleCursor.queued_at));
   getDb().prepare(`
     UPDATE dag_surface_projection_queue
     SET status = 'stale', applied_at = ?
     WHERE run_id = ? AND actor_id = ? AND status = 'pending' AND generation < ?
-  `).run(timestamp, actor.run_id, actor.actor_id, actor.generation);
+  `).run(transitionAt, actor.run_id, actor.actor_id, actor.generation);
   const changed = getDb().prepare(`
     UPDATE dag_surface_projections
     SET generation = ?, last_activity_sequence = 0,
@@ -420,7 +427,7 @@ function advanceProjectionGeneration(
   `).run(
     actor.generation,
     Number(staleCursor.cursor),
-    timestamp,
+    transitionAt,
     actor.run_id,
     actor.actor_id,
     projection.generation,
@@ -529,9 +536,22 @@ function boundedString(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
   const normalized = value.trim();
   if (!normalized) return undefined;
-  return normalized.length <= MAX_PROJECTED_STRING_LENGTH
-    ? normalized
-    : `${normalized.slice(0, MAX_PROJECTED_STRING_LENGTH - 1)}…`;
+  if (Buffer.byteLength(JSON.stringify(normalized), "utf8") <= MAX_PROJECTED_STRING_BYTES) {
+    return normalized;
+  }
+  const characters = [...normalized];
+  let low = 0;
+  let high = characters.length;
+  while (low < high) {
+    const midpoint = Math.ceil((low + high) / 2);
+    const candidate = `${characters.slice(0, midpoint).join("")}…`;
+    if (Buffer.byteLength(JSON.stringify(candidate), "utf8") <= MAX_PROJECTED_STRING_BYTES) {
+      low = midpoint;
+    } else {
+      high = midpoint - 1;
+    }
+  }
+  return `${characters.slice(0, low).join("")}…`;
 }
 
 function firstString(payload: DagActivityEventV1["payload"], keys: readonly string[]): string | undefined {
@@ -596,6 +616,20 @@ function assertOwnedNode(node: GenerativeUiStoredNodeV1, projection: DagLiveSurf
       "identity_mismatch",
       `A2UI node ${projection.surface_id} is not owned by actor ${projection.run_id}/${projection.actor_id}`,
     );
+  }
+}
+
+/** Verify that a canonical A2UI node is the active projector-owned surface for this actor. */
+export function isDagLiveSurfaceProjectionNode(
+  node: GenerativeUiStoredNodeV1,
+  projection: DagLiveSurfaceProjectionRecord,
+): boolean {
+  if (projection.visibility_state === "removed") return false;
+  try {
+    assertOwnedNode(node, projection);
+    return true;
+  } catch {
+    return false;
   }
 }
 
@@ -680,6 +714,12 @@ function buildProjectedNode(input: {
     findings: boundedFindings,
   };
   const content = { data };
+  while (
+    data.findings.length > 1
+    && Buffer.byteLength(JSON.stringify(content), "utf8") > MAX_PROJECTED_CONTENT_BYTES
+  ) {
+    data.findings.shift();
+  }
   if (Buffer.byteLength(JSON.stringify(content), "utf8") > MAX_PROJECTED_CONTENT_BYTES) {
     throw new DagLiveSurfaceProjectionError("a2ui_rejected", "Projected DAG live surface content exceeds its budget");
   }
@@ -1005,6 +1045,7 @@ function visibilityContent(
 ): Record<string, unknown> {
   assertOwnedNode(node, projection);
   const data = projectedDataFromNode(node)!;
+  data.actor.generation = projection.generation;
   data.state.visibility = visibility;
   data.state.surface_revision = nextRevision;
   if (focusedUntil === undefined) delete data.state.focused_until;
@@ -1065,7 +1106,8 @@ export function controlDagLiveSurface(input: {
   return getDb().transaction((): DagLiveSurfaceControlResult => {
     const actor = getDagActor(normalized.run_id, normalized.actor_id);
     if (!actor) throw new Error(`Unknown DAG actor: ${normalized.run_id}/${normalized.actor_id}`);
-    const projection = requireProjection(normalized.run_id, normalized.actor_id);
+    let projection = requireProjection(normalized.run_id, normalized.actor_id);
+    projection = advanceProjectionGeneration(projection, actor, normalized.created_at);
     if (
       projection.node_id !== actor.node_id
       || projection.surface_id !== actor.surface_id
@@ -1121,7 +1163,7 @@ export function controlDagLiveSurface(input: {
     const visibility: DagLiveSurfaceVisibilityState = normalized.operation === "focused" ? "focused" : "removed";
     const updated = getDb().prepare(`
       UPDATE dag_surface_projections
-      SET surface_revision = ?, visibility_state = ?, focused_until = ?, updated_at = ?
+      SET surface_revision = ?, visibility_state = ?, focused_until = ?, updated_at = MAX(updated_at, ?)
       WHERE run_id = ? AND actor_id = ? AND generation = ? AND surface_revision = ?
     `).run(
       nextRevision,
@@ -1165,31 +1207,78 @@ export function controlDagLiveSurface(input: {
   }).immediate();
 }
 
-/** Replay journal history into missing/pending projections without trusting process memory. */
+function recoverableRunIds(): string[] {
+  return (getDb().prepare(`
+    SELECT DISTINCT e.run_id
+    FROM dag_activity_events e
+    JOIN dag_actors a
+      ON a.run_id = e.run_id AND a.actor_id = e.actor_id AND a.node_id = e.node_id
+      AND (e.surface_id IS NULL OR e.surface_id = a.surface_id)
+    LEFT JOIN dag_surface_projection_queue q ON q.journal_seq = e.seq
+    WHERE q.journal_seq IS NULL OR q.status = 'pending'
+    ORDER BY e.run_id
+  `).all() as Array<{ run_id: string }>).map((row) => row.run_id);
+}
+
+function recoverableActivityPage(runId: string, afterSeq: number): RecoverableActivityRow[] {
+  return getDb().prepare(`
+    SELECT e.seq, e.received_at, e.event_id, e.run_id, e.actor_id, e.event_json
+    FROM dag_activity_events e
+    JOIN dag_actors a
+      ON a.run_id = e.run_id AND a.actor_id = e.actor_id AND a.node_id = e.node_id
+      AND (e.surface_id IS NULL OR e.surface_id = a.surface_id)
+    LEFT JOIN dag_surface_projection_queue q ON q.journal_seq = e.seq
+    WHERE e.run_id = ? AND e.seq > ?
+      AND (q.journal_seq IS NULL OR q.status = 'pending')
+    ORDER BY e.seq
+    LIMIT 500
+  `).all(runId, afterSeq) as RecoverableActivityRow[];
+}
+
+function recoveryEntry(row: RecoverableActivityRow): DagActivityJournalEntry {
+  const value = parseJsonRow<unknown>(row.event_json);
+  const validation = validateDagActivityEventV1(value);
+  if (!validation.valid) {
+    throw new DagLiveSurfaceProjectionError(
+      "projection_state_conflict",
+      `Activity Journal contains invalid event ${row.event_id}`,
+    );
+  }
+  return {
+    seq: Number(row.seq),
+    received_at: Number(row.received_at),
+    event: value as DagActivityEventV1,
+  };
+}
+
+/** Replay only missing/pending actor events without rescanning settled history. */
 export function recoverDagLiveSurfaceProjections(runId?: string): DagLiveSurfaceRecoveryResult {
-  const runIds = runId === undefined
-    ? (getDb().prepare("SELECT DISTINCT run_id FROM dag_activity_events ORDER BY run_id").all() as Array<{ run_id: string }>)
-      .map((row) => row.run_id)
-    : [assertIdentifier(runId, "run_id")];
+  const runIds = runId === undefined ? recoverableRunIds() : [assertIdentifier(runId, "run_id")];
   const result: DagLiveSurfaceRecoveryResult = { runs: runIds, projected_events: 0, failed: [] };
+  const failedActors = new Set<string>();
   for (const currentRunId of runIds) {
     let afterSeq = 0;
     while (true) {
-      const page = listDagActivityEvents({ run_id: currentRunId, after_seq: afterSeq, limit: 500 });
-      for (const entry of page.events) {
+      const page = recoverableActivityPage(currentRunId, afterSeq);
+      if (page.length === 0) break;
+      for (const row of page) {
         try {
-          const projected = projectDagActivityJournalEntry(entry);
+          const projected = projectDagActivityJournalEntry(recoveryEntry(row));
           result.projected_events += projected.applied_count;
         } catch (error) {
-          result.failed.push({
-            run_id: currentRunId,
-            event_id: entry.event.event_id,
-            error: error instanceof Error ? error.message : String(error),
-          });
+          const actorKey = `${currentRunId}\u0000${row.actor_id}`;
+          if (!failedActors.has(actorKey)) {
+            failedActors.add(actorKey);
+            result.failed.push({
+              run_id: currentRunId,
+              event_id: row.event_id,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
         }
       }
-      afterSeq = page.next_after_seq;
-      if (!page.has_more) break;
+      afterSeq = Number(page.at(-1)!.seq);
+      if (page.length < 500) break;
     }
   }
   return result;

--- a/homerail_manager/src/generative-ui/dag-live-surface-projector.ts
+++ b/homerail_manager/src/generative-ui/dag-live-surface-projector.ts
@@ -1,0 +1,1196 @@
+import { createHash } from "node:crypto";
+import {
+  GENERATIVE_UI_IR_VERSION,
+  HOMERAIL_A2UI_CATALOG_ID,
+  HOMERAIL_A2UI_MAX_COMPONENTS,
+  HOMERAIL_A2UI_VERSION,
+  GenerativeUiActorType,
+  GenerativeUiImportance,
+  GenerativeUiPhase,
+  GenerativeUiSurface,
+  redactTelemetry,
+  validateDagActivityEventV1,
+  type DagActivityEventV1,
+  type DagActivityType,
+  type GenerativeUiDocumentV1,
+  type GenerativeUiNodeV1,
+  type GenerativeUiStoredNodeV1,
+  type HomerailA2uiSurfaceV1,
+} from "homerail-protocol";
+import {
+  listDagActivityEvents,
+  type DagActivityJournalEntry,
+} from "../persistence/dag-activity-journal.js";
+import {
+  getDagActor,
+  type DagActorRecord,
+} from "../persistence/dag-actors.js";
+import { encodeJson, getDb, parseJsonRow } from "../persistence/db.js";
+import { getGenerativeUiKindRegistry } from "./kind-registry.js";
+import { persistentGenerativeUiDocumentService } from "./shadow-service.js";
+
+const CORE_PLUGIN_ID = "com.homerail.core";
+const GENERATED_VIEW_KIND = "com.homerail.core/generated_view";
+const GENERATED_VIEW_KIND_VERSION = 2;
+const PROJECTOR_ID = "dag-live-surface-projector";
+const PROJECTOR_DATA_VERSION = 1;
+const MAX_PROJECTED_STRING_LENGTH = 2_048;
+const MAX_PROJECTED_FINDINGS = 8;
+const MAX_PROJECTED_CONTENT_BYTES = 32 * 1024;
+const MAX_FOCUS_UNTIL = 8_640_000_000_000_000;
+
+export type DagLiveSurfaceActivityState = Exclude<DagActivityType, "tool_used">;
+export type DagLiveSurfaceVisibilityState = "visible" | "focused" | "removed";
+export type DagLiveSurfaceQueueStatus = "pending" | "applied" | "stale" | "rejected";
+export type DagLiveSurfaceControlOperation = "focused" | "removed";
+
+export interface DagLiveSurfaceProjectionRecord {
+  run_id: string;
+  actor_id: string;
+  node_id: string;
+  surface_id: string;
+  document_id: string;
+  generation: number;
+  last_activity_sequence: number;
+  journal_cursor: number;
+  surface_revision: number;
+  activity_state: DagLiveSurfaceActivityState;
+  visibility_state: DagLiveSurfaceVisibilityState;
+  last_event_id?: string;
+  focused_until?: number;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface DagLiveSurfaceQueueRecord {
+  journal_seq: number;
+  event_id: string;
+  run_id: string;
+  actor_id: string;
+  node_id: string;
+  surface_id: string;
+  generation: number;
+  activity_sequence: number;
+  status: DagLiveSurfaceQueueStatus;
+  transaction_id?: string;
+  surface_revision?: number;
+  queued_at: number;
+  applied_at?: number;
+  failure?: unknown;
+}
+
+export interface DagLiveSurfaceProjectionResult {
+  projection: DagLiveSurfaceProjectionRecord;
+  queue: DagLiveSurfaceQueueRecord;
+  inserted: boolean;
+  applied_count: number;
+}
+
+export interface DagLiveSurfaceControlResult {
+  projection: DagLiveSurfaceProjectionRecord;
+  control_id: string;
+  transaction_id: string;
+  deduplicated: boolean;
+}
+
+export interface DagLiveSurfaceRecoveryResult {
+  runs: string[];
+  projected_events: number;
+  failed: Array<{ run_id: string; event_id: string; error: string }>;
+}
+
+export class DagLiveSurfaceProjectionError extends Error {
+  constructor(
+    public readonly code:
+      | "identity_mismatch"
+      | "generation_conflict"
+      | "surface_revision_conflict"
+      | "a2ui_revision_conflict"
+      | "a2ui_rejected"
+      | "projection_state_conflict",
+    message: string,
+  ) {
+    super(message);
+    this.name = "DagLiveSurfaceProjectionError";
+  }
+}
+
+interface ProjectionRow {
+  run_id: string;
+  actor_id: string;
+  node_id: string;
+  surface_id: string;
+  document_id: string;
+  generation: number;
+  last_activity_sequence: number;
+  journal_cursor: number;
+  surface_revision: number;
+  activity_state: DagLiveSurfaceActivityState;
+  visibility_state: DagLiveSurfaceVisibilityState;
+  last_event_id: string | null;
+  focused_until: number | null;
+  created_at: number;
+  updated_at: number;
+}
+
+interface QueueRow {
+  journal_seq: number;
+  event_id: string;
+  run_id: string;
+  actor_id: string;
+  node_id: string;
+  surface_id: string;
+  generation: number;
+  activity_sequence: number;
+  status: DagLiveSurfaceQueueStatus;
+  transaction_id: string | null;
+  surface_revision: number | null;
+  queued_at: number;
+  applied_at: number | null;
+  failure_json: string | null;
+}
+
+interface QueuedActivityRow extends QueueRow {
+  received_at: number;
+  event_json: string;
+}
+
+interface ControlRow {
+  control_id: string;
+  run_id: string;
+  actor_id: string;
+  node_id: string;
+  surface_id: string;
+  operation: DagLiveSurfaceControlOperation;
+  expected_surface_revision: number;
+  committed_surface_revision: number;
+  focused_until: number | null;
+  transaction_id: string;
+  input_digest: string;
+  created_at: number;
+}
+
+interface ProjectedFinding {
+  id: string;
+  title: string;
+  detail?: string;
+  sequence: number;
+  timestamp: number;
+}
+
+interface ProjectedData {
+  projector: { id: typeof PROJECTOR_ID; version: typeof PROJECTOR_DATA_VERSION };
+  actor: {
+    id: string;
+    role: string;
+    node_id: string;
+    generation: number;
+  };
+  title: string;
+  state: {
+    activity: DagLiveSurfaceActivityState;
+    visibility: DagLiveSurfaceVisibilityState;
+    label: string;
+    summary: string;
+    tone: "info" | "positive" | "warning" | "critical";
+    progress: number;
+    event_id: string;
+    round_id: string;
+    sequence: number;
+    updated_at: number;
+    surface_revision: number;
+    focused_until?: number;
+  };
+  findings: ProjectedFinding[];
+}
+
+const LIVE_SURFACE_A2UI: HomerailA2uiSurfaceV1 = {
+  version: HOMERAIL_A2UI_VERSION,
+  catalogId: HOMERAIL_A2UI_CATALOG_ID,
+  components: [
+    { id: "root", component: "Column", children: ["header", "summary", "progress", "findings"] },
+    { id: "header", component: "Row", children: ["title", "status"], justify: "spaceBetween", align: "center" },
+    { id: "title", component: "Text", text: { path: "/data/title" } },
+    { id: "status", component: "HrStatusBadge", text: { path: "/data/state/label" }, tone: { path: "/data/state/tone" } },
+    { id: "summary", component: "Text", text: { path: "/data/state/summary" }, variant: "body" },
+    { id: "progress", component: "HrProgress", value: { path: "/data/state/progress" }, tone: { path: "/data/state/tone" } },
+    {
+      id: "findings",
+      component: "HrList",
+      source: { path: "/data/findings" },
+      maxItems: MAX_PROJECTED_FINDINGS,
+      itemTitlePath: "/title",
+      itemDetailPath: "/detail",
+    },
+  ],
+};
+
+function projectionFromRow(row: ProjectionRow): DagLiveSurfaceProjectionRecord {
+  return {
+    run_id: row.run_id,
+    actor_id: row.actor_id,
+    node_id: row.node_id,
+    surface_id: row.surface_id,
+    document_id: row.document_id,
+    generation: Number(row.generation),
+    last_activity_sequence: Number(row.last_activity_sequence),
+    journal_cursor: Number(row.journal_cursor),
+    surface_revision: Number(row.surface_revision),
+    activity_state: row.activity_state,
+    visibility_state: row.visibility_state,
+    ...(row.last_event_id === null ? {} : { last_event_id: row.last_event_id }),
+    ...(row.focused_until === null ? {} : { focused_until: Number(row.focused_until) }),
+    created_at: Number(row.created_at),
+    updated_at: Number(row.updated_at),
+  };
+}
+
+function queueFromRow(row: QueueRow): DagLiveSurfaceQueueRecord {
+  return {
+    journal_seq: Number(row.journal_seq),
+    event_id: row.event_id,
+    run_id: row.run_id,
+    actor_id: row.actor_id,
+    node_id: row.node_id,
+    surface_id: row.surface_id,
+    generation: Number(row.generation),
+    activity_sequence: Number(row.activity_sequence),
+    status: row.status,
+    ...(row.transaction_id === null ? {} : { transaction_id: row.transaction_id }),
+    ...(row.surface_revision === null ? {} : { surface_revision: Number(row.surface_revision) }),
+    queued_at: Number(row.queued_at),
+    ...(row.applied_at === null ? {} : { applied_at: Number(row.applied_at) }),
+    ...(row.failure_json === null ? {} : { failure: parseJsonRow(row.failure_json) }),
+  };
+}
+
+function getProjectionRow(runId: string, actorId: string): ProjectionRow | undefined {
+  return getDb().prepare("SELECT * FROM dag_surface_projections WHERE run_id = ? AND actor_id = ?")
+    .get(runId, actorId) as ProjectionRow | undefined;
+}
+
+function requireProjection(runId: string, actorId: string): DagLiveSurfaceProjectionRecord {
+  const row = getProjectionRow(runId, actorId);
+  if (!row) throw new Error(`DAG live surface does not exist: ${runId}/${actorId}`);
+  return projectionFromRow(row);
+}
+
+function getQueueRow(journalSeq: number): QueueRow | undefined {
+  return getDb().prepare("SELECT * FROM dag_surface_projection_queue WHERE journal_seq = ?")
+    .get(journalSeq) as QueueRow | undefined;
+}
+
+function assertIdentifier(value: string, label: string): string {
+  const normalized = value.trim();
+  if (!normalized || normalized.length > 256) {
+    throw new Error(`${label} must be between 1 and 256 characters`);
+  }
+  return normalized;
+}
+
+function assertNonNegativeSafeInteger(value: number, label: string): number {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${label} must be a non-negative safe integer`);
+  }
+  return value;
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object") {
+    const result: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      const nested = (value as Record<string, unknown>)[key];
+      if (nested !== undefined) result[key] = canonicalize(nested);
+    }
+    return result;
+  }
+  return value;
+}
+
+function digest(value: unknown): string {
+  return createHash("sha256").update(JSON.stringify(canonicalize(value))).digest("hex");
+}
+
+function transactionId(kind: "activity" | "control", id: string): string {
+  return `dag-live-surface-${kind}-${createHash("sha256").update(id).digest("hex")}`;
+}
+
+export function dagLiveSurfaceDocumentId(runId: string): string {
+  return `dag-live-${createHash("sha256").update(runId).digest("hex").slice(0, 32)}`;
+}
+
+function scopeFor(runId: string) {
+  return { type: "run", id: runId } as const;
+}
+
+function ensureProjection(actor: DagActorRecord, timestamp: number): DagLiveSurfaceProjectionRecord {
+  const scope = scopeFor(actor.run_id);
+  const activeDocument = persistentGenerativeUiDocumentService.findActiveForScope(scope, "canonical");
+  const document = activeDocument ?? persistentGenerativeUiDocumentService.createOrGet({
+    documentId: dagLiveSurfaceDocumentId(actor.run_id),
+    scope,
+    purpose: "canonical",
+    createdAt: new Date(timestamp).toISOString(),
+  });
+  const existing = getProjectionRow(actor.run_id, actor.actor_id);
+  if (existing) {
+    if (
+      existing.node_id !== actor.node_id
+      || existing.surface_id !== actor.surface_id
+      || existing.document_id !== document.document_id
+    ) {
+      throw new DagLiveSurfaceProjectionError(
+        "identity_mismatch",
+        `DAG live surface ownership changed for ${actor.run_id}/${actor.actor_id}`,
+      );
+    }
+    return projectionFromRow(existing);
+  }
+
+  getDb().prepare(`
+    INSERT INTO dag_surface_projections(
+      run_id, actor_id, node_id, surface_id, document_id, generation,
+      last_activity_sequence, journal_cursor, surface_revision,
+      activity_state, visibility_state, last_event_id, focused_until,
+      created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, 0, 0, 0, 'started', 'visible', NULL, NULL, ?, ?)
+  `).run(
+    actor.run_id,
+    actor.actor_id,
+    actor.node_id,
+    actor.surface_id,
+    document.document_id,
+    actor.generation,
+    timestamp,
+    timestamp,
+  );
+  return requireProjection(actor.run_id, actor.actor_id);
+}
+
+function assertJournalIdentity(entry: DagActivityJournalEntry, actor: DagActorRecord): void {
+  const { event } = entry;
+  if (
+    event.run_id !== actor.run_id
+    || event.actor_id !== actor.actor_id
+    || event.node_id !== actor.node_id
+    || (event.surface_id !== undefined && event.surface_id !== actor.surface_id)
+  ) {
+    throw new DagLiveSurfaceProjectionError(
+      "identity_mismatch",
+      `Activity ${event.event_id} does not belong to ${actor.run_id}/${actor.actor_id}/${actor.node_id}/${actor.surface_id}`,
+    );
+  }
+  if (event.generation > actor.generation) {
+    throw new DagLiveSurfaceProjectionError(
+      "generation_conflict",
+      `Activity ${event.event_id} generation ${event.generation} is ahead of actor generation ${actor.generation}`,
+    );
+  }
+}
+
+function advanceProjectionGeneration(
+  projection: DagLiveSurfaceProjectionRecord,
+  actor: DagActorRecord,
+  timestamp: number,
+): DagLiveSurfaceProjectionRecord {
+  if (projection.generation > actor.generation) {
+    throw new DagLiveSurfaceProjectionError(
+      "generation_conflict",
+      `Surface ${projection.surface_id} generation ${projection.generation} is ahead of actor generation ${actor.generation}`,
+    );
+  }
+  if (projection.generation === actor.generation) return projection;
+
+  const staleCursor = getDb().prepare(`
+    SELECT COALESCE(MAX(journal_seq), 0) AS cursor
+    FROM dag_surface_projection_queue
+    WHERE run_id = ? AND actor_id = ? AND status = 'pending' AND generation < ?
+  `).get(actor.run_id, actor.actor_id, actor.generation) as { cursor: number };
+  getDb().prepare(`
+    UPDATE dag_surface_projection_queue
+    SET status = 'stale', applied_at = ?
+    WHERE run_id = ? AND actor_id = ? AND status = 'pending' AND generation < ?
+  `).run(timestamp, actor.run_id, actor.actor_id, actor.generation);
+  const changed = getDb().prepare(`
+    UPDATE dag_surface_projections
+    SET generation = ?, last_activity_sequence = 0,
+        journal_cursor = MAX(journal_cursor, ?), updated_at = ?
+    WHERE run_id = ? AND actor_id = ? AND generation = ? AND surface_revision = ?
+  `).run(
+    actor.generation,
+    Number(staleCursor.cursor),
+    timestamp,
+    actor.run_id,
+    actor.actor_id,
+    projection.generation,
+    projection.surface_revision,
+  );
+  if (changed.changes !== 1) {
+    throw new DagLiveSurfaceProjectionError(
+      "surface_revision_conflict",
+      `DAG live surface ${actor.run_id}/${actor.actor_id} changed while advancing generation`,
+    );
+  }
+  return requireProjection(actor.run_id, actor.actor_id);
+}
+
+function enqueueJournalEntry(entry: DagActivityJournalEntry): { inserted: boolean; queue: DagLiveSurfaceQueueRecord } {
+  const actor = getDagActor(entry.event.run_id, entry.event.actor_id);
+  if (!actor) throw new Error(`Unknown DAG actor: ${entry.event.run_id}/${entry.event.actor_id}`);
+  assertJournalIdentity(entry, actor);
+  let projection = ensureProjection(actor, entry.received_at);
+  projection = advanceProjectionGeneration(projection, actor, entry.received_at);
+
+  const existing = getQueueRow(entry.seq);
+  if (existing) {
+    if (
+      existing.event_id !== entry.event.event_id
+      || existing.run_id !== actor.run_id
+      || existing.actor_id !== actor.actor_id
+      || existing.node_id !== actor.node_id
+      || existing.surface_id !== actor.surface_id
+      || existing.generation !== entry.event.generation
+      || existing.activity_sequence !== entry.event.sequence
+    ) {
+      throw new DagLiveSurfaceProjectionError(
+        "projection_state_conflict",
+        `Projection queue cursor ${entry.seq} identifies different activity content`,
+      );
+    }
+    return { inserted: false, queue: queueFromRow(existing) };
+  }
+
+  const sameEvent = getDb().prepare("SELECT * FROM dag_surface_projection_queue WHERE event_id = ?")
+    .get(entry.event.event_id) as QueueRow | undefined;
+  if (sameEvent) {
+    throw new DagLiveSurfaceProjectionError(
+      "projection_state_conflict",
+      `Projection event id ${entry.event.event_id} is already bound to journal cursor ${sameEvent.journal_seq}`,
+    );
+  }
+
+  getDb().prepare(`
+    INSERT INTO dag_surface_projection_queue(
+      journal_seq, event_id, run_id, actor_id, node_id, surface_id,
+      generation, activity_sequence, status, transaction_id,
+      surface_revision, queued_at, applied_at, failure_json
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending', NULL, NULL, ?, NULL, NULL)
+  `).run(
+    entry.seq,
+    entry.event.event_id,
+    actor.run_id,
+    actor.actor_id,
+    actor.node_id,
+    actor.surface_id,
+    entry.event.generation,
+    entry.event.sequence,
+    entry.received_at,
+  );
+
+  if (entry.event.generation < actor.generation) {
+    getDb().prepare(`
+      UPDATE dag_surface_projection_queue
+      SET status = 'stale', applied_at = ?
+      WHERE journal_seq = ? AND status = 'pending'
+    `).run(entry.received_at, entry.seq);
+    getDb().prepare(`
+      UPDATE dag_surface_projections
+      SET journal_cursor = MAX(journal_cursor, ?), updated_at = ?
+      WHERE run_id = ? AND actor_id = ?
+    `).run(entry.seq, entry.received_at, actor.run_id, actor.actor_id);
+  }
+  return { inserted: true, queue: queueFromRow(getQueueRow(entry.seq)!) };
+}
+
+function queuedActivity(runId: string, actorId: string, generation: number, sequence: number): QueuedActivityRow | undefined {
+  return getDb().prepare(`
+    SELECT q.*, e.received_at, e.event_json
+    FROM dag_surface_projection_queue q
+    JOIN dag_activity_events e ON e.seq = q.journal_seq
+    WHERE q.run_id = ? AND q.actor_id = ? AND q.generation = ?
+      AND q.activity_sequence = ? AND q.status = 'pending'
+  `).get(runId, actorId, generation, sequence) as QueuedActivityRow | undefined;
+}
+
+function decodeQueuedActivity(row: QueuedActivityRow): DagActivityEventV1 {
+  const value = parseJsonRow<unknown>(row.event_json);
+  const validation = validateDagActivityEventV1(value);
+  if (!validation.valid) {
+    throw new DagLiveSurfaceProjectionError(
+      "projection_state_conflict",
+      `Projection queue contains an invalid activity event at journal cursor ${row.journal_seq}`,
+    );
+  }
+  return value as DagActivityEventV1;
+}
+
+function boundedString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim();
+  if (!normalized) return undefined;
+  return normalized.length <= MAX_PROJECTED_STRING_LENGTH
+    ? normalized
+    : `${normalized.slice(0, MAX_PROJECTED_STRING_LENGTH - 1)}…`;
+}
+
+function firstString(payload: DagActivityEventV1["payload"], keys: readonly string[]): string | undefined {
+  for (const key of keys) {
+    const value = boundedString(payload[key]);
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function projectedProgress(
+  event: DagActivityEventV1,
+  previous: ProjectedData | undefined,
+): number {
+  if (event.type === "completed") return 100;
+  const raw = event.payload.progress ?? event.payload.percent;
+  if (typeof raw === "number" && Number.isFinite(raw)) return Math.max(0, Math.min(100, raw));
+  if (event.type === "started") return 0;
+  return previous?.state.progress ?? 0;
+}
+
+function statePresentation(type: DagLiveSurfaceActivityState): {
+  label: string;
+  tone: ProjectedData["state"]["tone"];
+  phase: GenerativeUiPhase;
+} {
+  switch (type) {
+    case "started": return { label: "Started", tone: "info", phase: GenerativeUiPhase.RUNNING };
+    case "progress": return { label: "In progress", tone: "info", phase: GenerativeUiPhase.RUNNING };
+    case "finding": return { label: "Finding", tone: "positive", phase: GenerativeUiPhase.RUNNING };
+    case "blocked": return { label: "Blocked", tone: "warning", phase: GenerativeUiPhase.BLOCKED };
+    case "completed": return { label: "Completed", tone: "positive", phase: GenerativeUiPhase.SUCCEEDED };
+    case "failed": return { label: "Failed", tone: "critical", phase: GenerativeUiPhase.FAILED };
+  }
+}
+
+function projectedDataFromNode(node: GenerativeUiStoredNodeV1 | undefined): ProjectedData | undefined {
+  const content = node?.content;
+  if (!content || typeof content !== "object" || Array.isArray(content)) return undefined;
+  const data = content.data;
+  if (!data || typeof data !== "object" || Array.isArray(data)) return undefined;
+  const candidate = data as Partial<ProjectedData>;
+  if (candidate.projector?.id !== PROJECTOR_ID || candidate.projector.version !== PROJECTOR_DATA_VERSION) {
+    return undefined;
+  }
+  return structuredClone(candidate as ProjectedData);
+}
+
+function assertOwnedNode(node: GenerativeUiStoredNodeV1, projection: DagLiveSurfaceProjectionRecord): void {
+  const data = projectedDataFromNode(node);
+  if (
+    node.id !== projection.surface_id
+    || node.kind !== GENERATED_VIEW_KIND
+    || node.kind_version !== GENERATED_VIEW_KIND_VERSION
+    || node.owner.id !== CORE_PLUGIN_ID
+    || node.provenance?.run_id !== projection.run_id
+    || node.provenance?.actor_id !== projection.actor_id
+    || data?.actor.id !== projection.actor_id
+    || data.actor.node_id !== projection.node_id
+  ) {
+    throw new DagLiveSurfaceProjectionError(
+      "identity_mismatch",
+      `A2UI node ${projection.surface_id} is not owned by actor ${projection.run_id}/${projection.actor_id}`,
+    );
+  }
+}
+
+function activeCoreVersion(): string {
+  const definition = getGenerativeUiKindRegistry().uiProjection().kinds.find((kind) => (
+    kind.enabled
+    && kind.plugin_id === CORE_PLUGIN_ID
+    && kind.kind === GENERATED_VIEW_KIND
+    && kind.kind_version === GENERATED_VIEW_KIND_VERSION
+  ));
+  if (!definition) throw new Error("Active Core A2UI generated-view kind is unavailable");
+  return definition.plugin_version;
+}
+
+function nextVisibility(
+  projection: DagLiveSurfaceProjectionRecord,
+  eventReceivedAt: number,
+): DagLiveSurfaceVisibilityState {
+  if (
+    projection.visibility_state === "focused"
+    && (projection.focused_until === undefined || eventReceivedAt <= projection.focused_until)
+  ) return "focused";
+  return "visible";
+}
+
+function buildProjectedNode(input: {
+  actor: DagActorRecord;
+  projection: DagLiveSurfaceProjectionRecord;
+  event: DagActivityEventV1;
+  received_at: number;
+  existing?: GenerativeUiStoredNodeV1;
+}): { node: GenerativeUiNodeV1; activity: DagLiveSurfaceActivityState; visibility: DagLiveSurfaceVisibilityState } {
+  if (input.event.type === "tool_used") throw new Error("tool_used does not create an A2UI mutation");
+  if (input.existing) assertOwnedNode(input.existing, input.projection);
+  const previous = projectedDataFromNode(input.existing);
+  const activity = input.event.type;
+  const presentation = statePresentation(activity);
+  const visibility = nextVisibility(input.projection, input.received_at);
+  const title = previous?.title
+    ?? firstString(input.event.payload, ["title", "task"])
+    ?? input.actor.role;
+  const summary = firstString(input.event.payload, ["message", "summary", "detail", "reason", "error"])
+    ?? presentation.label;
+  const findings = previous?.findings ? [...previous.findings] : [];
+  if (activity === "finding") {
+    const detail = firstString(input.event.payload, ["detail", "description"]);
+    findings.push({
+      id: input.event.event_id,
+      title: firstString(input.event.payload, ["title", "message", "summary"]) ?? "Finding",
+      ...(detail ? { detail } : {}),
+      sequence: input.event.sequence,
+      timestamp: input.event.timestamp,
+    });
+  }
+  const boundedFindings = findings.slice(-MAX_PROJECTED_FINDINGS);
+  const surfaceRevision = input.projection.surface_revision + 1;
+  const data: ProjectedData = {
+    projector: { id: PROJECTOR_ID, version: PROJECTOR_DATA_VERSION },
+    actor: {
+      id: input.actor.actor_id,
+      role: input.actor.role,
+      node_id: input.actor.node_id,
+      generation: input.event.generation,
+    },
+    title,
+    state: {
+      activity,
+      visibility,
+      label: presentation.label,
+      summary,
+      tone: presentation.tone,
+      progress: projectedProgress(input.event, previous),
+      event_id: input.event.event_id,
+      round_id: input.event.round_id,
+      sequence: input.event.sequence,
+      updated_at: input.event.timestamp,
+      surface_revision: surfaceRevision,
+      ...(visibility === "focused" && input.projection.focused_until !== undefined
+        ? { focused_until: input.projection.focused_until }
+        : {}),
+    },
+    findings: boundedFindings,
+  };
+  const content = { data };
+  if (Buffer.byteLength(JSON.stringify(content), "utf8") > MAX_PROJECTED_CONTENT_BYTES) {
+    throw new DagLiveSurfaceProjectionError("a2ui_rejected", "Projected DAG live surface content exceeds its budget");
+  }
+  if (LIVE_SURFACE_A2UI.components.length > HOMERAIL_A2UI_MAX_COMPONENTS) {
+    throw new DagLiveSurfaceProjectionError("a2ui_rejected", "Projected DAG live surface exceeds the A2UI component budget");
+  }
+
+  return {
+    activity,
+    visibility,
+    node: {
+      ir_version: GENERATIVE_UI_IR_VERSION,
+      id: input.projection.surface_id,
+      kind: GENERATED_VIEW_KIND,
+      kind_version: GENERATED_VIEW_KIND_VERSION,
+      owner: input.existing?.owner ?? { id: CORE_PLUGIN_ID, version: activeCoreVersion() },
+      surface: GenerativeUiSurface.EXECUTION,
+      importance: visibility === "focused" ? GenerativeUiImportance.CRITICAL : GenerativeUiImportance.PRIMARY,
+      status: {
+        phase: presentation.phase,
+        label: presentation.label,
+        progress: data.state.progress,
+      },
+      content,
+      a2ui: structuredClone(LIVE_SURFACE_A2UI),
+      presentation: { density: "summary" },
+      lifecycle: { persistence: "session", removable: true },
+      fallback: {
+        title,
+        summary,
+        ...(boundedFindings.length ? { items: boundedFindings.map((finding) => finding.title) } : {}),
+      },
+      provenance: {
+        actor: "agent",
+        actor_id: input.actor.actor_id,
+        run_id: input.actor.run_id,
+      },
+    },
+  };
+}
+
+function applyQueuedActivity(row: QueuedActivityRow): boolean {
+  const actor = getDagActor(row.run_id, row.actor_id);
+  if (!actor) throw new Error(`Unknown DAG actor: ${row.run_id}/${row.actor_id}`);
+  let projection = requireProjection(row.run_id, row.actor_id);
+  const event = decodeQueuedActivity(row);
+  assertJournalIdentity({ seq: row.journal_seq, received_at: row.received_at, event }, actor);
+  if (event.generation !== actor.generation || projection.generation !== actor.generation) {
+    throw new DagLiveSurfaceProjectionError(
+      "generation_conflict",
+      `Queued activity ${event.event_id} no longer targets the active actor generation`,
+    );
+  }
+  if (event.sequence !== projection.last_activity_sequence + 1) return false;
+
+  if (projection.visibility_state === "removed") {
+    const document = persistentGenerativeUiDocumentService.get(
+      projection.document_id,
+      scopeFor(actor.run_id),
+    );
+    if (document?.nodes.some((node) => node.id === projection.surface_id)) {
+      throw new DagLiveSurfaceProjectionError(
+        "projection_state_conflict",
+        `Removed DAG live surface ${projection.surface_id} unexpectedly exists in A2UI`,
+      );
+    }
+  }
+
+  if (event.type === "tool_used" || projection.visibility_state === "removed") {
+    const activityState = event.type === "tool_used" ? projection.activity_state : event.type;
+    const updated = getDb().prepare(`
+      UPDATE dag_surface_projections
+      SET last_activity_sequence = ?, journal_cursor = MAX(journal_cursor, ?),
+          activity_state = ?, last_event_id = ?, updated_at = ?
+      WHERE run_id = ? AND actor_id = ? AND generation = ?
+        AND last_activity_sequence = ? AND surface_revision = ?
+    `).run(
+      event.sequence,
+      row.journal_seq,
+      activityState,
+      event.event_id,
+      row.received_at,
+      actor.run_id,
+      actor.actor_id,
+      actor.generation,
+      projection.last_activity_sequence,
+      projection.surface_revision,
+    );
+    if (updated.changes !== 1) {
+      throw new DagLiveSurfaceProjectionError(
+        "surface_revision_conflict",
+        "DAG live surface changed before non-visual activity commit",
+      );
+    }
+    getDb().prepare(`
+      UPDATE dag_surface_projection_queue
+      SET status = 'applied', surface_revision = ?, applied_at = ?
+      WHERE journal_seq = ? AND status = 'pending'
+    `).run(projection.surface_revision, row.received_at, row.journal_seq);
+    return true;
+  }
+
+  const scope = scopeFor(actor.run_id);
+  const document = persistentGenerativeUiDocumentService.get(projection.document_id, scope);
+  if (!document) throw new Error(`A2UI document not found: ${projection.document_id}`);
+  const existing = document.nodes.find((node) => node.id === projection.surface_id);
+  const projected = buildProjectedNode({
+    actor,
+    projection,
+    event,
+    received_at: row.received_at,
+    ...(existing ? { existing } : {}),
+  });
+  const txId = transactionId("activity", event.event_id);
+  const operation = existing
+    ? {
+        op: "patch" as const,
+        node_id: existing.id,
+        if_revision: existing.revision,
+        changes: {
+          surface: projected.node.surface,
+          importance: projected.node.importance,
+          status: projected.node.status,
+          content: projected.node.content,
+          a2ui: projected.node.a2ui,
+          presentation: projected.node.presentation,
+          lifecycle: projected.node.lifecycle,
+          fallback: projected.node.fallback,
+          provenance: projected.node.provenance,
+        },
+      }
+    : { op: "put" as const, node: projected.node };
+  const result = persistentGenerativeUiDocumentService.apply({
+    ir_version: GENERATIVE_UI_IR_VERSION,
+    transaction_id: txId,
+    document_id: document.document_id,
+    base_revision: document.revision,
+    actor: { type: GenerativeUiActorType.SYSTEM, id: PROJECTOR_ID },
+    operations: [operation],
+    created_at: new Date(row.received_at).toISOString(),
+  }, scope);
+  if (result.status === "conflict") {
+    throw new DagLiveSurfaceProjectionError(
+      "a2ui_revision_conflict",
+      `A2UI document or surface changed before ${event.event_id} could commit`,
+    );
+  }
+  if (result.status !== "applied") {
+    throw new DagLiveSurfaceProjectionError(
+      "a2ui_rejected",
+      `A2UI transaction ${txId} was ${result.status}: ${JSON.stringify(result.errors ?? [])}`,
+    );
+  }
+
+  const nextSurfaceRevision = projection.surface_revision + 1;
+  const updated = getDb().prepare(`
+    UPDATE dag_surface_projections
+    SET generation = ?, last_activity_sequence = ?, journal_cursor = MAX(journal_cursor, ?),
+        surface_revision = ?, activity_state = ?, visibility_state = ?,
+        last_event_id = ?, focused_until = CASE WHEN ? = 'focused' THEN focused_until ELSE NULL END,
+        updated_at = ?
+    WHERE run_id = ? AND actor_id = ? AND generation = ?
+      AND last_activity_sequence = ? AND surface_revision = ?
+  `).run(
+    actor.generation,
+    event.sequence,
+    row.journal_seq,
+    nextSurfaceRevision,
+    projected.activity,
+    projected.visibility,
+    event.event_id,
+    projected.visibility,
+    row.received_at,
+    actor.run_id,
+    actor.actor_id,
+    projection.generation,
+    projection.last_activity_sequence,
+    projection.surface_revision,
+  );
+  if (updated.changes !== 1) {
+    throw new DagLiveSurfaceProjectionError("surface_revision_conflict", "DAG live surface changed before A2UI commit bookkeeping");
+  }
+  const queueUpdated = getDb().prepare(`
+    UPDATE dag_surface_projection_queue
+    SET status = 'applied', transaction_id = ?, surface_revision = ?, applied_at = ?
+    WHERE journal_seq = ? AND status = 'pending'
+  `).run(txId, nextSurfaceRevision, row.received_at, row.journal_seq);
+  if (queueUpdated.changes !== 1) {
+    throw new DagLiveSurfaceProjectionError("projection_state_conflict", "DAG live surface queue changed before commit");
+  }
+  projection = requireProjection(actor.run_id, actor.actor_id);
+  return projection.last_activity_sequence === event.sequence;
+}
+
+function markRejected(row: QueuedActivityRow, error: DagLiveSurfaceProjectionError): void {
+  const failure = redactTelemetry({ code: error.code, message: error.message });
+  getDb().prepare(`
+    UPDATE dag_surface_projection_queue
+    SET status = 'rejected', applied_at = ?, failure_json = ?
+    WHERE journal_seq = ? AND status = 'pending'
+  `).run(Date.now(), encodeJson(failure), row.journal_seq);
+}
+
+function drainActor(runId: string, actorId: string): number {
+  let applied = 0;
+  while (true) {
+    const projection = requireProjection(runId, actorId);
+    const row = queuedActivity(runId, actorId, projection.generation, projection.last_activity_sequence + 1);
+    if (!row) return applied;
+    try {
+      const changed = getDb().transaction(() => applyQueuedActivity(row)).immediate();
+      if (!changed) return applied;
+      applied += 1;
+    } catch (error) {
+      if (error instanceof DagLiveSurfaceProjectionError && error.code === "a2ui_rejected") {
+        markRejected(row, error);
+      }
+      throw error;
+    }
+  }
+}
+
+/**
+ * Queue one durable Activity Journal entry and drain every now-contiguous event
+ * for that logical actor. Worker payload is treated as data only; the fixed
+ * projector owns all A2UI components and document mutations.
+ */
+export function projectDagActivityJournalEntry(entry: DagActivityJournalEntry): DagLiveSurfaceProjectionResult {
+  if (!Number.isSafeInteger(entry.seq) || entry.seq < 1) throw new Error("journal seq must be a positive safe integer");
+  if (!Number.isSafeInteger(entry.received_at) || entry.received_at < 0) throw new Error("received_at must be non-negative");
+  const validation = validateDagActivityEventV1(entry.event);
+  if (!validation.valid) throw new Error(`Invalid DAG activity event: ${JSON.stringify(validation.errors)}`);
+  const enqueued = getDb().transaction(() => enqueueJournalEntry(entry)).immediate();
+  const appliedCount = enqueued.queue.status === "stale"
+    ? 0
+    : drainActor(entry.event.run_id, entry.event.actor_id);
+  return {
+    projection: requireProjection(entry.event.run_id, entry.event.actor_id),
+    queue: queueFromRow(getQueueRow(entry.seq)!),
+    inserted: enqueued.inserted,
+    applied_count: appliedCount,
+  };
+}
+
+export function getDagLiveSurfaceProjection(
+  runId: string,
+  actorId: string,
+): DagLiveSurfaceProjectionRecord | undefined {
+  const row = getProjectionRow(assertIdentifier(runId, "run_id"), assertIdentifier(actorId, "actor_id"));
+  return row ? projectionFromRow(row) : undefined;
+}
+
+export function listDagLiveSurfaceProjections(runId: string): DagLiveSurfaceProjectionRecord[] {
+  const rows = getDb().prepare("SELECT * FROM dag_surface_projections WHERE run_id = ? ORDER BY actor_id")
+    .all(assertIdentifier(runId, "run_id")) as ProjectionRow[];
+  return rows.map(projectionFromRow);
+}
+
+export function listDagLiveSurfaceQueue(input: {
+  run_id: string;
+  actor_id?: string;
+  status?: DagLiveSurfaceQueueStatus;
+}): DagLiveSurfaceQueueRecord[] {
+  const runId = assertIdentifier(input.run_id, "run_id");
+  const conditions = ["run_id = ?"];
+  const params: string[] = [runId];
+  if (input.actor_id !== undefined) {
+    conditions.push("actor_id = ?");
+    params.push(assertIdentifier(input.actor_id, "actor_id"));
+  }
+  if (input.status !== undefined) {
+    if (!["pending", "applied", "stale", "rejected"].includes(input.status)) throw new Error("invalid queue status");
+    conditions.push("status = ?");
+    params.push(input.status);
+  }
+  return (getDb().prepare(`
+    SELECT * FROM dag_surface_projection_queue
+    WHERE ${conditions.join(" AND ")}
+    ORDER BY journal_seq
+  `).all(...params) as QueueRow[]).map(queueFromRow);
+}
+
+export function getDagLiveSurfaceDocument(runId: string): GenerativeUiDocumentV1 | undefined {
+  const normalizedRunId = assertIdentifier(runId, "run_id");
+  const projection = getDb().prepare(`
+    SELECT document_id FROM dag_surface_projections
+    WHERE run_id = ? ORDER BY actor_id LIMIT 1
+  `).get(normalizedRunId) as { document_id: string } | undefined;
+  return projection
+    ? persistentGenerativeUiDocumentService.get(projection.document_id, scopeFor(normalizedRunId))
+    : undefined;
+}
+
+function controlDigest(input: {
+  control_id: string;
+  run_id: string;
+  actor_id: string;
+  operation: DagLiveSurfaceControlOperation;
+  expected_surface_revision: number;
+  focused_until?: number;
+}): string {
+  return digest({
+    control_id: input.control_id,
+    run_id: input.run_id,
+    actor_id: input.actor_id,
+    operation: input.operation,
+    expected_surface_revision: input.expected_surface_revision,
+    ...(input.focused_until === undefined ? {} : { focused_until: input.focused_until }),
+  });
+}
+
+function existingControl(controlId: string): ControlRow | undefined {
+  return getDb().prepare("SELECT * FROM dag_surface_projection_controls WHERE control_id = ?")
+    .get(controlId) as ControlRow | undefined;
+}
+
+function visibilityContent(
+  node: GenerativeUiStoredNodeV1,
+  projection: DagLiveSurfaceProjectionRecord,
+  visibility: DagLiveSurfaceVisibilityState,
+  nextRevision: number,
+  focusedUntil?: number,
+): Record<string, unknown> {
+  assertOwnedNode(node, projection);
+  const data = projectedDataFromNode(node)!;
+  data.state.visibility = visibility;
+  data.state.surface_revision = nextRevision;
+  if (focusedUntil === undefined) delete data.state.focused_until;
+  else data.state.focused_until = focusedUntil;
+  return { data };
+}
+
+/** Trusted Manager-side focus/removal boundary. Worker code has no access to it. */
+export function controlDagLiveSurface(input: {
+  control_id: string;
+  run_id: string;
+  actor_id: string;
+  operation: DagLiveSurfaceControlOperation;
+  expected_surface_revision: number;
+  focused_until?: number;
+  created_at?: number;
+}): DagLiveSurfaceControlResult {
+  const normalized = {
+    control_id: assertIdentifier(input.control_id, "control_id"),
+    run_id: assertIdentifier(input.run_id, "run_id"),
+    actor_id: assertIdentifier(input.actor_id, "actor_id"),
+    operation: input.operation,
+    expected_surface_revision: assertNonNegativeSafeInteger(input.expected_surface_revision, "expected_surface_revision"),
+    ...(input.focused_until === undefined
+      ? {}
+      : { focused_until: assertNonNegativeSafeInteger(input.focused_until, "focused_until") }),
+    created_at: input.created_at === undefined ? Date.now() : assertNonNegativeSafeInteger(input.created_at, "created_at"),
+  };
+  if (normalized.operation !== "focused" && normalized.operation !== "removed") {
+    throw new Error("operation must be focused or removed");
+  }
+  if (normalized.focused_until !== undefined && normalized.focused_until > MAX_FOCUS_UNTIL) {
+    throw new Error("focused_until is outside the supported timestamp range");
+  }
+  if (normalized.created_at > MAX_FOCUS_UNTIL) {
+    throw new Error("created_at is outside the supported timestamp range");
+  }
+  if (normalized.operation === "removed" && normalized.focused_until !== undefined) {
+    throw new Error("removed control cannot include focused_until");
+  }
+  const inputDigest = controlDigest(normalized);
+  const previous = existingControl(normalized.control_id);
+  if (previous) {
+    if (previous.input_digest !== inputDigest) {
+      throw new DagLiveSurfaceProjectionError(
+        "projection_state_conflict",
+        `DAG live surface control id ${normalized.control_id} was reused with different input`,
+      );
+    }
+    return {
+      projection: requireProjection(previous.run_id, previous.actor_id),
+      control_id: previous.control_id,
+      transaction_id: previous.transaction_id,
+      deduplicated: true,
+    };
+  }
+
+  return getDb().transaction((): DagLiveSurfaceControlResult => {
+    const actor = getDagActor(normalized.run_id, normalized.actor_id);
+    if (!actor) throw new Error(`Unknown DAG actor: ${normalized.run_id}/${normalized.actor_id}`);
+    const projection = requireProjection(normalized.run_id, normalized.actor_id);
+    if (
+      projection.node_id !== actor.node_id
+      || projection.surface_id !== actor.surface_id
+      || projection.generation !== actor.generation
+    ) {
+      throw new DagLiveSurfaceProjectionError("identity_mismatch", "DAG live surface no longer matches its logical actor");
+    }
+    if (projection.surface_revision !== normalized.expected_surface_revision) {
+      throw new DagLiveSurfaceProjectionError(
+        "surface_revision_conflict",
+        `DAG live surface revision is ${projection.surface_revision}, expected ${normalized.expected_surface_revision}`,
+      );
+    }
+    const scope = scopeFor(normalized.run_id);
+    const document = persistentGenerativeUiDocumentService.get(projection.document_id, scope);
+    const node = document?.nodes.find((candidate) => candidate.id === projection.surface_id);
+    if (!document || !node) {
+      throw new DagLiveSurfaceProjectionError("projection_state_conflict", "DAG live surface A2UI node is unavailable");
+    }
+    assertOwnedNode(node, projection);
+    const nextRevision = projection.surface_revision + 1;
+    const txId = transactionId("control", normalized.control_id);
+    const operation = normalized.operation === "removed"
+      ? { op: "remove" as const, node_id: node.id, if_revision: node.revision }
+      : {
+          op: "patch" as const,
+          node_id: node.id,
+          if_revision: node.revision,
+          changes: {
+            importance: GenerativeUiImportance.CRITICAL,
+            content: visibilityContent(node, projection, "focused", nextRevision, normalized.focused_until),
+          },
+        };
+    const result = persistentGenerativeUiDocumentService.apply({
+      ir_version: GENERATIVE_UI_IR_VERSION,
+      transaction_id: txId,
+      document_id: document.document_id,
+      base_revision: document.revision,
+      actor: { type: GenerativeUiActorType.SYSTEM, id: PROJECTOR_ID },
+      operations: [operation],
+      created_at: new Date(normalized.created_at).toISOString(),
+    }, scope);
+    if (result.status === "conflict") {
+      throw new DagLiveSurfaceProjectionError("a2ui_revision_conflict", "A2UI surface changed before control commit");
+    }
+    if (result.status !== "applied") {
+      throw new DagLiveSurfaceProjectionError(
+        "a2ui_rejected",
+        `A2UI control transaction ${txId} was ${result.status}: ${JSON.stringify(result.errors ?? [])}`,
+      );
+    }
+
+    const visibility: DagLiveSurfaceVisibilityState = normalized.operation === "focused" ? "focused" : "removed";
+    const updated = getDb().prepare(`
+      UPDATE dag_surface_projections
+      SET surface_revision = ?, visibility_state = ?, focused_until = ?, updated_at = ?
+      WHERE run_id = ? AND actor_id = ? AND generation = ? AND surface_revision = ?
+    `).run(
+      nextRevision,
+      visibility,
+      normalized.operation === "focused" ? normalized.focused_until ?? null : null,
+      normalized.created_at,
+      normalized.run_id,
+      normalized.actor_id,
+      actor.generation,
+      normalized.expected_surface_revision,
+    );
+    if (updated.changes !== 1) {
+      throw new DagLiveSurfaceProjectionError("surface_revision_conflict", "DAG live surface changed before control bookkeeping");
+    }
+    getDb().prepare(`
+      INSERT INTO dag_surface_projection_controls(
+        control_id, run_id, actor_id, node_id, surface_id, operation,
+        expected_surface_revision, committed_surface_revision, focused_until,
+        transaction_id, input_digest, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      normalized.control_id,
+      normalized.run_id,
+      normalized.actor_id,
+      actor.node_id,
+      actor.surface_id,
+      normalized.operation,
+      normalized.expected_surface_revision,
+      nextRevision,
+      normalized.operation === "focused" ? normalized.focused_until ?? null : null,
+      txId,
+      inputDigest,
+      normalized.created_at,
+    );
+    return {
+      projection: requireProjection(normalized.run_id, normalized.actor_id),
+      control_id: normalized.control_id,
+      transaction_id: txId,
+      deduplicated: false,
+    };
+  }).immediate();
+}
+
+/** Replay journal history into missing/pending projections without trusting process memory. */
+export function recoverDagLiveSurfaceProjections(runId?: string): DagLiveSurfaceRecoveryResult {
+  const runIds = runId === undefined
+    ? (getDb().prepare("SELECT DISTINCT run_id FROM dag_activity_events ORDER BY run_id").all() as Array<{ run_id: string }>)
+      .map((row) => row.run_id)
+    : [assertIdentifier(runId, "run_id")];
+  const result: DagLiveSurfaceRecoveryResult = { runs: runIds, projected_events: 0, failed: [] };
+  for (const currentRunId of runIds) {
+    let afterSeq = 0;
+    while (true) {
+      const page = listDagActivityEvents({ run_id: currentRunId, after_seq: afterSeq, limit: 500 });
+      for (const entry of page.events) {
+        try {
+          const projected = projectDagActivityJournalEntry(entry);
+          result.projected_events += projected.applied_count;
+        } catch (error) {
+          result.failed.push({
+            run_id: currentRunId,
+            event_id: entry.event.event_id,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+      afterSeq = page.next_after_seq;
+      if (!page.has_more) break;
+    }
+  }
+  return result;
+}

--- a/homerail_manager/src/generative-ui/persistent-document-service.ts
+++ b/homerail_manager/src/generative-ui/persistent-document-service.ts
@@ -388,6 +388,12 @@ export class PersistentGenerativeUiDocumentService implements GenerativeUiDocume
 
   clear(): void {
     getDb().transaction(() => {
+      // Live DAG surfaces are derived from the Activity Journal and can be
+      // rebuilt. Remove their ownership metadata before the shared document
+      // store so the document retention FK remains strict in normal writes.
+      getDb().prepare("DELETE FROM dag_surface_projection_controls").run();
+      getDb().prepare("DELETE FROM dag_surface_projection_queue").run();
+      getDb().prepare("DELETE FROM dag_surface_projections").run();
       getDb().prepare("DELETE FROM generative_ui_user_overrides").run();
       getDb().prepare("DELETE FROM generative_ui_transactions").run();
       getDb().prepare("DELETE FROM generative_ui_documents").run();

--- a/homerail_manager/src/index.ts
+++ b/homerail_manager/src/index.ts
@@ -6,6 +6,7 @@ import { recoverStaleVoiceSessions } from "./server/voice-session-registry.js";
 import { markRecoveryComplete } from "./health/index.js";
 import { cleanupPluginPackageStaging, recoverPluginPackageTrash } from "./plugins/package-lifecycle.js";
 import { shutdownHostShellManagerAgents } from "./server/host-shell-manager-agent.js";
+import { recoverDagLiveSurfaceProjections } from "./generative-ui/dag-live-surface-projector.js";
 
 initEventLogging();
 
@@ -17,6 +18,9 @@ const server = createServer(port);
 // the server accepts traffic. The first-worker hook (wired in createServer)
 // re-dispatches their READY nodes once a worker reconnects.
 const recovery = recoverAllActiveRuns();
+// Logical actors are restored before Activity Journal replay. The projector
+// can therefore re-establish exact ownership and drain any crash-pending gaps.
+const surfaceRecovery = recoverDagLiveSurfaceProjections();
 // Reset voice sessions stuck in running/submitted (no live process after restart).
 const voiceRecovery = recoverStaleVoiceSessions();
 const pluginTrashRecovery = recoverPluginPackageTrash();
@@ -27,6 +31,9 @@ server.listen(port, host, () => {
   console.error(`homerail_manager listening on ${host}:${port}`);
   console.error(
     `cold recovery: recovered=${recovery.recovered.length} failed=${recovery.failed.length} skipped=${recovery.skipped.length}`,
+  );
+  console.error(
+    `live surface recovery: projected=${surfaceRecovery.projected_events} failed=${surfaceRecovery.failed.length}`,
   );
   if (voiceRecovery.recovered.length) {
     console.error(`voice recovery: reset ${voiceRecovery.recovered.length} stale session(s)`);

--- a/homerail_manager/src/persistence/db.ts
+++ b/homerail_manager/src/persistence/db.ts
@@ -1154,7 +1154,6 @@ function validateDagLiveSurfaceSchemaV21(db: SqliteDatabase): void {
       );
     }
   };
-
   requireNamedIndex(
     "dag_actors",
     "idx_dag_actors_projection_identity",
@@ -1264,6 +1263,64 @@ function validateDagLiveSurfaceSchemaV21(db: SqliteDatabase): void {
   )) {
     throw new Error("Schema migration 21 is incomplete: projection queue journal constraint is missing");
   }
+}
+
+const DAG_SURFACE_QUEUE_JOURNAL_IDENTITY_TRIGGER_V22 = `
+  CREATE TRIGGER trg_dag_surface_projection_queue_journal_identity
+    BEFORE INSERT ON dag_surface_projection_queue
+    WHEN NOT EXISTS (
+      SELECT 1
+      FROM dag_activity_events e
+      WHERE e.seq = NEW.journal_seq
+        AND e.event_id = NEW.event_id
+        AND e.run_id = NEW.run_id
+        AND e.actor_id = NEW.actor_id
+        AND e.node_id = NEW.node_id
+        AND e.generation = NEW.generation
+        AND e.activity_sequence = NEW.activity_sequence
+        AND (e.surface_id IS NULL OR e.surface_id = NEW.surface_id)
+    )
+    BEGIN
+      SELECT RAISE(ABORT, 'projection queue journal identity mismatch');
+    END
+`;
+
+const DAG_SURFACE_QUEUE_IMMUTABLE_IDENTITY_TRIGGER_V22 = `
+  CREATE TRIGGER trg_dag_surface_projection_queue_identity_immutable
+    BEFORE UPDATE OF journal_seq, event_id, run_id, actor_id, node_id,
+      surface_id, generation, activity_sequence
+    ON dag_surface_projection_queue
+    BEGIN
+      SELECT RAISE(ABORT, 'projection queue identity is immutable');
+    END
+`;
+
+function normalizedSchemaSql(sql: string): string {
+  return sql.replace(/\s+/g, " ").trim().replace(/;$/, "").toLowerCase();
+}
+
+function validateDagLiveSurfaceQueueTriggersV22(db: SqliteDatabase): void {
+  const requireTrigger = (name: string, expectedSql: string): void => {
+    const trigger = db.prepare(`
+      SELECT tbl_name, sql FROM sqlite_master WHERE type = 'trigger' AND name = ?
+    `).get(name) as { tbl_name: string; sql: string | null } | undefined;
+    if (
+      !trigger
+      || trigger.tbl_name !== "dag_surface_projection_queue"
+      || !trigger.sql
+      || normalizedSchemaSql(trigger.sql) !== normalizedSchemaSql(expectedSql)
+    ) {
+      throw new Error(`Schema migration 22 is incomplete: trigger ${name} is missing or invalid`);
+    }
+  };
+  requireTrigger(
+    "trg_dag_surface_projection_queue_journal_identity",
+    DAG_SURFACE_QUEUE_JOURNAL_IDENTITY_TRIGGER_V22,
+  );
+  requireTrigger(
+    "trg_dag_surface_projection_queue_identity_immutable",
+    DAG_SURFACE_QUEUE_IMMUTABLE_IDENTITY_TRIGGER_V22,
+  );
 }
 
 function validateGenerativeUiSchemaV3(db: SqliteDatabase): void {
@@ -2708,7 +2765,6 @@ const SCHEMA_MIGRATIONS: readonly SchemaMigration[] = [
       CREATE UNIQUE INDEX IF NOT EXISTS idx_dag_surface_projection_queue_transaction_id
         ON dag_surface_projection_queue(transaction_id)
         WHERE transaction_id IS NOT NULL;
-
       CREATE TABLE IF NOT EXISTS dag_surface_projection_controls (
         control_id TEXT PRIMARY KEY,
         run_id TEXT NOT NULL,
@@ -2730,6 +2786,14 @@ const SCHEMA_MIGRATIONS: readonly SchemaMigration[] = [
         ON dag_surface_projection_controls(run_id, actor_id, created_at, control_id);
     `),
     validate: validateDagLiveSurfaceSchemaV21,
+  },
+  {
+    version: 22,
+    up: (db) => db.exec([
+      DAG_SURFACE_QUEUE_JOURNAL_IDENTITY_TRIGGER_V22,
+      DAG_SURFACE_QUEUE_IMMUTABLE_IDENTITY_TRIGGER_V22,
+    ].map((sql) => `${sql.replace("CREATE TRIGGER", "CREATE TRIGGER IF NOT EXISTS")};`).join("\n")),
+    validate: validateDagLiveSurfaceQueueTriggersV22,
   },
   {
     version: 23,

--- a/homerail_manager/src/persistence/db.ts
+++ b/homerail_manager/src/persistence/db.ts
@@ -38,6 +38,9 @@ const CLEARABLE_TABLES = new Set([
   "dag_actor_provisioned_workers",
   "dag_actor_checkpoints",
   "dag_actor_runtimes",
+  "dag_surface_projection_controls",
+  "dag_surface_projection_queue",
+  "dag_surface_projections",
   "dag_actor_commands",
   "dag_actors",
   "dag_activity_events",
@@ -1040,6 +1043,226 @@ function validateDagActorLeaseSchemaV24(db: SqliteDatabase): void {
   const checkpointTrigger = compactSchemaSql(db, "trigger", "trg_dag_actor_checkpoints_no_update");
   if (!checkpointTrigger.includes("beforeupdateondag_actor_checkpoints") || !checkpointTrigger.includes("raise(abort,'dagactorcheckpointsareappend-only')")) {
     throw new Error("Schema migration 24 is incomplete: checkpoint append-only trigger is missing or invalid");
+  }
+}
+
+function validateDagLiveSurfaceSchemaV21(db: SqliteDatabase): void {
+  const requiredColumns: Record<string, readonly string[]> = {
+    dag_surface_projections: [
+      "run_id",
+      "actor_id",
+      "node_id",
+      "surface_id",
+      "document_id",
+      "generation",
+      "last_activity_sequence",
+      "journal_cursor",
+      "surface_revision",
+      "activity_state",
+      "visibility_state",
+      "last_event_id",
+      "focused_until",
+      "created_at",
+      "updated_at",
+    ],
+    dag_surface_projection_queue: [
+      "journal_seq",
+      "event_id",
+      "run_id",
+      "actor_id",
+      "node_id",
+      "surface_id",
+      "generation",
+      "activity_sequence",
+      "status",
+      "transaction_id",
+      "surface_revision",
+      "queued_at",
+      "applied_at",
+      "failure_json",
+    ],
+    dag_surface_projection_controls: [
+      "control_id",
+      "run_id",
+      "actor_id",
+      "node_id",
+      "surface_id",
+      "operation",
+      "expected_surface_revision",
+      "committed_surface_revision",
+      "focused_until",
+      "transaction_id",
+      "input_digest",
+      "created_at",
+    ],
+  };
+  for (const [table, columns] of Object.entries(requiredColumns)) {
+    if (!hasTable(db, table)) {
+      throw new Error(`Schema migration 21 is incomplete: missing table ${table}`);
+    }
+    for (const column of columns) {
+      if (!hasColumn(db, table, column)) {
+        throw new Error(`Schema migration 21 is incomplete: ${table} is missing column ${column}`);
+      }
+    }
+  }
+
+  type IndexEntry = { name: string; unique: number; partial: number };
+  const indexColumns = (name: string): string[] => (
+    db.prepare(`PRAGMA index_info(${name})`).all() as Array<{ seqno: number; name: string }>
+  ).sort((left, right) => left.seqno - right.seqno).map((entry) => entry.name);
+  const columnsMatch = (actual: readonly string[], expected: readonly string[]): boolean => (
+    actual.length === expected.length && actual.every((column, position) => column === expected[position])
+  );
+  const requirePrimaryKey = (table: string, expectedColumns: readonly string[]): void => {
+    const columns = (db.prepare(`PRAGMA table_info(${table})`).all() as Array<{
+      name: string;
+      pk: number;
+    }>).filter((entry) => entry.pk > 0)
+      .sort((left, right) => left.pk - right.pk)
+      .map((entry) => entry.name);
+    if (!columnsMatch(columns, expectedColumns)) {
+      throw new Error(`Schema migration 21 is incomplete: ${table} has an invalid primary key`);
+    }
+  };
+  const requireNamedIndex = (
+    table: string,
+    name: string,
+    expectedColumns: readonly string[],
+    unique: number,
+    partial: number,
+  ): void => {
+    const index = (db.prepare(`PRAGMA index_list(${table})`).all() as IndexEntry[])
+      .find((entry) => entry.name === name);
+    if (!index || index.unique !== unique || index.partial !== partial) {
+      throw new Error(`Schema migration 21 is incomplete: index ${name} is missing or invalid`);
+    }
+    if (!columnsMatch(indexColumns(name), expectedColumns)) {
+      throw new Error(`Schema migration 21 is incomplete: index ${name} has invalid columns`);
+    }
+  };
+  const requireUniqueConstraint = (table: string, expectedColumns: readonly string[]): void => {
+    const indexes = db.prepare(`PRAGMA index_list(${table})`).all() as IndexEntry[];
+    const found = indexes.some((index) => (
+      index.unique === 1
+      && index.partial === 0
+      && columnsMatch(indexColumns(index.name), expectedColumns)
+    ));
+    if (!found) {
+      throw new Error(
+        `Schema migration 21 is incomplete: ${table} is missing unique constraint (${expectedColumns.join(", ")})`,
+      );
+    }
+  };
+
+  requireNamedIndex(
+    "dag_actors",
+    "idx_dag_actors_projection_identity",
+    ["run_id", "actor_id", "node_id", "surface_id"],
+    1,
+    0,
+  );
+  requirePrimaryKey("dag_surface_projections", ["run_id", "actor_id"]);
+  requireUniqueConstraint("dag_surface_projections", ["document_id", "surface_id"]);
+  requirePrimaryKey("dag_surface_projection_queue", ["journal_seq"]);
+  requireUniqueConstraint("dag_surface_projection_queue", ["event_id"]);
+  requireUniqueConstraint(
+    "dag_surface_projection_queue",
+    ["run_id", "actor_id", "generation", "activity_sequence"],
+  );
+  requireNamedIndex(
+    "dag_surface_projection_queue",
+    "idx_dag_surface_projection_queue_actor_status",
+    ["run_id", "actor_id", "status", "generation", "activity_sequence"],
+    0,
+    0,
+  );
+  requireNamedIndex(
+    "dag_surface_projection_queue",
+    "idx_dag_surface_projection_queue_transaction_id",
+    ["transaction_id"],
+    1,
+    1,
+  );
+  const transactionIndexSql = (db.prepare(
+    "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?",
+  ).get("idx_dag_surface_projection_queue_transaction_id") as { sql: string | null } | undefined)?.sql
+    ?.replace(/\s+/g, " ").trim().toLowerCase();
+  if (!transactionIndexSql || !/\bwhere transaction_id is not null;?$/.test(transactionIndexSql)) {
+    throw new Error(
+      "Schema migration 21 is incomplete: index idx_dag_surface_projection_queue_transaction_id has an invalid predicate",
+    );
+  }
+  requirePrimaryKey("dag_surface_projection_controls", ["control_id"]);
+  requireUniqueConstraint("dag_surface_projection_controls", ["transaction_id"]);
+  requireUniqueConstraint(
+    "dag_surface_projection_controls",
+    ["run_id", "actor_id", "committed_surface_revision"],
+  );
+  requireNamedIndex(
+    "dag_surface_projection_controls",
+    "idx_dag_surface_projection_controls_actor_created",
+    ["run_id", "actor_id", "created_at", "control_id"],
+    0,
+    0,
+  );
+
+  type ForeignKeyEntry = {
+    id: number;
+    seq: number;
+    table: string;
+    from: string;
+    to: string;
+    on_delete: string;
+  };
+  const hasForeignKey = (
+    table: string,
+    referencedTable: string,
+    fromColumns: readonly string[],
+    toColumns: readonly string[],
+    onDelete: "CASCADE" | "RESTRICT",
+  ): boolean => {
+    const entries = db.prepare(`PRAGMA foreign_key_list(${table})`).all() as ForeignKeyEntry[];
+    const groups = new Map<number, ForeignKeyEntry[]>();
+    for (const entry of entries) {
+      const group = groups.get(entry.id) ?? [];
+      group.push(entry);
+      groups.set(entry.id, group);
+    }
+    return [...groups.values()].some((group) => {
+      const ordered = group.sort((left, right) => left.seq - right.seq);
+      return ordered.length === fromColumns.length
+        && ordered.every((entry, position) => (
+          entry.table === referencedTable
+          && entry.from === fromColumns[position]
+          && entry.to === toColumns[position]
+          && entry.on_delete.toUpperCase() === onDelete
+        ));
+    });
+  };
+  const actorIdentityColumns = ["run_id", "actor_id", "node_id", "surface_id"] as const;
+  for (const table of Object.keys(requiredColumns)) {
+    if (!hasForeignKey(table, "dag_actors", actorIdentityColumns, actorIdentityColumns, "CASCADE")) {
+      throw new Error(`Schema migration 21 is incomplete: ${table} actor identity constraint is missing`);
+    }
+  }
+  if (!hasForeignKey(
+    "dag_surface_projections",
+    "generative_ui_documents",
+    ["document_id"],
+    ["document_id"],
+    "RESTRICT",
+  )) {
+    throw new Error("Schema migration 21 is incomplete: projection document retention constraint is missing");
+  }
+  if (!hasForeignKey(
+    "dag_surface_projection_queue",
+    "dag_activity_events",
+    ["journal_seq"],
+    ["seq"],
+    "CASCADE",
+  )) {
+    throw new Error("Schema migration 21 is incomplete: projection queue journal constraint is missing");
   }
 }
 
@@ -2421,7 +2644,93 @@ const SCHEMA_MIGRATIONS: readonly SchemaMigration[] = [
     `),
     validate: validateDagActorSchemaV20,
   },
-  // Versions 21 and 22 are reserved for the parallel live-surface projector work.
+  {
+    version: 21,
+    up: (db) => db.exec(`
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_dag_actors_projection_identity
+        ON dag_actors(run_id, actor_id, node_id, surface_id);
+
+      CREATE TABLE IF NOT EXISTS dag_surface_projections (
+        run_id TEXT NOT NULL,
+        actor_id TEXT NOT NULL,
+        node_id TEXT NOT NULL,
+        surface_id TEXT NOT NULL,
+        document_id TEXT NOT NULL,
+        generation INTEGER NOT NULL CHECK(generation >= 1),
+        last_activity_sequence INTEGER NOT NULL DEFAULT 0 CHECK(last_activity_sequence >= 0),
+        journal_cursor INTEGER NOT NULL DEFAULT 0 CHECK(journal_cursor >= 0),
+        surface_revision INTEGER NOT NULL DEFAULT 0 CHECK(surface_revision >= 0),
+        activity_state TEXT NOT NULL CHECK(activity_state IN (
+          'started', 'progress', 'finding', 'blocked', 'completed', 'failed'
+        )),
+        visibility_state TEXT NOT NULL DEFAULT 'visible' CHECK(visibility_state IN (
+          'visible', 'focused', 'removed'
+        )),
+        last_event_id TEXT,
+        focused_until INTEGER CHECK(focused_until IS NULL OR focused_until >= 0),
+        created_at INTEGER NOT NULL CHECK(created_at >= 0),
+        updated_at INTEGER NOT NULL CHECK(updated_at >= 0),
+        PRIMARY KEY(run_id, actor_id),
+        UNIQUE(document_id, surface_id),
+        FOREIGN KEY(run_id, actor_id, node_id, surface_id)
+          REFERENCES dag_actors(run_id, actor_id, node_id, surface_id) ON DELETE CASCADE,
+        FOREIGN KEY(document_id) REFERENCES generative_ui_documents(document_id) ON DELETE RESTRICT
+      );
+
+      CREATE TABLE IF NOT EXISTS dag_surface_projection_queue (
+        journal_seq INTEGER PRIMARY KEY,
+        event_id TEXT NOT NULL UNIQUE,
+        run_id TEXT NOT NULL,
+        actor_id TEXT NOT NULL,
+        node_id TEXT NOT NULL,
+        surface_id TEXT NOT NULL,
+        generation INTEGER NOT NULL CHECK(generation >= 1),
+        activity_sequence INTEGER NOT NULL CHECK(activity_sequence >= 1),
+        status TEXT NOT NULL CHECK(status IN ('pending', 'applied', 'stale', 'rejected')),
+        transaction_id TEXT,
+        surface_revision INTEGER CHECK(surface_revision IS NULL OR surface_revision >= 0),
+        queued_at INTEGER NOT NULL CHECK(queued_at >= 0),
+        applied_at INTEGER CHECK(applied_at IS NULL OR applied_at >= queued_at),
+        failure_json TEXT,
+        CHECK(
+          (status = 'pending' AND applied_at IS NULL AND transaction_id IS NULL AND surface_revision IS NULL AND failure_json IS NULL)
+          OR (status = 'applied' AND applied_at IS NOT NULL AND surface_revision IS NOT NULL AND failure_json IS NULL)
+          OR (status = 'stale' AND applied_at IS NOT NULL AND transaction_id IS NULL AND surface_revision IS NULL AND failure_json IS NULL)
+          OR (status = 'rejected' AND applied_at IS NOT NULL AND transaction_id IS NULL AND surface_revision IS NULL AND failure_json IS NOT NULL)
+        ),
+        UNIQUE(run_id, actor_id, generation, activity_sequence),
+        FOREIGN KEY(journal_seq) REFERENCES dag_activity_events(seq) ON DELETE CASCADE,
+        FOREIGN KEY(run_id, actor_id, node_id, surface_id)
+          REFERENCES dag_actors(run_id, actor_id, node_id, surface_id) ON DELETE CASCADE
+      );
+      CREATE INDEX IF NOT EXISTS idx_dag_surface_projection_queue_actor_status
+        ON dag_surface_projection_queue(run_id, actor_id, status, generation, activity_sequence);
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_dag_surface_projection_queue_transaction_id
+        ON dag_surface_projection_queue(transaction_id)
+        WHERE transaction_id IS NOT NULL;
+
+      CREATE TABLE IF NOT EXISTS dag_surface_projection_controls (
+        control_id TEXT PRIMARY KEY,
+        run_id TEXT NOT NULL,
+        actor_id TEXT NOT NULL,
+        node_id TEXT NOT NULL,
+        surface_id TEXT NOT NULL,
+        operation TEXT NOT NULL CHECK(operation IN ('focused', 'removed')),
+        expected_surface_revision INTEGER NOT NULL CHECK(expected_surface_revision >= 0),
+        committed_surface_revision INTEGER NOT NULL CHECK(committed_surface_revision >= 1),
+        focused_until INTEGER CHECK(focused_until IS NULL OR focused_until >= 0),
+        transaction_id TEXT NOT NULL UNIQUE,
+        input_digest TEXT NOT NULL CHECK(length(input_digest) = 64),
+        created_at INTEGER NOT NULL CHECK(created_at >= 0),
+        UNIQUE(run_id, actor_id, committed_surface_revision),
+        FOREIGN KEY(run_id, actor_id, node_id, surface_id)
+          REFERENCES dag_actors(run_id, actor_id, node_id, surface_id) ON DELETE CASCADE
+      );
+      CREATE INDEX IF NOT EXISTS idx_dag_surface_projection_controls_actor_created
+        ON dag_surface_projection_controls(run_id, actor_id, created_at, control_id);
+    `),
+    validate: validateDagLiveSurfaceSchemaV21,
+  },
   {
     version: 23,
     up: (db) => {

--- a/homerail_manager/src/runtime/dag-activity-stream.ts
+++ b/homerail_manager/src/runtime/dag-activity-stream.ts
@@ -1,5 +1,6 @@
 import { appendDagActivityEvent } from "../persistence/dag-activity-journal.js";
 import { getDagActorByNode } from "../persistence/dag-actors.js";
+import { projectDagActivityJournalEntry } from "../generative-ui/dag-live-surface-projector.js";
 
 export interface DagActivityStreamContext {
   runId: string;
@@ -37,5 +38,9 @@ export function ingestDagActivityStream(
       throw new Error("DAG activity surface identity does not match the logical actor registry");
     }
   }
-  return appendDagActivityEvent(activity);
+  const stored = appendDagActivityEvent(activity);
+  // Legacy journal-only runs may not have a logical actor. Every current DAG
+  // Worker does; only those events enter the trusted A2UI projector boundary.
+  if (actor) projectDagActivityJournalEntry(stored);
+  return stored;
 }

--- a/homerail_manager/src/server/routes.ts
+++ b/homerail_manager/src/server/routes.ts
@@ -28,6 +28,10 @@ import { listDagTriggers } from "../persistence/dag-triggers.js";
 import { listDagActivityEvents } from "../persistence/dag-activity-journal.js";
 import { listDagActorCommands, type DagActorCommandStatus } from "../persistence/dag-actors.js";
 import { listDagRunRounds } from "../persistence/dag-run-rounds.js";
+import {
+  getDagLiveSurfaceDocument,
+  listDagLiveSurfaceProjections,
+} from "../generative-ui/dag-live-surface-projector.js";
 
 interface BaseResponse {
   success: boolean;
@@ -624,8 +628,30 @@ export function inspectionRoutesHandler(
     return true;
   }
 
+  // GET /api/runs/:run_id/live-surfaces
+  if (pathname.match(/^\/api\/runs\/[^/]+\/live-surfaces$/) && req.method === "GET") {
+    let runId = "";
+    try {
+      runId = decodeURIComponent(pathname.split("/")[3] ?? "");
+    } catch {
+      json(res, 400, { success: false, message: "Invalid encoded run ID", error: "Invalid encoded run ID" });
+      return true;
+    }
+    if (!runId || !loadRunMetadata(runId)) {
+      _notFound(res, runId ? `Run not found: ${runId}` : "Invalid run ID");
+      return true;
+    }
+    const projections = listDagLiveSurfaceProjections(runId);
+    _ok(res, `Live surfaces retrieved (${projections.length} actors)`, {
+      run_id: runId,
+      projections,
+      document: getDagLiveSurfaceDocument(runId) ?? null,
+    });
+    return true;
+  }
+
   // GET /api/runs/:run_id
-  if (pathname.startsWith("/api/runs/") && !pathname.includes("/activities") && !pathname.includes("/events") && !pathname.includes("/handoffs") && !pathname.includes("/chats") && !pathname.includes("/scorecard") && !pathname.includes("/eval-run") && !pathname.includes("/supervise") && !pathname.includes("/inject") && !pathname.includes("/experience") && !pathname.includes("/status") && !pathname.includes("/audit") && !pathname.includes("/rounds") && !pathname.includes("/commands") && !pathname.includes("/complete") && req.method === "GET") {
+  if (pathname.startsWith("/api/runs/") && !pathname.includes("/activities") && !pathname.includes("/events") && !pathname.includes("/handoffs") && !pathname.includes("/chats") && !pathname.includes("/scorecard") && !pathname.includes("/eval-run") && !pathname.includes("/supervise") && !pathname.includes("/inject") && !pathname.includes("/experience") && !pathname.includes("/status") && !pathname.includes("/audit") && !pathname.includes("/rounds") && !pathname.includes("/commands") && !pathname.includes("/complete") && !pathname.includes("/live-surfaces") && req.method === "GET") {
     const runId = _parseRunId(pathname, "/api/runs/");
     if (!runId) {
       _notFound(res, "Invalid run ID");

--- a/homerail_manager/src/server/routes.ts
+++ b/homerail_manager/src/server/routes.ts
@@ -30,6 +30,7 @@ import { listDagActorCommands, type DagActorCommandStatus } from "../persistence
 import { listDagRunRounds } from "../persistence/dag-run-rounds.js";
 import {
   getDagLiveSurfaceDocument,
+  isDagLiveSurfaceProjectionNode,
   listDagLiveSurfaceProjections,
 } from "../generative-ui/dag-live-surface-projector.js";
 
@@ -642,10 +643,20 @@ export function inspectionRoutesHandler(
       return true;
     }
     const projections = listDagLiveSurfaceProjections(runId);
+    const projectionBySurface = new Map(projections.map((projection) => [projection.surface_id, projection]));
+    const document = getDagLiveSurfaceDocument(runId);
     _ok(res, `Live surfaces retrieved (${projections.length} actors)`, {
       run_id: runId,
       projections,
-      document: getDagLiveSurfaceDocument(runId) ?? null,
+      document: document
+        ? {
+            ...document,
+            nodes: document.nodes.filter((node) => {
+              const projection = projectionBySurface.get(node.id);
+              return projection !== undefined && isDagLiveSurfaceProjectionNode(node, projection);
+            }),
+          }
+        : null,
     });
     return true;
   }

--- a/homerail_manager/tests/dag-activity-stream.test.ts
+++ b/homerail_manager/tests/dag-activity-stream.test.ts
@@ -206,6 +206,64 @@ nodes:
     })).toThrow("surface identity does not match");
   });
 
+  it("projects a registered actor stream into the run live-surface read API", async () => {
+    const dag = parseDAGYaml(`
+name: activity-live-surface
+workflow_id: activity-live-surface
+agents:
+  worker:
+    agent_type: deterministic
+    system: HANDOFF port=done content=ok
+nodes:
+  research:
+    agent: worker
+    extra:
+      agent_runtime:
+        actor_id: researcher
+        surface_id: surface-research
+    outputs:
+      done:
+        to: ""
+`);
+    createActiveRun("run-live-surface", dag);
+    const built = buildCurrentDispatchEnvelope("run-live-surface", "research");
+    expect(built.ok).toBe(true);
+    if (!built.ok) return;
+    ingestDagActivityStream({
+      event: "dag_activity",
+      activity: event({
+        event_id: "live-surface-started",
+        run_id: "run-live-surface",
+        round_id: built.envelope.sessionId,
+        node_id: "research",
+        actor_id: "researcher",
+        surface_id: "surface-research",
+        type: "started",
+      }),
+    }, {
+      runId: "run-live-surface",
+      nodeId: "research",
+      roundId: built.envelope.sessionId,
+    });
+
+    server = createServer(0, undefined, undefined, false, { autoDetectCodex: false });
+    const baseUrl = `http://127.0.0.1:${await listen(server)}`;
+    const response = await fetch(`${baseUrl}/api/runs/run-live-surface/live-surfaces`);
+    const body = await response.json() as {
+      success: boolean;
+      data: {
+        projections: Array<{ actor_id: string; surface_revision: number }>;
+        document: { scope: { type: string; id: string }; nodes: Array<{ id: string; a2ui?: unknown }> };
+      };
+    };
+    expect(response.status).toBe(200);
+    expect(body.data.projections).toMatchObject([{ actor_id: "researcher", surface_revision: 1 }]);
+    expect(body.data.document).toMatchObject({
+      scope: { type: "run", id: "run-live-surface" },
+      nodes: [{ id: "surface-research", a2ui: expect.any(Object) }],
+    });
+  });
+
   it("replays bounded activity pages by run and actor", async () => {
     appendDagActivityEvent(event({ event_id: "research-1", actor_id: "researcher", sequence: 1 }));
     appendDagActivityEvent(event({ event_id: "writer-1", actor_id: "writer", sequence: 1 }));

--- a/homerail_manager/tests/dag-activity-stream.test.ts
+++ b/homerail_manager/tests/dag-activity-stream.test.ts
@@ -3,7 +3,12 @@ import * as http from "node:http";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import type { DagActivityEventV1 } from "homerail-protocol";
+import { GenerativeUiActorType, type DagActivityEventV1 } from "homerail-protocol";
+import {
+  controlDagLiveSurface,
+  getDagLiveSurfaceDocument,
+} from "../src/generative-ui/dag-live-surface-projector.js";
+import { persistentGenerativeUiDocumentService } from "../src/generative-ui/shadow-service.js";
 import { closeDb, getDb } from "../src/persistence/db.js";
 import { appendDagActivityEvent } from "../src/persistence/dag-activity-journal.js";
 import { ensureRunDir } from "../src/persistence/store.js";
@@ -246,6 +251,22 @@ nodes:
       roundId: built.envelope.sessionId,
     });
 
+    const scope = { type: "run" as const, id: "run-live-surface" };
+    const canonical = getDagLiveSurfaceDocument("run-live-surface")!;
+    const { revision: _revision, updated_at: _updatedAt, ...projectedNode } = canonical.nodes[0]!;
+    expect(persistentGenerativeUiDocumentService.apply({
+      ir_version: 1,
+      transaction_id: "seed-unrelated-canonical-node",
+      document_id: canonical.document_id,
+      base_revision: canonical.revision,
+      actor: { type: GenerativeUiActorType.SYSTEM, id: "route-boundary-test" },
+      operations: [{
+        op: "put",
+        node: { ...structuredClone(projectedNode), id: "unrelated-canonical-node" },
+      }],
+      created_at: new Date().toISOString(),
+    }, scope)).toMatchObject({ status: "applied" });
+
     server = createServer(0, undefined, undefined, false, { autoDetectCodex: false });
     const baseUrl = `http://127.0.0.1:${await listen(server)}`;
     const response = await fetch(`${baseUrl}/api/runs/run-live-surface/live-surfaces`);
@@ -262,6 +283,32 @@ nodes:
       scope: { type: "run", id: "run-live-surface" },
       nodes: [{ id: "surface-research", a2ui: expect.any(Object) }],
     });
+    expect(body.data.document.nodes.map((node) => node.id)).not.toContain("unrelated-canonical-node");
+
+    expect(controlDagLiveSurface({
+      control_id: "remove-route-surface",
+      run_id: "run-live-surface",
+      actor_id: "researcher",
+      operation: "removed",
+      expected_surface_revision: 1,
+    })).toMatchObject({ projection: { visibility_state: "removed" } });
+    const removedDocument = getDagLiveSurfaceDocument("run-live-surface")!;
+    expect(persistentGenerativeUiDocumentService.apply({
+      ir_version: 1,
+      transaction_id: "reuse-removed-surface-id",
+      document_id: removedDocument.document_id,
+      base_revision: removedDocument.revision,
+      actor: { type: GenerativeUiActorType.SYSTEM, id: "unrelated-producer" },
+      operations: [{
+        op: "put",
+        node: { ...structuredClone(projectedNode), id: "surface-research" },
+      }],
+      created_at: new Date().toISOString(),
+    }, scope)).toMatchObject({ status: "applied" });
+    const reusedResponse = await fetch(`${baseUrl}/api/runs/run-live-surface/live-surfaces`);
+    const reused = await reusedResponse.json() as typeof body;
+    expect(reusedResponse.status).toBe(200);
+    expect(reused.data.document.nodes).toEqual([]);
   });
 
   it("replays bounded activity pages by run and actor", async () => {

--- a/homerail_manager/tests/dag-actors.test.ts
+++ b/homerail_manager/tests/dag-actors.test.ts
@@ -109,9 +109,13 @@ describe("durable DAG logical actors and command inbox", () => {
   it("upgrades a v19 database and validates migration v20 on repeated startup", () => {
     getDb().exec(`
       DROP TABLE dag_run_rounds;
+      DROP TABLE dag_surface_projection_controls;
+      DROP TABLE dag_surface_projection_queue;
+      DROP TABLE dag_surface_projections;
+      DROP INDEX idx_dag_actors_projection_identity;
       DROP TABLE dag_actor_commands;
       DROP TABLE dag_actors;
-      DELETE FROM schema_migrations WHERE version IN (20, 23);
+      DELETE FROM schema_migrations WHERE version IN (20, 21, 23);
     `);
     closeDb();
 

--- a/homerail_manager/tests/dag-actors.test.ts
+++ b/homerail_manager/tests/dag-actors.test.ts
@@ -115,7 +115,7 @@ describe("durable DAG logical actors and command inbox", () => {
       DROP INDEX idx_dag_actors_projection_identity;
       DROP TABLE dag_actor_commands;
       DROP TABLE dag_actors;
-      DELETE FROM schema_migrations WHERE version IN (20, 21, 23);
+      DELETE FROM schema_migrations WHERE version IN (20, 21, 22, 23);
     `);
     closeDb();
 

--- a/homerail_manager/tests/dag-live-surface-projector.test.ts
+++ b/homerail_manager/tests/dag-live-surface-projector.test.ts
@@ -12,6 +12,7 @@ import {
   DagLiveSurfaceProjectionError,
   getDagLiveSurfaceDocument,
   getDagLiveSurfaceProjection,
+  isDagLiveSurfaceProjectionNode,
   listDagLiveSurfaceProjections,
   listDagLiveSurfaceQueue,
   projectDagActivityJournalEntry,
@@ -96,25 +97,46 @@ describe("DAG Live Surface Projector", () => {
     fs.rmSync(home, { recursive: true, force: true });
   });
 
-  it("upgrades v20 to v21 once and validates its ownership indexes on restart", () => {
+  it("upgrades v20 through v22 once and validates its ownership indexes on restart", () => {
     getDb().exec(`
       DROP TABLE dag_surface_projection_controls;
       DROP TABLE dag_surface_projection_queue;
       DROP TABLE dag_surface_projections;
       DROP INDEX idx_dag_actors_projection_identity;
-      DELETE FROM schema_migrations WHERE version = 21;
+      DELETE FROM schema_migrations WHERE version IN (21, 22);
     `);
     closeDb();
 
     const migrated = getDb();
-    expect(migrated.prepare("SELECT version FROM schema_migrations WHERE version = 21").get())
-      .toEqual({ version: 21 });
+    expect(migrated.prepare("SELECT version FROM schema_migrations WHERE version IN (21, 22) ORDER BY version").all())
+      .toEqual([{ version: 21 }, { version: 22 }]);
     expect(migrated.prepare("PRAGMA index_list(dag_actors)").all()).toEqual(expect.arrayContaining([
       expect.objectContaining({ name: "idx_dag_actors_projection_identity", unique: 1 }),
     ]));
     closeDb();
-    expect(getDb().prepare("SELECT COUNT(*) AS count FROM schema_migrations WHERE version = 21").get())
-      .toEqual({ count: 1 });
+    expect(getDb().prepare("SELECT COUNT(*) AS count FROM schema_migrations WHERE version IN (21, 22)").get())
+      .toEqual({ count: 2 });
+  });
+
+  it("upgrades an existing v21 database with projection identity triggers", () => {
+    getDb().exec(`
+      DROP TRIGGER trg_dag_surface_projection_queue_journal_identity;
+      DROP TRIGGER trg_dag_surface_projection_queue_identity_immutable;
+      DELETE FROM schema_migrations WHERE version = 22;
+    `);
+    closeDb();
+
+    const migrated = getDb();
+    expect(migrated.prepare("SELECT version FROM schema_migrations WHERE version = 22").get())
+      .toEqual({ version: 22 });
+    expect(migrated.prepare(`
+      SELECT name FROM sqlite_master
+      WHERE type = 'trigger' AND name LIKE 'trg_dag_surface_projection_queue_%'
+      ORDER BY name
+    `).all()).toEqual([
+      { name: "trg_dag_surface_projection_queue_identity_immutable" },
+      { name: "trg_dag_surface_projection_queue_journal_identity" },
+    ]);
   });
 
   it("fails closed when a v21 marker points at an unbounded transaction index", () => {
@@ -126,6 +148,29 @@ describe("DAG Live Surface Projector", () => {
     closeDb();
     expect(() => getDb()).toThrow(
       "Schema migration 21 is incomplete: index idx_dag_surface_projection_queue_transaction_id is missing or invalid",
+    );
+  });
+
+  it("fails closed when the projection queue journal-identity trigger is missing", () => {
+    getDb().exec("DROP TRIGGER trg_dag_surface_projection_queue_journal_identity");
+    closeDb();
+    expect(() => getDb()).toThrow(
+      "Schema migration 22 is incomplete: trigger trg_dag_surface_projection_queue_journal_identity is missing or invalid",
+    );
+  });
+
+  it("fails closed when a projection trigger name is occupied by a no-op definition", () => {
+    getDb().exec(`
+      DROP TRIGGER trg_dag_surface_projection_queue_journal_identity;
+      CREATE TRIGGER trg_dag_surface_projection_queue_journal_identity
+        BEFORE INSERT ON dag_surface_projection_queue
+        BEGIN
+          SELECT COUNT(*) FROM dag_activity_events;
+        END;
+    `);
+    closeDb();
+    expect(() => getDb()).toThrow(
+      "Schema migration 22 is incomplete: trigger trg_dag_surface_projection_queue_journal_identity is missing or invalid",
     );
   });
 
@@ -248,6 +293,48 @@ describe("DAG Live Surface Projector", () => {
     expect(listDagLiveSurfaceQueue({ run_id: runId })).toEqual([]);
   });
 
+  it("binds every projection queue row to the exact immutable journal identity", () => {
+    const runId = "queue-identity";
+    ensureRunDir(runId);
+    register(runId, "alpha");
+    register(runId, "beta");
+    const entry = appendDagActivityEvent(activity({ run_id: runId, actor_id: "alpha", sequence: 1 }));
+    const insert = getDb().prepare(`
+      INSERT INTO dag_surface_projection_queue(
+        journal_seq, event_id, run_id, actor_id, node_id, surface_id,
+        generation, activity_sequence, status, transaction_id,
+        surface_revision, queued_at, applied_at, failure_json
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending', NULL, NULL, ?, NULL, NULL)
+    `);
+
+    expect(() => insert.run(
+      entry.seq,
+      entry.event.event_id,
+      runId,
+      "beta",
+      "beta",
+      "surface:beta",
+      1,
+      1,
+      entry.received_at,
+    )).toThrow("projection queue journal identity mismatch");
+
+    insert.run(
+      entry.seq,
+      entry.event.event_id,
+      runId,
+      "alpha",
+      "alpha",
+      "surface:alpha",
+      1,
+      1,
+      entry.received_at,
+    );
+    expect(() => getDb().prepare(`
+      UPDATE dag_surface_projection_queue SET actor_id = 'beta' WHERE journal_seq = ?
+    `).run(entry.seq)).toThrow("projection queue identity is immutable");
+  });
+
   it("commits the A2UI transaction and queue cursor atomically", () => {
     const runId = "atomic-commit";
     ensureRunDir(runId);
@@ -294,6 +381,50 @@ describe("DAG Live Surface Projector", () => {
     expect(JSON.stringify(getDagLiveSurfaceDocument(runId))).toBe(firstSnapshot);
     expect(getDb().prepare("SELECT COUNT(*) AS count FROM generative_ui_transactions").get())
       .toEqual(firstTransactions);
+    expect(recoverDagLiveSurfaceProjections()).toEqual({ runs: [], projected_events: 0, failed: [] });
+  });
+
+  it("ignores legacy journal rows without a registered logical actor during startup recovery", () => {
+    const runId = "legacy-journal-only";
+    ensureRunDir(runId);
+    appendDagActivityEvent(activity({ run_id: runId, actor_id: "worker", sequence: 1 }));
+    closeDb();
+
+    expect(recoverDagLiveSurfaceProjections()).toEqual({ runs: [], projected_events: 0, failed: [] });
+    expect(listDagLiveSurfaceQueue({ run_id: runId })).toEqual([]);
+  });
+
+  it("continues recovery after a poison row so later valid actor activity is not starved", () => {
+    const runId = "poison-then-valid";
+    ensureRunDir(runId);
+    register(runId, "worker");
+    appendDagActivityEvent(activity({
+      run_id: runId,
+      actor_id: "worker",
+      sequence: 1,
+      generation: 2,
+      event_id: "future-generation",
+    }));
+    appendDagActivityEvent(activity({
+      run_id: runId,
+      actor_id: "worker",
+      sequence: 1,
+      generation: 1,
+      event_id: "current-generation",
+      type: "started",
+    }));
+    closeDb();
+
+    expect(recoverDagLiveSurfaceProjections()).toMatchObject({
+      runs: [runId],
+      projected_events: 1,
+      failed: [{ run_id: runId, event_id: "future-generation" }],
+    });
+    expect(getDagLiveSurfaceProjection(runId, "worker")).toMatchObject({
+      generation: 1,
+      last_activity_sequence: 1,
+      surface_revision: 1,
+    });
   });
 
   it("uses a fixed bounded A2UI catalog while retaining only recent findings", () => {
@@ -310,15 +441,24 @@ describe("DAG Live Surface Projector", () => {
         components: Array.from({ length: 200 }, (_, index) => ({ id: `untrusted-${index}` })),
       },
     }));
+    const largeText = "汉🚀\u0000".repeat(700);
     for (let sequence = 2; sequence <= 13; sequence += 1) {
       appendAndProject(activity({
         run_id: runId,
         actor_id: "worker",
         sequence,
         type: "finding",
-        payload: { title: `Finding ${sequence}`, detail: "bounded detail" },
+        payload: { title: `Finding ${sequence} ${largeText}`, detail: largeText },
       }));
     }
+
+    expect(appendAndProject(activity({
+      run_id: runId,
+      actor_id: "worker",
+      sequence: 14,
+      type: "progress",
+      payload: { message: "continued after large findings", progress: 75 },
+    }))).toMatchObject({ applied_count: 1, queue: { status: "applied" } });
 
     const document = getDagLiveSurfaceDocument(runId)!;
     const node = document.nodes[0]!;
@@ -326,6 +466,82 @@ describe("DAG Live Surface Projector", () => {
     expect(node.a2ui?.components.map((component) => component.id)).not.toContain("untrusted-1");
     expect((node.content.data as { findings: unknown[] }).findings).toHaveLength(8);
     expect(JSON.stringify(node.content)).not.toContain("untrusted-199");
+    expect(Buffer.byteLength(JSON.stringify(node.content), "utf8")).toBeLessThanOrEqual(32 * 1024);
+    expect(listDagLiveSurfaceQueue({ run_id: runId }).every((entry) => entry.status === "applied")).toBe(true);
+  });
+
+  it("accepts a trusted control immediately after an actor generation advances", () => {
+    const runId = "generation-control";
+    ensureRunDir(runId);
+    register(runId, "worker");
+    appendAndProject(activity({ run_id: runId, actor_id: "worker", sequence: 1, type: "started" }));
+    expect(appendAndProject(activity({
+      run_id: runId,
+      actor_id: "worker",
+      sequence: 3,
+      payload: { message: "old generation gap" },
+    }))).toMatchObject({ applied_count: 0, queue: { status: "pending" } });
+    const actor = getDagActor(runId, "worker")!;
+    advanceDagActorGeneration({
+      run_id: runId,
+      actor_id: "worker",
+      expected_generation: actor.generation,
+      expected_version: actor.version,
+    });
+
+    expect(controlDagLiveSurface({
+      control_id: "generation-two-focus",
+      run_id: runId,
+      actor_id: "worker",
+      operation: "focused",
+      expected_surface_revision: 1,
+      created_at: 0,
+    })).toMatchObject({
+      projection: { generation: 2, surface_revision: 2, visibility_state: "focused" },
+    });
+    expect(contentData(runId, "worker")).toMatchObject({
+      actor: { id: "worker", generation: 2 },
+      state: { surface_revision: 2, visibility: "focused" },
+    });
+    expect(listDagLiveSurfaceQueue({ run_id: runId })).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        activity_sequence: 3,
+        status: "stale",
+        applied_at: expect.any(Number),
+        queued_at: expect.any(Number),
+      }),
+    ]));
+    const stale = listDagLiveSurfaceQueue({ run_id: runId })
+      .find((entry) => entry.activity_sequence === 3)!;
+    expect(stale.applied_at).toBeGreaterThanOrEqual(stale.queued_at);
+  });
+
+  it("keeps a valid surface visible across a non-visual generation transition", () => {
+    const runId = "non-visual-generation";
+    ensureRunDir(runId);
+    register(runId, "worker");
+    appendAndProject(activity({ run_id: runId, actor_id: "worker", sequence: 1, type: "started" }));
+    const actor = getDagActor(runId, "worker")!;
+    advanceDagActorGeneration({
+      run_id: runId,
+      actor_id: "worker",
+      expected_generation: actor.generation,
+      expected_version: actor.version,
+    });
+    expect(appendAndProject(activity({
+      run_id: runId,
+      actor_id: "worker",
+      sequence: 1,
+      generation: 2,
+      type: "tool_used",
+      payload: { tool: "search" },
+    }))).toMatchObject({ applied_count: 1, queue: { status: "applied" } });
+
+    const projection = getDagLiveSurfaceProjection(runId, "worker")!;
+    const node = getDagLiveSurfaceDocument(runId)!.nodes[0]!;
+    expect(projection).toMatchObject({ generation: 2, visibility_state: "visible" });
+    expect(contentData(runId, "worker")).toMatchObject({ actor: { generation: 1 } });
+    expect(isDagLiveSurfaceProjectionNode(node, projection)).toBe(true);
   });
 
   it("focuses and removes a surface through revision-checked idempotent controls", () => {

--- a/homerail_manager/tests/dag-live-surface-projector.test.ts
+++ b/homerail_manager/tests/dag-live-surface-projector.test.ts
@@ -1,0 +1,398 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  DAG_ACTIVITY_EVENT_SCHEMA_VERSION,
+  HOMERAIL_A2UI_MAX_COMPONENTS,
+  type DagActivityEventV1,
+} from "homerail-protocol";
+import {
+  controlDagLiveSurface,
+  DagLiveSurfaceProjectionError,
+  getDagLiveSurfaceDocument,
+  getDagLiveSurfaceProjection,
+  listDagLiveSurfaceProjections,
+  listDagLiveSurfaceQueue,
+  projectDagActivityJournalEntry,
+  recoverDagLiveSurfaceProjections,
+} from "../src/generative-ui/dag-live-surface-projector.js";
+import {
+  appendDagActivityEvent,
+  type DagActivityJournalEntry,
+} from "../src/persistence/dag-activity-journal.js";
+import {
+  advanceDagActorGeneration,
+  getDagActor,
+  registerDagActor,
+} from "../src/persistence/dag-actors.js";
+import { closeDb, getDb } from "../src/persistence/db.js";
+import { ensureRunDir } from "../src/persistence/store.js";
+
+const BASE_TIME = 1_784_000_000_000;
+
+function register(runId: string, actorId: string, nodeId = actorId, surfaceId = `surface:${actorId}`): void {
+  registerDagActor({
+    run_id: runId,
+    actor_id: actorId,
+    node_id: nodeId,
+    role: `${actorId} worker`,
+    surface_id: surfaceId,
+  });
+}
+
+function activity(input: {
+  run_id: string;
+  actor_id: string;
+  sequence: number;
+  type?: DagActivityEventV1["type"];
+  generation?: number;
+  node_id?: string;
+  surface_id?: string;
+  event_id?: string;
+  payload?: DagActivityEventV1["payload"];
+}): DagActivityEventV1 {
+  return {
+    schema_version: DAG_ACTIVITY_EVENT_SCHEMA_VERSION,
+    event_id: input.event_id ?? `${input.run_id}-${input.actor_id}-g${input.generation ?? 1}-s${input.sequence}`,
+    run_id: input.run_id,
+    round_id: `round-${input.generation ?? 1}`,
+    node_id: input.node_id ?? input.actor_id,
+    actor_id: input.actor_id,
+    generation: input.generation ?? 1,
+    surface_id: input.surface_id ?? `surface:${input.actor_id}`,
+    sequence: input.sequence,
+    timestamp: BASE_TIME + input.sequence,
+    type: input.type ?? "progress",
+    payload: input.payload ?? { message: `step ${input.sequence}`, progress: input.sequence * 10 },
+  };
+}
+
+function appendAndProject(event: DagActivityEventV1): ReturnType<typeof projectDagActivityJournalEntry> {
+  return projectDagActivityJournalEntry(appendDagActivityEvent(event));
+}
+
+function contentData(runId: string, actorId: string): Record<string, unknown> {
+  const document = getDagLiveSurfaceDocument(runId);
+  const node = document?.nodes.find((candidate) => candidate.id === `surface:${actorId}`);
+  return node?.content.data as Record<string, unknown>;
+}
+
+describe("DAG Live Surface Projector", () => {
+  let home: string;
+  let previousHome: string | undefined;
+
+  beforeEach(() => {
+    closeDb();
+    previousHome = process.env.HOMERAIL_HOME;
+    home = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-live-surface-"));
+    process.env.HOMERAIL_HOME = home;
+  });
+
+  afterEach(() => {
+    closeDb();
+    if (previousHome === undefined) delete process.env.HOMERAIL_HOME;
+    else process.env.HOMERAIL_HOME = previousHome;
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it("upgrades v20 to v21 once and validates its ownership indexes on restart", () => {
+    getDb().exec(`
+      DROP TABLE dag_surface_projection_controls;
+      DROP TABLE dag_surface_projection_queue;
+      DROP TABLE dag_surface_projections;
+      DROP INDEX idx_dag_actors_projection_identity;
+      DELETE FROM schema_migrations WHERE version = 21;
+    `);
+    closeDb();
+
+    const migrated = getDb();
+    expect(migrated.prepare("SELECT version FROM schema_migrations WHERE version = 21").get())
+      .toEqual({ version: 21 });
+    expect(migrated.prepare("PRAGMA index_list(dag_actors)").all()).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: "idx_dag_actors_projection_identity", unique: 1 }),
+    ]));
+    closeDb();
+    expect(getDb().prepare("SELECT COUNT(*) AS count FROM schema_migrations WHERE version = 21").get())
+      .toEqual({ count: 1 });
+  });
+
+  it("fails closed when a v21 marker points at an unbounded transaction index", () => {
+    getDb().exec(`
+      DROP INDEX idx_dag_surface_projection_queue_transaction_id;
+      CREATE UNIQUE INDEX idx_dag_surface_projection_queue_transaction_id
+        ON dag_surface_projection_queue(transaction_id);
+    `);
+    closeDb();
+    expect(() => getDb()).toThrow(
+      "Schema migration 21 is incomplete: index idx_dag_surface_projection_queue_transaction_id is missing or invalid",
+    );
+  });
+
+  it("projects three actors into three stable native A2UI blocks without cross-over", () => {
+    const runId = "three-actors";
+    ensureRunDir(runId);
+    for (const actorId of ["research", "build", "verify"]) register(runId, actorId);
+
+    for (const actorId of ["research", "build", "verify"]) {
+      appendAndProject(activity({
+        run_id: runId,
+        actor_id: actorId,
+        sequence: 1,
+        type: "started",
+        payload: { message: `${actorId} started` },
+      }));
+    }
+
+    const document = getDagLiveSurfaceDocument(runId)!;
+    expect(document.revision).toBe(3);
+    expect(document.nodes.map((node) => node.id).sort()).toEqual([
+      "surface:build",
+      "surface:research",
+      "surface:verify",
+    ]);
+    expect(document.nodes.every((node) => node.kind === "com.homerail.core/generated_view" && node.kind_version === 2))
+      .toBe(true);
+    expect(document.nodes.every((node) => node.a2ui?.catalogId === "https://homerail.dev/a2ui/catalogs/core/v1"))
+      .toBe(true);
+    expect(listDagLiveSurfaceProjections(runId)).toMatchObject([
+      { actor_id: "build", surface_id: "surface:build", surface_revision: 1 },
+      { actor_id: "research", surface_id: "surface:research", surface_revision: 1 },
+      { actor_id: "verify", surface_id: "surface:verify", surface_revision: 1 },
+    ]);
+
+    appendAndProject(activity({ run_id: runId, actor_id: "research", sequence: 2, payload: { message: "source found" } }));
+    const updated = getDagLiveSurfaceDocument(runId)!;
+    expect(updated.revision).toBe(4);
+    expect(updated.nodes.find((node) => node.id === "surface:research")?.revision).toBe(2);
+    expect(updated.nodes.find((node) => node.id === "surface:build")?.revision).toBe(1);
+    expect(contentData(runId, "research")).toMatchObject({
+      actor: { id: "research", node_id: "research" },
+      state: { summary: "source found", sequence: 2 },
+    });
+  });
+
+  it("queues out-of-order activity, deduplicates replay, and rejects late generations", () => {
+    const runId = "ordered-events";
+    ensureRunDir(runId);
+    register(runId, "worker");
+
+    const second = appendDagActivityEvent(activity({ run_id: runId, actor_id: "worker", sequence: 2 }));
+    expect(projectDagActivityJournalEntry(second)).toMatchObject({ applied_count: 0 });
+    expect(getDagLiveSurfaceDocument(runId)).toMatchObject({ revision: 0, nodes: [] });
+    expect(listDagLiveSurfaceQueue({ run_id: runId })).toMatchObject([{ status: "pending", activity_sequence: 2 }]);
+
+    const first = appendDagActivityEvent(activity({
+      run_id: runId,
+      actor_id: "worker",
+      sequence: 1,
+      type: "started",
+    }));
+    expect(projectDagActivityJournalEntry(first)).toMatchObject({ applied_count: 2 });
+    expect(getDagLiveSurfaceProjection(runId, "worker")).toMatchObject({
+      last_activity_sequence: 2,
+      surface_revision: 2,
+    });
+    expect(projectDagActivityJournalEntry(first)).toMatchObject({ inserted: false, applied_count: 0 });
+    expect(getDagLiveSurfaceDocument(runId)?.revision).toBe(2);
+
+    const actor = getDagActor(runId, "worker")!;
+    advanceDagActorGeneration({
+      run_id: runId,
+      actor_id: "worker",
+      expected_generation: actor.generation,
+      expected_version: actor.version,
+    });
+    const late = appendDagActivityEvent(activity({ run_id: runId, actor_id: "worker", sequence: 3, generation: 1 }));
+    expect(projectDagActivityJournalEntry(late)).toMatchObject({ queue: { status: "stale" }, applied_count: 0 });
+    expect(getDagLiveSurfaceDocument(runId)?.revision).toBe(2);
+
+    const generationTwoSecond = appendDagActivityEvent(activity({
+      run_id: runId,
+      actor_id: "worker",
+      sequence: 2,
+      generation: 2,
+    }));
+    expect(projectDagActivityJournalEntry(generationTwoSecond).applied_count).toBe(0);
+    const generationTwoFirst = appendDagActivityEvent(activity({
+      run_id: runId,
+      actor_id: "worker",
+      sequence: 1,
+      generation: 2,
+      type: "started",
+    }));
+    expect(projectDagActivityJournalEntry(generationTwoFirst).applied_count).toBe(2);
+    expect(getDagLiveSurfaceProjection(runId, "worker")).toMatchObject({
+      generation: 2,
+      last_activity_sequence: 2,
+      surface_revision: 4,
+    });
+  });
+
+  it("fails closed when an actor event claims another node or surface", () => {
+    const runId = "ownership";
+    ensureRunDir(runId);
+    register(runId, "alpha");
+    register(runId, "beta");
+    const spoofed = appendDagActivityEvent(activity({
+      run_id: runId,
+      actor_id: "alpha",
+      node_id: "beta",
+      surface_id: "surface:beta",
+      sequence: 1,
+    }));
+    expect(() => projectDagActivityJournalEntry(spoofed)).toThrowError(
+      expect.objectContaining<DagLiveSurfaceProjectionError>({ code: "identity_mismatch" }),
+    );
+    expect(listDagLiveSurfaceProjections(runId)).toEqual([]);
+    expect(listDagLiveSurfaceQueue({ run_id: runId })).toEqual([]);
+  });
+
+  it("commits the A2UI transaction and queue cursor atomically", () => {
+    const runId = "atomic-commit";
+    ensureRunDir(runId);
+    register(runId, "worker");
+    const entry = appendDagActivityEvent(activity({
+      run_id: runId,
+      actor_id: "worker",
+      sequence: 1,
+      type: "started",
+    }));
+    getDb().exec(`
+      CREATE TRIGGER reject_live_surface_queue_commit
+      BEFORE UPDATE OF status ON dag_surface_projection_queue
+      WHEN OLD.status = 'pending' AND NEW.status = 'applied'
+      BEGIN
+        SELECT RAISE(ABORT, 'forced projector bookkeeping failure');
+      END
+    `);
+
+    expect(() => projectDagActivityJournalEntry(entry)).toThrow("forced projector bookkeeping failure");
+    expect(getDagLiveSurfaceDocument(runId)).toMatchObject({ revision: 0, nodes: [] });
+    expect(getDagLiveSurfaceProjection(runId, "worker")).toMatchObject({ surface_revision: 0 });
+    expect(listDagLiveSurfaceQueue({ run_id: runId })).toMatchObject([{ status: "pending" }]);
+
+    getDb().exec("DROP TRIGGER reject_live_surface_queue_commit");
+    expect(projectDagActivityJournalEntry(entry)).toMatchObject({ inserted: false, applied_count: 1 });
+    expect(getDagLiveSurfaceDocument(runId)).toMatchObject({ revision: 1, nodes: [{ id: "surface:worker" }] });
+  });
+
+  it("replays a crash-pending journal into the same document on every restart", () => {
+    const runId = "restart-replay";
+    ensureRunDir(runId);
+    register(runId, "worker");
+    appendDagActivityEvent(activity({ run_id: runId, actor_id: "worker", sequence: 1, type: "started" }));
+    appendDagActivityEvent(activity({ run_id: runId, actor_id: "worker", sequence: 2, type: "completed" }));
+    closeDb();
+
+    expect(recoverDagLiveSurfaceProjections(runId)).toMatchObject({ projected_events: 2, failed: [] });
+    const firstSnapshot = JSON.stringify(getDagLiveSurfaceDocument(runId));
+    const firstTransactions = getDb().prepare("SELECT COUNT(*) AS count FROM generative_ui_transactions").get();
+    closeDb();
+
+    expect(recoverDagLiveSurfaceProjections(runId)).toMatchObject({ projected_events: 0, failed: [] });
+    expect(JSON.stringify(getDagLiveSurfaceDocument(runId))).toBe(firstSnapshot);
+    expect(getDb().prepare("SELECT COUNT(*) AS count FROM generative_ui_transactions").get())
+      .toEqual(firstTransactions);
+  });
+
+  it("uses a fixed bounded A2UI catalog while retaining only recent findings", () => {
+    const runId = "bounded-payload";
+    ensureRunDir(runId);
+    register(runId, "worker");
+    appendAndProject(activity({
+      run_id: runId,
+      actor_id: "worker",
+      sequence: 1,
+      type: "started",
+      payload: {
+        message: "started",
+        components: Array.from({ length: 200 }, (_, index) => ({ id: `untrusted-${index}` })),
+      },
+    }));
+    for (let sequence = 2; sequence <= 13; sequence += 1) {
+      appendAndProject(activity({
+        run_id: runId,
+        actor_id: "worker",
+        sequence,
+        type: "finding",
+        payload: { title: `Finding ${sequence}`, detail: "bounded detail" },
+      }));
+    }
+
+    const document = getDagLiveSurfaceDocument(runId)!;
+    const node = document.nodes[0]!;
+    expect(node.a2ui?.components.length).toBeLessThanOrEqual(HOMERAIL_A2UI_MAX_COMPONENTS);
+    expect(node.a2ui?.components.map((component) => component.id)).not.toContain("untrusted-1");
+    expect((node.content.data as { findings: unknown[] }).findings).toHaveLength(8);
+    expect(JSON.stringify(node.content)).not.toContain("untrusted-199");
+  });
+
+  it("focuses and removes a surface through revision-checked idempotent controls", () => {
+    const runId = "surface-controls";
+    ensureRunDir(runId);
+    register(runId, "worker");
+    appendAndProject(activity({ run_id: runId, actor_id: "worker", sequence: 1, type: "started" }));
+
+    const focus = controlDagLiveSurface({
+      control_id: "focus-1",
+      run_id: runId,
+      actor_id: "worker",
+      operation: "focused",
+      expected_surface_revision: 1,
+      focused_until: BASE_TIME + 10_000,
+      created_at: BASE_TIME + 100,
+    });
+    expect(focus).toMatchObject({ deduplicated: false, projection: { surface_revision: 2, visibility_state: "focused" } });
+    expect(getDagLiveSurfaceDocument(runId)?.nodes[0]).toMatchObject({ importance: "critical", revision: 2 });
+    expect(controlDagLiveSurface({
+      control_id: "focus-1",
+      run_id: runId,
+      actor_id: "worker",
+      operation: "focused",
+      expected_surface_revision: 1,
+      focused_until: BASE_TIME + 10_000,
+      created_at: BASE_TIME + 999,
+    })).toMatchObject({ deduplicated: true, projection: { surface_revision: 2 } });
+    expect(() => controlDagLiveSurface({
+      control_id: "stale-focus",
+      run_id: runId,
+      actor_id: "worker",
+      operation: "focused",
+      expected_surface_revision: 1,
+    })).toThrowError(expect.objectContaining<DagLiveSurfaceProjectionError>({ code: "surface_revision_conflict" }));
+
+    expect(controlDagLiveSurface({
+      control_id: "remove-1",
+      run_id: runId,
+      actor_id: "worker",
+      operation: "removed",
+      expected_surface_revision: 2,
+      created_at: BASE_TIME + 200,
+    })).toMatchObject({ projection: { surface_revision: 3, visibility_state: "removed" } });
+    expect(getDagLiveSurfaceDocument(runId)?.nodes).toEqual([]);
+
+    expect(appendAndProject(activity({
+      run_id: runId,
+      actor_id: "worker",
+      sequence: 2,
+      payload: { message: "late progress after removal", progress: 50 },
+    }))).toMatchObject({ applied_count: 1 });
+    expect(getDagLiveSurfaceProjection(runId, "worker")).toMatchObject({
+      activity_state: "progress",
+      last_activity_sequence: 2,
+      surface_revision: 3,
+      visibility_state: "removed",
+    });
+    expect(getDagLiveSurfaceDocument(runId)?.nodes).toEqual([]);
+
+    closeDb();
+    expect(recoverDagLiveSurfaceProjections(runId)).toMatchObject({ projected_events: 0, failed: [] });
+    expect(getDagLiveSurfaceProjection(runId, "worker")).toMatchObject({
+      last_activity_sequence: 2,
+      surface_revision: 3,
+      visibility_state: "removed",
+    });
+    expect(getDagLiveSurfaceDocument(runId)?.nodes).toEqual([]);
+  });
+});

--- a/homerail_manager/tests/generative-ui-persistent-document-service.test.ts
+++ b/homerail_manager/tests/generative-ui-persistent-document-service.test.ts
@@ -188,7 +188,7 @@ describe("PersistentGenerativeUiDocumentService", () => {
 
     expect(getDb().prepare("SELECT version FROM schema_migrations ORDER BY version").all())
       .toEqual([
-        ...Array.from({ length: 20 }, (_, index) => ({ version: index + 1 })),
+        ...Array.from({ length: 21 }, (_, index) => ({ version: index + 1 })),
         { version: 23 },
         { version: 24 },
       ]);
@@ -274,7 +274,7 @@ describe("PersistentGenerativeUiDocumentService", () => {
 
     expect(getDb().prepare("SELECT version FROM schema_migrations ORDER BY version").all())
       .toEqual([
-        ...Array.from({ length: 20 }, (_, index) => ({ version: index + 1 })),
+        ...Array.from({ length: 21 }, (_, index) => ({ version: index + 1 })),
         { version: 23 },
         { version: 24 },
       ]);

--- a/homerail_manager/tests/generative-ui-persistent-document-service.test.ts
+++ b/homerail_manager/tests/generative-ui-persistent-document-service.test.ts
@@ -187,11 +187,7 @@ describe("PersistentGenerativeUiDocumentService", () => {
     legacy.close();
 
     expect(getDb().prepare("SELECT version FROM schema_migrations ORDER BY version").all())
-      .toEqual([
-        ...Array.from({ length: 21 }, (_, index) => ({ version: index + 1 })),
-        { version: 23 },
-        { version: 24 },
-      ]);
+      .toEqual(Array.from({ length: 24 }, (_, index) => ({ version: index + 1 })));
     expect(getDb().prepare("SELECT data FROM voice_agent_sessions WHERE session_id = ?").get("legacy-v2"))
       .toEqual({ data: legacyPayload });
     expect(getDb().prepare(`
@@ -273,11 +269,7 @@ describe("PersistentGenerativeUiDocumentService", () => {
     mainDb.close();
 
     expect(getDb().prepare("SELECT version FROM schema_migrations ORDER BY version").all())
-      .toEqual([
-        ...Array.from({ length: 21 }, (_, index) => ({ version: index + 1 })),
-        { version: 23 },
-        { version: 24 },
-      ]);
+      .toEqual(Array.from({ length: 24 }, (_, index) => ({ version: index + 1 })));
     expect(getDb().prepare(`
       SELECT name FROM sqlite_master
       WHERE type = 'table' AND name IN ('generative_ui_documents', 'generative_ui_user_overrides')


### PR DESCRIPTION
Parent epic: #36

Implements: #41
Depends on: #38 / PR #48 (merged)

## Why

Workers must not receive arbitrary Canvas mutation authority. A trusted projector must turn accepted Activity Events into stable Actor-owned A2UI Blocks under ordering, ownership, size, and CAS constraints.

## What changed

- adds the Live Surface Projector service
- persists exact `(run_id, actor_id, node_id, surface_id)` ownership
- maintains per-Surface revision, event cursor, ordered projection queue, and control journal
- maps started, progress, finding, blocked, completed, failed, removed, and focused states to native A2UI transactions
- rejects duplicate, out-of-order, stale-generation, stale-revision, and cross-Actor mutations
- constrains payload size, materialized node count, catalog capability, and transaction boundaries
- replays missing or pending Activity Journal entries after Manager restart to restore the same Surface state
- exposes bounded read APIs consumed by the task canvas

## Invariants

- Workers cannot write the main Canvas directly
- an Actor cannot write another Actor's Surface
- duplicate events do not create duplicate Blocks
- old generations and revisions cannot overwrite current state
- projector replay is deterministic and idempotent

## Migrations

Migrations 21 and 22 add and harden projection state, queue, controls, ownership constraints, append-only guards, indexes, and repeat-start validation. They remain ordered before the merged multi-round migration 23 and Worker lease migration 24.

## Verification

- rebased onto `origin/main@93cf8a10ee30575de5bbd8b4341e741a8ec03556`
- HEAD: `f27c331deba827b49bee828964dcd95d66b7e809`
- focused projector, activity, Actor, multi-round, lease, reaper, and migration suite: 98 passed
- full `npm run ci` passed
- Protocol 247; Plugin SDK 34; Manager 859 (2 skipped); Node 187 (2 skipped); Worker 216 (1 skipped); CLI 241; Agent UI 290; live-validator 13
- approximately 2087 passed, 5 skipped, 0 failed

## Out of scope

- task canvas layout and animation: #42
- Manager Supervisor commentary: #43
- branch intervention: #44

## Residual risk

The projector persists and serves trusted A2UI state, but the final task-canvas presentation remains in #42. Model-backed live DAG validation is manual by repository policy; this rebase was validated with deterministic cross-feature tests and the complete local CI suite.