### PR TITLE
Add realtime DAG task canvas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,9 +102,10 @@ jobs:
       - name: Typecheck, build, and test
         env:
           HOMERAIL_HOME: ${{ runner.temp }}/homerail-ci
-          # Windows filesystem and process startup contention makes the default
-          # CPU-minus-one Vitest pool prone to unrelated short-test timeouts.
-          VITEST_MAX_WORKERS: "2"
+          # Windows filesystem and process startup contention makes parallel
+          # Vitest files prone to unrelated short-test timeouts. Keep the
+          # per-test timeout strict and serialize files on this runner only.
+          VITEST_MAX_WORKERS: "1"
         run: npm run ci
 
   agent-ui-coverage:

--- a/agent-ui/scripts/task-canvas-visual.mjs
+++ b/agent-ui/scripts/task-canvas-visual.mjs
@@ -1,0 +1,530 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import process from 'node:process'
+import { chromium } from 'playwright'
+
+const baseUrl = process.env.TASK_CANVAS_BASE_URL || 'http://127.0.0.1:4177'
+const outputDir = path.resolve('test-results/task-canvas-visual')
+const baseTime = 1_789_000_000_000
+const actors = ['build', 'research', 'verify']
+const surface = {
+  version: 'v1.0',
+  catalogId: 'https://homerail.dev/a2ui/catalogs/core/v1',
+  components: [
+    { id: 'root', component: 'Column', children: ['header', 'summary', 'progress', 'findings'] },
+    { id: 'header', component: 'Row', children: ['title', 'status'], justify: 'spaceBetween', align: 'center' },
+    { id: 'title', component: 'Text', text: { path: '/data/title' } },
+    { id: 'status', component: 'HrStatusBadge', text: { path: '/data/state/label' }, tone: { path: '/data/state/tone' } },
+    { id: 'summary', component: 'Text', text: { path: '/data/state/summary' }, variant: 'body' },
+    { id: 'progress', component: 'HrProgress', value: { path: '/data/state/progress' }, tone: { path: '/data/state/tone' } },
+    {
+      id: 'findings',
+      component: 'HrList',
+      source: { path: '/data/findings' },
+      maxItems: 14,
+      itemTitlePath: '/title',
+      itemDetailPath: '/detail',
+    },
+  ],
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function actorLabel(actor) {
+  return actor === 'build' ? 'Implementation Worker'
+    : actor === 'research' ? 'Research Worker'
+      : 'Verification Worker'
+}
+
+function activityMeta(activity) {
+  if (activity === 'completed') {
+    return { phase: 'succeeded', label: 'Completed', tone: 'positive', progress: 100 }
+  }
+  if (activity === 'failed') {
+    return { phase: 'failed', label: 'Failed', tone: 'critical', progress: 86 }
+  }
+  if (activity === 'finding') {
+    return { phase: 'running', label: 'Finding evidence', tone: 'info', progress: 62 }
+  }
+  return { phase: 'running', label: 'In progress', tone: 'info', progress: 38 }
+}
+
+function modeSpecs(mode) {
+  const specs = {
+    build: { revision: 1, activity: 'progress', visibility: 'visible' },
+    research: { revision: 2, activity: 'finding', visibility: 'visible' },
+    verify: { revision: 3, activity: 'progress', visibility: 'visible' },
+  }
+  if (mode === 'focus') {
+    specs.research = {
+      revision: 4,
+      activity: 'finding',
+      visibility: 'focused',
+      focusedUntil: Date.now() + 1800,
+    }
+  }
+  if (mode === 'complete') {
+    specs.build = { revision: 5, activity: 'completed', visibility: 'visible' }
+    specs.research = { revision: 5, activity: 'progress', visibility: 'visible' }
+  }
+  if (mode === 'fail' || mode === 'remove') {
+    specs.build = { revision: 5, activity: 'completed', visibility: 'visible' }
+    specs.research = {
+      revision: mode === 'remove' ? 6 : 5,
+      activity: 'progress',
+      visibility: mode === 'remove' ? 'removed' : 'visible',
+    }
+    specs.verify = { revision: 6, activity: 'failed', visibility: 'visible' }
+  }
+  return specs
+}
+
+function makeNode(actor, spec) {
+  const meta = activityMeta(spec.activity)
+  const actorIndex = actors.indexOf(actor)
+  const updatedAt = baseTime + spec.revision * 100 + actorIndex
+  const findings = Array.from({ length: actor === 'research' ? 14 : 11 }, (_, index) => ({
+    id: actor + ':' + index,
+    title: actor === 'build'
+      ? 'Module ' + (index + 1) + ' compiled'
+      : actor === 'research'
+        ? 'Evidence source ' + (index + 1)
+        : 'Scenario ' + (index + 1) + ' checked',
+    detail: spec.activity === 'failed' && index === 0
+      ? 'Viewport assertion needs attention'
+      : 'Latest projector state is preserved',
+  }))
+  const summary = spec.activity === 'completed'
+    ? 'All implementation checkpoints are complete.'
+    : spec.activity === 'failed'
+      ? 'Mobile viewport verification reported a blocking mismatch.'
+      : actor === 'research'
+        ? 'Comparing projector evidence and recovered activity history.'
+        : actor === 'build'
+          ? 'Applying the task canvas integration without interrupting other Blocks.'
+          : 'Checking desktop, touch, reconnect, and motion behavior.'
+  return {
+    ir_version: 1,
+    id: 'surface:' + actor,
+    kind: 'com.homerail.core/generated_view',
+    kind_version: 2,
+    owner: { id: 'com.homerail.core', version: '0.1.0' },
+    surface: 'execution',
+    importance: spec.visibility === 'focused' ? 'critical' : 'primary',
+    status: { phase: meta.phase, label: meta.label, progress: meta.progress },
+    content: {
+      data: {
+        projector: { id: 'dag-live-surface-projector', version: 1 },
+        actor: {
+          id: actor,
+          role: 'Worker',
+          node_id: 'node:' + actor,
+          generation: 1,
+        },
+        title: actorLabel(actor),
+        state: {
+          activity: spec.activity,
+          visibility: spec.visibility,
+          label: meta.label,
+          summary,
+          tone: meta.tone,
+          progress: meta.progress,
+          event_id: 'event:' + actor + ':' + spec.revision,
+          round_id: 'round:visual',
+          sequence: spec.revision,
+          updated_at: updatedAt,
+          surface_revision: spec.revision,
+          ...(spec.focusedUntil === undefined ? {} : { focused_until: spec.focusedUntil }),
+        },
+        findings,
+      },
+    },
+    a2ui: surface,
+    presentation: {
+      density: 'summary',
+      canvas_size: '1x2',
+      motion_profile: 'standard',
+    },
+    lifecycle: { persistence: 'session', removable: true },
+    fallback: { title: actorLabel(actor), summary },
+    provenance: { actor: 'agent', actor_id: actor, run_id: 'run:visual' },
+    revision: spec.revision,
+    updated_at: new Date(updatedAt).toISOString(),
+  }
+}
+
+function makeProjection(actor, spec) {
+  const actorIndex = actors.indexOf(actor)
+  return {
+    run_id: 'run:visual',
+    actor_id: actor,
+    node_id: 'node:' + actor,
+    surface_id: 'surface:' + actor,
+    document_id: 'document:run:visual',
+    generation: 1,
+    last_activity_sequence: spec.revision,
+    journal_cursor: spec.revision,
+    surface_revision: spec.revision,
+    activity_state: spec.activity,
+    visibility_state: spec.visibility,
+    last_event_id: 'event:' + actor + ':' + spec.revision,
+    ...(spec.focusedUntil === undefined ? {} : { focused_until: spec.focusedUntil }),
+    created_at: baseTime,
+    updated_at: baseTime + spec.revision * 100 + actorIndex,
+  }
+}
+
+function makeSnapshot(mode) {
+  const specs = modeSpecs(mode)
+  const documentRevision = {
+    initial: 3,
+    focus: 4,
+    complete: 5,
+    fail: 6,
+    remove: 7,
+  }[mode]
+  return {
+    run_id: 'run:visual',
+    projections: actors.map(actor => makeProjection(actor, specs[actor])),
+    document: {
+      ir_version: 1,
+      document_id: 'document:run:visual',
+      scope: { type: 'run', id: 'run:visual' },
+      revision: documentRevision,
+      nodes: actors.flatMap(actor => (
+        specs[actor].visibility === 'removed' ? [] : [makeNode(actor, specs[actor])]
+      )),
+      updated_at: new Date(baseTime + documentRevision * 100).toISOString(),
+    },
+  }
+}
+
+async function installSnapshotRoute(page, initialMode, holdInitial = false) {
+  const controller = {
+    mode: initialMode,
+    snapshot: makeSnapshot(initialMode),
+    holdInitial,
+    release: null,
+  }
+  let releaseGate
+  const gate = new Promise(resolve => { releaseGate = resolve })
+  controller.release = () => {
+    controller.holdInitial = false
+    releaseGate()
+  }
+  controller.setMode = mode => {
+    controller.mode = mode
+    controller.snapshot = makeSnapshot(mode)
+  }
+  await page.route('**/api/runs/**/live-surfaces', async route => {
+    if (controller.holdInitial) await gate
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        message: 'visual fixture',
+        data: controller.snapshot,
+      }),
+    })
+  })
+  return controller
+}
+
+async function waitForReady(page) {
+  await page.locator('[data-state="ready"]').waitFor()
+  await page.locator('[data-generative-ui-node]').first().waitFor()
+  await page.waitForFunction(() => (
+    document.querySelectorAll('[data-generative-ui-node]').length === 3
+  ))
+  await page.waitForFunction(() => (
+    document.querySelectorAll('.homerail-a2ui, .generative-ui-fallback--unavailable').length === 3
+  ))
+  const a2uiCount = await page.locator('.homerail-a2ui').count()
+  const fallbackText = await page.locator('.generative-ui-fallback--unavailable').allTextContents()
+  assert(
+    a2uiCount === 3,
+    'A2UI content did not render for all Workers; rendered=' + a2uiCount
+      + '; fallback=' + JSON.stringify(fallbackText),
+  )
+  assert(fallbackText.length === 0, 'A Worker fell back to unavailable rendering')
+}
+
+async function screenshot(page, name) {
+  await page.screenshot({
+    path: path.join(outputDir, name),
+    fullPage: false,
+    animations: 'allow',
+  })
+}
+
+async function layoutMetrics(page) {
+  return page.evaluate(() => {
+    const root = document.querySelector('#app')
+    const blocks = [...document.querySelectorAll('[data-generative-ui-node]')]
+    const horizontalScrollers = [document.documentElement, document.body, ...document.querySelectorAll('*')]
+      .filter(element => {
+        const style = getComputedStyle(element)
+        return element.scrollWidth > element.clientWidth + 2
+          && (style.overflowX === 'auto' || style.overflowX === 'scroll')
+      })
+      .map(element => element.id ? '#' + element.id : '.' + [...element.classList].slice(0, 2).join('.'))
+    return {
+      viewport: { width: innerWidth, height: innerHeight },
+      blockCount: blocks.length,
+      blockWidths: blocks.map(block => Math.round(block.getBoundingClientRect().width)),
+      rootClientWidth: root.clientWidth,
+      rootScrollWidth: root.scrollWidth,
+      documentOverflowX: document.documentElement.scrollWidth - innerWidth,
+      documentOverflowY: document.documentElement.scrollHeight - innerHeight,
+      horizontalScrollers,
+      internalVerticalScrollers: blocks.filter(block => {
+        const body = block.querySelector('.generative-ui-node-host__body')
+        return body && body.scrollHeight > body.clientHeight + 2
+      }).length,
+    }
+  })
+}
+
+async function runDesktop(browser, evidence) {
+  const context = await browser.newContext({
+    viewport: { width: 1920, height: 1080 },
+    deviceScaleFactor: 1,
+  })
+  const page = await context.newPage()
+  const pageErrors = []
+  page.on('pageerror', error => pageErrors.push(error.message))
+  const controller = await installSnapshotRoute(page, 'initial', true)
+
+  await page.goto(baseUrl + '/task-canvas-harness.html', { waitUntil: 'domcontentloaded' })
+  await page.locator('[data-state="loading"]').waitFor()
+  await screenshot(page, 'desktop-loading.png')
+  await page.evaluate(() => {
+    window.__taskCanvasTransitionClasses = []
+    window.__taskCanvasTransitionObserver = new MutationObserver(records => {
+      for (const record of records) {
+        if (!(record.target instanceof HTMLElement)) continue
+        const value = record.target.className
+        if (typeof value === 'string' && value.includes('generative-ui-node-')) {
+          window.__taskCanvasTransitionClasses.push(value)
+        }
+      }
+    })
+    window.__taskCanvasTransitionObserver.observe(document.querySelector('#app'), {
+      subtree: true,
+      childList: true,
+      attributes: true,
+      attributeFilter: ['class'],
+    })
+  })
+  controller.release()
+  await page.waitForFunction(() => (
+    document.querySelectorAll('[data-generative-ui-node]').length === 3
+  ))
+  await page.waitForTimeout(32)
+  const transitionClasses = await page.evaluate(() => window.__taskCanvasTransitionClasses)
+  assert(
+    transitionClasses.some(value => value.includes('generative-ui-node-enter-active')),
+    'Initial Worker appearance transition was not observed: ' + JSON.stringify(transitionClasses),
+  )
+  await screenshot(page, 'desktop-enter.png')
+  await waitForReady(page)
+  await page.waitForTimeout(350)
+  await screenshot(page, 'desktop-ready.png')
+
+  const initialMetrics = await layoutMetrics(page)
+  assert(initialMetrics.blockCount === 3, 'Desktop did not render three Worker Blocks')
+  assert(initialMetrics.documentOverflowX === 0, 'Desktop page has horizontal overflow')
+  assert(initialMetrics.documentOverflowY === 0, 'Desktop page has vertical overflow')
+  assert(new Set(initialMetrics.blockWidths).size <= 2, 'Desktop Worker widths are inconsistent')
+
+  controller.setMode('focus')
+  const research = page.locator('[data-generative-ui-node="surface:research"]')
+  await page.waitForFunction(() => (
+    document.querySelector('[data-generative-ui-node="surface:research"]')
+      ?.getAttribute('data-lifecycle-motion') === 'update'
+  ))
+  await page.waitForFunction(() => (
+    document.querySelector('[data-generative-ui-node="surface:research"]')
+      ?.getAttribute('data-attention') === 'true'
+  ))
+  assert(await research.getAttribute('aria-selected') === 'true', 'Manager focus did not restore selection')
+  const focusStates = await page.locator('[data-generative-ui-node]').evaluateAll(blocks => (
+    blocks.map(block => ({
+      id: block.getAttribute('data-generative-ui-node'),
+      className: block.className,
+      opacity: getComputedStyle(block).opacity,
+      visibility: getComputedStyle(block).visibility,
+      left: Math.round(block.getBoundingClientRect().left),
+      width: Math.round(block.getBoundingClientRect().width),
+    }))
+  ))
+  assert(
+    focusStates.every(state => Number(state.opacity) > 0.95 && state.visibility === 'visible'),
+    'A focus update blanked a Worker Block: ' + JSON.stringify(focusStates),
+  )
+  await screenshot(page, 'desktop-update-focus.png')
+  await page.waitForFunction(() => (
+    document.querySelector('[data-generative-ui-node="surface:research"]')
+      ?.getAttribute('data-attention') === 'false'
+  ), null, { timeout: 5000 })
+
+  controller.setMode('complete')
+  await page.waitForFunction(() => (
+    document.querySelector('[data-generative-ui-node="surface:build"]')
+      ?.getAttribute('data-lifecycle-motion') === 'complete'
+  ))
+  await screenshot(page, 'desktop-complete.png')
+
+  controller.setMode('fail')
+  await page.waitForFunction(() => (
+    document.querySelector('[data-generative-ui-node="surface:verify"]')
+      ?.getAttribute('data-lifecycle-motion') === 'fail'
+  ))
+  await screenshot(page, 'desktop-fail.png')
+
+  const verify = page.locator('[data-generative-ui-node="surface:verify"]')
+  await verify.locator('.generative-ui-node-host__expand').click()
+  await page.waitForFunction(() => (
+    document.querySelector('[data-generative-ui-node="surface:verify"]')
+      ?.getAttribute('data-expanded') === 'true'
+  ))
+  const expandedBox = await verify.boundingBox()
+  assert(expandedBox && expandedBox.width > 1800 && expandedBox.height > 1000, 'Desktop fullscreen did not fill the viewport')
+  await screenshot(page, 'desktop-fullscreen.png')
+  await verify.locator('.generative-ui-node-host__expand').click()
+
+  controller.setMode('remove')
+  await page.locator('[data-generative-ui-node="surface:research"].generative-ui-node-leave-active').waitFor()
+  await page.waitForTimeout(120)
+  await screenshot(page, 'desktop-remove-exit.png')
+  await page.locator('[data-generative-ui-node="surface:research"]').waitFor({ state: 'detached' })
+  await page.waitForTimeout(350)
+  const postRemoveStates = await page.locator('[data-generative-ui-node]').evaluateAll(blocks => (
+    blocks.map(block => ({
+      id: block.getAttribute('data-generative-ui-node'),
+      left: Math.round(block.getBoundingClientRect().left),
+      width: Math.round(block.getBoundingClientRect().width),
+    }))
+  ))
+  assert(
+    postRemoveStates.length === 2
+      && postRemoveStates[0].left === 0
+      && postRemoveStates[1].left - postRemoveStates[0].left
+        <= postRemoveStates[0].width + 20,
+    'Remaining Workers did not compact after removal: ' + JSON.stringify(postRemoveStates),
+  )
+  await screenshot(page, 'desktop-remove.png')
+  assert(await page.locator('[aria-selected="true"]').count() === 1, 'Selection was not reconciled after removal')
+
+  evidence.desktop = {
+    initial: initialMetrics,
+    afterRemoval: await layoutMetrics(page),
+    focusStates,
+    postRemoveStates,
+    transitionClasses,
+    pageErrors,
+  }
+  assert(pageErrors.length === 0, 'Desktop page errors: ' + pageErrors.join('; '))
+  await context.close()
+}
+
+async function runMobile(browser, evidence) {
+  const context = await browser.newContext({
+    viewport: { width: 390, height: 844 },
+    deviceScaleFactor: 1,
+    hasTouch: true,
+    isMobile: true,
+  })
+  const page = await context.newPage()
+  const pageErrors = []
+  page.on('pageerror', error => pageErrors.push(error.message))
+  await installSnapshotRoute(page, 'initial')
+  await page.goto(baseUrl + '/task-canvas-harness.html', { waitUntil: 'domcontentloaded' })
+  await waitForReady(page)
+  await page.waitForTimeout(350)
+  await page.locator('#app').evaluate(element => element.scrollTo({ left: 0, behavior: 'auto' }))
+  await page.waitForTimeout(150)
+  const build = page.locator('[data-generative-ui-node="surface:build"]')
+  await build.click({ position: { x: 40, y: 80 } })
+  await page.waitForFunction(() => (
+    document.querySelector('[data-generative-ui-node="surface:build"]')
+      ?.getAttribute('aria-selected') === 'true'
+  ))
+  await screenshot(page, 'mobile-ready.png')
+
+  const metrics = await layoutMetrics(page)
+  assert(metrics.blockCount === 3, 'Mobile did not render three Worker Blocks')
+  assert(metrics.rootScrollWidth > metrics.rootClientWidth * 2.5, 'Mobile does not expose the horizontal Worker rail')
+  assert(metrics.documentOverflowX === 0, 'Mobile page has horizontal overflow')
+  assert(metrics.documentOverflowY === 0, 'Mobile page has vertical overflow')
+  assert(metrics.horizontalScrollers.length === 1 && metrics.horizontalScrollers[0] === '#app', 'Mobile has nested horizontal scrolling')
+  assert(metrics.internalVerticalScrollers >= 1, 'Mobile Worker content does not own its vertical overflow')
+
+  await build.locator('.generative-ui-node-host__expand').tap()
+  await page.waitForFunction(() => (
+    document.querySelector('[data-generative-ui-node="surface:build"]')
+      ?.getAttribute('data-expanded') === 'true'
+  ))
+  const expandedBox = await build.boundingBox()
+  assert(expandedBox && expandedBox.width >= 370 && expandedBox.height >= 820, 'Mobile touch fullscreen is not viewport sized')
+  await screenshot(page, 'mobile-fullscreen.png')
+  await build.locator('.generative-ui-node-host__expand').tap()
+
+  evidence.mobile = { metrics, pageErrors }
+  assert(pageErrors.length === 0, 'Mobile page errors: ' + pageErrors.join('; '))
+  await context.close()
+}
+
+async function runReducedMotion(browser, evidence) {
+  const context = await browser.newContext({
+    viewport: { width: 1280, height: 800 },
+    reducedMotion: 'reduce',
+  })
+  const page = await context.newPage()
+  const controller = await installSnapshotRoute(page, 'initial')
+  await page.goto(baseUrl + '/task-canvas-harness.html', { waitUntil: 'domcontentloaded' })
+  await waitForReady(page)
+  assert(
+    await page.locator('.generative-ui-surface-host').getAttribute('data-reduced-motion') === 'true',
+    'Reduced-motion preference was not detected',
+  )
+
+  controller.setMode('focus')
+  await page.waitForFunction(() => (
+    document.querySelector('[data-generative-ui-node="surface:research"]')
+      ?.getAttribute('data-attention') === 'true'
+  ))
+  const animationNames = await page.locator('[data-generative-ui-node="surface:research"]').evaluate(element => ({
+    host: getComputedStyle(element).animationName,
+    body: getComputedStyle(element.querySelector('.generative-ui-node-host__body')).animationName,
+  }))
+  assert(animationNames.host === 'none' && animationNames.body === 'none', 'Reduced motion still runs attention or update animation')
+  await screenshot(page, 'reduced-motion-focus.png')
+
+  controller.setMode('remove')
+  const startedAt = Date.now()
+  await page.locator('[data-generative-ui-node="surface:research"]').waitFor({ state: 'detached' })
+  const removeDurationMs = Date.now() - startedAt
+  assert(removeDurationMs < 500, 'Reduced-motion removal remained artificially delayed')
+  evidence.reducedMotion = { animationNames, removeDurationMs }
+  await context.close()
+}
+
+await fs.mkdir(outputDir, { recursive: true })
+const browser = await chromium.launch({ headless: true })
+const evidence = {}
+try {
+  await runDesktop(browser, evidence)
+  await runMobile(browser, evidence)
+  await runReducedMotion(browser, evidence)
+  await fs.writeFile(
+    path.join(outputDir, 'metrics.json'),
+    JSON.stringify(evidence, null, 2) + '\n',
+  )
+  process.stdout.write(JSON.stringify(evidence, null, 2) + '\n')
+} finally {
+  await browser.close()
+}

--- a/agent-ui/src/api/agent/agent-generative-ui-api.ts
+++ b/agent-ui/src/api/agent/agent-generative-ui-api.ts
@@ -22,6 +22,17 @@ export {
 } from '@/api/services/generative-ui-api'
 
 export type {
+  DagLiveSurfaceActivityState,
+  DagLiveSurfaceProjectionRecord,
+  DagLiveSurfaceSnapshot,
+  DagLiveSurfaceVisibilityState,
+} from '@/api/services/dag-live-surface-api'
+export {
+  getDagLiveSurfaces,
+  normalizeDagLiveSurfaceSnapshot,
+} from '@/api/services/dag-live-surface-api'
+
+export type {
   AgentToolReferenceV1,
   AgentToolResponseV1,
   AgentToolStatusV1,

--- a/agent-ui/src/api/services/dag-live-surface-api.test.ts
+++ b/agent-ui/src/api/services/dag-live-surface-api.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest'
+import { HOMERAIL_A2UI_CATALOG_ID } from 'homerail-protocol'
+import { normalizeDagLiveSurfaceSnapshot } from './dag-live-surface-api'
+
+function projectedNode(actorId: string, revision: number, activity = 'progress') {
+  const surfaceId = `surface:${actorId}`
+  return {
+    ir_version: 1,
+    id: surfaceId,
+    kind: 'com.homerail.core/generated_view',
+    kind_version: 2,
+    owner: { id: 'com.homerail.core', version: '0.1.0' },
+    surface: 'execution',
+    importance: 'primary',
+    status: { phase: 'running', label: 'In progress', progress: revision * 10 },
+    content: {
+      data: {
+        projector: { id: 'dag-live-surface-projector', version: 1 },
+        actor: { id: actorId, role: 'Worker', node_id: `node:${actorId}`, generation: 1 },
+        title: `Worker ${actorId}`,
+        state: {
+          activity,
+          visibility: 'visible',
+          label: 'In progress',
+          summary: 'Working',
+          tone: 'info',
+          progress: revision * 10,
+          event_id: `event:${actorId}:${revision}`,
+          round_id: 'round:1',
+          sequence: revision,
+          updated_at: 1_789_000_000_000 + revision,
+          surface_revision: revision,
+        },
+        findings: [],
+      },
+    },
+    a2ui: {
+      version: 'v1.0',
+      catalogId: HOMERAIL_A2UI_CATALOG_ID,
+      components: [
+        { id: 'root', component: 'Column', children: ['title'] },
+        { id: 'title', component: 'Text', text: { path: '/data/title' } },
+      ],
+    },
+    presentation: { density: 'summary' },
+    lifecycle: { persistence: 'session', removable: true },
+    fallback: { title: `Worker ${actorId}`, summary: 'Working' },
+    provenance: { actor: 'agent', actor_id: actorId, run_id: 'run:one' },
+    revision,
+    updated_at: `2026-07-15T10:00:0${revision}.000Z`,
+  }
+}
+
+function projection(actorId: string, revision: number) {
+  return {
+    run_id: 'run:one',
+    actor_id: actorId,
+    node_id: `node:${actorId}`,
+    surface_id: `surface:${actorId}`,
+    document_id: 'document:run:one',
+    generation: 1,
+    last_activity_sequence: revision,
+    journal_cursor: revision,
+    surface_revision: revision,
+    activity_state: 'progress',
+    visibility_state: 'visible',
+    last_event_id: `event:${actorId}:${revision}`,
+    created_at: 1_789_000_000_000,
+    updated_at: 1_789_000_000_000 + revision,
+  }
+}
+
+function snapshot() {
+  const actors = ['build', 'research', 'verify']
+  return {
+    run_id: 'run:one',
+    projections: actors.map((actor, index) => projection(actor, index + 1)),
+    document: {
+      ir_version: 1,
+      document_id: 'document:run:one',
+      scope: { type: 'run', id: 'run:one' },
+      revision: 3,
+      nodes: actors.map((actor, index) => projectedNode(actor, index + 1)),
+      updated_at: '2026-07-15T10:00:03.000Z',
+    },
+  }
+}
+
+describe('DAG live surface API contract', () => {
+  it('accepts the #41 projector snapshot and preserves actor order', () => {
+    const normalized = normalizeDagLiveSurfaceSnapshot(snapshot(), 'run:one')
+    expect(normalized.projections.map(item => item.actor_id)).toEqual(['build', 'research', 'verify'])
+    expect(normalized.document?.nodes.map(node => node.id)).toEqual([
+      'surface:build',
+      'surface:research',
+      'surface:verify',
+    ])
+  })
+
+  it('rejects cross-run, duplicate, and forged projector identities', () => {
+    const crossRun = snapshot()
+    crossRun.projections[0]!.run_id = 'run:other'
+    expect(() => normalizeDagLiveSurfaceSnapshot(crossRun, 'run:one')).toThrow('projection run_id mismatch')
+
+    const duplicate = snapshot()
+    duplicate.projections[1]!.actor_id = duplicate.projections[0]!.actor_id
+    expect(() => normalizeDagLiveSurfaceSnapshot(duplicate)).toThrow('duplicate actor or surface')
+
+    const forged = snapshot()
+    forged.document.nodes[0]!.content.data.projector.id = 'another-projector'
+    expect(() => normalizeDagLiveSurfaceSnapshot(forged)).toThrow('does not match its projection')
+  })
+
+  it('rejects state revisions that disagree with projector recovery metadata', () => {
+    const value = snapshot()
+    value.document.nodes[2]!.content.data.state.surface_revision = 99
+    expect(() => normalizeDagLiveSurfaceSnapshot(value)).toThrow('does not match its projection')
+  })
+
+  it('rejects active projections without their recovered document node', () => {
+    const missingNode = snapshot()
+    missingNode.document.nodes.pop()
+    expect(() => normalizeDagLiveSurfaceSnapshot(missingNode))
+      .toThrow('active projection surface:verify has no node')
+
+    const missingDocument = snapshot()
+    missingDocument.document = null as unknown as ReturnType<typeof snapshot>['document']
+    expect(() => normalizeDagLiveSurfaceSnapshot(missingDocument))
+      .toThrow('active projections require a document')
+  })
+})

--- a/agent-ui/src/api/services/dag-live-surface-api.ts
+++ b/agent-ui/src/api/services/dag-live-surface-api.ts
@@ -1,0 +1,221 @@
+import {
+  validateGenerativeUiDocument,
+  type GenerativeUiDocumentV1,
+} from 'homerail-protocol'
+import { http, type ApiResponse } from '@/api/clients/http-client'
+
+export type DagLiveSurfaceActivityState =
+  | 'started'
+  | 'progress'
+  | 'finding'
+  | 'blocked'
+  | 'completed'
+  | 'failed'
+
+export type DagLiveSurfaceVisibilityState = 'visible' | 'focused' | 'removed'
+
+export interface DagLiveSurfaceProjectionRecord {
+  run_id: string
+  actor_id: string
+  node_id: string
+  surface_id: string
+  document_id: string
+  generation: number
+  last_activity_sequence: number
+  journal_cursor: number
+  surface_revision: number
+  activity_state: DagLiveSurfaceActivityState
+  visibility_state: DagLiveSurfaceVisibilityState
+  last_event_id?: string
+  focused_until?: number
+  created_at: number
+  updated_at: number
+}
+
+export interface DagLiveSurfaceSnapshot {
+  run_id: string
+  projections: DagLiveSurfaceProjectionRecord[]
+  document: GenerativeUiDocumentV1 | null
+}
+
+const ACTIVITY_STATES = new Set<DagLiveSurfaceActivityState>([
+  'started',
+  'progress',
+  'finding',
+  'blocked',
+  'completed',
+  'failed',
+])
+const VISIBILITY_STATES = new Set<DagLiveSurfaceVisibilityState>(['visible', 'focused', 'removed'])
+
+function objectValue(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`Invalid DAG live surface response: ${label} must be an object`)
+  }
+  return value as Record<string, unknown>
+}
+
+function requiredString(value: unknown, label: string): string {
+  if (typeof value !== 'string' || !value) {
+    throw new Error(`Invalid DAG live surface response: ${label} must be a non-empty string`)
+  }
+  return value
+}
+
+function optionalString(value: unknown, label: string): string | undefined {
+  if (value === undefined) return undefined
+  return requiredString(value, label)
+}
+
+function safeInteger(value: unknown, label: string): number {
+  if (!Number.isSafeInteger(value) || Number(value) < 0) {
+    throw new Error(`Invalid DAG live surface response: ${label} must be a non-negative safe integer`)
+  }
+  return Number(value)
+}
+
+function activityState(value: unknown): DagLiveSurfaceActivityState {
+  if (!ACTIVITY_STATES.has(value as DagLiveSurfaceActivityState)) {
+    throw new Error('Invalid DAG live surface response: activity_state is invalid')
+  }
+  return value as DagLiveSurfaceActivityState
+}
+
+function visibilityState(value: unknown): DagLiveSurfaceVisibilityState {
+  if (!VISIBILITY_STATES.has(value as DagLiveSurfaceVisibilityState)) {
+    throw new Error('Invalid DAG live surface response: visibility_state is invalid')
+  }
+  return value as DagLiveSurfaceVisibilityState
+}
+
+function normalizeProjection(value: unknown): DagLiveSurfaceProjectionRecord {
+  const record = objectValue(value, 'projection')
+  return {
+    run_id: requiredString(record.run_id, 'run_id'),
+    actor_id: requiredString(record.actor_id, 'actor_id'),
+    node_id: requiredString(record.node_id, 'node_id'),
+    surface_id: requiredString(record.surface_id, 'surface_id'),
+    document_id: requiredString(record.document_id, 'document_id'),
+    generation: safeInteger(record.generation, 'generation'),
+    last_activity_sequence: safeInteger(record.last_activity_sequence, 'last_activity_sequence'),
+    journal_cursor: safeInteger(record.journal_cursor, 'journal_cursor'),
+    surface_revision: safeInteger(record.surface_revision, 'surface_revision'),
+    activity_state: activityState(record.activity_state),
+    visibility_state: visibilityState(record.visibility_state),
+    ...(optionalString(record.last_event_id, 'last_event_id')
+      ? { last_event_id: String(record.last_event_id) }
+      : {}),
+    ...(record.focused_until === undefined
+      ? {}
+      : { focused_until: safeInteger(record.focused_until, 'focused_until') }),
+    created_at: safeInteger(record.created_at, 'created_at'),
+    updated_at: safeInteger(record.updated_at, 'updated_at'),
+  }
+}
+
+function projectedData(node: GenerativeUiDocumentV1['nodes'][number]): Record<string, unknown> {
+  const content = objectValue(node.content, `node ${node.id} content`)
+  return objectValue(content.data, `node ${node.id} content.data`)
+}
+
+function verifyProjectedNode(
+  node: GenerativeUiDocumentV1['nodes'][number],
+  projection: DagLiveSurfaceProjectionRecord,
+): void {
+  const data = projectedData(node)
+  const projector = objectValue(data.projector, `node ${node.id} projector`)
+  const actor = objectValue(data.actor, `node ${node.id} actor`)
+  const state = objectValue(data.state, `node ${node.id} state`)
+  if (
+    node.id !== projection.surface_id
+    || node.kind !== 'com.homerail.core/generated_view'
+    || node.kind_version !== 2
+    || node.owner.id !== 'com.homerail.core'
+    || node.provenance?.run_id !== projection.run_id
+    || node.provenance?.actor_id !== projection.actor_id
+    || projector.id !== 'dag-live-surface-projector'
+    || projector.version !== 1
+    || actor.id !== projection.actor_id
+    || actor.node_id !== projection.node_id
+    || state.activity !== projection.activity_state
+    || state.visibility !== projection.visibility_state
+    || state.surface_revision !== projection.surface_revision
+  ) {
+    throw new Error(`Invalid DAG live surface response: node ${node.id} does not match its projection`)
+  }
+}
+
+export function normalizeDagLiveSurfaceSnapshot(
+  value: unknown,
+  expectedRunId?: string,
+): DagLiveSurfaceSnapshot {
+  const record = objectValue(value, 'snapshot')
+  const runId = requiredString(record.run_id, 'run_id')
+  if (expectedRunId && runId !== expectedRunId) {
+    throw new Error(`Invalid DAG live surface response: expected run ${expectedRunId}, received ${runId}`)
+  }
+  if (!Array.isArray(record.projections)) {
+    throw new Error('Invalid DAG live surface response: projections must be an array')
+  }
+  const projections = record.projections.map(normalizeProjection)
+  const actorIds = new Set<string>()
+  const surfaceIds = new Set<string>()
+  for (const projection of projections) {
+    if (projection.run_id !== runId) {
+      throw new Error('Invalid DAG live surface response: projection run_id mismatch')
+    }
+    if (actorIds.has(projection.actor_id) || surfaceIds.has(projection.surface_id)) {
+      throw new Error('Invalid DAG live surface response: duplicate actor or surface projection')
+    }
+    actorIds.add(projection.actor_id)
+    surfaceIds.add(projection.surface_id)
+  }
+
+  let document: GenerativeUiDocumentV1 | null = null
+  if (record.document === null) {
+    if (projections.some(projection => projection.visibility_state !== 'removed')) {
+      throw new Error('Invalid DAG live surface response: active projections require a document')
+    }
+  } else {
+    const validation = validateGenerativeUiDocument(record.document)
+    if (!validation.value || validation.errors.length) {
+      throw new Error('Invalid DAG live surface response: document failed protocol validation')
+    }
+    document = structuredClone(validation.value)
+    if (document.scope.type !== 'run' || document.scope.id !== runId) {
+      throw new Error('Invalid DAG live surface response: document run scope mismatch')
+    }
+    const projectionBySurface = new Map(projections.map(projection => [projection.surface_id, projection]))
+    const nodeIds = new Set(document.nodes.map(node => node.id))
+    for (const node of document.nodes) {
+      const projection = projectionBySurface.get(node.id)
+      if (!projection || projection.visibility_state === 'removed') {
+        throw new Error(`Invalid DAG live surface response: node ${node.id} has no active projection`)
+      }
+      if (projection.document_id !== document.document_id) {
+        throw new Error('Invalid DAG live surface response: projection document_id mismatch')
+      }
+      verifyProjectedNode(node, projection)
+    }
+    for (const projection of projections) {
+      if (projection.visibility_state === 'removed') continue
+      if (projection.document_id !== document.document_id || !nodeIds.has(projection.surface_id)) {
+        throw new Error(`Invalid DAG live surface response: active projection ${projection.surface_id} has no node`)
+      }
+    }
+  }
+
+  return { run_id: runId, projections, document }
+}
+
+export async function getDagLiveSurfaces(
+  runId: string,
+): Promise<ApiResponse<DagLiveSurfaceSnapshot>> {
+  const response = await http.get<unknown>(
+    `/api/runs/${encodeURIComponent(runId)}/live-surfaces`,
+  )
+  return {
+    ...response,
+    data: normalizeDagLiveSurfaceSnapshot(response.data, runId),
+  }
+}

--- a/agent-ui/src/components/agent/AgentVoiceCockpit.vue
+++ b/agent-ui/src/components/agent/AgentVoiceCockpit.vue
@@ -37,6 +37,7 @@ import {
 } from '@/agent/voice-session-restore'
 import GenerativeUiCanonicalSurface from '@/components/generative-ui/GenerativeUiCanonicalSurface.vue'
 import GenerativeUiShadowPreview from '@/components/generative-ui/GenerativeUiShadowPreview.vue'
+import DagTaskCanvas from '@/components/generative-ui/DagTaskCanvas.vue'
 import {
   resolveVoiceGenerativeUiPresentation,
   showLegacyWidgetAlongsideCanonical,
@@ -194,6 +195,8 @@ const workspace = ref<VoiceWorkspace | null>(null)
 const generativeUiCanonicalAvailable = ref(false)
 const generativeUiCanonicalResolved = ref(false)
 const generativeUiCanonicalNodeIds = ref<Set<string>>(new Set())
+const dagTaskCanvasAvailable = ref(false)
+const dagTaskCanvasResolved = ref(false)
 const selectedGenerativeUiNodeId = ref('')
 const sessionTransitioning = ref(true)
 const voiceSessionTransitions = new VoiceSessionTransitionGuard()
@@ -281,11 +284,14 @@ watch(
   [
     () => workspace.value?.session_id,
     () => workspace.value?.generative_ui_mode,
+    () => workspace.value?.manager_run_id,
   ],
   () => {
     generativeUiCanonicalAvailable.value = false
     generativeUiCanonicalResolved.value = false
     generativeUiCanonicalNodeIds.value = new Set()
+    dagTaskCanvasAvailable.value = false
+    dagTaskCanvasResolved.value = false
     selectedGenerativeUiNodeId.value = ''
   },
 )
@@ -309,12 +315,28 @@ function onGenerativeUiCanonicalAvailability(payload: {
   }
 }
 
+function onDagTaskCanvasAvailability(payload: {
+  available: boolean
+  node_ids: string[]
+  loading?: boolean
+}): void {
+  if (payload.loading) {
+    dagTaskCanvasResolved.value = false
+    dagTaskCanvasAvailable.value = false
+    return
+  }
+  dagTaskCanvasResolved.value = true
+  dagTaskCanvasAvailable.value = payload.available
+}
+
 function beginVoiceSessionTransition(): number {
   const generation = voiceSessionTransitions.begin()
   sessionTransitioning.value = true
   generativeUiCanonicalResolved.value = false
   generativeUiCanonicalAvailable.value = false
   generativeUiCanonicalNodeIds.value = new Set()
+  dagTaskCanvasAvailable.value = false
+  dagTaskCanvasResolved.value = false
   selectedGenerativeUiNodeId.value = ''
   workspace.value = null
   return generation
@@ -762,11 +784,17 @@ const workspaceExecutionProgressText = computed(() => {
     return ''
   return workspaceProgressText.value
 })
-const executionCardVisible = computed(() =>
-  Boolean(primaryExecutionWidget.value || workspace.value?.manager_run_id)
-)
+const dagTaskCanvasPresent = computed(() => Boolean(
+  workspace.value?.manager_run_id
+  && (!dagTaskCanvasResolved.value || dagTaskCanvasAvailable.value)
+))
+const executionCardVisible = computed(() => Boolean(
+  !dagTaskCanvasPresent.value
+  && (primaryExecutionWidget.value || workspace.value?.manager_run_id)
+))
 const canonicalOwnsCanvasScroll = computed(() =>
   generativeUiPresentation.value.show_canonical
+  && !dagTaskCanvasPresent.value
   && !taskDraft.value
   && canvasWidgets.value.length === 0
   && !executionCardVisible.value
@@ -958,6 +986,7 @@ const canPreviewNextImage = computed(
 const hasVoiceStageContent = computed(() =>
   Boolean(
     taskDraft.value ||
+    dagTaskCanvasPresent.value ||
     artifactWidgets.value.length ||
     executionCardVisible.value ||
     taskContextWidgets.value.length ||
@@ -4942,12 +4971,21 @@ function summarizeTask(value: string): string {
               :class="{
                 'voice-card-grid--status-active': statusFocusActive,
                 'voice-card-grid--deck-active': deckPreviewFocusActive,
-                'voice-card-grid--canonical-active': generativeUiPresentation.show_canonical,
-                'voice-card-grid--canonical-scroll-owner': canonicalOwnsCanvasScroll
+                'voice-card-grid--canonical-active': generativeUiPresentation.show_canonical && !dagTaskCanvasPresent,
+                'voice-card-grid--canonical-scroll-owner': canonicalOwnsCanvasScroll,
+                'voice-card-grid--dag-task-active': dagTaskCanvasPresent
               }"
             >
+              <DagTaskCanvas
+                v-if="workspace?.manager_run_id"
+                :run-id="workspace.manager_run_id"
+                :refresh-token="workspace.updated_at"
+                embedded
+                @availability="onDagTaskCanvasAvailability"
+                @open-preview="openWidgetPreview"
+              />
               <GenerativeUiCanonicalSurface
-                v-if="generativeUiPresentation.request_canonical && workspace"
+                v-if="generativeUiPresentation.request_canonical && workspace && !dagTaskCanvasPresent"
                 ref="generativeUiCanonicalSurfaceRef"
                 :session-id="workspace.session_id"
                 :refresh-token="workspace.updated_at"

--- a/agent-ui/src/components/generative-ui/A2uiRenderer.vue
+++ b/agent-ui/src/components/generative-ui/A2uiRenderer.vue
@@ -31,18 +31,18 @@ const emit = defineEmits<{
 }>()
 
 const { locale } = useI18n()
-const surface = computed<HomerailA2uiSurfaceV1>(() => validateA2uiSurfaceForNode(
-  props.surface ?? props.node.a2ui,
-  props.node,
+const resolvedSurface = computed<HomerailA2uiSurfaceV1>(() => validateA2uiSurfaceForNode(
+  structuredClone(toRaw(props.surface ?? props.node.a2ui)),
+  structuredClone(toRaw(props.node)),
 ))
-const components = computed(() => indexA2uiSurface(surface.value))
+const components = computed(() => indexA2uiSurface(resolvedSurface.value))
 const dataModel = ref<unknown>(structuredClone(toRaw(props.node.content)))
 
 watch(
   () => `${props.node.id}:${props.node.revision}`,
   () => { dataModel.value = structuredClone(toRaw(props.node.content)) },
 )
-watch(surface, value => emit('surface-actions', [...a2uiActionNames(value)]), { immediate: true })
+watch(resolvedSurface, value => emit('surface-actions', [...a2uiActionNames(value)]), { immediate: true })
 
 const runtime = computed<A2uiRuntime>(() => ({
   components: components.value,
@@ -63,7 +63,6 @@ const rootScope = computed(() => ({ value: dataModel.value, key: 'root' }))
     :data-device="context.device"
     :data-viewport="context.viewport"
     :data-expanded="expanded ? 'true' : 'false'"
-    :data-surface-properties="surface.surfaceProperties ? 'true' : 'false'"
   >
     <A2uiNode
       :key="`${node.id}:${node.revision}`"
@@ -568,6 +567,51 @@ div.hr-a2ui__artifact { display: grid; min-height: 220px; grid-template-rows: mi
 .hr-a2ui__dag-node > i { position: absolute; right: 10px; bottom: 7px; left: 10px; height: 3px; overflow: hidden; background: rgba(255, 255, 255, 0.07); }
 .hr-a2ui__dag-node > i b { display: block; width: var(--progress); height: 100%; background: var(--tone); }
 @keyframes hr-a2ui-edge { to { stroke-dashoffset: -20; } }
+
+@container generative-ui-block (max-width: 420px) {
+  .homerail-a2ui {
+    --hr-a2ui-gap-sm: 8px;
+    --hr-a2ui-gap-md: 12px;
+    --hr-a2ui-gap-lg: 16px;
+    font-size: 13px;
+  }
+
+  .hr-a2ui__text h1 { font-size: 24px; }
+  .hr-a2ui__text h2 { font-size: 21px; }
+  .hr-a2ui__text h3 { font-size: 17px; }
+  .hr-a2ui__card { padding: 10px; }
+  .hr-a2ui__metric strong { font-size: 23px; }
+  .hr-a2ui__list li { gap: 7px; padding-block: 8px; }
+  .hr-a2ui__image[data-variant='mediumFeature'] { height: 132px; }
+  .hr-a2ui__image[data-variant='largeFeature'] { height: 180px; }
+  .hr-a2ui__image[data-variant='header'] { height: 150px; }
+}
+
+@container generative-ui-block (min-width: 760px) {
+  .homerail-a2ui {
+    --hr-a2ui-gap-sm: 12px;
+    --hr-a2ui-gap-md: 20px;
+    --hr-a2ui-gap-lg: 28px;
+    font-size: 15px;
+  }
+
+  .hr-a2ui__text h1 { font-size: 36px; }
+  .hr-a2ui__text h2 { font-size: 29px; }
+  .hr-a2ui__text h3 { font-size: 21px; }
+}
+
+@container generative-ui-block (max-height: 360px) {
+  .homerail-a2ui {
+    --hr-a2ui-gap-sm: 7px;
+    --hr-a2ui-gap-md: 10px;
+    --hr-a2ui-gap-lg: 14px;
+  }
+
+  .hr-a2ui__card { padding: 9px; }
+  .hr-a2ui__list li { padding-block: 7px; }
+  .hr-a2ui__image,
+  .hr-a2ui__video { max-height: 180px; }
+}
 
 .homerail-a2ui[data-viewport='compact'] .hr-a2ui__grid { grid-template-columns: repeat(var(--compact-columns), minmax(0, 1fr)); }
 .homerail-a2ui[data-viewport='compact'] .hr-a2ui__grid-item { grid-column: span 1 !important; }

--- a/agent-ui/src/components/generative-ui/DagTaskCanvas.test.ts
+++ b/agent-ui/src/components/generative-ui/DagTaskCanvas.test.ts
@@ -1,0 +1,372 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, type App } from 'vue'
+import {
+  HOMERAIL_A2UI_CATALOG_ID,
+  type GenerativeUiStoredNodeV1,
+} from 'homerail-protocol'
+import type {
+  DagLiveSurfaceActivityState,
+  DagLiveSurfaceSnapshot,
+  DagLiveSurfaceVisibilityState,
+} from '@/api/services/dag-live-surface-api'
+import { dagTaskCanvasSelectionStorageKey } from '@/generative-ui/dag-task-canvas'
+import { i18n } from '@/plugins/i18n'
+import DagTaskCanvas from './DagTaskCanvas.vue'
+
+const mocks = vi.hoisted(() => ({
+  getDagLiveSurfaces: vi.fn(),
+  onEvent: vi.fn(() => () => undefined),
+  onStateChange: vi.fn(() => () => undefined),
+}))
+
+vi.mock('@/api/agent', () => ({
+  getDagLiveSurfaces: mocks.getDagLiveSurfaces,
+}))
+
+vi.mock('@/api/clients/events-ws', () => ({
+  voiceWs: {
+    on: mocks.onEvent,
+    onStateChange: mocks.onStateChange,
+  },
+}))
+
+function node(
+  actorId: string,
+  revision: number,
+  activity: DagLiveSurfaceActivityState = 'progress',
+  visibility: DagLiveSurfaceVisibilityState = 'visible',
+): GenerativeUiStoredNodeV1 {
+  const phase = activity === 'completed' ? 'succeeded' : activity === 'failed' ? 'failed' : 'running'
+  return {
+    ir_version: 1,
+    id: `surface:${actorId}`,
+    kind: 'com.homerail.core/generated_view',
+    kind_version: 2,
+    owner: { id: 'com.homerail.core', version: '0.1.0' },
+    surface: 'execution',
+    importance: visibility === 'focused' ? 'critical' : 'primary',
+    status: { phase, label: activity, progress: activity === 'completed' ? 100 : revision * 10 },
+    content: {
+      data: {
+        projector: { id: 'dag-live-surface-projector', version: 1 },
+        actor: { id: actorId, role: 'Worker', node_id: `node:${actorId}`, generation: 1 },
+        title: `Worker ${actorId}`,
+        state: {
+          activity,
+          visibility,
+          label: activity,
+          summary: `Update ${revision}`,
+          tone: activity === 'failed' ? 'critical' : 'info',
+          progress: revision * 10,
+          event_id: `event:${actorId}:${revision}`,
+          round_id: 'round:1',
+          sequence: revision,
+          updated_at: 1_789_000_000_000 + revision,
+          surface_revision: revision,
+        },
+        findings: Array.from({ length: revision }, (_, index) => ({
+          id: `${actorId}:${index}`,
+          title: `Finding ${index + 1}`,
+        })),
+      },
+    },
+    a2ui: {
+      version: 'v1.0',
+      catalogId: HOMERAIL_A2UI_CATALOG_ID,
+      components: [
+        { id: 'root', component: 'Column', children: ['header', 'summary', 'progress'] },
+        { id: 'header', component: 'Row', children: ['title', 'status'], justify: 'spaceBetween' },
+        { id: 'title', component: 'Text', text: { path: '/data/title' } },
+        { id: 'status', component: 'HrStatusBadge', text: { path: '/data/state/label' }, tone: { path: '/data/state/tone' } },
+        { id: 'summary', component: 'Text', text: { path: '/data/state/summary' } },
+        { id: 'progress', component: 'HrProgress', value: { path: '/data/state/progress' }, tone: { path: '/data/state/tone' } },
+      ],
+    },
+    presentation: { density: 'summary' },
+    lifecycle: { persistence: 'session', removable: true },
+    fallback: { title: `Worker ${actorId}`, summary: `Update ${revision}` },
+    provenance: { actor: 'agent', actor_id: actorId, run_id: 'run:one' },
+    revision,
+    updated_at: `2026-07-15T10:00:0${revision}.000Z`,
+  }
+}
+
+function snapshot(): DagLiveSurfaceSnapshot {
+  const actors = ['build', 'research', 'verify']
+  return {
+    run_id: 'run:one',
+    projections: actors.map((actorId, index) => ({
+      run_id: 'run:one',
+      actor_id: actorId,
+      node_id: `node:${actorId}`,
+      surface_id: `surface:${actorId}`,
+      document_id: 'document:run:one',
+      generation: 1,
+      last_activity_sequence: index + 1,
+      journal_cursor: index + 1,
+      surface_revision: index + 1,
+      activity_state: 'progress',
+      visibility_state: 'visible',
+      created_at: 1_789_000_000_000,
+      updated_at: 1_789_000_000_000 + index,
+    })),
+    document: {
+      ir_version: 1,
+      document_id: 'document:run:one',
+      scope: { type: 'run', id: 'run:one' },
+      revision: 3,
+      nodes: actors.map((actorId, index) => node(actorId, index + 1)),
+      updated_at: '2026-07-15T10:00:03.000Z',
+    },
+  }
+}
+
+let app: App<Element> | null = null
+let root: HTMLElement | null = null
+let controls: { refresh: () => Promise<void> } | null = null
+
+function mount(props: Record<string, unknown> = {}): HTMLElement {
+  root = document.createElement('div')
+  document.body.appendChild(root)
+  app = createApp(DagTaskCanvas, {
+    runId: 'run:one',
+    autoRefresh: false,
+    ...props,
+  })
+  app.use(i18n)
+  controls = app.mount(root) as unknown as { refresh: () => Promise<void> }
+  return root
+}
+
+async function settle(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+  await nextTick()
+  await Promise.resolve()
+  await nextTick()
+}
+
+afterEach(() => {
+  app?.unmount()
+  root?.remove()
+  app = null
+  root = null
+  controls = null
+  mocks.getDagLiveSurfaces.mockReset()
+  mocks.onEvent.mockClear()
+  mocks.onStateChange.mockClear()
+  sessionStorage.clear()
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+})
+
+describe('DagTaskCanvas', () => {
+  it('holds the final three-Block geometry while loading, then renders ordered 1x2 Workers', async () => {
+    let resolveRequest!: (value: { success: true; data: DagLiveSurfaceSnapshot }) => void
+    mocks.getDagLiveSurfaces.mockReturnValue(new Promise(resolve => { resolveRequest = resolve }))
+    const mounted = mount()
+
+    expect(mounted.querySelector('[data-state="loading"]')).toBeTruthy()
+    expect(mounted.querySelectorAll('.dag-task-canvas__skeleton-block')).toHaveLength(3)
+
+    resolveRequest({ success: true, data: snapshot() })
+    await settle()
+    const blocks = [...mounted.querySelectorAll<HTMLElement>('[data-generative-ui-node]')]
+    expect(blocks.map(block => block.dataset.generativeUiNode)).toEqual([
+      'surface:build',
+      'surface:research',
+      'surface:verify',
+    ])
+    expect(blocks.map(block => block.dataset.canvasSize)).toEqual(['1x2', '1x2', '1x2'])
+    expect(mounted.querySelectorAll('.homerail-a2ui')).toHaveLength(3)
+    expect(mounted.querySelector('.generative-ui-fallback--unavailable')).toBeNull()
+    expect(mounted.querySelector('[data-state="ready"]')).toBeTruthy()
+  })
+
+  it('flattens into the Cockpit grid for one horizontal scroll layer and keeps all legal sizes', async () => {
+    const sized = snapshot()
+    sized.document!.nodes[0]!.presentation = { density: 'glance', canvas_size: '1x1' }
+    sized.document!.nodes[1]!.presentation = { density: 'detail', canvas_size: '2x2' }
+    sized.document!.nodes[2]!.presentation = { density: 'immersive', canvas_size: '3x3' }
+    mocks.getDagLiveSurfaces.mockResolvedValue({ success: true, data: sized })
+
+    const mounted = mount({ embedded: true })
+    await settle()
+
+    expect(mounted.querySelector('.dag-task-canvas--embedded')).toBeTruthy()
+    expect(mounted.querySelector('.generative-ui-surface-host--embedded')).toBeTruthy()
+    expect([...mounted.querySelectorAll<HTMLElement>('[data-generative-ui-node]')]
+      .map(block => block.dataset.canvasSize)).toEqual(['1x1', '2x2', '3x3'])
+  })
+
+  it('restores selection and supports internal collapse plus touch-compatible fullscreen exit', async () => {
+    sessionStorage.setItem(dagTaskCanvasSelectionStorageKey('run:one'), 'surface:build')
+    mocks.getDagLiveSurfaces.mockResolvedValue({ success: true, data: snapshot() })
+    const mounted = mount()
+    await settle()
+
+    const build = mounted.querySelector<HTMLElement>('[data-generative-ui-node="surface:build"]')!
+    expect(build.classList.contains('generative-ui-node-host--selected')).toBe(true)
+
+    build.querySelector<HTMLButtonElement>('.generative-ui-node-host__minimize')!.click()
+    await nextTick()
+    expect(build.dataset.collapsed).toBe('true')
+    expect(build.querySelector('.generative-ui-node-host__minimal')?.textContent).toContain('Worker build')
+
+    build.querySelector<HTMLButtonElement>('.generative-ui-node-host__minimize')!.click()
+    build.querySelector<HTMLButtonElement>('.generative-ui-node-host__expand')!.click()
+    await nextTick()
+    expect(build.dataset.expanded).toBe('true')
+    expect(document.body.classList.contains('generative-ui-node-expanded')).toBe(true)
+
+    build.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    await nextTick()
+    expect(build.dataset.expanded).toBe('false')
+    expect(document.body.classList.contains('generative-ui-node-expanded')).toBe(false)
+  })
+
+  it('reconciles update, complete, fail, and remove, then retains the last snapshot while stale', async () => {
+    vi.useFakeTimers()
+    const initial = snapshot()
+    mocks.getDagLiveSurfaces.mockResolvedValueOnce({ success: true, data: initial })
+    const mounted = mount()
+    await settle()
+
+    const updated = snapshot()
+    updated.document!.revision = 4
+    updated.document!.updated_at = '2026-07-15T10:00:04.000Z'
+    updated.projections[0] = {
+      ...updated.projections[0]!,
+      surface_revision: 4,
+      activity_state: 'progress',
+      updated_at: 1_789_000_000_100,
+    }
+    updated.document!.nodes[0] = node('build', 4, 'progress')
+    mocks.getDagLiveSurfaces.mockResolvedValueOnce({ success: true, data: updated })
+    await controls!.refresh()
+    await settle()
+    expect(mounted.querySelector('[data-generative-ui-node="surface:build"]')?.getAttribute('data-lifecycle-motion'))
+      .toBe('update')
+    await vi.advanceTimersByTimeAsync(700)
+
+    const completed = snapshot()
+    completed.document!.revision = 5
+    completed.document!.updated_at = '2026-07-15T10:00:05.000Z'
+    completed.projections[0] = {
+      ...completed.projections[0]!,
+      surface_revision: 5,
+      activity_state: 'completed',
+      updated_at: 1_789_000_000_200,
+    }
+    completed.document!.nodes[0] = node('build', 5, 'completed')
+    mocks.getDagLiveSurfaces.mockResolvedValueOnce({ success: true, data: completed })
+    await controls!.refresh()
+    await settle()
+    expect(mounted.querySelector('[data-generative-ui-node="surface:build"]')?.getAttribute('data-lifecycle-motion'))
+      .toBe('complete')
+    await vi.advanceTimersByTimeAsync(1000)
+
+    const failed = snapshot()
+    failed.document!.revision = 6
+    failed.document!.updated_at = '2026-07-15T10:00:06.000Z'
+    failed.projections[0] = {
+      ...failed.projections[0]!,
+      surface_revision: 6,
+      activity_state: 'failed',
+      updated_at: 1_789_000_000_300,
+    }
+    failed.document!.nodes[0] = node('build', 6, 'failed')
+    failed.projections[1] = { ...failed.projections[1]!, visibility_state: 'removed' }
+    failed.document!.nodes = failed.document!.nodes.filter(candidate => candidate.id !== 'surface:research')
+    mocks.getDagLiveSurfaces.mockResolvedValueOnce({ success: true, data: failed })
+    await controls!.refresh()
+    await settle()
+    expect(mounted.querySelector('[data-generative-ui-node="surface:build"]')?.getAttribute('data-lifecycle-motion'))
+      .toBe('fail')
+    expect(mounted.querySelector('[data-generative-ui-node="surface:research"]')
+      ?.classList.contains('generative-ui-node-leave-active')).toBe(true)
+    await vi.advanceTimersByTimeAsync(350)
+    await nextTick()
+    expect(mounted.querySelector('[data-generative-ui-node="surface:research"]')).toBeNull()
+    await vi.advanceTimersByTimeAsync(650)
+    expect(mounted.querySelectorAll('[data-generative-ui-node]')).toHaveLength(2)
+
+    mocks.getDagLiveSurfaces.mockRejectedValueOnce(new Error('Manager restarting'))
+    await controls!.refresh()
+    await settle()
+    expect(mounted.querySelector('[data-state="stale"]')).toBeTruthy()
+    expect(mounted.querySelectorAll('[data-generative-ui-node]')).toHaveLength(2)
+
+    const recovered = snapshot()
+    recovered.document!.revision = 7
+    recovered.document!.nodes[0] = node('build', 7, 'completed')
+    recovered.projections[0] = {
+      ...recovered.projections[0]!,
+      surface_revision: 7,
+      activity_state: 'completed',
+      updated_at: 1_789_000_000_400,
+    }
+    mocks.getDagLiveSurfaces.mockResolvedValueOnce({ success: true, data: recovered })
+    await controls!.refresh()
+    await settle()
+    expect(mounted.querySelector('[data-state="ready"]')).toBeTruthy()
+    expect([...mounted.querySelectorAll<HTMLElement>('[data-generative-ui-node]')]
+      .map(block => block.dataset.generativeUiNode)).toEqual([
+        'surface:build',
+        'surface:research',
+        'surface:verify',
+      ])
+  })
+
+  it('coalesces overlapping recovery signals into a serial refresh queue', async () => {
+    mocks.getDagLiveSurfaces.mockResolvedValueOnce({ success: true, data: snapshot() })
+    mount()
+    await settle()
+
+    const pending: Array<(value: { success: true; data: DagLiveSurfaceSnapshot }) => void> = []
+    let activeRequests = 0
+    let maxActiveRequests = 0
+    mocks.getDagLiveSurfaces.mockImplementation(() => new Promise(resolve => {
+      activeRequests += 1
+      maxActiveRequests = Math.max(maxActiveRequests, activeRequests)
+      pending.push(value => {
+        activeRequests -= 1
+        resolve(value)
+      })
+    }))
+
+    const first = controls!.refresh()
+    const second = controls!.refresh()
+    const third = controls!.refresh()
+    expect(first).toBe(second)
+    expect(second).toBe(third)
+    expect(pending).toHaveLength(1)
+
+    pending.shift()!({ success: true, data: snapshot() })
+    await settle()
+    expect(pending).toHaveLength(1)
+    pending.shift()!({ success: true, data: snapshot() })
+    await Promise.all([first, second, third])
+    expect(maxActiveRequests).toBe(1)
+    expect(mocks.getDagLiveSurfaces).toHaveBeenCalledTimes(3)
+  })
+
+  it('disables transition motion when the browser requests reduced motion', async () => {
+    vi.stubGlobal('matchMedia', vi.fn(() => ({
+      matches: true,
+      media: '(prefers-reduced-motion: reduce)',
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })))
+    mocks.getDagLiveSurfaces.mockResolvedValue({ success: true, data: snapshot() })
+    const mounted = mount()
+    await settle()
+
+    expect(mounted.querySelector('.generative-ui-surface-host')
+      ?.getAttribute('data-reduced-motion')).toBe('true')
+  })
+})

--- a/agent-ui/src/components/generative-ui/DagTaskCanvas.vue
+++ b/agent-ui/src/components/generative-ui/DagTaskCanvas.vue
@@ -1,0 +1,370 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import type { GenerativeUiPreviewRequestV1 } from '@/generative-ui/types'
+import {
+  getDagLiveSurfaces,
+  type DagLiveSurfaceSnapshot,
+} from '@/api/agent'
+import { voiceWs } from '@/api/clients/events-ws'
+import { resolveGenerativeUiDeviceContext } from '@/generative-ui/device-context'
+import { GenerativeUiRendererRegistry } from '@/generative-ui/renderer-registry'
+import {
+  createDagTaskCanvasComposition,
+  dagTaskCanvasSelectionStorageKey,
+  dagTaskCanvasSnapshotVersion,
+  projectorFocusedSurface,
+  resolveDagTaskCanvasSelection,
+} from '@/generative-ui/dag-task-canvas'
+import A2uiRenderer from './A2uiRenderer.vue'
+import GenerativeUiSurfaceHost from './GenerativeUiSurfaceHost.vue'
+
+const props = withDefaults(defineProps<{
+  runId: string
+  refreshToken?: string | number | null
+  pollIntervalMs?: number
+  autoRefresh?: boolean
+  embedded?: boolean
+}>(), {
+  refreshToken: null,
+  pollIntervalMs: 1000,
+  autoRefresh: true,
+  embedded: false,
+})
+
+const emit = defineEmits<{
+  (event: 'availability', payload: {
+    available: boolean
+    node_ids: string[]
+    loading?: boolean
+    stale?: boolean
+  }): void
+  (event: 'select-node', payload: { node_id: string }): void
+  (event: 'open-preview', payload: GenerativeUiPreviewRequestV1): void
+}>()
+
+const snapshot = ref<DagLiveSurfaceSnapshot | null>(null)
+const snapshotVersion = ref('')
+const selectedNodeId = ref('')
+const resolved = ref(false)
+const loading = ref(true)
+const stale = ref(false)
+const clock = ref(Date.now())
+const viewportRevision = ref(0)
+let mounted = false
+let requestGeneration = 0
+let refreshRequested = false
+let refreshLoop: Promise<void> | null = null
+let pollTimer = 0
+let eventRefreshTimer = 0
+let unsubscribeEvents: (() => void) | null = null
+let unsubscribeState: (() => void) | null = null
+
+const context = computed(() => {
+  void viewportRevision.value
+  return resolveGenerativeUiDeviceContext({
+    width: typeof window === 'undefined' ? 1440 : window.innerWidth,
+    height: typeof window === 'undefined' ? 900 : window.innerHeight,
+    userAgent: typeof navigator === 'undefined' ? '' : navigator.userAgent,
+    maxTouchPoints: typeof navigator === 'undefined' ? 0 : navigator.maxTouchPoints,
+    activeRunId: props.runId,
+  })
+})
+const documentValue = computed(() => snapshot.value?.document ?? null)
+const composition = computed(() => snapshot.value
+  ? createDagTaskCanvasComposition(snapshot.value, context.value)
+  : null)
+const nodeIds = computed(() => composition.value?.items.map(item => item.node_id) ?? [])
+const available = computed(() => Boolean(documentValue.value && composition.value?.items.length))
+const initialLoading = computed(() => loading.value && !snapshot.value)
+const focusedSurface = computed(() => {
+  void clock.value
+  return snapshot.value ? projectorFocusedSurface(snapshot.value) : null
+})
+const rendererRegistry = computed(() => {
+  const seen = new Set<string>()
+  return new GenerativeUiRendererRegistry((documentValue.value?.nodes ?? []).flatMap((node) => {
+    const key = `${node.owner.version}:${node.surface}:${context.value.device}`
+    if (seen.has(key)) return []
+    seen.add(key)
+    return [{
+      renderer_api_version: 1 as const,
+      plugin_id: node.owner.id,
+      plugin_version: node.owner.version,
+      renderer_id: `dag-task-canvas:${node.owner.version}:${node.surface}:${context.value.device}`,
+      kind: node.kind,
+      kind_version: node.kind_version,
+      surface: node.surface,
+      device: context.value.device,
+      mode: 'core_projection' as const,
+      component: A2uiRenderer,
+    }]
+  }))
+})
+
+function storedSelection(runId: string): string {
+  try {
+    return sessionStorage.getItem(dagTaskCanvasSelectionStorageKey(runId)) ?? ''
+  } catch {
+    return ''
+  }
+}
+
+function persistSelection(nodeId: string): void {
+  try {
+    if (nodeId) sessionStorage.setItem(dagTaskCanvasSelectionStorageKey(props.runId), nodeId)
+    else sessionStorage.removeItem(dagTaskCanvasSelectionStorageKey(props.runId))
+  } catch {
+    // Storage can be unavailable in hardened or private browser contexts.
+  }
+}
+
+function publishAvailability(): void {
+  emit('availability', {
+    available: available.value,
+    node_ids: [...nodeIds.value],
+    ...(initialLoading.value ? { loading: true } : {}),
+    ...(stale.value ? { stale: true } : {}),
+  })
+}
+
+function acceptSelection(nodeId: string): void {
+  if (!nodeIds.value.includes(nodeId)) return
+  selectedNodeId.value = nodeId
+  persistSelection(nodeId)
+  emit('select-node', { node_id: nodeId })
+}
+
+async function performRefresh(): Promise<void> {
+  const runId = props.runId
+  if (!runId) return
+  const generation = ++requestGeneration
+  if (!snapshot.value) {
+    loading.value = true
+    publishAvailability()
+  }
+  try {
+    const response = await getDagLiveSurfaces(runId)
+    if (!mounted || generation !== requestGeneration || props.runId !== runId) return
+    clock.value = Date.now()
+    const nextVersion = dagTaskCanvasSnapshotVersion(response.data)
+    if (nextVersion !== snapshotVersion.value) {
+      snapshot.value = response.data
+      snapshotVersion.value = nextVersion
+    }
+    selectedNodeId.value = resolveDagTaskCanvasSelection(
+      response.data,
+      selectedNodeId.value,
+      storedSelection(runId),
+    )
+    persistSelection(selectedNodeId.value)
+    resolved.value = true
+    loading.value = false
+    stale.value = false
+    publishAvailability()
+  } catch {
+    if (!mounted || generation !== requestGeneration || props.runId !== runId) return
+    resolved.value = true
+    loading.value = false
+    stale.value = Boolean(snapshot.value)
+    publishAvailability()
+  }
+}
+
+async function drainRefreshQueue(): Promise<void> {
+  try {
+    while (mounted && refreshRequested) {
+      refreshRequested = false
+      await performRefresh()
+    }
+  } finally {
+    refreshLoop = null
+  }
+}
+
+function refresh(): Promise<void> {
+  refreshRequested = true
+  refreshLoop ??= drainRefreshQueue()
+  return refreshLoop
+}
+
+function scheduleRefresh(): void {
+  if (eventRefreshTimer) window.clearTimeout(eventRefreshTimer)
+  eventRefreshTimer = window.setTimeout(() => {
+    eventRefreshTimer = 0
+    void refresh()
+  }, 80)
+}
+
+function resetRun(): void {
+  requestGeneration += 1
+  refreshRequested = false
+  snapshot.value = null
+  snapshotVersion.value = ''
+  selectedNodeId.value = ''
+  resolved.value = false
+  loading.value = true
+  stale.value = false
+  publishAvailability()
+  if (mounted) void refresh()
+}
+
+function configurePolling(): void {
+  if (pollTimer) window.clearInterval(pollTimer)
+  pollTimer = 0
+  if (!mounted || !props.autoRefresh) return
+  pollTimer = window.setInterval(() => void refresh(), Math.max(250, props.pollIntervalMs))
+}
+
+function onVisibilityChange(): void {
+  if (document.visibilityState === 'visible') scheduleRefresh()
+}
+
+function onResize(): void {
+  viewportRevision.value += 1
+}
+
+watch(() => props.runId, resetRun)
+watch(() => props.refreshToken, () => mounted && scheduleRefresh())
+watch(() => [props.autoRefresh, props.pollIntervalMs] as const, configurePolling)
+
+onMounted(() => {
+  mounted = true
+  window.addEventListener('resize', onResize)
+  window.addEventListener('online', scheduleRefresh)
+  document.addEventListener('visibilitychange', onVisibilityChange)
+  unsubscribeEvents = voiceWs.on('*', message => {
+    if (message.type.startsWith('DAG_') || message.type.startsWith('dag:')) scheduleRefresh()
+  })
+  unsubscribeState = voiceWs.onStateChange(state => {
+    if (state === 'connected') scheduleRefresh()
+  })
+  configurePolling()
+  resetRun()
+})
+
+onUnmounted(() => {
+  mounted = false
+  requestGeneration += 1
+  if (pollTimer) window.clearInterval(pollTimer)
+  if (eventRefreshTimer) window.clearTimeout(eventRefreshTimer)
+  window.removeEventListener('resize', onResize)
+  window.removeEventListener('online', scheduleRefresh)
+  document.removeEventListener('visibilitychange', onVisibilityChange)
+  unsubscribeEvents?.()
+  unsubscribeState?.()
+})
+
+defineExpose({ refresh })
+</script>
+
+<template>
+  <section
+    v-if="initialLoading || available"
+    class="dag-task-canvas"
+    :class="{
+      'dag-task-canvas--stale': stale,
+      'dag-task-canvas--embedded': embedded,
+    }"
+    data-testid="dag-task-canvas"
+    :data-state="initialLoading ? 'loading' : stale ? 'stale' : 'ready'"
+    :data-resolved="resolved ? 'true' : 'false'"
+    :aria-busy="initialLoading"
+  >
+    <div v-if="initialLoading" class="dag-task-canvas__skeleton" aria-hidden="true">
+      <div v-for="index in 3" :key="index" class="dag-task-canvas__skeleton-block">
+        <span />
+        <span />
+        <span />
+      </div>
+    </div>
+    <GenerativeUiSurfaceHost
+      v-else-if="documentValue && composition"
+      :document="documentValue"
+      :composition="composition"
+      :registry="rendererRegistry"
+      :interactive="false"
+      action-mode="disabled"
+      :selected-node-id="selectedNodeId"
+      :focused-node-id="focusedSurface?.nodeId"
+      :focused-until="focusedSurface?.focusedUntil"
+      :embedded="embedded"
+      @select-node="acceptSelection($event.node_id)"
+      @open-preview="emit('open-preview', $event)"
+    />
+  </section>
+</template>
+
+<style scoped>
+.dag-task-canvas {
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.dag-task-canvas--stale {
+  opacity: 0.9;
+}
+
+.dag-task-canvas--embedded,
+.dag-task-canvas--embedded .dag-task-canvas__skeleton {
+  display: contents;
+}
+
+.dag-task-canvas--embedded .dag-task-canvas__skeleton-block {
+  height: 100%;
+  grid-column: auto / span 1;
+  grid-row: 1 / span 2;
+  scroll-snap-align: start;
+}
+
+.dag-task-canvas__skeleton {
+  display: grid;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  grid-auto-flow: column;
+  grid-auto-columns: calc((100% - 28px) / 3);
+  gap: 14px;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+.dag-task-canvas__skeleton-block {
+  display: grid;
+  min-width: 0;
+  min-height: 0;
+  align-content: start;
+  gap: 14px;
+  border: 1px solid rgba(116, 228, 227, 0.12);
+  border-radius: 8px;
+  background: rgba(10, 20, 23, 0.88);
+  padding: 64px 20px 20px;
+}
+
+.dag-task-canvas__skeleton-block span {
+  height: 10px;
+  border-radius: 3px;
+  background: rgba(208, 235, 232, 0.08);
+}
+
+.dag-task-canvas__skeleton-block span:nth-child(1) { width: 58%; }
+.dag-task-canvas__skeleton-block span:nth-child(2) { width: 84%; }
+.dag-task-canvas__skeleton-block span:nth-child(3) { width: 70%; }
+
+@media (max-width: 640px) {
+  .dag-task-canvas__skeleton {
+    grid-auto-columns: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dag-task-canvas,
+  .dag-task-canvas * {
+    scroll-behavior: auto !important;
+    transition-duration: 1ms !important;
+  }
+}
+</style>

--- a/agent-ui/src/components/generative-ui/GenerativeUiNodeHost.vue
+++ b/agent-ui/src/components/generative-ui/GenerativeUiNodeHost.vue
@@ -9,7 +9,7 @@ import type {
   GenerativeUiStoredNodeV1,
   GenerativeUiSurfaceContextV1,
 } from 'homerail-protocol'
-import { Maximize2, Minimize2 } from 'lucide-vue-next'
+import { ChevronDown, ChevronUp, Maximize2, Minimize2 } from 'lucide-vue-next'
 import {
   confirmPluginAction,
   invokePluginAction,
@@ -31,6 +31,7 @@ import type {
   GenerativeUiActionRequestV1,
   GenerativeUiPreviewRequestV1,
 } from '@/generative-ui/types'
+import type { GenerativeUiLifecycleMotion } from '@/generative-ui/motion-profiles'
 import GenerativeUiFallbackRenderer from './GenerativeUiFallbackRenderer.vue'
 import DeclarativeRenderer from './DeclarativeRenderer.vue'
 import CustomRendererSandbox from './CustomRendererSandbox.vue'
@@ -67,6 +68,7 @@ const props = withDefaults(defineProps<{
   attention?: boolean
   motionProfile?: GenerativeUiMotionProfile
   attentionDurationMs?: number
+  lifecycleMotion?: GenerativeUiLifecycleMotion
 }>(), {
   interactive: true,
   actionMode: 'emit',
@@ -74,6 +76,7 @@ const props = withDefaults(defineProps<{
   attention: false,
   motionProfile: 'standard',
   attentionDurationMs: 2400,
+  lifecycleMotion: 'idle',
 })
 
 const emit = defineEmits<{
@@ -125,6 +128,7 @@ const supplementaryActions = computed(() => inlineRendererActions.value.ready
   : [])
 const customRendererFailure = ref<string>()
 const expanded = ref(false)
+const collapsed = ref(false)
 const unavailable = computed(() => resolution.value.mode === 'unavailable' || Boolean(customRendererFailure.value))
 const fallbackReason = computed(() => (
   customRendererFailure.value
@@ -148,7 +152,13 @@ watch(expanded, value => {
 })
 
 function toggleExpanded(): void {
+  if (!expanded.value && collapsed.value) collapsed.value = false
   expanded.value = !expanded.value
+}
+
+function toggleCollapsed(): void {
+  if (!collapsed.value && expanded.value) expanded.value = false
+  collapsed.value = !collapsed.value
 }
 
 function createActionRequestId(): string {
@@ -422,6 +432,7 @@ function acceptInlineRendererActions(names: string[]): void {
         'generative-ui-node-host--expanded': expanded,
         'generative-ui-node-host--selected': selected,
         'generative-ui-node-host--attention': attention,
+        'generative-ui-node-host--collapsed': collapsed,
       },
     ]"
     :data-generative-ui-node="node.id"
@@ -432,6 +443,9 @@ function acceptInlineRendererActions(names: string[]): void {
     :data-motion-profile="motionProfile"
     :data-attention="attention ? 'true' : 'false'"
     :data-expanded="expanded ? 'true' : 'false'"
+    :data-collapsed="collapsed ? 'true' : 'false'"
+    :data-lifecycle-motion="lifecycleMotion"
+    :data-status-phase="node.status?.phase || 'unknown'"
     :style="{ '--generative-ui-attention-duration': `${attentionDurationMs}ms` }"
     :aria-selected="selected"
     tabindex="0"
@@ -439,18 +453,32 @@ function acceptInlineRendererActions(names: string[]): void {
     @keydown.enter.self="emit('select', { node_id: node.id })"
     @keydown.esc.stop="expanded = false"
   >
-    <button
-      type="button"
-      class="generative-ui-node-host__expand"
-      :title="expanded ? t('voice.generativeUi.collapse') : t('voice.generativeUi.expand')"
-      :aria-label="expanded ? t('voice.generativeUi.collapse') : t('voice.generativeUi.expand')"
-      :aria-pressed="expanded"
-      @click.stop="toggleExpanded"
-    >
-      <Minimize2 v-if="expanded" :size="18" aria-hidden="true" />
-      <Maximize2 v-else :size="18" aria-hidden="true" />
-    </button>
-    <RendererErrorBoundary
+    <div class="generative-ui-node-host__toolbar">
+      <button
+        type="button"
+        class="generative-ui-node-host__tool generative-ui-node-host__minimize"
+        :title="collapsed ? t('voice.generativeUi.restore') : t('voice.generativeUi.minimize')"
+        :aria-label="collapsed ? t('voice.generativeUi.restore') : t('voice.generativeUi.minimize')"
+        :aria-pressed="collapsed"
+        @click.stop="toggleCollapsed"
+      >
+        <ChevronUp v-if="collapsed" :size="18" aria-hidden="true" />
+        <ChevronDown v-else :size="18" aria-hidden="true" />
+      </button>
+      <button
+        type="button"
+        class="generative-ui-node-host__tool generative-ui-node-host__expand"
+        :title="expanded ? t('voice.generativeUi.collapse') : t('voice.generativeUi.expand')"
+        :aria-label="expanded ? t('voice.generativeUi.collapse') : t('voice.generativeUi.expand')"
+        :aria-pressed="expanded"
+        @click.stop="toggleExpanded"
+      >
+        <Minimize2 v-if="expanded" :size="18" aria-hidden="true" />
+        <Maximize2 v-else :size="18" aria-hidden="true" />
+      </button>
+    </div>
+    <div v-if="!collapsed" class="generative-ui-node-host__body">
+      <RendererErrorBoundary
       v-if="registeredComponent"
       :reset-key="resetKey"
       @renderer-error="reportRendererError"
@@ -469,7 +497,7 @@ function acceptInlineRendererActions(names: string[]): void {
         <GenerativeUiFallbackRenderer :node="node" unavailable :reason="error" />
       </template>
     </RendererErrorBoundary>
-    <RendererErrorBoundary
+      <RendererErrorBoundary
       v-else-if="declarativeDocument"
       :reset-key="resetKey"
       @renderer-error="reportRendererError"
@@ -479,7 +507,7 @@ function acceptInlineRendererActions(names: string[]): void {
         <GenerativeUiFallbackRenderer :node="node" unavailable :reason="error" />
       </template>
     </RendererErrorBoundary>
-    <RendererErrorBoundary
+      <RendererErrorBoundary
       v-else-if="customRenderer && !customRendererFailure"
       :reset-key="resetKey"
       @renderer-error="reportRendererError"
@@ -501,14 +529,14 @@ function acceptInlineRendererActions(names: string[]): void {
         <GenerativeUiFallbackRenderer :node="node" unavailable :reason="error" />
       </template>
     </RendererErrorBoundary>
-    <GenerativeUiFallbackRenderer
+      <GenerativeUiFallbackRenderer
       v-else
       :node="node"
       :unavailable="unavailable"
       :reason="fallbackReason"
     />
 
-    <nav
+      <nav
       v-if="interactive !== false && actionMode !== 'disabled' && supplementaryActions.length"
       class="generative-ui-node-host__actions"
       aria-label="Actions"
@@ -524,7 +552,7 @@ function acceptInlineRendererActions(names: string[]): void {
         {{ action.label }}
       </button>
     </nav>
-    <template v-for="action in availableActions" :key="`status:${action.id}`">
+      <template v-for="action in availableActions" :key="`status:${action.id}`">
       <div
         v-if="actionStates[action.id]"
         class="generative-ui-node-host__action-state"
@@ -599,7 +627,17 @@ function acceptInlineRendererActions(names: string[]): void {
             : t('voice.generativeUi.actions.retry') }}
         </button>
       </div>
-    </template>
+      </template>
+    </div>
+    <div v-else class="generative-ui-node-host__minimal" aria-live="polite">
+      <strong>{{ node.fallback.title }}</strong>
+      <span>{{ node.status?.label || node.fallback.summary }}</span>
+      <progress
+        v-if="node.status?.progress !== undefined"
+        :value="node.status.progress"
+        max="100"
+      />
+    </div>
   </article>
 </template>
 
@@ -607,16 +645,19 @@ function acceptInlineRendererActions(names: string[]): void {
 .generative-ui-node-host {
   position: relative;
   display: grid;
+  grid-template-rows: 50px minmax(0, 1fr);
   min-width: 0;
   min-height: 0;
-  align-content: start;
+  align-content: stretch;
   border: 1px solid rgba(116, 228, 227, 0.16);
   border-radius: 8px;
   background: rgba(10, 20, 23, 0.88);
-  padding: 20px 58px 20px 20px;
+  overflow: hidden;
   outline: none;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.035);
   transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+  container-name: generative-ui-block;
+  container-type: size;
 }
 
 .generative-ui-node-host:hover,
@@ -688,14 +729,22 @@ function acceptInlineRendererActions(names: string[]): void {
   }
 }
 
-.generative-ui-node-host__expand {
-  position: absolute;
-  top: 10px;
-  right: 10px;
+.generative-ui-node-host__toolbar {
+  position: relative;
   z-index: 3;
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  padding: 8px 10px 4px;
+}
+
+.generative-ui-node-host__tool {
   display: grid;
-  width: 34px;
-  height: 34px;
+  width: 38px;
+  height: 38px;
+  flex: 0 0 38px;
   place-items: center;
   border: 1px solid rgba(116, 228, 227, 0.22);
   border-radius: 7px;
@@ -704,11 +753,98 @@ function acceptInlineRendererActions(names: string[]): void {
   cursor: pointer;
 }
 
-.generative-ui-node-host__expand:hover,
-.generative-ui-node-host__expand:focus-visible {
+.generative-ui-node-host__tool:hover,
+.generative-ui-node-host__tool:focus-visible {
   border-color: rgba(116, 228, 227, 0.58);
   color: #f5fffe;
   outline: none;
+}
+
+.generative-ui-node-host__body {
+  min-width: 0;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 4px 20px 20px;
+  scrollbar-gutter: stable;
+}
+
+.generative-ui-node-host__minimal {
+  display: grid;
+  min-width: 0;
+  min-height: 0;
+  align-content: center;
+  gap: 8px;
+  overflow: hidden;
+  padding: 12px 20px 20px;
+  color: rgba(224, 248, 246, 0.76);
+}
+
+.generative-ui-node-host__minimal strong,
+.generative-ui-node-host__minimal span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.generative-ui-node-host__minimal strong {
+  color: #f1fffe;
+  font-size: 14px;
+}
+
+.generative-ui-node-host__minimal span {
+  font-size: 12px;
+}
+
+.generative-ui-node-host__minimal progress {
+  width: min(100%, 320px);
+  height: 5px;
+  accent-color: #74e4df;
+}
+
+.generative-ui-node-host[data-status-phase='succeeded'] {
+  border-color: rgba(74, 222, 128, 0.38);
+}
+
+.generative-ui-node-host[data-status-phase='failed'] {
+  border-color: rgba(248, 113, 113, 0.5);
+}
+
+.generative-ui-node-host[data-status-phase='blocked'] {
+  border-color: rgba(250, 204, 21, 0.42);
+}
+
+[data-motion-profile='standard'][data-lifecycle-motion='update'] .generative-ui-node-host__body,
+[data-motion-profile='standard'][data-lifecycle-motion='update'] .generative-ui-node-host__minimal {
+  animation: generative-ui-standard-update 700ms ease-out both;
+}
+
+[data-motion-profile='standard'][data-lifecycle-motion='complete'] .generative-ui-node-host__body,
+[data-motion-profile='standard'][data-lifecycle-motion='complete'] .generative-ui-node-host__minimal {
+  animation: generative-ui-standard-complete 1000ms ease-out both;
+}
+
+[data-motion-profile='standard'][data-lifecycle-motion='fail'] .generative-ui-node-host__body,
+[data-motion-profile='standard'][data-lifecycle-motion='fail'] .generative-ui-node-host__minimal {
+  animation: generative-ui-standard-fail 1000ms ease-out both;
+}
+
+@keyframes generative-ui-standard-update {
+  0% { background-color: rgba(116, 228, 223, 0.2); }
+  100% { background-color: transparent; }
+}
+
+@keyframes generative-ui-standard-complete {
+  0% { background-color: rgba(74, 222, 128, 0.24); }
+  45% { background-color: rgba(74, 222, 128, 0.1); }
+  100% { background-color: transparent; }
+}
+
+@keyframes generative-ui-standard-fail {
+  0% { background-color: rgba(248, 113, 113, 0.28); }
+  45% { background-color: rgba(248, 113, 113, 0.1); }
+  100% { background-color: transparent; }
 }
 
 .generative-ui-node-host--expanded {
@@ -722,10 +858,9 @@ function acceptInlineRendererActions(names: string[]): void {
   grid-column: auto !important;
   grid-row: auto !important;
   overflow-x: hidden;
-  overflow-y: auto;
+  overflow-y: hidden;
   border-color: rgba(116, 228, 227, 0.46);
   background: #091316;
-  padding: 32px 64px 32px 32px;
   box-shadow: 0 28px 90px rgba(0, 0, 0, 0.72);
 }
 
@@ -835,5 +970,30 @@ function acceptInlineRendererActions(names: string[]): void {
   font: inherit;
   font-weight: 750;
   cursor: pointer;
+}
+
+@media (pointer: coarse) {
+  .generative-ui-node-host__tool {
+    width: 42px;
+    height: 42px;
+    flex-basis: 42px;
+  }
+}
+
+@media (max-width: 640px) {
+  .generative-ui-node-host--expanded {
+    inset: 8px !important;
+  }
+
+  .generative-ui-node-host__body {
+    padding: 2px 14px 16px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-motion-profile][data-lifecycle-motion] .generative-ui-node-host__body,
+  [data-motion-profile][data-lifecycle-motion] .generative-ui-node-host__minimal {
+    animation: none;
+  }
 }
 </style>

--- a/agent-ui/src/components/generative-ui/GenerativeUiSurfaceHost.vue
+++ b/agent-ui/src/components/generative-ui/GenerativeUiSurfaceHost.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onUnmounted, ref, watch } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import type {
   GenerativeUiCompositionV1,
   GenerativeUiDocumentV1,
@@ -23,7 +23,10 @@ import type {
 import GenerativeUiNodeHost from './GenerativeUiNodeHost.vue'
 import type { PluginActionResponse } from '@/api/agent'
 import { canvasColumnCount, canvasRowCount, resolveCanvasSize } from '@/generative-ui/canvas-layout'
-import { resolveGenerativeUiMotionProfile } from '@/generative-ui/motion-profiles'
+import {
+  resolveGenerativeUiMotionProfile,
+  type GenerativeUiLifecycleMotion,
+} from '@/generative-ui/motion-profiles'
 
 const props = withDefaults(defineProps<{
   document: GenerativeUiDocumentV1
@@ -35,11 +38,19 @@ const props = withDefaults(defineProps<{
   interactive?: boolean
   actionMode?: GenerativeUiActionMode
   selectedNodeId?: string | null
+  focusedNodeId?: string | null
+  focusedUntil?: number | null
+  autoFocusLatest?: boolean
+  embedded?: boolean
 }>(), {
   surface: undefined,
   placement: 'all',
   interactive: true,
   actionMode: 'emit',
+  focusedNodeId: null,
+  focusedUntil: null,
+  autoFocusLatest: true,
+  embedded: false,
 })
 
 const emit = defineEmits<{
@@ -77,17 +88,58 @@ const canvasColumns = computed(() => canvasColumnCount(props.composition.context
 const canvasRows = computed(() => canvasRowCount(renderedWithLayout.value.map(entry => entry.canvasSize)))
 const contentLayout = computed(() => renderedWithLayout.value.length === 1 ? 'single' : 'flow')
 const attentionNodeId = ref<string | null>(null)
+const lifecycleMotionByNodeId = ref<Record<string, GenerativeUiLifecycleMotion>>({})
+const reducedMotion = ref(false)
 let attentionTimer = 0
+const lifecycleTimers = new Map<string, number>()
+const lifecycleGenerations = new Map<string, number>()
+let reducedMotionQuery: MediaQueryList | null = null
 
-function showAttention(nodeId: string): void {
+const transitionDuration = computed(() => reducedMotion.value
+  ? { enter: 1, leave: 1 }
+  : { enter: 300, leave: 300 })
+
+function reducedMotionPreferred(): boolean {
+  return reducedMotion.value || (
+    typeof window.matchMedia === 'function'
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  )
+}
+
+function showAttention(nodeId: string, requestedDuration?: number): void {
   const profile = renderedWithLayout.value.find(entry => entry.node.id === nodeId)?.motionProfile
   if (!profile) return
+  const duration = Math.max(0, Math.min(requestedDuration ?? profile.attentionDurationMs, profile.attentionDurationMs))
+  if (!duration) return
   attentionNodeId.value = nodeId
   if (attentionTimer) window.clearTimeout(attentionTimer)
   attentionTimer = window.setTimeout(() => {
     if (attentionNodeId.value === nodeId) attentionNodeId.value = null
     attentionTimer = 0
-  }, profile.attentionDurationMs)
+  }, duration)
+}
+
+async function showLifecycleMotion(
+  nodeId: string,
+  motion: Exclude<GenerativeUiLifecycleMotion, 'idle'>,
+  duration: number,
+): Promise<void> {
+  const generation = (lifecycleGenerations.get(nodeId) ?? 0) + 1
+  lifecycleGenerations.set(nodeId, generation)
+  const existingTimer = lifecycleTimers.get(nodeId)
+  if (existingTimer) window.clearTimeout(existingTimer)
+  if (lifecycleMotionByNodeId.value[nodeId] !== 'idle') {
+    lifecycleMotionByNodeId.value = { ...lifecycleMotionByNodeId.value, [nodeId]: 'idle' }
+    await nextTick()
+    if (lifecycleGenerations.get(nodeId) !== generation) return
+  }
+  lifecycleMotionByNodeId.value = { ...lifecycleMotionByNodeId.value, [nodeId]: motion }
+  lifecycleTimers.set(nodeId, window.setTimeout(() => {
+    if (lifecycleMotionByNodeId.value[nodeId] === motion) {
+      lifecycleMotionByNodeId.value = { ...lifecycleMotionByNodeId.value, [nodeId]: 'idle' }
+    }
+    lifecycleTimers.delete(nodeId)
+  }, duration))
 }
 
 function focusableNodes(): HTMLElement[] {
@@ -106,9 +158,14 @@ function focus(direction: GenerativeUiFocusDirection): void {
 function focusNode(nodeId: string): boolean {
   const target = focusableNodes().find(element => element.dataset.generativeUiNode === nodeId)
   if (!target) return false
-  showAttention(nodeId)
   target.focus({ preventScroll: true })
-  target.scrollIntoView?.({ behavior: 'smooth', block: 'nearest', inline: 'start' })
+  target.scrollIntoView?.({
+    behavior: reducedMotionPreferred() ? 'auto' : 'smooth',
+    block: 'nearest',
+    inline: 'start',
+  })
+  const body = target.querySelector<HTMLElement>('.generative-ui-node-host__body')
+  body?.scrollTo?.({ top: body.scrollHeight, behavior: reducedMotionPreferred() ? 'auto' : 'smooth' })
   emit('focus-node', { node_id: nodeId })
   return true
 }
@@ -117,21 +174,75 @@ let renderedRevisions = new Map<string, number>()
 watch(
   renderedWithLayout,
   async (entries) => {
-    const changed = entries.filter(entry => renderedRevisions.get(entry.node.id) !== entry.node.revision)
+    const activeNodeIds = new Set(entries.map(entry => entry.node.id))
+    for (const [nodeId, timer] of lifecycleTimers) {
+      if (activeNodeIds.has(nodeId)) continue
+      window.clearTimeout(timer)
+      lifecycleTimers.delete(nodeId)
+      lifecycleGenerations.delete(nodeId)
+    }
+    lifecycleMotionByNodeId.value = Object.fromEntries(
+      Object.entries(lifecycleMotionByNodeId.value)
+        .filter(([nodeId]) => activeNodeIds.has(nodeId)),
+    )
+    const previousRevisions = renderedRevisions
+    const changed = entries.filter(entry => previousRevisions.get(entry.node.id) !== entry.node.revision)
     renderedRevisions = new Map(entries.map(entry => [entry.node.id, entry.node.revision]))
     if (!changed.length) return
+    for (const entry of changed) {
+      if (!previousRevisions.has(entry.node.id)) continue
+      const phase = entry.node.status?.phase
+      const motion = phase === 'succeeded' ? 'complete' : phase === 'failed' ? 'fail' : 'update'
+      const duration = motion === 'complete'
+        ? entry.motionProfile.completeDurationMs
+        : motion === 'fail'
+          ? entry.motionProfile.failDurationMs
+          : entry.motionProfile.updateDurationMs
+      void showLifecycleMotion(entry.node.id, motion, duration)
+    }
+    if (!props.autoFocusLatest || props.focusedNodeId) return
     await nextTick()
     const latest = [...changed].sort((left, right) => (
       right.node.updated_at.localeCompare(left.node.updated_at)
       || right.item.rank - left.item.rank
     ))[0]!
-    focusNode(latest.node.id)
+    if (focusNode(latest.node.id)) showAttention(latest.node.id)
   },
   { immediate: true, flush: 'post' },
 )
 
+watch(
+  () => [props.focusedNodeId, props.focusedUntil] as const,
+  async ([nodeId, focusedUntil]) => {
+    if (!nodeId) return
+    const remaining = focusedUntil === null
+      ? undefined
+      : Math.max(0, focusedUntil - Date.now())
+    if (remaining === 0) return
+    await nextTick()
+    if (focusNode(nodeId)) showAttention(nodeId, remaining)
+  },
+  { immediate: true, flush: 'post' },
+)
+
+function syncReducedMotion(event?: MediaQueryListEvent): void {
+  reducedMotion.value = event?.matches ?? reducedMotionQuery?.matches ?? false
+}
+
+onMounted(() => {
+  if (typeof window.matchMedia !== 'function') return
+  reducedMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)')
+  syncReducedMotion()
+  reducedMotionQuery.addEventListener?.('change', syncReducedMotion)
+})
+
 onUnmounted(() => {
   if (attentionTimer) window.clearTimeout(attentionTimer)
+  for (const timer of lifecycleTimers.values()) window.clearTimeout(timer)
+  lifecycleTimers.clear()
+  lifecycleGenerations.clear()
+  reducedMotionQuery?.removeEventListener?.('change', syncReducedMotion)
+  reducedMotionQuery = null
 })
 
 function onKeydown(event: KeyboardEvent): void {
@@ -153,17 +264,20 @@ defineExpose({ focus, focusNode })
   <section
     ref="root"
     class="generative-ui-surface-host"
+    :class="{ 'generative-ui-surface-host--embedded': embedded }"
     :data-device="composition.context.device"
     :data-viewport="composition.context.viewport"
     :data-surface="surface || 'all'"
     :data-canvas-columns="canvasColumns"
     :data-canvas-rows="canvasRows"
     :data-content-layout="contentLayout"
+    :data-reduced-motion="reducedMotion ? 'true' : 'false'"
     @keydown="onKeydown"
   >
     <TransitionGroup
       name="generative-ui-node"
-      :duration="{ enter: 300, leave: 300 }"
+      appear
+      :duration="transitionDuration"
     >
       <GenerativeUiNodeHost
         v-for="entry in renderedWithLayout"
@@ -181,6 +295,7 @@ defineExpose({ focus, focusNode })
         :action-mode="actionMode"
         :selected="entry.node.id === selectedNodeId"
         :attention="entry.node.id === attentionNodeId"
+        :lifecycle-motion="lifecycleMotionByNodeId[entry.node.id] || 'idle'"
         :motion-profile="entry.motionProfile.id"
         :attention-duration-ms="entry.motionProfile.attentionDurationMs"
         @action="emit('action', $event)"
@@ -211,6 +326,10 @@ defineExpose({ focus, focusNode })
   scrollbar-width: thin;
 }
 
+.generative-ui-surface-host--embedded {
+  display: contents;
+}
+
 .generative-ui-surface-host[data-canvas-rows='3'] {
   --generative-ui-canvas-rows: 3;
 }
@@ -233,7 +352,7 @@ defineExpose({ focus, focusNode })
 .generative-ui-surface-host :deep(.generative-ui-node-host) {
   height: 100%;
   overflow-x: hidden;
-  overflow-y: auto;
+  overflow-y: hidden;
   scroll-snap-align: start;
 }
 

--- a/agent-ui/src/generative-ui/dag-task-canvas.test.ts
+++ b/agent-ui/src/generative-ui/dag-task-canvas.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { DagLiveSurfaceSnapshot } from '@/api/services/dag-live-surface-api'
+import {
+  createDagTaskCanvasComposition,
+  dagTaskCanvasSelectionStorageKey,
+  projectorFocusedSurface,
+  resolveDagTaskCanvasSelection,
+} from './dag-task-canvas'
+
+function snapshot(): DagLiveSurfaceSnapshot {
+  const actors = ['build', 'research', 'verify']
+  return {
+    run_id: 'run:one',
+    projections: actors.map((actor, index) => ({
+      run_id: 'run:one',
+      actor_id: actor,
+      node_id: `node:${actor}`,
+      surface_id: `surface:${actor}`,
+      document_id: 'document:run:one',
+      generation: 1,
+      last_activity_sequence: 1,
+      journal_cursor: index + 1,
+      surface_revision: 1,
+      activity_state: 'progress',
+      visibility_state: 'visible',
+      created_at: 100,
+      updated_at: 100 + index,
+    })),
+    document: {
+      ir_version: 1,
+      document_id: 'document:run:one',
+      scope: { type: 'run', id: 'run:one' },
+      revision: 1,
+      nodes: actors.map(actor => ({
+        ir_version: 1,
+        id: `surface:${actor}`,
+        kind: 'com.homerail.core/generated_view',
+        kind_version: 2,
+        owner: { id: 'com.homerail.core', version: '0.1.0' },
+        surface: 'execution',
+        importance: 'primary',
+        content: {},
+        presentation: { density: 'summary' },
+        fallback: { title: actor },
+        revision: 1,
+        updated_at: '2026-07-15T10:00:00.000Z',
+      })),
+      updated_at: '2026-07-15T10:00:00.000Z',
+    },
+  }
+}
+
+const context = {
+  device: 'desktop',
+  input: 'mouse',
+  viewport: 'wide',
+  attention: 'focused',
+  active_run_id: 'run:one',
+} as const
+
+describe('DAG task canvas composition', () => {
+  it('creates three ordered 1x2 Worker Blocks from projector order', () => {
+    const composition = createDagTaskCanvasComposition(snapshot(), context)
+    expect(composition?.items.map(item => ({ id: item.node_id, variant: item.variant, rank: item.rank })))
+      .toEqual([
+        { id: 'surface:build', variant: 'summary', rank: 0 },
+        { id: 'surface:research', variant: 'summary', rank: 1 },
+        { id: 'surface:verify', variant: 'summary', rank: 2 },
+      ])
+  })
+
+  it('restores Manager focus first, then current, stored, and latest selection', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    const value = snapshot()
+    value.projections[1]!.visibility_state = 'focused'
+    value.projections[1]!.focused_until = 2_000
+    expect(projectorFocusedSurface(value)).toEqual({ nodeId: 'surface:research', focusedUntil: 2_000 })
+    expect(resolveDagTaskCanvasSelection(value, 'surface:build', 'surface:verify')).toBe('surface:research')
+
+    value.projections[1]!.visibility_state = 'visible'
+    expect(resolveDagTaskCanvasSelection(value, 'surface:build', 'surface:verify')).toBe('surface:build')
+    expect(resolveDagTaskCanvasSelection(value, '', 'surface:verify')).toBe('surface:verify')
+    expect(resolveDagTaskCanvasSelection(value)).toBe('surface:verify')
+    vi.useRealTimers()
+  })
+
+  it('omits removed surfaces while keeping one task bounded to one Block', () => {
+    const value = snapshot()
+    value.projections[1]!.visibility_state = 'removed'
+    value.document!.nodes.splice(1, 1)
+    expect(createDagTaskCanvasComposition(value, context)?.items.map(item => item.node_id))
+      .toEqual(['surface:build', 'surface:verify'])
+    expect(dagTaskCanvasSelectionStorageKey('run:one')).toContain('run:one')
+  })
+
+  it('does not restore a current or stored selection after that Block is removed', () => {
+    const value = snapshot()
+    value.projections[0]!.visibility_state = 'removed'
+    value.document!.nodes = value.document!.nodes.filter(node => node.id !== 'surface:build')
+
+    expect(resolveDagTaskCanvasSelection(value, 'surface:build', 'surface:build'))
+      .toBe('surface:verify')
+  })
+})

--- a/agent-ui/src/generative-ui/dag-task-canvas.ts
+++ b/agent-ui/src/generative-ui/dag-task-canvas.ts
@@ -1,0 +1,101 @@
+import type {
+  GenerativeUiCompositionV1,
+  GenerativeUiStoredNodeV1,
+  GenerativeUiSurfaceContextV1,
+} from 'homerail-protocol'
+import type { DagLiveSurfaceSnapshot } from '@/api/services/dag-live-surface-api'
+
+function activeNodes(snapshot: DagLiveSurfaceSnapshot): Map<string, GenerativeUiStoredNodeV1> {
+  return new Map(snapshot.document?.nodes.map(node => [node.id, node]) ?? [])
+}
+
+function visibleNodeIds(snapshot: DagLiveSurfaceSnapshot): Set<string> {
+  const nodes = activeNodes(snapshot)
+  return new Set(snapshot.projections.flatMap(projection => (
+    projection.visibility_state !== 'removed' && nodes.has(projection.surface_id)
+      ? [projection.surface_id]
+      : []
+  )))
+}
+
+export function createDagTaskCanvasComposition(
+  snapshot: DagLiveSurfaceSnapshot,
+  context: GenerativeUiSurfaceContextV1,
+): GenerativeUiCompositionV1 | null {
+  if (!snapshot.document) return null
+  const nodes = activeNodes(snapshot)
+  const items = snapshot.projections.flatMap((projection) => {
+    const node = nodes.get(projection.surface_id)
+    if (!node || projection.visibility_state === 'removed') return []
+    return [{
+      node_id: node.id,
+      node_revision: node.revision,
+      surface: node.surface,
+      variant: node.presentation?.density ?? 'summary',
+      rank: 0,
+      placement: 'primary' as const,
+      pinned: projection.visibility_state === 'focused',
+      visibility: 'visible' as const,
+    }]
+  }).map((item, rank) => ({ ...item, rank }))
+  return {
+    composition_version: 1,
+    document_id: snapshot.document.document_id,
+    document_revision: snapshot.document.revision,
+    context,
+    items,
+    hidden_node_ids: [],
+  }
+}
+
+export function projectorFocusedSurface(snapshot: DagLiveSurfaceSnapshot): {
+  nodeId: string
+  focusedUntil?: number
+} | null {
+  const nodes = activeNodes(snapshot)
+  const focused = snapshot.projections
+    .filter(projection => (
+      projection.visibility_state === 'focused'
+      && nodes.has(projection.surface_id)
+      && (projection.focused_until === undefined || projection.focused_until >= Date.now())
+    ))
+    .sort((left, right) => right.updated_at - left.updated_at)[0]
+  return focused
+    ? { nodeId: focused.surface_id, ...(focused.focused_until === undefined ? {} : { focusedUntil: focused.focused_until }) }
+    : null
+}
+
+export function resolveDagTaskCanvasSelection(
+  snapshot: DagLiveSurfaceSnapshot,
+  currentNodeId?: string | null,
+  storedNodeId?: string | null,
+): string {
+  const visible = visibleNodeIds(snapshot)
+  const focused = projectorFocusedSurface(snapshot)
+  if (focused) return focused.nodeId
+  if (currentNodeId && visible.has(currentNodeId)) return currentNodeId
+  if (storedNodeId && visible.has(storedNodeId)) return storedNodeId
+  return snapshot.projections
+    .filter(projection => visible.has(projection.surface_id))
+    .sort((left, right) => right.updated_at - left.updated_at)[0]?.surface_id ?? ''
+}
+
+export function dagTaskCanvasSnapshotVersion(snapshot: DagLiveSurfaceSnapshot): string {
+  return [
+    snapshot.run_id,
+    snapshot.document?.document_id ?? '',
+    snapshot.document?.revision ?? -1,
+    ...snapshot.projections.map(projection => [
+      projection.actor_id,
+      projection.surface_id,
+      projection.surface_revision,
+      projection.activity_state,
+      projection.visibility_state,
+      projection.focused_until ?? '',
+    ].join(':')),
+  ].join('|')
+}
+
+export function dagTaskCanvasSelectionStorageKey(runId: string): string {
+  return `homerail.dag-task-canvas.selection.${runId}`
+}

--- a/agent-ui/src/generative-ui/motion-profiles.test.ts
+++ b/agent-ui/src/generative-ui/motion-profiles.test.ts
@@ -6,6 +6,9 @@ describe('Generative UI motion profiles', () => {
     expect(resolveGenerativeUiMotionProfile()).toEqual({
       id: 'standard',
       attentionDurationMs: 2400,
+      updateDurationMs: 700,
+      completeDurationMs: 1000,
+      failDurationMs: 1000,
     })
   })
 

--- a/agent-ui/src/generative-ui/motion-profiles.ts
+++ b/agent-ui/src/generative-ui/motion-profiles.ts
@@ -1,13 +1,21 @@
 import type { GenerativeUiMotionProfile } from 'homerail-protocol'
 
+export type GenerativeUiLifecycleMotion = 'idle' | 'update' | 'complete' | 'fail'
+
 export interface GenerativeUiMotionProfileDefinition {
   id: GenerativeUiMotionProfile
   attentionDurationMs: number
+  updateDurationMs: number
+  completeDurationMs: number
+  failDurationMs: number
 }
 
 const STANDARD_MOTION_PROFILE: GenerativeUiMotionProfileDefinition = Object.freeze({
   id: 'standard',
   attentionDurationMs: 2400,
+  updateDurationMs: 700,
+  completeDurationMs: 1000,
+  failDurationMs: 1000,
 })
 
 const MOTION_PROFILES: Readonly<Record<GenerativeUiMotionProfile, GenerativeUiMotionProfileDefinition>> = {

--- a/agent-ui/src/locales/en-US/voice.json
+++ b/agent-ui/src/locales/en-US/voice.json
@@ -303,6 +303,8 @@
     "previewUnavailable": "Generative UI preview unavailable",
     "expand": "Expand content",
     "collapse": "Exit expanded view",
+    "minimize": "Collapse content",
+    "restore": "Restore content",
     "actions": {
       "submitting": "Submitting action…",
       "statusUnknown": "Action status needs refresh",

--- a/agent-ui/src/locales/zh-Hans/voice.json
+++ b/agent-ui/src/locales/zh-Hans/voice.json
@@ -303,6 +303,8 @@
     "previewUnavailable": "生成式 UI 预览不可用",
     "expand": "放大此内容",
     "collapse": "退出放大",
+    "minimize": "收起内容",
+    "restore": "恢复内容",
     "actions": {
       "submitting": "正在提交操作…",
       "statusUnknown": "操作状态需要刷新",

--- a/agent-ui/src/locales/zh-Hant/voice.json
+++ b/agent-ui/src/locales/zh-Hant/voice.json
@@ -303,6 +303,8 @@
     "previewUnavailable": "生成式 UI 預覽不可用",
     "expand": "放大此內容",
     "collapse": "退出放大",
+    "minimize": "收起內容",
+    "restore": "恢復內容",
     "actions": {
       "submitting": "正在提交操作…",
       "statusUnknown": "操作狀態需要刷新",

--- a/agent-ui/src/task-canvas-harness.ts
+++ b/agent-ui/src/task-canvas-harness.ts
@@ -1,0 +1,15 @@
+import { createApp } from 'vue'
+import { i18n } from '@/plugins/i18n'
+import DagTaskCanvas from '@/components/generative-ui/DagTaskCanvas.vue'
+import './styles/tailwind.css'
+import './style.css'
+import './styles/main.css'
+import './styles/scrollbar.css'
+
+const app = createApp(DagTaskCanvas, {
+  runId: 'run:visual',
+  pollIntervalMs: 300,
+  embedded: true,
+})
+app.use(i18n)
+app.mount('#app')

--- a/agent-ui/task-canvas-harness.html
+++ b/agent-ui/task-canvas-harness.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>HomeRail DAG Task Canvas</title>
+    <style>
+      html,
+      body,
+      #app {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        overflow: hidden;
+        background: #031313;
+      }
+
+      #app {
+        box-sizing: border-box;
+        display: grid;
+        padding: 24px;
+        grid-auto-flow: column;
+        grid-auto-columns: calc((100% - 32px) / 3);
+        grid-template-columns: none;
+        grid-template-rows: repeat(2, minmax(0, 1fr));
+        align-items: stretch;
+        gap: 16px;
+        overflow-x: auto;
+        overflow-y: hidden;
+        scroll-snap-type: x proximity;
+        -webkit-overflow-scrolling: touch;
+      }
+
+      @media (max-width: 640px) {
+        #app {
+          grid-auto-columns: 100%;
+          gap: 14px;
+          padding: 12px;
+          scroll-snap-type: x mandatory;
+          scrollbar-width: none;
+        }
+
+        #app::-webkit-scrollbar { display: none; }
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/task-canvas-harness.ts"></script>
+  </body>
+</html>


### PR DESCRIPTION
Parent epic: #36

Implements: #42

## Why

The UI needs to present concurrent Actor work as compact, stable, recoverable Blocks while preserving HomeRail selection, focus, fullscreen, scrolling, and responsive behavior.

## What changed

- adds a realtime DAG task canvas backed by the Live Surface read API
- preserves projector order and legal 1x1, 1x2, 2x2, and 3x3 Block sizes
- supports three horizontal 1x2 Worker Blocks with a single bounded horizontal scroller
- adds enter, update, complete, fail, remove, and timed-focus motion profiles
- preserves selected Block state across refresh and reconnect
- retains the last valid snapshot during Manager unavailability and falls back safely when no live Surface exists
- adds internal Block scrolling, collapse/minimal expression, touch-friendly fullscreen, and responsive A2UI media/text rules
- respects `prefers-reduced-motion`
- avoids loading-background overlap, duplicate Blocks, permanent remove gaps, and document double scrollbars

## Invariants

- one task remains one bounded Block
- updates preserve stable identity and do not jump layout
- text does not scale directly with viewport width
- focus attracts attention temporarily without hiding other Blocks
- removal reflows remaining Blocks only after the exit transition

## Verification

- rebased onto `origin/main@bf48d567` after PR #51 merged
- full local `npm run ci`: 2101 passed, 5 skipped, 0 failed
- focused task-canvas UI suite: 17/17 passed
- UI typecheck and production build passed
- Playwright visual harness passed desktop 1920x1080, mobile 390x844, fullscreen, focus, enter/update/remove, complete/fail, and reduced-motion checks
- desktop Blocks measured 629px each with a 16px gap and no document overflow
- mobile Blocks measured 390px with `#app` as the only horizontal scroller
- GitHub Actions run 29402360361 passed Linux Node 20/24, Windows Node 24, Agent UI coverage, and Docker smoke
- Live DAG patterns remains intentionally skipped by workflow policy

## CI stabilization

The first Windows runs timed out in two different pre-existing Manager tests under parallel filesystem and SQLite load. Windows CI now serializes Vitest files with `VITEST_MAX_WORKERS=1` while retaining the existing strict per-test timeout. The serialized Manager suite passed locally (859 passed, 2 skipped) and the hosted Windows job passed in 13m29s.

## Out of scope

- Manager task decomposition and commentary: #43
- user branch intervention: #44
- final real-model three-Worker scenario: #45

## Residual risk

The visual harness uses protocol-valid projected snapshots. A real Manager process disconnect/restart visual E2E remains covered by final #45 acceptance.