### PR TITLE
Add branch-local DAG actor interventions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,9 +103,11 @@ jobs:
         env:
           HOMERAIL_HOME: ${{ runner.temp }}/homerail-ci
           # Windows filesystem and process startup contention makes parallel
-          # Vitest files prone to unrelated short-test timeouts. Keep the
-          # per-test timeout strict and serialize files on this runner only.
+          # Vitest files and SQLite-heavy tests prone to unrelated short-test
+          # timeouts. Serialize files and retain bounded Windows-only margins.
           VITEST_MAX_WORKERS: "1"
+          VITEST_TEST_TIMEOUT: "15000"
+          VITEST_HOOK_TIMEOUT: "30000"
         run: npm run ci
 
   agent-ui-coverage:

--- a/agent-ui/scripts/task-canvas-visual.mjs
+++ b/agent-ui/scripts/task-canvas-visual.mjs
@@ -69,6 +69,16 @@ function modeSpecs(mode) {
     specs.build = { revision: 5, activity: 'completed', visibility: 'visible' }
     specs.research = { revision: 5, activity: 'progress', visibility: 'visible' }
   }
+  if (mode === 'intervention') {
+    specs.build = { revision: 5, activity: 'completed', visibility: 'visible' }
+    specs.research = {
+      revision: 7,
+      generation: 2,
+      activity: 'progress',
+      visibility: 'focused',
+      focusedUntil: Date.now() + 1800,
+    }
+  }
   if (mode === 'fail' || mode === 'remove') {
     specs.build = { revision: 5, activity: 'completed', visibility: 'visible' }
     specs.research = {
@@ -121,7 +131,7 @@ function makeNode(actor, spec) {
           id: actor,
           role: 'Worker',
           node_id: 'node:' + actor,
-          generation: 1,
+          generation: spec.generation || 1,
         },
         title: actorLabel(actor),
         state: {
@@ -163,7 +173,7 @@ function makeProjection(actor, spec) {
     node_id: 'node:' + actor,
     surface_id: 'surface:' + actor,
     document_id: 'document:run:visual',
-    generation: 1,
+    generation: spec.generation || 1,
     last_activity_sequence: spec.revision,
     journal_cursor: spec.revision,
     surface_revision: spec.revision,
@@ -182,12 +192,33 @@ function makeSnapshot(mode) {
     initial: 3,
     focus: 4,
     complete: 5,
+    intervention: 7,
     fail: 6,
     remove: 7,
   }[mode]
   return {
     run_id: 'run:visual',
     projections: actors.map(actor => makeProjection(actor, specs[actor])),
+    surface_states: actors.map(actor => ({
+      actor_id: actor,
+      surface_id: 'surface:' + actor,
+      generation_state: 'current',
+      superseded_count: mode === 'intervention' && actor === 'research' ? 1 : 0,
+      ...(mode === 'intervention' && actor === 'research'
+        ? {
+            latest_intervention: {
+              intervention_id: 'intervention:visual:research:retry',
+              run_id: 'run:visual',
+              actor_id: 'research',
+              operation: 'retry',
+              status: 'applied',
+              created_at: baseTime + 650,
+              started_at: baseTime + 660,
+              completed_at: baseTime + 670,
+            },
+          }
+        : {}),
+    })),
     document: {
       ir_version: 1,
       document_id: 'document:run:visual',
@@ -201,12 +232,46 @@ function makeSnapshot(mode) {
   }
 }
 
+function makeResearchHistory() {
+  const oldNode = makeNode('research', {
+    revision: 2,
+    generation: 1,
+    activity: 'finding',
+    visibility: 'visible',
+  })
+  return {
+    run_id: 'run:visual',
+    actor_id: 'research',
+    generation_state: 'superseded',
+    total: 1,
+    history: [{
+      run_id: 'run:visual',
+      actor_id: 'research',
+      generation: 1,
+      node_id: 'node:research',
+      surface_id: 'surface:research',
+      document_id: 'document:run:visual',
+      node_revision: oldNode.revision,
+      document_revision: 3,
+      surface_revision: 2,
+      activity_state: 'finding',
+      visibility_state: 'visible',
+      last_event_id: 'event:research:2',
+      node_snapshot: oldNode,
+      superseded_by_generation: 2,
+      intervention_id: 'intervention:visual:research:retry',
+      created_at: baseTime + 650,
+    }],
+  }
+}
+
 async function installSnapshotRoute(page, initialMode, holdInitial = false) {
   const controller = {
     mode: initialMode,
     snapshot: makeSnapshot(initialMode),
     holdInitial,
     release: null,
+    historyRequests: 0,
   }
   let releaseGate
   const gate = new Promise(resolve => { releaseGate = resolve })
@@ -227,6 +292,18 @@ async function installSnapshotRoute(page, initialMode, holdInitial = false) {
         success: true,
         message: 'visual fixture',
         data: controller.snapshot,
+      }),
+    })
+  })
+  await page.route('**/api/runs/**/actors/**/surface-history**', async route => {
+    controller.historyRequests += 1
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        message: 'visual history fixture',
+        data: makeResearchHistory(),
       }),
     })
   })
@@ -378,6 +455,34 @@ async function runDesktop(browser, evidence) {
   ))
   await screenshot(page, 'desktop-complete.png')
 
+  controller.setMode('intervention')
+  await page.waitForFunction(() => (
+    document.querySelector('[data-generative-ui-node="surface:research"]')
+      ?.getAttribute('data-superseded-count') === '1'
+  ))
+  await research.locator('.generative-ui-node-host__expand').click()
+  await page.locator('[data-generation-history] [role="tab"]').nth(1).waitFor()
+  assert(controller.historyRequests === 1, 'Generation history was not loaded exactly once on expansion')
+  await screenshot(page, 'desktop-intervention-current.png')
+  await page.locator('[data-generation-history] [role="tab"]').nth(1).click()
+  await page.waitForFunction(() => (
+    document.querySelector('[data-generative-ui-node="surface:research"]')
+      ?.getAttribute('data-generation-state') === 'superseded'
+  ))
+  await page.waitForFunction(() => {
+    const host = document.querySelector('[data-generative-ui-node="surface:research"]')
+    const body = host?.querySelector('.generative-ui-node-host__body')
+    const banner = host?.querySelector('.generative-ui-node-host__historical-banner')
+    return body?.scrollTop === 0 && banner?.getBoundingClientRect().top >= body?.getBoundingClientRect().top
+  })
+  const historicalText = await research.innerText()
+  assert(!historicalText.includes('node:research'), 'Historical view exposed an internal node id')
+  assert(!historicalText.includes('intervention:visual'), 'Historical view exposed an intervention id')
+  assert(await research.locator('.generative-ui-node-host__historical-banner').count() === 1, 'Historical read-only banner is missing')
+  await screenshot(page, 'desktop-intervention-history.png')
+  await page.locator('[data-generation-history] [role="tab"]').first().click()
+  await research.locator('.generative-ui-node-host__expand').click()
+
   controller.setMode('fail')
   await page.waitForFunction(() => (
     document.querySelector('[data-generative-ui-node="surface:verify"]')
@@ -441,7 +546,7 @@ async function runMobile(browser, evidence) {
   const page = await context.newPage()
   const pageErrors = []
   page.on('pageerror', error => pageErrors.push(error.message))
-  await installSnapshotRoute(page, 'initial')
+  const controller = await installSnapshotRoute(page, 'intervention')
   await page.goto(baseUrl + '/task-canvas-harness.html', { waitUntil: 'domcontentloaded' })
   await waitForReady(page)
   await page.waitForTimeout(350)
@@ -454,6 +559,8 @@ async function runMobile(browser, evidence) {
       ?.getAttribute('aria-selected') === 'true'
   ))
   await screenshot(page, 'mobile-ready.png')
+
+  assert(await build.locator('[data-generation-badge="intervention"]').count() === 0, 'Mobile should hide the verbose intervention badge')
 
   const metrics = await layoutMetrics(page)
   assert(metrics.blockCount === 3, 'Mobile did not render three Worker Blocks')
@@ -473,7 +580,31 @@ async function runMobile(browser, evidence) {
   await screenshot(page, 'mobile-fullscreen.png')
   await build.locator('.generative-ui-node-host__expand').tap()
 
-  evidence.mobile = { metrics, pageErrors }
+  const research = page.locator('[data-generative-ui-node="surface:research"]')
+  await research.locator('.generative-ui-node-host__expand').tap()
+  await page.locator('[data-generation-history] [role="tab"]').nth(1).waitFor()
+  assert(controller.historyRequests === 1, 'Mobile history should load once on expansion')
+  await page.locator('[data-generation-history] [role="tab"]').nth(1).tap()
+  await page.waitForFunction(() => (
+    document.querySelector('[data-generative-ui-node="surface:research"]')
+      ?.getAttribute('data-generation-state') === 'superseded'
+  ))
+  await page.waitForFunction(() => {
+    const host = document.querySelector('[data-generative-ui-node="surface:research"]')
+    const body = host?.querySelector('.generative-ui-node-host__body')
+    const banner = host?.querySelector('.generative-ui-node-host__historical-banner')
+    return body?.scrollTop === 0 && banner?.getBoundingClientRect().top >= body?.getBoundingClientRect().top
+  })
+  const mobileHistoryLayout = await page.locator('[data-generation-history]').evaluate(element => ({
+    direction: getComputedStyle(element).flexDirection,
+    width: Math.round(element.getBoundingClientRect().width),
+    scrollWidth: element.scrollWidth,
+  }))
+  assert(mobileHistoryLayout.direction === 'column', 'Mobile history controls did not stack')
+  assert(mobileHistoryLayout.scrollWidth <= mobileHistoryLayout.width + 2, 'Mobile history controls overflow horizontally')
+  await screenshot(page, 'mobile-intervention-history.png')
+
+  evidence.mobile = { metrics, mobileHistoryLayout, pageErrors }
   assert(pageErrors.length === 0, 'Mobile page errors: ' + pageErrors.join('; '))
   await context.close()
 }

--- a/agent-ui/src/api/agent/agent-generative-ui-api.ts
+++ b/agent-ui/src/api/agent/agent-generative-ui-api.ts
@@ -22,13 +22,24 @@ export {
 } from '@/api/services/generative-ui-api'
 
 export type {
+  DagActorInterventionList,
+  DagActorInterventionOperation,
+  DagActorInterventionStatus,
+  DagActorInterventionSummary,
+  DagActorSurfaceHistory,
   DagLiveSurfaceActivityState,
   DagLiveSurfaceProjectionRecord,
   DagLiveSurfaceSnapshot,
+  DagLiveSurfaceState,
   DagLiveSurfaceVisibilityState,
+  DagSurfaceGenerationSnapshot,
 } from '@/api/services/dag-live-surface-api'
 export {
+  getDagActorInterventions,
+  getDagActorSurfaceHistory,
   getDagLiveSurfaces,
+  normalizeDagActorInterventions,
+  normalizeDagActorSurfaceHistory,
   normalizeDagLiveSurfaceSnapshot,
 } from '@/api/services/dag-live-surface-api'
 

--- a/agent-ui/src/api/services/dag-live-surface-api.test.ts
+++ b/agent-ui/src/api/services/dag-live-surface-api.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import { HOMERAIL_A2UI_CATALOG_ID } from 'homerail-protocol'
-import { normalizeDagLiveSurfaceSnapshot } from './dag-live-surface-api'
+import {
+  normalizeDagActorInterventions,
+  normalizeDagActorSurfaceHistory,
+  normalizeDagLiveSurfaceSnapshot,
+} from './dag-live-surface-api'
 
 function projectedNode(actorId: string, revision: number, activity = 'progress') {
   const surfaceId = `surface:${actorId}`
@@ -95,6 +99,79 @@ describe('DAG live surface API contract', () => {
       'surface:research',
       'surface:verify',
     ])
+    expect(normalized.surface_states).toEqual([])
+  })
+
+  it('accepts current generation metadata while remaining backward compatible', () => {
+    const value = snapshot()
+    Object.assign(value, {
+      surface_states: [{
+        actor_id: 'build',
+        surface_id: 'surface:build',
+        generation_state: 'current',
+        superseded_count: 2,
+        latest_intervention: {
+          intervention_id: 'intervention:one',
+          run_id: 'run:one',
+          actor_id: 'build',
+          operation: 'retry',
+          status: 'applied',
+          created_at: 1_789_000_000_500,
+        },
+      }],
+    })
+
+    const normalized = normalizeDagLiveSurfaceSnapshot(value)
+    expect(normalized.surface_states?.[0]).toMatchObject({
+      actor_id: 'build',
+      generation_state: 'current',
+      superseded_count: 2,
+      latest_intervention: { operation: 'retry', status: 'applied' },
+    })
+  })
+
+  it('validates read-only Actor history and intervention lists', () => {
+    const historicalNode = projectedNode('build', 4)
+    const history = normalizeDagActorSurfaceHistory({
+      run_id: 'run:one',
+      actor_id: 'build',
+      generation_state: 'superseded',
+      history: [{
+        run_id: 'run:one',
+        actor_id: 'build',
+        generation: 1,
+        node_id: 'node:build',
+        surface_id: 'surface:build',
+        document_id: 'document:run:one',
+        node_revision: 4,
+        document_revision: 8,
+        surface_revision: 4,
+        activity_state: 'failed',
+        visibility_state: 'visible',
+        node_snapshot: historicalNode,
+        superseded_by_generation: 2,
+        intervention_id: 'intervention:one',
+        created_at: 1_789_000_000_500,
+      }],
+      total: 1,
+    }, 'run:one', 'build')
+    expect(history.history[0]?.node_snapshot).not.toBe(historicalNode)
+    expect(history.history[0]?.node_snapshot.fallback.title).toBe('Worker build')
+
+    const interventions = normalizeDagActorInterventions({
+      run_id: 'run:one',
+      actor_id: 'build',
+      interventions: [{
+        intervention_id: 'intervention:one',
+        run_id: 'run:one',
+        actor_id: 'build',
+        operation: 'retry',
+        status: 'applied',
+        created_at: 1_789_000_000_500,
+      }],
+      total: 1,
+    }, 'run:one', 'build')
+    expect(interventions.interventions[0]?.operation).toBe('retry')
   })
 
   it('rejects cross-run, duplicate, and forged projector identities', () => {

--- a/agent-ui/src/api/services/dag-live-surface-api.ts
+++ b/agent-ui/src/api/services/dag-live-surface-api.ts
@@ -1,6 +1,8 @@
 import {
   validateGenerativeUiDocument,
+  validateGenerativeUiStoredNode,
   type GenerativeUiDocumentV1,
+  type GenerativeUiStoredNodeV1,
 } from 'homerail-protocol'
 import { http, type ApiResponse } from '@/api/clients/http-client'
 
@@ -13,6 +15,69 @@ export type DagLiveSurfaceActivityState =
   | 'failed'
 
 export type DagLiveSurfaceVisibilityState = 'visible' | 'focused' | 'removed'
+
+export type DagActorInterventionOperation =
+  | 'interrupt'
+  | 'cancel'
+  | 'retry'
+  | 'reassign'
+  | 'checkpoint_fork'
+
+export type DagActorInterventionStatus = 'queued' | 'applying' | 'applied' | 'failed'
+
+export interface DagActorInterventionSummary {
+  intervention_id: string
+  run_id: string
+  actor_id: string
+  operation: DagActorInterventionOperation
+  status: DagActorInterventionStatus
+  instruction?: string
+  created_at: number
+  started_at?: number
+  completed_at?: number
+}
+
+export interface DagLiveSurfaceState {
+  actor_id: string
+  surface_id: string
+  generation_state: 'current'
+  superseded_count: number
+  latest_intervention?: DagActorInterventionSummary
+}
+
+export interface DagSurfaceGenerationSnapshot {
+  run_id: string
+  actor_id: string
+  generation: number
+  node_id: string
+  surface_id: string
+  document_id: string
+  node_revision: number
+  document_revision: number
+  surface_revision: number
+  activity_state: string
+  visibility_state: string
+  last_event_id?: string
+  node_snapshot: GenerativeUiStoredNodeV1
+  superseded_by_generation: number
+  intervention_id: string
+  created_at: number
+}
+
+export interface DagActorSurfaceHistory {
+  run_id: string
+  actor_id: string
+  generation_state: 'superseded'
+  history: DagSurfaceGenerationSnapshot[]
+  total: number
+}
+
+export interface DagActorInterventionList {
+  run_id: string
+  actor_id: string
+  interventions: DagActorInterventionSummary[]
+  total: number
+}
 
 export interface DagLiveSurfaceProjectionRecord {
   run_id: string
@@ -35,6 +100,7 @@ export interface DagLiveSurfaceProjectionRecord {
 export interface DagLiveSurfaceSnapshot {
   run_id: string
   projections: DagLiveSurfaceProjectionRecord[]
+  surface_states?: DagLiveSurfaceState[]
   document: GenerativeUiDocumentV1 | null
 }
 
@@ -47,6 +113,19 @@ const ACTIVITY_STATES = new Set<DagLiveSurfaceActivityState>([
   'failed',
 ])
 const VISIBILITY_STATES = new Set<DagLiveSurfaceVisibilityState>(['visible', 'focused', 'removed'])
+const INTERVENTION_OPERATIONS = new Set<DagActorInterventionOperation>([
+  'interrupt',
+  'cancel',
+  'retry',
+  'reassign',
+  'checkpoint_fork',
+])
+const INTERVENTION_STATUSES = new Set<DagActorInterventionStatus>([
+  'queued',
+  'applying',
+  'applied',
+  'failed',
+])
 
 function objectValue(value: unknown, label: string): Record<string, unknown> {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
@@ -65,6 +144,13 @@ function requiredString(value: unknown, label: string): string {
 function optionalString(value: unknown, label: string): string | undefined {
   if (value === undefined) return undefined
   return requiredString(value, label)
+}
+
+function literal<T extends string>(value: unknown, allowed: Set<T>, label: string): T {
+  if (!allowed.has(value as T)) {
+    throw new Error(`Invalid DAG live surface response: ${label} is invalid`)
+  }
+  return value as T
 }
 
 function safeInteger(value: unknown, label: string): number {
@@ -110,6 +196,65 @@ function normalizeProjection(value: unknown): DagLiveSurfaceProjectionRecord {
       : { focused_until: safeInteger(record.focused_until, 'focused_until') }),
     created_at: safeInteger(record.created_at, 'created_at'),
     updated_at: safeInteger(record.updated_at, 'updated_at'),
+  }
+}
+
+function normalizeIntervention(value: unknown): DagActorInterventionSummary {
+  const record = objectValue(value, 'intervention')
+  return {
+    intervention_id: requiredString(record.intervention_id, 'intervention_id'),
+    run_id: requiredString(record.run_id, 'run_id'),
+    actor_id: requiredString(record.actor_id, 'actor_id'),
+    operation: literal(record.operation, INTERVENTION_OPERATIONS, 'operation'),
+    status: literal(record.status, INTERVENTION_STATUSES, 'status'),
+    ...(optionalString(record.instruction, 'instruction') ? { instruction: String(record.instruction) } : {}),
+    created_at: safeInteger(record.created_at, 'created_at'),
+    ...(record.started_at === undefined ? {} : { started_at: safeInteger(record.started_at, 'started_at') }),
+    ...(record.completed_at === undefined ? {} : { completed_at: safeInteger(record.completed_at, 'completed_at') }),
+  }
+}
+
+function normalizeSurfaceState(value: unknown): DagLiveSurfaceState {
+  const record = objectValue(value, 'surface_state')
+  if (record.generation_state !== 'current') {
+    throw new Error('Invalid DAG live surface response: generation_state must be current')
+  }
+  return {
+    actor_id: requiredString(record.actor_id, 'actor_id'),
+    surface_id: requiredString(record.surface_id, 'surface_id'),
+    generation_state: 'current',
+    superseded_count: safeInteger(record.superseded_count, 'superseded_count'),
+    ...(record.latest_intervention === undefined
+      ? {}
+      : { latest_intervention: normalizeIntervention(record.latest_intervention) }),
+  }
+}
+
+function normalizeGenerationSnapshot(value: unknown): DagSurfaceGenerationSnapshot {
+  const record = objectValue(value, 'surface history entry')
+  const validation = validateGenerativeUiStoredNode(record.node_snapshot)
+  if (!validation.value || validation.errors.length) {
+    throw new Error('Invalid DAG live surface response: historical node failed protocol validation')
+  }
+  return {
+    run_id: requiredString(record.run_id, 'run_id'),
+    actor_id: requiredString(record.actor_id, 'actor_id'),
+    generation: safeInteger(record.generation, 'generation'),
+    node_id: requiredString(record.node_id, 'node_id'),
+    surface_id: requiredString(record.surface_id, 'surface_id'),
+    document_id: requiredString(record.document_id, 'document_id'),
+    node_revision: safeInteger(record.node_revision, 'node_revision'),
+    document_revision: safeInteger(record.document_revision, 'document_revision'),
+    surface_revision: safeInteger(record.surface_revision, 'surface_revision'),
+    activity_state: requiredString(record.activity_state, 'activity_state'),
+    visibility_state: requiredString(record.visibility_state, 'visibility_state'),
+    ...(optionalString(record.last_event_id, 'last_event_id')
+      ? { last_event_id: String(record.last_event_id) }
+      : {}),
+    node_snapshot: structuredClone(validation.value),
+    superseded_by_generation: safeInteger(record.superseded_by_generation, 'superseded_by_generation'),
+    intervention_id: requiredString(record.intervention_id, 'intervention_id'),
+    created_at: safeInteger(record.created_at, 'created_at'),
   }
 }
 
@@ -171,6 +316,31 @@ export function normalizeDagLiveSurfaceSnapshot(
     surfaceIds.add(projection.surface_id)
   }
 
+  const surfaceStates = record.surface_states === undefined
+    ? []
+    : Array.isArray(record.surface_states)
+      ? record.surface_states.map(normalizeSurfaceState)
+      : (() => { throw new Error('Invalid DAG live surface response: surface_states must be an array') })()
+  const stateActors = new Set<string>()
+  const stateSurfaces = new Set<string>()
+  for (const state of surfaceStates) {
+    if (stateActors.has(state.actor_id) || stateSurfaces.has(state.surface_id)) {
+      throw new Error('Invalid DAG live surface response: duplicate surface state')
+    }
+    const projection = projections.find(candidate => candidate.actor_id === state.actor_id)
+    if (!projection || projection.surface_id !== state.surface_id) {
+      throw new Error('Invalid DAG live surface response: surface state does not match a projection')
+    }
+    if (
+      state.latest_intervention
+      && (state.latest_intervention.run_id !== runId || state.latest_intervention.actor_id !== state.actor_id)
+    ) {
+      throw new Error('Invalid DAG live surface response: intervention identity mismatch')
+    }
+    stateActors.add(state.actor_id)
+    stateSurfaces.add(state.surface_id)
+  }
+
   let document: GenerativeUiDocumentV1 | null = null
   if (record.document === null) {
     if (projections.some(projection => projection.visibility_state !== 'removed')) {
@@ -205,7 +375,58 @@ export function normalizeDagLiveSurfaceSnapshot(
     }
   }
 
-  return { run_id: runId, projections, document }
+  return { run_id: runId, projections, surface_states: surfaceStates, document }
+}
+
+export function normalizeDagActorSurfaceHistory(
+  value: unknown,
+  expectedRunId?: string,
+  expectedActorId?: string,
+): DagActorSurfaceHistory {
+  const record = objectValue(value, 'surface history')
+  const runId = requiredString(record.run_id, 'run_id')
+  const actorId = requiredString(record.actor_id, 'actor_id')
+  if (expectedRunId && runId !== expectedRunId) throw new Error('Invalid DAG surface history run identity')
+  if (expectedActorId && actorId !== expectedActorId) throw new Error('Invalid DAG surface history Actor identity')
+  if (record.generation_state !== 'superseded' || !Array.isArray(record.history)) {
+    throw new Error('Invalid DAG live surface response: malformed surface history')
+  }
+  const history = record.history.map(normalizeGenerationSnapshot)
+  for (const entry of history) {
+    if (
+      entry.run_id !== runId
+      || entry.actor_id !== actorId
+      || entry.node_snapshot.id !== entry.surface_id
+      || entry.node_snapshot.revision !== entry.node_revision
+    ) {
+      throw new Error('Invalid DAG live surface response: historical node identity mismatch')
+    }
+  }
+  const total = safeInteger(record.total, 'total')
+  if (total < history.length) throw new Error('Invalid DAG live surface response: history total is invalid')
+  return { run_id: runId, actor_id: actorId, generation_state: 'superseded', history, total }
+}
+
+export function normalizeDagActorInterventions(
+  value: unknown,
+  expectedRunId?: string,
+  expectedActorId?: string,
+): DagActorInterventionList {
+  const record = objectValue(value, 'intervention list')
+  const runId = requiredString(record.run_id, 'run_id')
+  const actorId = requiredString(record.actor_id, 'actor_id')
+  if (expectedRunId && runId !== expectedRunId) throw new Error('Invalid DAG intervention run identity')
+  if (expectedActorId && actorId !== expectedActorId) throw new Error('Invalid DAG intervention Actor identity')
+  if (!Array.isArray(record.interventions)) {
+    throw new Error('Invalid DAG live surface response: interventions must be an array')
+  }
+  const interventions = record.interventions.map(normalizeIntervention)
+  if (interventions.some(item => item.run_id !== runId || item.actor_id !== actorId)) {
+    throw new Error('Invalid DAG live surface response: intervention identity mismatch')
+  }
+  const total = safeInteger(record.total, 'total')
+  if (total < interventions.length) throw new Error('Invalid DAG live surface response: intervention total is invalid')
+  return { run_id: runId, actor_id: actorId, interventions, total }
 }
 
 export async function getDagLiveSurfaces(
@@ -217,5 +438,33 @@ export async function getDagLiveSurfaces(
   return {
     ...response,
     data: normalizeDagLiveSurfaceSnapshot(response.data, runId),
+  }
+}
+
+export async function getDagActorSurfaceHistory(
+  runId: string,
+  actorId: string,
+  limit = 20,
+): Promise<ApiResponse<DagActorSurfaceHistory>> {
+  const response = await http.get<unknown>(
+    `/api/runs/${encodeURIComponent(runId)}/actors/${encodeURIComponent(actorId)}/surface-history?limit=${limit}`,
+  )
+  return {
+    ...response,
+    data: normalizeDagActorSurfaceHistory(response.data, runId, actorId),
+  }
+}
+
+export async function getDagActorInterventions(
+  runId: string,
+  actorId: string,
+  limit = 20,
+): Promise<ApiResponse<DagActorInterventionList>> {
+  const response = await http.get<unknown>(
+    `/api/runs/${encodeURIComponent(runId)}/actors/${encodeURIComponent(actorId)}/interventions?limit=${limit}`,
+  )
+  return {
+    ...response,
+    data: normalizeDagActorInterventions(response.data, runId, actorId),
   }
 }

--- a/agent-ui/src/components/generative-ui/DagTaskCanvas.test.ts
+++ b/agent-ui/src/components/generative-ui/DagTaskCanvas.test.ts
@@ -15,11 +15,13 @@ import DagTaskCanvas from './DagTaskCanvas.vue'
 
 const mocks = vi.hoisted(() => ({
   getDagLiveSurfaces: vi.fn(),
+  getDagActorSurfaceHistory: vi.fn(),
   onEvent: vi.fn(() => () => undefined),
   onStateChange: vi.fn(() => () => undefined),
 }))
 
 vi.mock('@/api/agent', () => ({
+  getDagActorSurfaceHistory: mocks.getDagActorSurfaceHistory,
   getDagLiveSurfaces: mocks.getDagLiveSurfaces,
 }))
 
@@ -110,6 +112,12 @@ function snapshot(): DagLiveSurfaceSnapshot {
       created_at: 1_789_000_000_000,
       updated_at: 1_789_000_000_000 + index,
     })),
+    surface_states: actors.map(actorId => ({
+      actor_id: actorId,
+      surface_id: `surface:${actorId}`,
+      generation_state: 'current' as const,
+      superseded_count: 0,
+    })),
     document: {
       ir_version: 1,
       document_id: 'document:run:one',
@@ -153,6 +161,7 @@ afterEach(() => {
   root = null
   controls = null
   mocks.getDagLiveSurfaces.mockReset()
+  mocks.getDagActorSurfaceHistory.mockReset()
   mocks.onEvent.mockClear()
   mocks.onStateChange.mockClear()
   sessionStorage.clear()
@@ -225,12 +234,82 @@ describe('DagTaskCanvas', () => {
     expect(document.body.classList.contains('generative-ui-node-expanded')).toBe(false)
   })
 
+  it('shows compact intervention state and lazy read-only history only in expanded view', async () => {
+    const current = snapshot()
+    current.surface_states![0] = {
+      ...current.surface_states![0]!,
+      superseded_count: 1,
+      latest_intervention: {
+        intervention_id: 'intervention:retry',
+        run_id: 'run:one',
+        actor_id: 'build',
+        operation: 'retry',
+        status: 'applied',
+        created_at: 1_789_000_000_500,
+      },
+    }
+    mocks.getDagLiveSurfaces.mockResolvedValue({ success: true, data: current })
+    mocks.getDagActorSurfaceHistory.mockResolvedValue({
+      success: true,
+      data: {
+        run_id: 'run:one',
+        actor_id: 'build',
+        generation_state: 'superseded',
+        history: [{
+          run_id: 'run:one',
+          actor_id: 'build',
+          generation: 1,
+          node_id: 'node:build',
+          surface_id: 'surface:build',
+          document_id: 'document:run:one',
+          node_revision: 1,
+          document_revision: 3,
+          surface_revision: 1,
+          activity_state: 'failed',
+          visibility_state: 'visible',
+          node_snapshot: node('build', 1, 'failed'),
+          superseded_by_generation: 2,
+          intervention_id: 'intervention:retry',
+          created_at: 1_789_000_000_500,
+        }],
+        total: 1,
+      },
+    })
+
+    const mounted = mount()
+    await settle()
+    const build = mounted.querySelector<HTMLElement>('[data-generative-ui-node="surface:build"]')!
+    expect(build.querySelector('[data-generation-badge="current"]')?.textContent).toContain('Current')
+    expect(build.querySelector('[data-generation-badge="superseded"]')?.textContent).toContain('Superseded 1')
+    expect(build.querySelector('[data-generation-badge="intervention"]')?.textContent).toContain('Retry · Applied')
+    expect(mounted.querySelector('[data-generation-history]')).toBeNull()
+
+    build.querySelector<HTMLButtonElement>('.generative-ui-node-host__expand')!.click()
+    await settle()
+    expect(mocks.getDagActorSurfaceHistory).toHaveBeenCalledWith('run:one', 'build', 20)
+    const tabs = mounted.querySelectorAll<HTMLButtonElement>('[data-generation-history] [role="tab"]')
+    expect(tabs).toHaveLength(2)
+    tabs[1]!.click()
+    await nextTick()
+    expect(build.dataset.generationState).toBe('superseded')
+    expect(build.querySelector('.generative-ui-node-host__historical-banner')?.textContent)
+      .toContain('Historical content is read-only')
+    expect(build.textContent).not.toContain('node:build')
+    expect(build.textContent).not.toContain('intervention:retry')
+
+    build.querySelector<HTMLButtonElement>('.generative-ui-node-host__expand')!.click()
+    await nextTick()
+    expect(build.dataset.generationState).toBe('current')
+  })
+
   it('reconciles update, complete, fail, and remove, then retains the last snapshot while stale', async () => {
     vi.useFakeTimers()
     const initial = snapshot()
     mocks.getDagLiveSurfaces.mockResolvedValueOnce({ success: true, data: initial })
     const mounted = mount()
     await settle()
+    const unchangedResearchBlock = mounted.querySelector('[data-generative-ui-node="surface:research"]')
+    const unchangedVerifyBlock = mounted.querySelector('[data-generative-ui-node="surface:verify"]')
 
     const updated = snapshot()
     updated.document!.revision = 4
@@ -245,6 +324,10 @@ describe('DagTaskCanvas', () => {
     mocks.getDagLiveSurfaces.mockResolvedValueOnce({ success: true, data: updated })
     await controls!.refresh()
     await settle()
+    expect(mounted.querySelector('[data-generative-ui-node="surface:research"]')).toBe(unchangedResearchBlock)
+    expect(mounted.querySelector('[data-generative-ui-node="surface:verify"]')).toBe(unchangedVerifyBlock)
+    expect(mounted.querySelector('[data-generative-ui-node="surface:research"]')
+      ?.getAttribute('data-lifecycle-motion')).toBe('idle')
     expect(mounted.querySelector('[data-generative-ui-node="surface:build"]')?.getAttribute('data-lifecycle-motion'))
       .toBe('update')
     await vi.advanceTimersByTimeAsync(700)

--- a/agent-ui/src/components/generative-ui/DagTaskCanvas.vue
+++ b/agent-ui/src/components/generative-ui/DagTaskCanvas.vue
@@ -2,6 +2,7 @@
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import type { GenerativeUiPreviewRequestV1 } from '@/generative-ui/types'
 import {
+  getDagActorSurfaceHistory,
   getDagLiveSurfaces,
   type DagLiveSurfaceSnapshot,
 } from '@/api/agent'
@@ -13,8 +14,13 @@ import {
   dagTaskCanvasSelectionStorageKey,
   dagTaskCanvasSnapshotVersion,
   projectorFocusedSurface,
+  reconcileDagTaskCanvasSnapshot,
   resolveDagTaskCanvasSelection,
 } from '@/generative-ui/dag-task-canvas'
+import type {
+  GenerativeUiGenerationContext,
+  GenerativeUiGenerationHistoryEntry,
+} from '@/generative-ui/generation-history'
 import A2uiRenderer from './A2uiRenderer.vue'
 import GenerativeUiSurfaceHost from './GenerativeUiSurfaceHost.vue'
 
@@ -50,6 +56,12 @@ const loading = ref(true)
 const stale = ref(false)
 const clock = ref(Date.now())
 const viewportRevision = ref(0)
+const historyByActor = ref<Record<string, {
+  entries: GenerativeUiGenerationHistoryEntry[]
+  loaded: boolean
+  loading: boolean
+  error?: string
+}>>({})
 let mounted = false
 let requestGeneration = 0
 let refreshRequested = false
@@ -58,6 +70,7 @@ let pollTimer = 0
 let eventRefreshTimer = 0
 let unsubscribeEvents: (() => void) | null = null
 let unsubscribeState: (() => void) | null = null
+const historyRequests = new Map<string, Promise<void>>()
 
 const context = computed(() => {
   void viewportRevision.value
@@ -79,6 +92,29 @@ const initialLoading = computed(() => loading.value && !snapshot.value)
 const focusedSurface = computed(() => {
   void clock.value
   return snapshot.value ? projectorFocusedSurface(snapshot.value) : null
+})
+const generationContexts = computed<Record<string, GenerativeUiGenerationContext>>(() => {
+  const contexts: Record<string, GenerativeUiGenerationContext> = {}
+  for (const state of snapshot.value?.surface_states ?? []) {
+    const history = historyByActor.value[state.actor_id]
+    contexts[state.surface_id] = {
+      superseded_count: state.superseded_count,
+      ...(state.latest_intervention
+        ? {
+            latest_intervention: {
+              operation: state.latest_intervention.operation,
+              status: state.latest_intervention.status,
+              created_at: state.latest_intervention.created_at,
+            },
+          }
+        : {}),
+      history: history?.entries ?? [],
+      history_loading: history?.loading ?? false,
+      history_loaded: history?.loaded ?? false,
+      ...(history?.error ? { history_error: history.error } : {}),
+    }
+  }
+  return contexts
 })
 const rendererRegistry = computed(() => {
   const seen = new Set<string>()
@@ -134,6 +170,60 @@ function acceptSelection(nodeId: string): void {
   emit('select-node', { node_id: nodeId })
 }
 
+async function loadSurfaceHistory(nodeId: string): Promise<void> {
+  const state = snapshot.value?.surface_states?.find(candidate => candidate.surface_id === nodeId)
+  if (!state || state.superseded_count === 0) return
+  const actorId = state.actor_id
+  const existing = historyByActor.value[actorId]
+  if (existing?.loaded && existing.entries.length >= state.superseded_count) return
+  const requestKey = `${props.runId}:${actorId}`
+  const inflight = historyRequests.get(requestKey)
+  if (inflight) return inflight
+
+  const runId = props.runId
+  historyByActor.value = {
+    ...historyByActor.value,
+    [actorId]: {
+      entries: existing?.entries ?? [],
+      loaded: false,
+      loading: true,
+    },
+  }
+  const request = (async () => {
+    try {
+      const response = await getDagActorSurfaceHistory(runId, actorId, Math.min(100, Math.max(20, state.superseded_count)))
+      if (!mounted || props.runId !== runId) return
+      historyByActor.value = {
+        ...historyByActor.value,
+        [actorId]: {
+          entries: response.data.history.map(entry => ({
+            key: entry.intervention_id,
+            node: entry.node_snapshot,
+            created_at: entry.created_at,
+          })),
+          loaded: true,
+          loading: false,
+        },
+      }
+    } catch {
+      if (!mounted || props.runId !== runId) return
+      historyByActor.value = {
+        ...historyByActor.value,
+        [actorId]: {
+          entries: existing?.entries ?? [],
+          loaded: false,
+          loading: false,
+          error: 'unavailable',
+        },
+      }
+    } finally {
+      historyRequests.delete(requestKey)
+    }
+  })()
+  historyRequests.set(requestKey, request)
+  return request
+}
+
 async function performRefresh(): Promise<void> {
   const runId = props.runId
   if (!runId) return
@@ -148,7 +238,7 @@ async function performRefresh(): Promise<void> {
     clock.value = Date.now()
     const nextVersion = dagTaskCanvasSnapshotVersion(response.data)
     if (nextVersion !== snapshotVersion.value) {
-      snapshot.value = response.data
+      snapshot.value = reconcileDagTaskCanvasSnapshot(snapshot.value, response.data)
       snapshotVersion.value = nextVersion
     }
     selectedNodeId.value = resolveDagTaskCanvasSelection(
@@ -204,6 +294,8 @@ function resetRun(): void {
   resolved.value = false
   loading.value = true
   stale.value = false
+  historyByActor.value = {}
+  historyRequests.clear()
   publishAvailability()
   if (mounted) void refresh()
 }
@@ -287,8 +379,10 @@ defineExpose({ refresh })
       :selected-node-id="selectedNodeId"
       :focused-node-id="focusedSurface?.nodeId"
       :focused-until="focusedSurface?.focusedUntil"
+      :generation-contexts="generationContexts"
       :embedded="embedded"
       @select-node="acceptSelection($event.node_id)"
+      @request-generation-history="loadSurfaceHistory($event.node_id)"
       @open-preview="emit('open-preview', $event)"
     />
   </section>

--- a/agent-ui/src/components/generative-ui/GenerativeUiNodeHost.vue
+++ b/agent-ui/src/components/generative-ui/GenerativeUiNodeHost.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onUnmounted, ref, toRaw, watch } from 'vue'
+import { computed, nextTick, onUnmounted, ref, toRaw, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type {
   GenerativeUiCanvasSize,
@@ -32,6 +32,7 @@ import type {
   GenerativeUiPreviewRequestV1,
 } from '@/generative-ui/types'
 import type { GenerativeUiLifecycleMotion } from '@/generative-ui/motion-profiles'
+import type { GenerativeUiGenerationContext } from '@/generative-ui/generation-history'
 import GenerativeUiFallbackRenderer from './GenerativeUiFallbackRenderer.vue'
 import DeclarativeRenderer from './DeclarativeRenderer.vue'
 import CustomRendererSandbox from './CustomRendererSandbox.vue'
@@ -69,6 +70,7 @@ const props = withDefaults(defineProps<{
   motionProfile?: GenerativeUiMotionProfile
   attentionDurationMs?: number
   lifecycleMotion?: GenerativeUiLifecycleMotion
+  generation?: GenerativeUiGenerationContext
 }>(), {
   interactive: true,
   actionMode: 'emit',
@@ -89,14 +91,23 @@ const emit = defineEmits<{
   (event: 'open-preview', payload: GenerativeUiPreviewRequestV1): void
   (event: 'renderer-error', payload: { node_id: string; message: string }): void
   (event: 'select', payload: { node_id: string }): void
+  (event: 'request-generation-history', payload: { node_id: string }): void
 }>()
 
 const { t } = useI18n()
 const registry = computed(() => props.registry ?? emptyGenerativeUiRendererRegistry)
 const actionRegistry = computed(() => props.actionRegistry ?? emptyGenerativeUiActionRegistry)
-const availableActions = computed(() => actionRegistry.value.availableFor(props.node))
+const selectedHistoryKey = ref<string | null>(null)
+const selectedHistory = computed(() => (
+  props.generation?.history.find(entry => entry.key === selectedHistoryKey.value)
+))
+const viewingHistory = computed(() => Boolean(selectedHistory.value))
+const displayNode = computed(() => selectedHistory.value?.node ?? props.node)
+const availableActions = computed(() => (
+  viewingHistory.value ? [] : actionRegistry.value.availableFor(props.node)
+))
 const resolution = computed(() => registry.value.resolve(
-  props.node,
+  displayNode.value,
   props.placement.surface,
   props.context.device,
 ))
@@ -119,7 +130,7 @@ function initialInlineRendererActionState(): InlineRendererActionState {
   if (resolution.value.mode === 'custom') return { ready: false, names: new Set() }
   return {
     ready: true,
-    names: props.node.a2ui ? scanA2uiActionNames(props.node.a2ui) : new Set(),
+    names: displayNode.value.a2ui ? scanA2uiActionNames(displayNode.value.a2ui) : new Set(),
   }
 }
 const inlineRendererActions = ref<InlineRendererActionState>(initialInlineRendererActionState())
@@ -129,6 +140,7 @@ const supplementaryActions = computed(() => inlineRendererActions.value.ready
 const customRendererFailure = ref<string>()
 const expanded = ref(false)
 const collapsed = ref(false)
+const bodyElement = ref<HTMLElement | null>(null)
 const unavailable = computed(() => resolution.value.mode === 'unavailable' || Boolean(customRendererFailure.value))
 const fallbackReason = computed(() => (
   customRendererFailure.value
@@ -138,7 +150,7 @@ const fallbackReason = computed(() => (
     : undefined
 ))
 const resolutionName = computed(() => resolution.value.mode)
-const resetKey = computed(() => `${props.node.id}:${props.node.revision}:${resolutionName.value}`)
+const resetKey = computed(() => `${displayNode.value.id}:${displayNode.value.revision}:${resolutionName.value}`)
 const actionStates = ref<Record<string, ActionUiState>>({})
 const actionPollGenerations = new Map<string, number>()
 let unmounted = false
@@ -149,7 +161,54 @@ watch(resetKey, () => {
 })
 watch(expanded, value => {
   document.body.classList.toggle('generative-ui-node-expanded', value)
+  if (!value) {
+    selectedHistoryKey.value = null
+    return
+  }
+  if (props.generation?.superseded_count) {
+    emit('request-generation-history', { node_id: props.node.id })
+  }
 })
+
+watch(
+  () => props.generation?.superseded_count ?? 0,
+  (count, previous) => {
+    if (expanded.value && count > previous) {
+      emit('request-generation-history', { node_id: props.node.id })
+    }
+  },
+)
+
+watch(
+  () => props.generation?.history.map(entry => entry.key).join('|') ?? '',
+  () => {
+    if (selectedHistoryKey.value && !selectedHistory.value) selectedHistoryKey.value = null
+  },
+)
+
+function interventionOperationLabel(): string {
+  const operation = props.generation?.latest_intervention?.operation
+  return operation ? t(`voice.generativeUi.generations.operations.${operation}`) : ''
+}
+
+function interventionStatusLabel(): string {
+  const status = props.generation?.latest_intervention?.status
+  return status ? t(`voice.generativeUi.generations.statuses.${status}`) : ''
+}
+
+function requestHistory(): void {
+  emit('request-generation-history', { node_id: props.node.id })
+}
+
+function selectHistory(key: string | null): void {
+  selectedHistoryKey.value = key
+  void nextTick(() => {
+    const body = bodyElement.value
+    if (!body) return
+    if (typeof body.scrollTo === 'function') body.scrollTo({ top: 0, behavior: 'auto' })
+    else body.scrollTop = 0
+  })
+}
 
 function toggleExpanded(): void {
   if (!expanded.value && collapsed.value) collapsed.value = false
@@ -446,6 +505,8 @@ function acceptInlineRendererActions(names: string[]): void {
     :data-collapsed="collapsed ? 'true' : 'false'"
     :data-lifecycle-motion="lifecycleMotion"
     :data-status-phase="node.status?.phase || 'unknown'"
+    :data-generation-state="viewingHistory ? 'superseded' : generation ? 'current' : undefined"
+    :data-superseded-count="generation?.superseded_count"
     :style="{ '--generative-ui-attention-duration': `${attentionDurationMs}ms` }"
     :aria-selected="selected"
     tabindex="0"
@@ -454,6 +515,15 @@ function acceptInlineRendererActions(names: string[]): void {
     @keydown.esc.stop="expanded = false"
   >
     <div class="generative-ui-node-host__toolbar">
+      <div v-if="generation" class="generative-ui-node-host__generation-badges" aria-live="polite">
+        <span data-generation-badge="current">{{ t('voice.generativeUi.generations.current') }}</span>
+        <span v-if="generation.superseded_count" data-generation-badge="superseded">
+          {{ t('voice.generativeUi.generations.supersededCount', { count: generation.superseded_count }) }}
+        </span>
+        <span v-if="generation.latest_intervention" data-generation-badge="intervention">
+          {{ interventionOperationLabel() }} · {{ interventionStatusLabel() }}
+        </span>
+      </div>
       <button
         type="button"
         class="generative-ui-node-host__tool generative-ui-node-host__minimize"
@@ -477,7 +547,51 @@ function acceptInlineRendererActions(names: string[]): void {
         <Maximize2 v-else :size="18" aria-hidden="true" />
       </button>
     </div>
-    <div v-if="!collapsed" class="generative-ui-node-host__body">
+    <div v-if="!collapsed" ref="bodyElement" class="generative-ui-node-host__body">
+      <div
+        v-if="expanded && generation?.superseded_count"
+        class="generative-ui-node-host__history-switcher"
+        data-generation-history
+        @click.stop
+      >
+        <div class="generative-ui-node-host__history-tabs" role="tablist" :aria-label="t('voice.generativeUi.generations.history')">
+          <button
+            type="button"
+            role="tab"
+            :aria-selected="!viewingHistory"
+            :data-history-selected="!viewingHistory ? 'true' : 'false'"
+            @click="selectHistory(null)"
+          >
+            {{ t('voice.generativeUi.generations.current') }}
+          </button>
+          <button
+            v-for="(entry, index) in generation.history"
+            :key="entry.key"
+            type="button"
+            role="tab"
+            :aria-selected="selectedHistoryKey === entry.key"
+            :data-history-selected="selectedHistoryKey === entry.key ? 'true' : 'false'"
+            @click="selectHistory(entry.key)"
+          >
+            {{ t('voice.generativeUi.generations.supersededItem', { index: index + 1 }) }}
+          </button>
+        </div>
+        <span v-if="generation.history_loading" class="generative-ui-node-host__history-status" role="status">
+          {{ t('voice.generativeUi.generations.loading') }}
+        </span>
+        <button
+          v-else-if="generation.history_error"
+          type="button"
+          class="generative-ui-node-host__history-retry"
+          @click="requestHistory"
+        >
+          {{ t('voice.generativeUi.generations.retry') }}
+        </button>
+      </div>
+      <div v-if="viewingHistory" class="generative-ui-node-host__historical-banner" role="status">
+        <strong>{{ t('voice.generativeUi.generations.superseded') }}</strong>
+        <span>{{ t('voice.generativeUi.generations.readOnly') }}</span>
+      </div>
       <RendererErrorBoundary
       v-if="registeredComponent"
       :reset-key="resetKey"
@@ -485,7 +599,7 @@ function acceptInlineRendererActions(names: string[]): void {
     >
       <component
         :is="registeredComponent"
-        :node="node"
+        :node="displayNode"
         :placement="placement"
         :context="context"
         :expanded="expanded"
@@ -494,7 +608,7 @@ function acceptInlineRendererActions(names: string[]): void {
         @surface-actions="acceptInlineRendererActions"
       />
       <template #fallback="{ error }">
-        <GenerativeUiFallbackRenderer :node="node" unavailable :reason="error" />
+        <GenerativeUiFallbackRenderer :node="displayNode" unavailable :reason="error" />
       </template>
     </RendererErrorBoundary>
       <RendererErrorBoundary
@@ -502,9 +616,9 @@ function acceptInlineRendererActions(names: string[]): void {
       :reset-key="resetKey"
       @renderer-error="reportRendererError"
     >
-      <DeclarativeRenderer :node="node" :document="declarativeDocument" />
+      <DeclarativeRenderer :node="displayNode" :document="declarativeDocument" />
       <template #fallback="{ error }">
-        <GenerativeUiFallbackRenderer :node="node" unavailable :reason="error" />
+        <GenerativeUiFallbackRenderer :node="displayNode" unavailable :reason="error" />
       </template>
     </RendererErrorBoundary>
       <RendererErrorBoundary
@@ -513,7 +627,7 @@ function acceptInlineRendererActions(names: string[]): void {
       @renderer-error="reportRendererError"
     >
       <CustomRendererSandbox
-        :node="node"
+        :node="displayNode"
         :placement="placement"
         :context="context"
         :expanded="expanded"
@@ -526,18 +640,18 @@ function acceptInlineRendererActions(names: string[]): void {
         @renderer-error="reportRendererError"
       />
       <template #fallback="{ error }">
-        <GenerativeUiFallbackRenderer :node="node" unavailable :reason="error" />
+        <GenerativeUiFallbackRenderer :node="displayNode" unavailable :reason="error" />
       </template>
     </RendererErrorBoundary>
       <GenerativeUiFallbackRenderer
       v-else
-      :node="node"
+      :node="displayNode"
       :unavailable="unavailable"
       :reason="fallbackReason"
     />
 
       <nav
-      v-if="interactive !== false && actionMode !== 'disabled' && supplementaryActions.length"
+      v-if="!viewingHistory && interactive !== false && actionMode !== 'disabled' && supplementaryActions.length"
       class="generative-ui-node-host__actions"
       aria-label="Actions"
     >
@@ -738,6 +852,108 @@ function acceptInlineRendererActions(names: string[]): void {
   justify-content: flex-end;
   gap: 6px;
   padding: 8px 10px 4px;
+}
+
+.generative-ui-node-host__generation-badges {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+  margin-right: auto;
+  overflow: hidden;
+}
+
+.generative-ui-node-host__generation-badges span {
+  max-width: min(220px, 34cqw);
+  flex: 0 1 auto;
+  overflow: hidden;
+  border: 1px solid rgba(116, 228, 227, 0.18);
+  border-radius: 999px;
+  padding: 4px 8px;
+  color: rgba(218, 245, 243, 0.68);
+  background: rgba(10, 31, 33, 0.72);
+  font-size: 11px;
+  font-weight: 720;
+  line-height: 1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.generative-ui-node-host__generation-badges span[data-generation-badge='current'] {
+  border-color: rgba(74, 222, 128, 0.26);
+  color: rgba(187, 247, 208, 0.9);
+  background: rgba(22, 101, 52, 0.16);
+}
+
+.generative-ui-node-host__generation-badges span[data-generation-badge='superseded'] {
+  border-color: rgba(250, 204, 21, 0.24);
+  color: rgba(254, 240, 138, 0.82);
+  background: rgba(113, 63, 18, 0.14);
+}
+
+.generative-ui-node-host__history-switcher {
+  position: sticky;
+  top: -4px;
+  z-index: 4;
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin: -4px 0 14px;
+  border-bottom: 1px solid rgba(116, 228, 227, 0.13);
+  background: rgba(9, 19, 22, 0.96);
+  padding: 8px 0 10px;
+}
+
+.generative-ui-node-host__history-tabs {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.generative-ui-node-host__history-tabs button,
+.generative-ui-node-host__history-retry {
+  min-height: 32px;
+  border: 1px solid rgba(116, 228, 227, 0.18);
+  border-radius: 6px;
+  padding: 6px 10px;
+  color: rgba(218, 245, 243, 0.7);
+  background: rgba(8, 28, 31, 0.7);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 720;
+  cursor: pointer;
+}
+
+.generative-ui-node-host__history-tabs button[data-history-selected='true'] {
+  border-color: rgba(116, 228, 227, 0.52);
+  color: #efffff;
+  background: rgba(38, 151, 145, 0.2);
+}
+
+.generative-ui-node-host__history-status {
+  flex: 0 0 auto;
+  color: rgba(218, 245, 243, 0.58);
+  font-size: 12px;
+}
+
+.generative-ui-node-host__historical-banner {
+  display: flex;
+  min-width: 0;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 12px;
+  border-left: 3px solid rgba(250, 204, 21, 0.64);
+  background: rgba(113, 63, 18, 0.12);
+  padding: 8px 10px;
+  color: rgba(254, 240, 138, 0.74);
+  font-size: 12px;
+}
+
+.generative-ui-node-host__historical-banner strong {
+  color: rgba(254, 249, 195, 0.94);
 }
 
 .generative-ui-node-host__tool {
@@ -987,6 +1203,19 @@ function acceptInlineRendererActions(names: string[]): void {
 
   .generative-ui-node-host__body {
     padding: 2px 14px 16px;
+  }
+
+  .generative-ui-node-host__toolbar {
+    padding-inline: 8px;
+  }
+
+  .generative-ui-node-host__generation-badges span[data-generation-badge='intervention'] {
+    display: none;
+  }
+
+  .generative-ui-node-host__history-switcher {
+    align-items: flex-start;
+    flex-direction: column;
   }
 }
 

--- a/agent-ui/src/components/generative-ui/GenerativeUiSurfaceHost.vue
+++ b/agent-ui/src/components/generative-ui/GenerativeUiSurfaceHost.vue
@@ -27,6 +27,7 @@ import {
   resolveGenerativeUiMotionProfile,
   type GenerativeUiLifecycleMotion,
 } from '@/generative-ui/motion-profiles'
+import type { GenerativeUiGenerationContext } from '@/generative-ui/generation-history'
 
 const props = withDefaults(defineProps<{
   document: GenerativeUiDocumentV1
@@ -40,6 +41,7 @@ const props = withDefaults(defineProps<{
   selectedNodeId?: string | null
   focusedNodeId?: string | null
   focusedUntil?: number | null
+  generationContexts?: Record<string, GenerativeUiGenerationContext>
   autoFocusLatest?: boolean
   embedded?: boolean
 }>(), {
@@ -64,6 +66,7 @@ const emit = defineEmits<{
   (event: 'renderer-error', payload: { node_id: string; message: string }): void
   (event: 'focus-node', payload: { node_id: string }): void
   (event: 'select-node', payload: { node_id: string }): void
+  (event: 'request-generation-history', payload: { node_id: string }): void
 }>()
 
 const root = ref<HTMLElement | null>(null)
@@ -298,11 +301,13 @@ defineExpose({ focus, focusNode })
         :lifecycle-motion="lifecycleMotionByNodeId[entry.node.id] || 'idle'"
         :motion-profile="entry.motionProfile.id"
         :attention-duration-ms="entry.motionProfile.attentionDurationMs"
+        :generation="generationContexts?.[entry.node.id]"
         @action="emit('action', $event)"
         @action-status="emit('action-status', $event)"
         @open-preview="emit('open-preview', $event)"
         @renderer-error="emit('renderer-error', $event)"
         @select="emit('select-node', $event)"
+        @request-generation-history="emit('request-generation-history', $event)"
       />
     </TransitionGroup>
   </section>

--- a/agent-ui/src/generative-ui/dag-task-canvas.ts
+++ b/agent-ui/src/generative-ui/dag-task-canvas.ts
@@ -93,7 +93,91 @@ export function dagTaskCanvasSnapshotVersion(snapshot: DagLiveSurfaceSnapshot): 
       projection.visibility_state,
       projection.focused_until ?? '',
     ].join(':')),
+    ...(snapshot.surface_states ?? []).map(state => [
+      state.actor_id,
+      state.surface_id,
+      state.superseded_count,
+      state.latest_intervention?.operation ?? '',
+      state.latest_intervention?.status ?? '',
+      state.latest_intervention?.created_at ?? '',
+    ].join(':')),
   ].join('|')
+}
+
+function projectionVersion(projection: DagLiveSurfaceSnapshot['projections'][number]): string {
+  return [
+    projection.run_id,
+    projection.actor_id,
+    projection.node_id,
+    projection.surface_id,
+    projection.document_id,
+    projection.generation,
+    projection.last_activity_sequence,
+    projection.journal_cursor,
+    projection.surface_revision,
+    projection.activity_state,
+    projection.visibility_state,
+    projection.last_event_id ?? '',
+    projection.focused_until ?? '',
+    projection.created_at,
+    projection.updated_at,
+  ].join(':')
+}
+
+function surfaceStateVersion(state: NonNullable<DagLiveSurfaceSnapshot['surface_states']>[number]): string {
+  return [
+    state.actor_id,
+    state.surface_id,
+    state.generation_state,
+    state.superseded_count,
+    state.latest_intervention?.intervention_id ?? '',
+    state.latest_intervention?.operation ?? '',
+    state.latest_intervention?.status ?? '',
+    state.latest_intervention?.created_at ?? '',
+  ].join(':')
+}
+
+/** Keep unaffected cards referentially stable while one Actor changes generation. */
+export function reconcileDagTaskCanvasSnapshot(
+  previous: DagLiveSurfaceSnapshot | null,
+  next: DagLiveSurfaceSnapshot,
+): DagLiveSurfaceSnapshot {
+  if (!previous || previous.run_id !== next.run_id) return next
+
+  const previousProjections = new Map(previous.projections.map(item => [item.actor_id, item]))
+  const projections = next.projections.map((item) => {
+    const prior = previousProjections.get(item.actor_id)
+    return prior && projectionVersion(prior) === projectionVersion(item) ? prior : item
+  })
+
+  const previousStates = new Map((previous.surface_states ?? []).map(item => [item.actor_id, item]))
+  const surfaceStates = (next.surface_states ?? []).map((item) => {
+    const prior = previousStates.get(item.actor_id)
+    return prior && surfaceStateVersion(prior) === surfaceStateVersion(item) ? prior : item
+  })
+
+  let document = next.document
+  if (
+    previous.document
+    && document
+    && previous.document.document_id === document.document_id
+  ) {
+    const previousNodes = new Map(previous.document.nodes.map(node => [node.id, node]))
+    document = {
+      ...document,
+      nodes: document.nodes.map((node) => {
+        const prior = previousNodes.get(node.id)
+        return prior && prior.revision === node.revision ? prior : node
+      }),
+    }
+  }
+
+  return {
+    ...next,
+    projections,
+    surface_states: surfaceStates,
+    document,
+  }
 }
 
 export function dagTaskCanvasSelectionStorageKey(runId: string): string {

--- a/agent-ui/src/generative-ui/generation-history.ts
+++ b/agent-ui/src/generative-ui/generation-history.ts
@@ -1,0 +1,22 @@
+import type { GenerativeUiStoredNodeV1 } from 'homerail-protocol'
+
+export interface GenerativeUiInterventionSummary {
+  operation: 'interrupt' | 'cancel' | 'retry' | 'reassign' | 'checkpoint_fork'
+  status: 'queued' | 'applying' | 'applied' | 'failed'
+  created_at: number
+}
+
+export interface GenerativeUiGenerationHistoryEntry {
+  key: string
+  node: GenerativeUiStoredNodeV1
+  created_at: number
+}
+
+export interface GenerativeUiGenerationContext {
+  superseded_count: number
+  latest_intervention?: GenerativeUiInterventionSummary
+  history: GenerativeUiGenerationHistoryEntry[]
+  history_loading: boolean
+  history_loaded: boolean
+  history_error?: string
+}

--- a/agent-ui/src/locales/en-US/voice.json
+++ b/agent-ui/src/locales/en-US/voice.json
@@ -307,6 +307,29 @@
     "collapse": "Exit expanded view",
     "minimize": "Collapse content",
     "restore": "Restore content",
+    "generations": {
+      "current": "Current",
+      "superseded": "Superseded",
+      "supersededCount": "Superseded {count}",
+      "supersededItem": "Superseded {index}",
+      "history": "Content history",
+      "readOnly": "Historical content is read-only",
+      "loading": "Loading history…",
+      "retry": "Retry history",
+      "operations": {
+        "interrupt": "Interrupt",
+        "cancel": "Cancel",
+        "retry": "Retry",
+        "reassign": "Reassign",
+        "checkpoint_fork": "Resume checkpoint"
+      },
+      "statuses": {
+        "queued": "Queued",
+        "applying": "Applying",
+        "applied": "Applied",
+        "failed": "Failed"
+      }
+    },
     "actions": {
       "submitting": "Submitting action…",
       "statusUnknown": "Action status needs refresh",

--- a/agent-ui/src/locales/zh-Hans/voice.json
+++ b/agent-ui/src/locales/zh-Hans/voice.json
@@ -307,6 +307,29 @@
     "collapse": "退出放大",
     "minimize": "收起内容",
     "restore": "恢复内容",
+    "generations": {
+      "current": "当前",
+      "superseded": "已替代",
+      "supersededCount": "已替代 {count}",
+      "supersededItem": "已替代 {index}",
+      "history": "内容历史",
+      "readOnly": "历史内容只读",
+      "loading": "正在读取历史…",
+      "retry": "重试读取",
+      "operations": {
+        "interrupt": "中断",
+        "cancel": "取消",
+        "retry": "重试",
+        "reassign": "改派",
+        "checkpoint_fork": "从检查点继续"
+      },
+      "statuses": {
+        "queued": "已排队",
+        "applying": "处理中",
+        "applied": "已完成",
+        "failed": "失败"
+      }
+    },
     "actions": {
       "submitting": "正在提交操作…",
       "statusUnknown": "操作状态需要刷新",

--- a/agent-ui/src/locales/zh-Hant/voice.json
+++ b/agent-ui/src/locales/zh-Hant/voice.json
@@ -307,6 +307,29 @@
     "collapse": "退出放大",
     "minimize": "收起內容",
     "restore": "恢復內容",
+    "generations": {
+      "current": "目前",
+      "superseded": "已替代",
+      "supersededCount": "已替代 {count}",
+      "supersededItem": "已替代 {index}",
+      "history": "內容歷史",
+      "readOnly": "歷史內容唯讀",
+      "loading": "正在讀取歷史…",
+      "retry": "重試讀取",
+      "operations": {
+        "interrupt": "中斷",
+        "cancel": "取消",
+        "retry": "重試",
+        "reassign": "改派",
+        "checkpoint_fork": "從檢查點繼續"
+      },
+      "statuses": {
+        "queued": "已排隊",
+        "applying": "處理中",
+        "applied": "已完成",
+        "failed": "失敗"
+      }
+    },
     "actions": {
       "submitting": "正在提交操作…",
       "statusUnknown": "操作狀態需要刷新",

--- a/docs/architecture/durable-dag-actors.md
+++ b/docs/architecture/durable-dag-actors.md
@@ -87,7 +87,33 @@ A Worker may claim a pending command directly after reconnect, so an unavailable
 5. allow only the claiming generation to acknowledge or fail the command;
 6. redact and size-bound model profiles, command payloads, and failure details before storage.
 
-The TypeScript runtime API exposes registration, binding CAS, generation advancement, command creation/listing/delivery/claim/ack/fail, and bounded reads. Manager LLM tools, long-lived waiting runs, Worker release, and A2UI writes remain follow-up responsibilities.
+The TypeScript runtime API exposes registration, binding CAS, generation advancement, command creation/listing/delivery/claim/ack/fail, and bounded reads.
+
+## Branch-local Intervention
+
+`dag_actor_interventions` is a second durable Inbox for operator corrections. It is separate from activity history because a user command is intent, not evidence that work happened. `intervene_dag_actor` and the matching HTTP endpoint accept only stable `run_id` and `actor_id` identities plus an actor state token. Physical Worker, node, container, lease, and socket identifiers never enter the public contract.
+
+Five operations share one generation transition:
+
+| Operation | Runtime effect |
+| --- | --- |
+| `retry` | Capture the current portable checkpoint, stop the old attempt, and make the same actor branch ready with a new generation. |
+| `reassign` | Apply `retry` semantics while excluding the previous physical execution target from the immediate redispatch. |
+| `checkpoint_fork` | Start the new generation from an explicitly selected immutable checkpoint version. |
+| `interrupt` | Stop the current branch attempt while retaining its checkpoint and projected evidence for a later decision. |
+| `cancel` | Cancel the branch and retire its lease so it cannot be dispatched again accidentally. |
+
+The write path enforces this order:
+
+1. verify the actor state token and idempotency key;
+2. commit a `queued` intervention row before changing runtime state;
+3. transition the row to `applying` and atomically capture/select the checkpoint, release the old lease, advance actor generation, reset only the affected branch, supersede its projected Surface, and mark the intervention `applied`;
+4. reject old-generation activity and handoffs through the existing generation and lease fences;
+5. redispatch only a branch that remains runnable.
+
+An exact idempotent retry returns the original result even when the caller still holds the old state token. Reusing the identity for different content or submitting a new command with a stale token returns a conflict. Startup recovery protects Actors with `queued` or `applying` interventions from ordinary orphaned-node demotion, then replays their Inbox after logical runs have been restored.
+
+`dag_surface_generation_snapshots` stores the previous A2UI node as append-only audit evidence. The current generation keeps the same stable `surface_id`, receives a new revision, focuses briefly, and starts with fresh findings. Other Actors and their node revisions do not change. The UI fetches historical generations only when a card is expanded and renders them read-only.
 
 ## Follow-up Boundaries
 

--- a/homerail_manager/src/events/bus.ts
+++ b/homerail_manager/src/events/bus.ts
@@ -14,6 +14,7 @@ export type DAGEventType =
   | "dag:actor_lease_acquired"
   | "dag:actor_lease_released"
   | "dag:actor_checkpoint_saved"
+  | "dag:actor_intervention_applied"
   | "dag:gateway_executed"
   | "dag:worker_manager_command_requested"
   | "dag:manager_command_received"
@@ -86,6 +87,7 @@ export const DAG_EVENT_TYPES: DAGEventType[] = [
   "dag:actor_lease_acquired",
   "dag:actor_lease_released",
   "dag:actor_checkpoint_saved",
+  "dag:actor_intervention_applied",
   "dag:gateway_executed",
   "dag:worker_manager_command_requested",
   "dag:manager_command_received",

--- a/homerail_manager/src/generative-ui/dag-live-surface-projector.ts
+++ b/homerail_manager/src/generative-ui/dag-live-surface-projector.ts
@@ -19,6 +19,13 @@ import {
 } from "homerail-protocol";
 import type { DagActivityJournalEntry } from "../persistence/dag-activity-journal.js";
 import {
+  createDagSurfaceGenerationSnapshot,
+  getDagActorIntervention,
+  listDagSurfaceGenerationSnapshots,
+  type DagActorInterventionOperation,
+  type DagSurfaceGenerationSnapshotRecord,
+} from "../persistence/dag-actor-interventions.js";
+import {
   getDagActor,
   type DagActorRecord,
 } from "../persistence/dag-actors.js";
@@ -35,6 +42,7 @@ const MAX_PROJECTED_STRING_BYTES = 1_024;
 const MAX_PROJECTED_FINDINGS = 8;
 const MAX_PROJECTED_CONTENT_BYTES = 32 * 1024;
 const MAX_FOCUS_UNTIL = 8_640_000_000_000_000;
+const INTERVENTION_FOCUS_DURATION_MS = 15_000;
 
 export type DagLiveSurfaceActivityState = Exclude<DagActivityType, "tool_used">;
 export type DagLiveSurfaceVisibilityState = "visible" | "focused" | "removed";
@@ -99,6 +107,17 @@ export interface DagLiveSurfaceControlRecord {
   committed_surface_revision: number;
   focused_until?: number;
   created_at: number;
+}
+
+export interface DagLiveSurfaceSupersessionResult {
+  projection: DagLiveSurfaceProjectionRecord;
+  intervention_id: string;
+  operation: DagActorInterventionOperation;
+  from_generation: number;
+  to_generation: number;
+  transaction_id: string;
+  snapshot?: DagSurfaceGenerationSnapshotRecord;
+  deduplicated: boolean;
 }
 
 export interface DagLiveSurfaceRecoveryResult {
@@ -218,6 +237,15 @@ interface ProjectedData {
     surface_revision: number;
     focused_until?: number;
   };
+  intervention?: {
+    intervention_id: string;
+    operation: DagActorInterventionOperation;
+    generation_state: "current";
+    supersedes_generation: number;
+    generation: number;
+    summary: string;
+    created_at: number;
+  };
   findings: ProjectedFinding[];
 }
 
@@ -329,7 +357,7 @@ function digest(value: unknown): string {
   return createHash("sha256").update(JSON.stringify(canonicalize(value))).digest("hex");
 }
 
-function transactionId(kind: "activity" | "control", id: string): string {
+function transactionId(kind: "activity" | "control" | "intervention", id: string): string {
   return `dag-live-surface-${kind}-${createHash("sha256").update(id).digest("hex")}`;
 }
 
@@ -722,6 +750,9 @@ function buildProjectedNode(input: {
         ? { focused_until: input.projection.focused_until }
         : {}),
     },
+    ...(previous?.intervention?.generation === input.event.generation
+      ? { intervention: previous.intervention }
+      : {}),
     findings: boundedFindings,
   };
   const content = { data };
@@ -1022,6 +1053,456 @@ export function getDagLiveSurfaceDocument(runId: string): GenerativeUiDocumentV1
   return projection
     ? persistentGenerativeUiDocumentService.get(projection.document_id, scopeFor(normalizedRunId))
     : undefined;
+}
+
+function interventionPresentation(operation: DagActorInterventionOperation): {
+  activity: DagLiveSurfaceActivityState;
+  label: string;
+  summary: string;
+  tone: ProjectedData["state"]["tone"];
+  phase: GenerativeUiPhase;
+} {
+  switch (operation) {
+    case "retry":
+      return {
+        activity: "started",
+        label: "Retrying",
+        summary: "Retry requested. Continuing with a new attempt.",
+        tone: "info",
+        phase: GenerativeUiPhase.RUNNING,
+      };
+    case "reassign":
+      return {
+        activity: "started",
+        label: "Reassigned",
+        summary: "Reassigned. Continuing with a new attempt.",
+        tone: "info",
+        phase: GenerativeUiPhase.RUNNING,
+      };
+    case "checkpoint_fork":
+      return {
+        activity: "started",
+        label: "Resuming",
+        summary: "Resuming from the selected checkpoint.",
+        tone: "info",
+        phase: GenerativeUiPhase.RUNNING,
+      };
+    case "interrupt":
+      return {
+        activity: "blocked",
+        label: "Interrupted",
+        summary: "Interrupted. Waiting for further direction.",
+        tone: "warning",
+        phase: GenerativeUiPhase.WAITING,
+      };
+    case "cancel":
+      return {
+        activity: "blocked",
+        label: "Cancelled",
+        summary: "Cancelled. Work is stopped.",
+        tone: "warning",
+        phase: GenerativeUiPhase.CANCELLED,
+      };
+  }
+}
+
+function interventionSummary(instruction: string | undefined, fallback: string): string {
+  if (instruction === undefined) return fallback;
+  const redacted = redactTelemetry(instruction);
+  return boundedString(redacted) ?? fallback;
+}
+
+function isMatchingInterventionNode(input: {
+  node: GenerativeUiStoredNodeV1;
+  projection: DagLiveSurfaceProjectionRecord;
+  intervention_id: string;
+  operation: DagActorInterventionOperation;
+  from_generation: number;
+  to_generation: number;
+}): boolean {
+  assertOwnedNode(input.node, input.projection);
+  const data = projectedDataFromNode(input.node);
+  return data?.actor.generation === input.to_generation
+    && data.state.surface_revision === input.projection.surface_revision
+    && data.intervention?.intervention_id === input.intervention_id
+    && data.intervention.operation === input.operation
+    && data.intervention.generation_state === "current"
+    && data.intervention.supersedes_generation === input.from_generation
+    && data.intervention.generation === input.to_generation;
+}
+
+function buildInterventionNode(input: {
+  actor: DagActorRecord;
+  projection: DagLiveSurfaceProjectionRecord;
+  existing?: GenerativeUiStoredNodeV1;
+  intervention_id: string;
+  operation: DagActorInterventionOperation;
+  from_generation: number;
+  summary: string;
+  created_at: number;
+  focused_until: number;
+}): { node: GenerativeUiNodeV1; activity: DagLiveSurfaceActivityState } {
+  if (input.existing) assertOwnedNode(input.existing, input.projection);
+  const previous = projectedDataFromNode(input.existing);
+  const presentation = interventionPresentation(input.operation);
+  const surfaceRevision = input.projection.surface_revision + 1;
+  const title = previous?.title ?? input.actor.role;
+  const data: ProjectedData = {
+    projector: { id: PROJECTOR_ID, version: PROJECTOR_DATA_VERSION },
+    actor: {
+      id: input.actor.actor_id,
+      role: input.actor.role,
+      node_id: input.actor.node_id,
+      generation: input.actor.generation,
+    },
+    title,
+    state: {
+      activity: presentation.activity,
+      visibility: "focused",
+      label: presentation.label,
+      summary: input.summary,
+      tone: presentation.tone,
+      progress: presentation.phase === GenerativeUiPhase.RUNNING ? 0 : previous?.state.progress ?? 0,
+      event_id: input.intervention_id,
+      round_id: previous?.state.round_id ?? `intervention:${input.intervention_id}`,
+      sequence: 0,
+      updated_at: input.created_at,
+      surface_revision: surfaceRevision,
+      focused_until: input.focused_until,
+    },
+    intervention: {
+      intervention_id: input.intervention_id,
+      operation: input.operation,
+      generation_state: "current",
+      supersedes_generation: input.from_generation,
+      generation: input.actor.generation,
+      summary: input.summary,
+      created_at: input.created_at,
+    },
+    findings: [],
+  };
+  const content = { data };
+  if (Buffer.byteLength(JSON.stringify(content), "utf8") > MAX_PROJECTED_CONTENT_BYTES) {
+    throw new DagLiveSurfaceProjectionError("a2ui_rejected", "Intervention DAG live surface content exceeds its budget");
+  }
+
+  return {
+    activity: presentation.activity,
+    node: {
+      ir_version: GENERATIVE_UI_IR_VERSION,
+      id: input.projection.surface_id,
+      kind: GENERATED_VIEW_KIND,
+      kind_version: GENERATED_VIEW_KIND_VERSION,
+      owner: input.existing?.owner ?? { id: CORE_PLUGIN_ID, version: activeCoreVersion() },
+      surface: GenerativeUiSurface.EXECUTION,
+      importance: GenerativeUiImportance.CRITICAL,
+      status: {
+        phase: presentation.phase,
+        label: presentation.label,
+        progress: data.state.progress,
+      },
+      content,
+      a2ui: structuredClone(LIVE_SURFACE_A2UI),
+      presentation: { density: "summary" },
+      lifecycle: { persistence: "session", removable: true },
+      fallback: { title, summary: input.summary },
+      provenance: {
+        actor: "agent",
+        actor_id: input.actor.actor_id,
+        run_id: input.actor.run_id,
+      },
+    },
+  };
+}
+
+/**
+ * Move one stable Actor surface from generation N to N+1 after the durable
+ * Actor row has already advanced. The old stored node is snapshotted before
+ * the fixed-id A2UI node is patched, and both writes share one DB transaction.
+ */
+export function supersedeDagLiveSurfaceForIntervention(input: {
+  run_id: string;
+  actor_id: string;
+  intervention_id: string;
+  operation?: DagActorInterventionOperation;
+  instruction?: string;
+  from_generation?: number;
+  to_generation?: number;
+  created_at?: number;
+}): DagLiveSurfaceSupersessionResult {
+  const normalized = {
+    run_id: assertIdentifier(input.run_id, "run_id"),
+    actor_id: assertIdentifier(input.actor_id, "actor_id"),
+    intervention_id: assertIdentifier(input.intervention_id, "intervention_id"),
+    ...(input.operation === undefined ? {} : { operation: input.operation }),
+    ...(input.instruction === undefined ? {} : { instruction: input.instruction.replace(/\s+/g, " ").trim() }),
+    ...(input.from_generation === undefined
+      ? {}
+      : { from_generation: assertNonNegativeSafeInteger(input.from_generation, "from_generation") }),
+    ...(input.to_generation === undefined
+      ? {}
+      : { to_generation: assertNonNegativeSafeInteger(input.to_generation, "to_generation") }),
+    created_at: input.created_at === undefined
+      ? Date.now()
+      : assertNonNegativeSafeInteger(input.created_at, "created_at"),
+  };
+  if (normalized.created_at > MAX_FOCUS_UNTIL) {
+    throw new Error("created_at is outside the supported timestamp range");
+  }
+
+  return getDb().transaction((): DagLiveSurfaceSupersessionResult => {
+    const intervention = getDagActorIntervention(normalized.intervention_id);
+    if (!intervention) throw new Error(`Unknown DAG actor intervention: ${normalized.intervention_id}`);
+    if (intervention.run_id !== normalized.run_id || intervention.actor_id !== normalized.actor_id) {
+      throw new DagLiveSurfaceProjectionError(
+        "identity_mismatch",
+        `DAG actor intervention ${normalized.intervention_id} belongs to a different Actor`,
+      );
+    }
+    if (normalized.operation !== undefined && normalized.operation !== intervention.operation) {
+      throw new DagLiveSurfaceProjectionError(
+        "identity_mismatch",
+        `DAG actor intervention ${normalized.intervention_id} operation does not match durable state`,
+      );
+    }
+    if (
+      intervention.instruction !== undefined
+      && normalized.instruction !== undefined
+      && normalized.instruction !== intervention.instruction
+    ) {
+      throw new DagLiveSurfaceProjectionError(
+        "identity_mismatch",
+        `DAG actor intervention ${normalized.intervention_id} instruction does not match durable state`,
+      );
+    }
+    if (intervention.status !== "applying" && intervention.status !== "applied") {
+      throw new DagLiveSurfaceProjectionError(
+        "projection_state_conflict",
+        `DAG actor intervention ${normalized.intervention_id} is ${intervention.status}, not applying`,
+      );
+    }
+    const fromGeneration = intervention.from_generation;
+    if (fromGeneration === undefined || intervention.expected_actor_generation !== fromGeneration) {
+      throw new DagLiveSurfaceProjectionError(
+        "generation_conflict",
+        `DAG actor intervention ${normalized.intervention_id} has no valid source generation`,
+      );
+    }
+    const toGeneration = fromGeneration + 1;
+    if (
+      (normalized.from_generation !== undefined && normalized.from_generation !== fromGeneration)
+      || (normalized.to_generation !== undefined && normalized.to_generation !== toGeneration)
+    ) {
+      throw new DagLiveSurfaceProjectionError(
+        "generation_conflict",
+        `DAG actor intervention ${normalized.intervention_id} generation does not match durable state`,
+      );
+    }
+    if (intervention.to_generation !== undefined && intervention.to_generation !== toGeneration) {
+      throw new DagLiveSurfaceProjectionError(
+        "generation_conflict",
+        `DAG actor intervention ${normalized.intervention_id} completed at a different generation`,
+      );
+    }
+    const actor = getDagActor(normalized.run_id, normalized.actor_id);
+    if (!actor) throw new Error(`Unknown DAG actor: ${normalized.run_id}/${normalized.actor_id}`);
+    if (actor.generation !== toGeneration) {
+      throw new DagLiveSurfaceProjectionError(
+        "generation_conflict",
+        `DAG actor ${normalized.run_id}/${normalized.actor_id} generation is ${actor.generation}, expected ${toGeneration}`,
+      );
+    }
+
+    let projection = getProjectionRow(normalized.run_id, normalized.actor_id)
+      ? requireProjection(normalized.run_id, normalized.actor_id)
+      : ensureProjection(actor, normalized.created_at);
+    if (
+      projection.node_id !== actor.node_id
+      || projection.surface_id !== actor.surface_id
+    ) {
+      throw new DagLiveSurfaceProjectionError(
+        "identity_mismatch",
+        "DAG live surface no longer matches its logical Actor",
+      );
+    }
+    if (projection.generation !== fromGeneration && projection.generation !== toGeneration) {
+      throw new DagLiveSurfaceProjectionError(
+        "generation_conflict",
+        `DAG live surface generation is ${projection.generation}, expected ${fromGeneration} or ${toGeneration}`,
+      );
+    }
+
+    const scope = scopeFor(normalized.run_id);
+    const document = persistentGenerativeUiDocumentService.get(projection.document_id, scope);
+    if (!document) throw new Error(`A2UI document not found: ${projection.document_id}`);
+    const existing = document.nodes.find((candidate) => candidate.id === projection.surface_id);
+    const txId = transactionId("intervention", normalized.intervention_id);
+    if (
+      projection.generation === toGeneration
+      && existing
+      && isMatchingInterventionNode({
+        node: existing,
+        projection,
+        intervention_id: normalized.intervention_id,
+        operation: intervention.operation,
+        from_generation: fromGeneration,
+        to_generation: toGeneration,
+      })
+    ) {
+      const snapshot = listDagSurfaceGenerationSnapshots({
+        run_id: normalized.run_id,
+        actor_id: normalized.actor_id,
+        limit: 1,
+      }).find((candidate) => (
+        candidate.generation === fromGeneration
+        && candidate.intervention_id === normalized.intervention_id
+      ));
+      return {
+        projection,
+        intervention_id: normalized.intervention_id,
+        operation: intervention.operation,
+        from_generation: fromGeneration,
+        to_generation: toGeneration,
+        transaction_id: txId,
+        ...(snapshot ? { snapshot } : {}),
+        deduplicated: true,
+      };
+    }
+
+    let snapshot: DagSurfaceGenerationSnapshotRecord | undefined;
+    if (existing) {
+      assertOwnedNode(existing, projection);
+      const previous = projectedDataFromNode(existing)!;
+      if (previous.actor.generation !== fromGeneration) {
+        throw new DagLiveSurfaceProjectionError(
+          "generation_conflict",
+          `A2UI surface generation is ${previous.actor.generation}, expected ${fromGeneration}`,
+        );
+      }
+      snapshot = createDagSurfaceGenerationSnapshot({
+        run_id: actor.run_id,
+        actor_id: actor.actor_id,
+        generation: fromGeneration,
+        node_id: actor.node_id,
+        surface_id: actor.surface_id,
+        document_id: projection.document_id,
+        node_revision: existing.revision,
+        document_revision: document.revision,
+        surface_revision: projection.surface_revision,
+        activity_state: projection.activity_state,
+        visibility_state: projection.visibility_state,
+        ...(projection.last_event_id === undefined ? {} : { last_event_id: projection.last_event_id }),
+        node_snapshot: existing,
+        superseded_by_generation: toGeneration,
+        intervention_id: normalized.intervention_id,
+        created_at: normalized.created_at,
+      }).snapshot;
+    }
+
+    projection = advanceProjectionGeneration(projection, actor, normalized.created_at);
+    const focusedUntil = Math.min(MAX_FOCUS_UNTIL, normalized.created_at + INTERVENTION_FOCUS_DURATION_MS);
+    const presentation = interventionPresentation(intervention.operation);
+    const summary = interventionSummary(
+      normalized.instruction ?? intervention.instruction,
+      presentation.summary,
+    );
+    const projected = buildInterventionNode({
+      actor,
+      projection,
+      ...(existing ? { existing } : {}),
+      intervention_id: normalized.intervention_id,
+      operation: intervention.operation,
+      from_generation: fromGeneration,
+      summary,
+      created_at: normalized.created_at,
+      focused_until: focusedUntil,
+    });
+    const operation = existing
+      ? {
+          op: "patch" as const,
+          node_id: existing.id,
+          if_revision: existing.revision,
+          changes: {
+            surface: projected.node.surface,
+            importance: projected.node.importance,
+            status: projected.node.status,
+            content: projected.node.content,
+            a2ui: projected.node.a2ui,
+            presentation: projected.node.presentation,
+            lifecycle: projected.node.lifecycle,
+            fallback: projected.node.fallback,
+            provenance: projected.node.provenance,
+          },
+        }
+      : { op: "put" as const, node: projected.node };
+    const result = persistentGenerativeUiDocumentService.apply({
+      ir_version: GENERATIVE_UI_IR_VERSION,
+      transaction_id: txId,
+      document_id: document.document_id,
+      base_revision: document.revision,
+      actor: { type: GenerativeUiActorType.SYSTEM, id: PROJECTOR_ID },
+      operations: [operation],
+      created_at: new Date(normalized.created_at).toISOString(),
+    }, scope);
+    if (result.status === "conflict") {
+      throw new DagLiveSurfaceProjectionError(
+        "a2ui_revision_conflict",
+        `A2UI surface changed before intervention ${normalized.intervention_id} could commit`,
+      );
+    }
+    if (result.status !== "applied") {
+      throw new DagLiveSurfaceProjectionError(
+        "a2ui_rejected",
+        `A2UI intervention transaction ${txId} was ${result.status}: ${JSON.stringify(result.errors ?? [])}`,
+      );
+    }
+
+    const nextSurfaceRevision = projection.surface_revision + 1;
+    const updated = getDb().prepare(`
+      UPDATE dag_surface_projections
+      SET generation = ?, last_activity_sequence = 0, surface_revision = ?,
+          activity_state = ?, visibility_state = 'focused', last_event_id = ?,
+          focused_until = ?, updated_at = MAX(updated_at, ?)
+      WHERE run_id = ? AND actor_id = ? AND generation = ? AND surface_revision = ?
+    `).run(
+      toGeneration,
+      nextSurfaceRevision,
+      projected.activity,
+      normalized.intervention_id,
+      focusedUntil,
+      normalized.created_at,
+      normalized.run_id,
+      normalized.actor_id,
+      projection.generation,
+      projection.surface_revision,
+    );
+    if (updated.changes !== 1) {
+      throw new DagLiveSurfaceProjectionError(
+        "surface_revision_conflict",
+        "DAG live surface changed before intervention bookkeeping",
+      );
+    }
+
+    return {
+      projection: requireProjection(normalized.run_id, normalized.actor_id),
+      intervention_id: normalized.intervention_id,
+      operation: intervention.operation,
+      from_generation: fromGeneration,
+      to_generation: toGeneration,
+      transaction_id: txId,
+      ...(snapshot ? { snapshot } : {}),
+      deduplicated: false,
+    };
+  }).immediate();
+}
+
+/** Full append-only Actor generation history for trusted Manager-side consumers. */
+export function listDagLiveSurfaceGenerationHistory(input: {
+  run_id: string;
+  actor_id: string;
+  limit?: number;
+}): DagSurfaceGenerationSnapshotRecord[] {
+  return listDagSurfaceGenerationSnapshots(input);
 }
 
 function controlDigest(input: {

--- a/homerail_manager/src/index.ts
+++ b/homerail_manager/src/index.ts
@@ -1,7 +1,7 @@
 import { createServer } from "./server/http.js";
 import { getHost, getPort } from "./config/env.js";
 import { initEventLogging } from "./persistence/store.js";
-import { recoverAllActiveRuns } from "./runtime/active-runs.js";
+import { recoverAllActiveRuns, recoverDagActorInterventions } from "./runtime/active-runs.js";
 import { recoverStaleVoiceSessions } from "./server/voice-session-registry.js";
 import { markRecoveryComplete } from "./health/index.js";
 import { cleanupPluginPackageStaging, recoverPluginPackageTrash } from "./plugins/package-lifecycle.js";
@@ -18,6 +18,9 @@ const server = createServer(port);
 // the server accepts traffic. The first-worker hook (wired in createServer)
 // re-dispatches their READY nodes once a worker reconnects.
 const recovery = recoverAllActiveRuns();
+// Intervention Inbox rows are replayed only after their logical runs and
+// Actors exist again. Applying is transactionally idempotent.
+const interventionRecovery = recoverDagActorInterventions();
 // Logical actors are restored before Activity Journal replay. The projector
 // can therefore re-establish exact ownership and drain any crash-pending gaps.
 const surfaceRecovery = recoverDagLiveSurfaceProjections();
@@ -35,6 +38,11 @@ server.listen(port, host, () => {
   console.error(
     `live surface recovery: projected=${surfaceRecovery.projected_events} failed=${surfaceRecovery.failed.length}`,
   );
+  if (interventionRecovery.applied.length || interventionRecovery.failed.length || interventionRecovery.skipped.length) {
+    console.error(
+      `actor intervention recovery: applied=${interventionRecovery.applied.length} failed=${interventionRecovery.failed.length} skipped=${interventionRecovery.skipped.length}`,
+    );
+  }
   if (voiceRecovery.recovered.length) {
     console.error(`voice recovery: reset ${voiceRecovery.recovered.length} stale session(s)`);
   }

--- a/homerail_manager/src/orchestration/change-orchestrator.ts
+++ b/homerail_manager/src/orchestration/change-orchestrator.ts
@@ -22,7 +22,10 @@ import {
   deduplicateWaitingActiveRunResume,
   decideActiveRunApproval,
   injectActiveRun,
+  interveneActiveRunActor,
   resumeWaitingActiveRun,
+  type InterveneDagActorRequest,
+  type InterveneDagActorResult,
   type ResumeWaitingRunRequest,
 } from "../runtime/active-runs.js";
 import type { DagApprovalRecord } from "../persistence/dag-runtime-primitives.js";
@@ -75,6 +78,10 @@ export interface InjectRunResponse {
   delivery_target_type?: "worker" | "node";
   delivery_target_id?: string;
   delivery_gap?: string;
+}
+
+export interface InterveneActorResponse extends InterveneDagActorResult {
+  redispatched: boolean;
 }
 
 export interface ResumeRunResponse {
@@ -447,6 +454,14 @@ export class ChangeOrchestrator {
       delivery_target_type: result.deliveryTargetType,
       delivery_target_id: result.deliveryTargetId,
       delivery_gap: result.deliveryGap,
+    };
+  }
+
+  interveneActor(runId: string, request: InterveneDagActorRequest): InterveneActorResponse {
+    const result = interveneActiveRunActor(runId, request);
+    return {
+      ...result,
+      redispatched: this.graphExecutor.tick(runId) > 0,
     };
   }
 

--- a/homerail_manager/src/orchestration/dispatch-tracker.ts
+++ b/homerail_manager/src/orchestration/dispatch-tracker.ts
@@ -1,3 +1,5 @@
+import { clearDagActorDispatchExclusion } from "../persistence/dag-actor-interventions.js";
+
 export type DispatchState = "provisioning" | "dispatched" | "failed";
 
 export interface DispatchTarget {
@@ -27,6 +29,7 @@ export function recordDispatch(
     dispatchedAt: Date.now(),
   });
   exclusions.delete(key(runId, nodeId));
+  clearDagActorDispatchExclusion({ run_id: runId, node_id: nodeId });
 }
 
 export function recordProvisioning(runId: string, nodeId: string): void {
@@ -62,6 +65,15 @@ export function findDispatchExclusion(
   return exclusions.get(key(runId, nodeId));
 }
 
+export function restoreDispatchExclusion(
+  runId: string,
+  nodeId: string,
+  targetType: "worker" | "node",
+  targetId: string,
+): void {
+  exclusions.set(key(runId, nodeId), { targetType, targetId });
+}
+
 /** Fence the current physical target for the next dispatch without exposing it to callers. */
 export function excludeCurrentDispatchTarget(
   runId: string,
@@ -92,6 +104,7 @@ export function isCurrentDispatchTarget(
 export function clearDispatchTarget(runId: string, nodeId: string): void {
   dispatches.delete(key(runId, nodeId));
   exclusions.delete(key(runId, nodeId));
+  clearDagActorDispatchExclusion({ run_id: runId, node_id: nodeId });
 }
 
 export function clearByTargetId(targetId: string): void {
@@ -99,9 +112,6 @@ export function clearByTargetId(targetId: string): void {
     if (target.targetId && target.targetId === targetId) {
       dispatches.delete(k);
     }
-  }
-  for (const [k, target] of exclusions.entries()) {
-    if (target.targetId === targetId) exclusions.delete(k);
   }
 }
 

--- a/homerail_manager/src/orchestration/dispatch-tracker.ts
+++ b/homerail_manager/src/orchestration/dispatch-tracker.ts
@@ -8,6 +8,7 @@ export interface DispatchTarget {
 }
 
 const dispatches = new Map<string, DispatchTarget>();
+const exclusions = new Map<string, { targetType: "worker" | "node"; targetId: string }>();
 
 function key(runId: string, nodeId: string): string {
   return `${runId}:${nodeId}`;
@@ -25,6 +26,7 @@ export function recordDispatch(
     targetId,
     dispatchedAt: Date.now(),
   });
+  exclusions.delete(key(runId, nodeId));
 }
 
 export function recordProvisioning(runId: string, nodeId: string): void {
@@ -53,6 +55,27 @@ export function findDispatchTarget(
   return dispatches.get(key(runId, nodeId));
 }
 
+export function findDispatchExclusion(
+  runId: string,
+  nodeId: string,
+): { targetType: "worker" | "node"; targetId: string } | undefined {
+  return exclusions.get(key(runId, nodeId));
+}
+
+/** Fence the current physical target for the next dispatch without exposing it to callers. */
+export function excludeCurrentDispatchTarget(
+  runId: string,
+  nodeId: string,
+): DispatchTarget | undefined {
+  const dispatchKey = key(runId, nodeId);
+  const current = dispatches.get(dispatchKey);
+  if (current?.state === "dispatched" && current.targetType && current.targetId) {
+    exclusions.set(dispatchKey, { targetType: current.targetType, targetId: current.targetId });
+  }
+  dispatches.delete(dispatchKey);
+  return current;
+}
+
 /** Bind an inbound transport message to the exact target selected at dispatch. */
 export function isCurrentDispatchTarget(
   runId: string,
@@ -68,6 +91,7 @@ export function isCurrentDispatchTarget(
 
 export function clearDispatchTarget(runId: string, nodeId: string): void {
   dispatches.delete(key(runId, nodeId));
+  exclusions.delete(key(runId, nodeId));
 }
 
 export function clearByTargetId(targetId: string): void {
@@ -76,8 +100,12 @@ export function clearByTargetId(targetId: string): void {
       dispatches.delete(k);
     }
   }
+  for (const [k, target] of exclusions.entries()) {
+    if (target.targetId === targetId) exclusions.delete(k);
+  }
 }
 
 export function _clearAllDispatches(): void {
   dispatches.clear();
+  exclusions.clear();
 }

--- a/homerail_manager/src/orchestration/ws-dispatch-adapter.ts
+++ b/homerail_manager/src/orchestration/ws-dispatch-adapter.ts
@@ -11,6 +11,7 @@ import { appendChatEntry } from "../persistence/store.js";
 import { appendSessionTranscriptEntry } from "../persistence/dag-session-files.js";
 import {
   findDispatchTarget,
+  findDispatchExclusion,
   clearDispatchTarget,
   recordDispatch,
   recordProvisioning,
@@ -308,8 +309,11 @@ export class WsDispatchAdapter implements DAGDispatcher {
       };
     }
 
-    const openWorkers = getAllWorkers().filter((candidate) => candidate.socket.readyState === WebSocket.OPEN);
-    const openNodes = getAllNodes().filter((candidate) => candidate.socket.readyState === WebSocket.OPEN);
+    const excluded = findDispatchExclusion(envelope.runId, envelope.nodeId);
+    const openNodes = getAllNodes().filter((candidate) =>
+      candidate.socket.readyState === WebSocket.OPEN
+      && !(excluded?.targetType === "node" && excluded.targetId === candidate.node_id)
+    );
     // Try to find a Docker-capable node for provisioning.
     if (this.provisionerOpts) {
       const dockerNode = openNodes.find(
@@ -360,10 +364,12 @@ export class WsDispatchAdapter implements DAGDispatcher {
   ):
     | { worker_id: string; socket: WebSocket }
     | undefined {
+    const excluded = findDispatchExclusion(envelope.runId, envelope.nodeId);
     const workers = getAllWorkers().filter(
       (w) =>
         w.socket.readyState === WebSocket.OPEN &&
-        hasCapabilities(w.capabilities, envelope.requiredCapabilities),
+        hasCapabilities(w.capabilities, envelope.requiredCapabilities) &&
+        !(excluded?.targetType === "worker" && excluded.targetId === w.worker_id),
     );
     if (workers.length === 0) return undefined;
 

--- a/homerail_manager/src/persistence/dag-actor-interventions.ts
+++ b/homerail_manager/src/persistence/dag-actor-interventions.ts
@@ -1,0 +1,594 @@
+import { createHash } from "node:crypto";
+import { redactTelemetry } from "homerail-protocol";
+import { getDagActor } from "./dag-actors.js";
+import { getDb, parseJsonRow } from "./db.js";
+
+export const DAG_ACTOR_INTERVENTION_OPERATIONS = [
+  "interrupt",
+  "cancel",
+  "retry",
+  "reassign",
+  "checkpoint_fork",
+] as const;
+export type DagActorInterventionOperation = typeof DAG_ACTOR_INTERVENTION_OPERATIONS[number];
+export type DagActorInterventionStatus = "queued" | "applying" | "applied" | "failed";
+
+export interface DagActorInterventionRecord {
+  intervention_id: string;
+  run_id: string;
+  actor_id: string;
+  operation: DagActorInterventionOperation;
+  status: DagActorInterventionStatus;
+  idempotency_key: string;
+  instruction?: string;
+  expected_actor_generation: number;
+  expected_actor_version: number;
+  checkpoint_version?: number;
+  from_generation?: number;
+  to_generation?: number;
+  resulting_actor_version?: number;
+  created_at: number;
+  started_at?: number;
+  completed_at?: number;
+  failure?: unknown;
+}
+
+export interface DagSurfaceGenerationSnapshotRecord {
+  run_id: string;
+  actor_id: string;
+  generation: number;
+  node_id: string;
+  surface_id: string;
+  document_id: string;
+  node_revision: number;
+  document_revision: number;
+  surface_revision: number;
+  activity_state: string;
+  visibility_state: string;
+  last_event_id?: string;
+  node_snapshot: unknown;
+  superseded_by_generation: number;
+  intervention_id: string;
+  created_at: number;
+}
+
+export class DagActorInterventionConflictError extends Error {
+  constructor(
+    public readonly code:
+      | "intervention_identity_conflict"
+      | "intervention_in_progress"
+      | "actor_generation_conflict"
+      | "actor_version_conflict"
+      | "intervention_status_conflict"
+      | "snapshot_identity_conflict",
+    message: string,
+  ) {
+    super(message);
+    this.name = "DagActorInterventionConflictError";
+  }
+}
+
+interface InterventionRow {
+  intervention_id: string;
+  run_id: string;
+  actor_id: string;
+  operation: DagActorInterventionOperation;
+  status: DagActorInterventionStatus;
+  idempotency_key: string;
+  payload_digest: string;
+  payload_json: string;
+  expected_actor_generation: number;
+  expected_actor_version: number;
+  checkpoint_version: number | null;
+  from_generation: number | null;
+  to_generation: number | null;
+  resulting_actor_version: number | null;
+  created_at: number;
+  started_at: number | null;
+  completed_at: number | null;
+  failure_json: string | null;
+}
+
+interface SnapshotRow {
+  run_id: string;
+  actor_id: string;
+  generation: number;
+  node_id: string;
+  surface_id: string;
+  document_id: string;
+  node_revision: number;
+  document_revision: number;
+  surface_revision: number;
+  activity_state: string;
+  visibility_state: string;
+  last_event_id: string | null;
+  node_snapshot_sha256: string;
+  node_snapshot_json: string;
+  superseded_by_generation: number;
+  intervention_id: string;
+  created_at: number;
+}
+
+function assertIdentifier(value: string, label: string, maxLength = 256): string {
+  const normalized = value.trim();
+  if (!normalized || normalized.length > maxLength || /[\u0000-\u001f\u007f]/.test(normalized)) {
+    throw new Error(`${label} must be between 1 and ${maxLength} printable characters`);
+  }
+  return normalized;
+}
+
+function assertPositiveInteger(value: number, label: string): number {
+  if (!Number.isSafeInteger(value) || value < 1) throw new Error(`${label} must be a positive safe integer`);
+  return value;
+}
+
+function assertTimestamp(value: number | undefined, label: string): number {
+  const normalized = value ?? Date.now();
+  if (!Number.isSafeInteger(normalized) || normalized < 0) {
+    throw new Error(`${label} must be a non-negative epoch millisecond integer`);
+  }
+  return normalized;
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object") {
+    const output: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      const nested = (value as Record<string, unknown>)[key];
+      if (nested !== undefined) output[key] = canonicalize(nested);
+    }
+    return output;
+  }
+  return value;
+}
+
+function encodeBounded(value: unknown, label: string, maxBytes: number): { json: string; digest: string } {
+  let redacted: unknown;
+  try {
+    redacted = canonicalize(redactTelemetry(value));
+  } catch {
+    throw new Error(`${label} must be JSON serializable`);
+  }
+  const json = JSON.stringify(redacted);
+  if (!json || Buffer.byteLength(json, "utf8") > maxBytes) {
+    throw new Error(`${label} exceeds ${maxBytes} bytes`);
+  }
+  return { json, digest: createHash("sha256").update(json).digest("hex") };
+}
+
+function normalizeInstruction(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (!normalized || normalized.length > 4_096) {
+    throw new Error("instruction must be between 1 and 4096 characters when provided");
+  }
+  return normalized;
+}
+
+function interventionFromRow(row: InterventionRow): DagActorInterventionRecord {
+  const payload = parseJsonRow<{ instruction?: unknown }>(row.payload_json);
+  return {
+    intervention_id: row.intervention_id,
+    run_id: row.run_id,
+    actor_id: row.actor_id,
+    operation: row.operation,
+    status: row.status,
+    idempotency_key: row.idempotency_key,
+    ...(typeof payload.instruction === "string" ? { instruction: payload.instruction } : {}),
+    expected_actor_generation: Number(row.expected_actor_generation),
+    expected_actor_version: Number(row.expected_actor_version),
+    ...(row.checkpoint_version === null ? {} : { checkpoint_version: Number(row.checkpoint_version) }),
+    ...(row.from_generation === null ? {} : { from_generation: Number(row.from_generation) }),
+    ...(row.to_generation === null ? {} : { to_generation: Number(row.to_generation) }),
+    ...(row.resulting_actor_version === null ? {} : { resulting_actor_version: Number(row.resulting_actor_version) }),
+    created_at: Number(row.created_at),
+    ...(row.started_at === null ? {} : { started_at: Number(row.started_at) }),
+    ...(row.completed_at === null ? {} : { completed_at: Number(row.completed_at) }),
+    ...(row.failure_json === null ? {} : { failure: parseJsonRow(row.failure_json) }),
+  };
+}
+
+function snapshotFromRow(row: SnapshotRow): DagSurfaceGenerationSnapshotRecord {
+  return {
+    run_id: row.run_id,
+    actor_id: row.actor_id,
+    generation: Number(row.generation),
+    node_id: row.node_id,
+    surface_id: row.surface_id,
+    document_id: row.document_id,
+    node_revision: Number(row.node_revision),
+    document_revision: Number(row.document_revision),
+    surface_revision: Number(row.surface_revision),
+    activity_state: row.activity_state,
+    visibility_state: row.visibility_state,
+    ...(row.last_event_id === null ? {} : { last_event_id: row.last_event_id }),
+    node_snapshot: parseJsonRow(row.node_snapshot_json),
+    superseded_by_generation: Number(row.superseded_by_generation),
+    intervention_id: row.intervention_id,
+    created_at: Number(row.created_at),
+  };
+}
+
+function interventionRowById(interventionId: string): InterventionRow | undefined {
+  return getDb().prepare("SELECT * FROM dag_actor_interventions WHERE intervention_id = ?")
+    .get(interventionId) as InterventionRow | undefined;
+}
+
+function sameIntervention(
+  row: InterventionRow,
+  input: {
+    intervention_id: string;
+    run_id: string;
+    actor_id: string;
+    operation: DagActorInterventionOperation;
+    idempotency_key: string;
+    payload_digest: string;
+    expected_actor_generation: number;
+    expected_actor_version: number;
+    checkpoint_version?: number;
+  },
+): boolean {
+  return row.intervention_id === input.intervention_id
+    && row.run_id === input.run_id
+    && row.actor_id === input.actor_id
+    && row.operation === input.operation
+    && row.idempotency_key === input.idempotency_key
+    && row.payload_digest === input.payload_digest
+    && row.expected_actor_generation === input.expected_actor_generation
+    && row.expected_actor_version === input.expected_actor_version
+    && row.checkpoint_version === (input.checkpoint_version ?? null);
+}
+
+export function createDagActorIntervention(input: {
+  intervention_id: string;
+  run_id: string;
+  actor_id: string;
+  operation: DagActorInterventionOperation;
+  instruction?: string;
+  expected_actor_generation: number;
+  expected_actor_version: number;
+  idempotency_key: string;
+  checkpoint_version?: number;
+  created_at?: number;
+}): { intervention: DagActorInterventionRecord; changed: boolean; deduplicated: boolean } {
+  const interventionId = assertIdentifier(input.intervention_id, "intervention_id");
+  const runId = assertIdentifier(input.run_id, "run_id");
+  const actorId = assertIdentifier(input.actor_id, "actor_id");
+  if (!DAG_ACTOR_INTERVENTION_OPERATIONS.includes(input.operation)) throw new Error("invalid intervention operation");
+  const instruction = normalizeInstruction(input.instruction);
+  const expectedGeneration = assertPositiveInteger(input.expected_actor_generation, "expected_actor_generation");
+  const expectedVersion = assertPositiveInteger(input.expected_actor_version, "expected_actor_version");
+  const idempotencyKey = assertIdentifier(input.idempotency_key, "idempotency_key");
+  const checkpointVersion = input.checkpoint_version === undefined
+    ? undefined
+    : assertPositiveInteger(input.checkpoint_version, "checkpoint_version");
+  if (input.operation === "checkpoint_fork" ? checkpointVersion === undefined : checkpointVersion !== undefined) {
+    throw new Error("checkpoint_version is required only for checkpoint_fork");
+  }
+  const createdAt = assertTimestamp(input.created_at, "created_at");
+  const payload = encodeBounded(instruction === undefined ? {} : { instruction }, "intervention payload", 65_536);
+  const normalized = {
+    intervention_id: interventionId,
+    run_id: runId,
+    actor_id: actorId,
+    operation: input.operation,
+    idempotency_key: idempotencyKey,
+    payload_digest: payload.digest,
+    expected_actor_generation: expectedGeneration,
+    expected_actor_version: expectedVersion,
+    ...(checkpointVersion === undefined ? {} : { checkpoint_version: checkpointVersion }),
+  };
+  const db = getDb();
+  return db.transaction(() => {
+    const byId = interventionRowById(interventionId);
+    const byKey = db.prepare(`
+      SELECT * FROM dag_actor_interventions
+      WHERE run_id = ? AND actor_id = ? AND idempotency_key = ?
+    `).get(runId, actorId, idempotencyKey) as InterventionRow | undefined;
+    const existing = byId ?? byKey;
+    if (existing) {
+      if (!sameIntervention(existing, normalized)) {
+        throw new DagActorInterventionConflictError(
+          "intervention_identity_conflict",
+          `DAG actor intervention identity was reused with different content`,
+        );
+      }
+      return { intervention: interventionFromRow(existing), changed: false, deduplicated: true };
+    }
+    const actor = getDagActor(runId, actorId);
+    if (!actor) throw new Error(`Unknown DAG actor: ${runId}/${actorId}`);
+    if (actor.generation !== expectedGeneration) {
+      throw new DagActorInterventionConflictError(
+        "actor_generation_conflict",
+        `DAG actor ${runId}/${actorId} generation changed before intervention`,
+      );
+    }
+    if (actor.version !== expectedVersion) {
+      throw new DagActorInterventionConflictError(
+        "actor_version_conflict",
+        `DAG actor ${runId}/${actorId} version changed before intervention`,
+      );
+    }
+    const active = db.prepare(`
+      SELECT intervention_id FROM dag_actor_interventions
+      WHERE run_id = ? AND actor_id = ? AND status IN ('queued', 'applying')
+    `).get(runId, actorId) as { intervention_id: string } | undefined;
+    if (active) {
+      throw new DagActorInterventionConflictError(
+        "intervention_in_progress",
+        `DAG actor ${runId}/${actorId} already has an active intervention`,
+      );
+    }
+    db.prepare(`
+      INSERT INTO dag_actor_interventions(
+        intervention_id, run_id, actor_id, operation, status, idempotency_key,
+        payload_digest, payload_json, expected_actor_generation, expected_actor_version,
+        checkpoint_version, created_at
+      ) VALUES (?, ?, ?, ?, 'queued', ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      interventionId,
+      runId,
+      actorId,
+      input.operation,
+      idempotencyKey,
+      payload.digest,
+      payload.json,
+      expectedGeneration,
+      expectedVersion,
+      checkpointVersion ?? null,
+      createdAt,
+    );
+    return {
+      intervention: interventionFromRow(interventionRowById(interventionId)!),
+      changed: true,
+      deduplicated: false,
+    };
+  }).immediate();
+}
+
+export function getDagActorIntervention(interventionId: string): DagActorInterventionRecord | undefined {
+  const row = interventionRowById(assertIdentifier(interventionId, "intervention_id"));
+  return row ? interventionFromRow(row) : undefined;
+}
+
+export function findDagActorInterventionByKey(input: {
+  run_id: string;
+  actor_id: string;
+  idempotency_key: string;
+}): DagActorInterventionRecord | undefined {
+  const row = getDb().prepare(`
+    SELECT * FROM dag_actor_interventions
+    WHERE run_id = ? AND actor_id = ? AND idempotency_key = ?
+  `).get(
+    assertIdentifier(input.run_id, "run_id"),
+    assertIdentifier(input.actor_id, "actor_id"),
+    assertIdentifier(input.idempotency_key, "idempotency_key"),
+  ) as InterventionRow | undefined;
+  return row ? interventionFromRow(row) : undefined;
+}
+
+export function listDagActorInterventions(input: {
+  run_id: string;
+  actor_id?: string;
+  status?: DagActorInterventionStatus;
+  limit?: number;
+}): DagActorInterventionRecord[] {
+  const conditions = ["run_id = ?"];
+  const params: unknown[] = [assertIdentifier(input.run_id, "run_id")];
+  if (input.actor_id !== undefined) {
+    conditions.push("actor_id = ?");
+    params.push(assertIdentifier(input.actor_id, "actor_id"));
+  }
+  if (input.status !== undefined) {
+    if (!["queued", "applying", "applied", "failed"].includes(input.status)) throw new Error("invalid intervention status");
+    conditions.push("status = ?");
+    params.push(input.status);
+  }
+  const limit = input.limit ?? 100;
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 500) throw new Error("limit must be between 1 and 500");
+  params.push(limit);
+  return (getDb().prepare(`
+    SELECT * FROM dag_actor_interventions WHERE ${conditions.join(" AND ")}
+    ORDER BY created_at DESC, intervention_id DESC LIMIT ?
+  `).all(...params) as InterventionRow[]).map(interventionFromRow);
+}
+
+export function markDagActorInterventionApplying(input: {
+  intervention_id: string;
+  from_generation: number;
+  started_at?: number;
+}): { intervention: DagActorInterventionRecord; changed: boolean; deduplicated: boolean } {
+  const interventionId = assertIdentifier(input.intervention_id, "intervention_id");
+  const fromGeneration = assertPositiveInteger(input.from_generation, "from_generation");
+  const startedAt = assertTimestamp(input.started_at, "started_at");
+  const db = getDb();
+  return db.transaction(() => {
+    const current = interventionRowById(interventionId);
+    if (!current) throw new Error(`Unknown DAG actor intervention: ${interventionId}`);
+    if (current.status === "applying" && current.from_generation === fromGeneration) {
+      return { intervention: interventionFromRow(current), changed: false, deduplicated: true };
+    }
+    if (current.status !== "queued") {
+      throw new DagActorInterventionConflictError(
+        "intervention_status_conflict",
+        `DAG actor intervention ${interventionId} is ${current.status}, not queued`,
+      );
+    }
+    const result = db.prepare(`
+      UPDATE dag_actor_interventions SET status = 'applying', started_at = ?, from_generation = ?
+      WHERE intervention_id = ? AND status = 'queued'
+    `).run(startedAt, fromGeneration, interventionId);
+    if (result.changes !== 1) throw new DagActorInterventionConflictError("intervention_status_conflict", "intervention changed concurrently");
+    return { intervention: interventionFromRow(interventionRowById(interventionId)!), changed: true, deduplicated: false };
+  }).immediate();
+}
+
+export function completeDagActorIntervention(input: {
+  intervention_id: string;
+  from_generation: number;
+  to_generation: number;
+  resulting_actor_version: number;
+  completed_at?: number;
+}): { intervention: DagActorInterventionRecord; changed: boolean; deduplicated: boolean } {
+  const interventionId = assertIdentifier(input.intervention_id, "intervention_id");
+  const fromGeneration = assertPositiveInteger(input.from_generation, "from_generation");
+  const toGeneration = assertPositiveInteger(input.to_generation, "to_generation");
+  const resultingVersion = assertPositiveInteger(input.resulting_actor_version, "resulting_actor_version");
+  if (toGeneration !== fromGeneration + 1) throw new Error("to_generation must equal from_generation + 1");
+  const completedAt = assertTimestamp(input.completed_at, "completed_at");
+  const db = getDb();
+  return db.transaction(() => {
+    const current = interventionRowById(interventionId);
+    if (!current) throw new Error(`Unknown DAG actor intervention: ${interventionId}`);
+    if (
+      current.status === "applied"
+      && current.from_generation === fromGeneration
+      && current.to_generation === toGeneration
+      && current.resulting_actor_version === resultingVersion
+    ) return { intervention: interventionFromRow(current), changed: false, deduplicated: true };
+    if (current.status !== "applying" || current.from_generation !== fromGeneration) {
+      throw new DagActorInterventionConflictError("intervention_status_conflict", `DAG actor intervention ${interventionId} is not applying`);
+    }
+    const result = db.prepare(`
+      UPDATE dag_actor_interventions SET
+        status = 'applied', to_generation = ?, resulting_actor_version = ?, completed_at = ?
+      WHERE intervention_id = ? AND status = 'applying' AND from_generation = ?
+    `).run(toGeneration, resultingVersion, completedAt, interventionId, fromGeneration);
+    if (result.changes !== 1) throw new DagActorInterventionConflictError("intervention_status_conflict", "intervention changed concurrently");
+    return { intervention: interventionFromRow(interventionRowById(interventionId)!), changed: true, deduplicated: false };
+  }).immediate();
+}
+
+export function failDagActorIntervention(input: {
+  intervention_id: string;
+  failure: unknown;
+  completed_at?: number;
+}): { intervention: DagActorInterventionRecord; changed: boolean; deduplicated: boolean } {
+  const interventionId = assertIdentifier(input.intervention_id, "intervention_id");
+  const failure = encodeBounded(input.failure, "intervention failure", 65_536).json;
+  const completedAt = assertTimestamp(input.completed_at, "completed_at");
+  const db = getDb();
+  return db.transaction(() => {
+    const current = interventionRowById(interventionId);
+    if (!current) throw new Error(`Unknown DAG actor intervention: ${interventionId}`);
+    if (current.status === "failed") return { intervention: interventionFromRow(current), changed: false, deduplicated: true };
+    if (current.status !== "queued" && current.status !== "applying") {
+      throw new DagActorInterventionConflictError("intervention_status_conflict", `DAG actor intervention ${interventionId} is ${current.status}`);
+    }
+    const result = db.prepare(`
+      UPDATE dag_actor_interventions SET status = 'failed', completed_at = ?, failure_json = ?
+      WHERE intervention_id = ? AND status IN ('queued', 'applying')
+    `).run(completedAt, failure, interventionId);
+    if (result.changes !== 1) throw new DagActorInterventionConflictError("intervention_status_conflict", "intervention changed concurrently");
+    return { intervention: interventionFromRow(interventionRowById(interventionId)!), changed: true, deduplicated: false };
+  }).immediate();
+}
+
+export function createDagSurfaceGenerationSnapshot(input: {
+  run_id: string;
+  actor_id: string;
+  generation: number;
+  node_id: string;
+  surface_id: string;
+  document_id: string;
+  node_revision: number;
+  document_revision: number;
+  surface_revision: number;
+  activity_state: string;
+  visibility_state: string;
+  last_event_id?: string;
+  node_snapshot: unknown;
+  superseded_by_generation: number;
+  intervention_id: string;
+  created_at?: number;
+}): { snapshot: DagSurfaceGenerationSnapshotRecord; changed: boolean; deduplicated: boolean } {
+  const runId = assertIdentifier(input.run_id, "run_id");
+  const actorId = assertIdentifier(input.actor_id, "actor_id");
+  const generation = assertPositiveInteger(input.generation, "generation");
+  const supersededBy = assertPositiveInteger(input.superseded_by_generation, "superseded_by_generation");
+  if (supersededBy !== generation + 1) throw new Error("superseded_by_generation must equal generation + 1");
+  const nodeId = assertIdentifier(input.node_id, "node_id");
+  const surfaceId = assertIdentifier(input.surface_id, "surface_id", 512);
+  const documentId = assertIdentifier(input.document_id, "document_id");
+  const interventionId = assertIdentifier(input.intervention_id, "intervention_id");
+  const nodeRevision = assertPositiveInteger(input.node_revision, "node_revision");
+  const documentRevision = assertPositiveInteger(input.document_revision, "document_revision");
+  const surfaceRevision = assertPositiveInteger(input.surface_revision, "surface_revision");
+  const lastEventId = input.last_event_id === undefined ? undefined : assertIdentifier(input.last_event_id, "last_event_id");
+  const createdAt = assertTimestamp(input.created_at, "created_at");
+  const encoded = encodeBounded(input.node_snapshot, "surface generation snapshot", 262_144);
+  const db = getDb();
+  return db.transaction(() => {
+    const existing = db.prepare(`
+      SELECT * FROM dag_surface_generation_snapshots
+      WHERE run_id = ? AND actor_id = ? AND generation = ?
+    `).get(runId, actorId, generation) as SnapshotRow | undefined;
+    if (existing) {
+      const same = existing.node_id === nodeId
+        && existing.surface_id === surfaceId
+        && existing.document_id === documentId
+        && existing.node_revision === nodeRevision
+        && existing.document_revision === documentRevision
+        && existing.surface_revision === surfaceRevision
+        && existing.activity_state === input.activity_state
+        && existing.visibility_state === input.visibility_state
+        && existing.last_event_id === (lastEventId ?? null)
+        && existing.node_snapshot_sha256 === encoded.digest
+        && existing.node_snapshot_json === encoded.json
+        && existing.superseded_by_generation === supersededBy
+        && existing.intervention_id === interventionId;
+      if (!same) throw new DagActorInterventionConflictError("snapshot_identity_conflict", "generation snapshot identifies different content");
+      return { snapshot: snapshotFromRow(existing), changed: false, deduplicated: true };
+    }
+    db.prepare(`
+      INSERT INTO dag_surface_generation_snapshots(
+        run_id, actor_id, generation, node_id, surface_id, document_id,
+        node_revision, document_revision, surface_revision, activity_state,
+        visibility_state, last_event_id, node_snapshot_sha256, node_snapshot_json,
+        superseded_by_generation, intervention_id, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      runId,
+      actorId,
+      generation,
+      nodeId,
+      surfaceId,
+      documentId,
+      nodeRevision,
+      documentRevision,
+      surfaceRevision,
+      input.activity_state,
+      input.visibility_state,
+      lastEventId ?? null,
+      encoded.digest,
+      encoded.json,
+      supersededBy,
+      interventionId,
+      createdAt,
+    );
+    const row = db.prepare(`
+      SELECT * FROM dag_surface_generation_snapshots
+      WHERE run_id = ? AND actor_id = ? AND generation = ?
+    `).get(runId, actorId, generation) as SnapshotRow;
+    return { snapshot: snapshotFromRow(row), changed: true, deduplicated: false };
+  }).immediate();
+}
+
+export function listDagSurfaceGenerationSnapshots(input: {
+  run_id: string;
+  actor_id: string;
+  limit?: number;
+}): DagSurfaceGenerationSnapshotRecord[] {
+  const limit = input.limit ?? 20;
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100) throw new Error("limit must be between 1 and 100");
+  return (getDb().prepare(`
+    SELECT * FROM dag_surface_generation_snapshots
+    WHERE run_id = ? AND actor_id = ?
+    ORDER BY generation DESC LIMIT ?
+  `).all(
+    assertIdentifier(input.run_id, "run_id"),
+    assertIdentifier(input.actor_id, "actor_id"),
+    limit,
+  ) as SnapshotRow[]).map(snapshotFromRow);
+}

--- a/homerail_manager/src/persistence/dag-actor-interventions.ts
+++ b/homerail_manager/src/persistence/dag-actor-interventions.ts
@@ -33,6 +33,16 @@ export interface DagActorInterventionRecord {
   failure?: unknown;
 }
 
+export interface DagActorDispatchExclusionRecord {
+  run_id: string;
+  actor_id: string;
+  node_id: string;
+  target_type: "worker" | "node";
+  target_id: string;
+  intervention_id: string;
+  created_at: number;
+}
+
 export interface DagSurfaceGenerationSnapshotRecord {
   run_id: string;
   actor_id: string;
@@ -105,6 +115,16 @@ interface SnapshotRow {
   node_snapshot_sha256: string;
   node_snapshot_json: string;
   superseded_by_generation: number;
+  intervention_id: string;
+  created_at: number;
+}
+
+interface DispatchExclusionRow {
+  run_id: string;
+  actor_id: string;
+  node_id: string;
+  target_type: "worker" | "node";
+  target_id: string;
   intervention_id: string;
   created_at: number;
 }
@@ -205,6 +225,18 @@ function snapshotFromRow(row: SnapshotRow): DagSurfaceGenerationSnapshotRecord {
     ...(row.last_event_id === null ? {} : { last_event_id: row.last_event_id }),
     node_snapshot: parseJsonRow(row.node_snapshot_json),
     superseded_by_generation: Number(row.superseded_by_generation),
+    intervention_id: row.intervention_id,
+    created_at: Number(row.created_at),
+  };
+}
+
+function dispatchExclusionFromRow(row: DispatchExclusionRow): DagActorDispatchExclusionRecord {
+  return {
+    run_id: row.run_id,
+    actor_id: row.actor_id,
+    node_id: row.node_id,
+    target_type: row.target_type,
+    target_id: row.target_id,
     intervention_id: row.intervention_id,
     created_at: Number(row.created_at),
   };
@@ -483,6 +515,76 @@ export function failDagActorIntervention(input: {
     if (result.changes !== 1) throw new DagActorInterventionConflictError("intervention_status_conflict", "intervention changed concurrently");
     return { intervention: interventionFromRow(interventionRowById(interventionId)!), changed: true, deduplicated: false };
   }).immediate();
+}
+
+export function upsertDagActorDispatchExclusion(input: {
+  run_id: string;
+  actor_id: string;
+  node_id: string;
+  target_type: "worker" | "node";
+  target_id: string;
+  intervention_id: string;
+  created_at?: number;
+}): DagActorDispatchExclusionRecord {
+  const runId = assertIdentifier(input.run_id, "run_id");
+  const actorId = assertIdentifier(input.actor_id, "actor_id");
+  const nodeId = assertIdentifier(input.node_id, "node_id");
+  if (input.target_type !== "worker" && input.target_type !== "node") {
+    throw new Error("target_type must be worker or node");
+  }
+  const targetId = assertIdentifier(input.target_id, "target_id");
+  const interventionId = assertIdentifier(input.intervention_id, "intervention_id");
+  const createdAt = assertTimestamp(input.created_at, "created_at");
+  const db = getDb();
+  return db.transaction(() => {
+    const actor = getDagActor(runId, actorId);
+    if (!actor || actor.node_id !== nodeId) {
+      throw new Error(`Unknown DAG actor dispatch identity: ${runId}/${actorId}/${nodeId}`);
+    }
+    const intervention = interventionRowById(interventionId);
+    if (
+      !intervention
+      || intervention.run_id !== runId
+      || intervention.actor_id !== actorId
+      || intervention.operation !== "reassign"
+      || !["queued", "applying", "applied"].includes(intervention.status)
+    ) {
+      throw new Error(`DAG actor dispatch exclusion requires a queued, applying, or applied reassign intervention`);
+    }
+    db.prepare(`
+      INSERT INTO dag_actor_dispatch_exclusions(
+        run_id, actor_id, node_id, target_type, target_id, intervention_id, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(run_id, node_id) DO UPDATE SET
+        actor_id = excluded.actor_id,
+        target_type = excluded.target_type,
+        target_id = excluded.target_id,
+        intervention_id = excluded.intervention_id,
+        created_at = excluded.created_at
+    `).run(runId, actorId, nodeId, input.target_type, targetId, interventionId, createdAt);
+    return dispatchExclusionFromRow(db.prepare(`
+      SELECT * FROM dag_actor_dispatch_exclusions WHERE run_id = ? AND node_id = ?
+    `).get(runId, nodeId) as DispatchExclusionRow);
+  }).immediate();
+}
+
+export function clearDagActorDispatchExclusion(input: {
+  run_id: string;
+  node_id: string;
+}): boolean {
+  const result = getDb().prepare(`
+    DELETE FROM dag_actor_dispatch_exclusions WHERE run_id = ? AND node_id = ?
+  `).run(
+    assertIdentifier(input.run_id, "run_id"),
+    assertIdentifier(input.node_id, "node_id"),
+  );
+  return result.changes > 0;
+}
+
+export function listDagActorDispatchExclusions(): DagActorDispatchExclusionRecord[] {
+  return (getDb().prepare(`
+    SELECT * FROM dag_actor_dispatch_exclusions ORDER BY created_at, run_id, node_id
+  `).all() as DispatchExclusionRow[]).map(dispatchExclusionFromRow);
 }
 
 export function createDagSurfaceGenerationSnapshot(input: {

--- a/homerail_manager/src/persistence/dag-actor-leases.ts
+++ b/homerail_manager/src/persistence/dag-actor-leases.ts
@@ -958,6 +958,21 @@ export function getLatestDagActorCheckpoint(input: {
   return row ? checkpointFromRow(row) : undefined;
 }
 
+export function getDagActorCheckpoint(input: {
+  run_id: string;
+  actor_id: string;
+  checkpoint_version: number;
+}): DagActorCheckpointRecord | undefined {
+  const runId = assertBoundedString(input.run_id, "run_id", 256);
+  const actorId = assertBoundedString(input.actor_id, "actor_id", 256);
+  const checkpointVersion = assertPositiveSafeInteger(input.checkpoint_version, "checkpoint_version");
+  const row = getDb().prepare(`
+    SELECT * FROM dag_actor_checkpoints
+    WHERE run_id = ? AND actor_id = ? AND checkpoint_version = ?
+  `).get(runId, actorId, checkpointVersion) as DagActorCheckpointRow | undefined;
+  return row ? checkpointFromRow(row) : undefined;
+}
+
 export function deleteExpiredDagActorRuntime(input: {
   run_id: string;
   actor_id: string;

--- a/homerail_manager/src/persistence/dag-actors.ts
+++ b/homerail_manager/src/persistence/dag-actors.ts
@@ -618,14 +618,18 @@ export async function deliverDagActorCommand(input: {
 export function cancelUnclaimedDagActorCommands(runId: string, completedAt?: number): DagActorCommandRecord[];
 export function cancelUnclaimedDagActorCommands(input: {
   run_id: string;
+  actor_id?: string;
   completed_at?: number;
   reason?: unknown;
 }): DagActorCommandRecord[];
 export function cancelUnclaimedDagActorCommands(
-  input: string | { run_id: string; completed_at?: number; reason?: unknown },
+  input: string | { run_id: string; actor_id?: string; completed_at?: number; reason?: unknown },
   requestedCompletedAt?: number,
 ): DagActorCommandRecord[] {
   const runId = assertIdentifier(typeof input === "string" ? input : input.run_id, "run_id");
+  const actorId = typeof input === "string" || input.actor_id === undefined
+    ? undefined
+    : assertIdentifier(input.actor_id, "actor_id");
   const completedAt = typeof input === "string"
     ? requestedCompletedAt ?? Date.now()
     : input.completed_at ?? Date.now();
@@ -641,9 +645,9 @@ export function cancelUnclaimedDagActorCommands(
   return db.transaction(() => {
     const candidates = db.prepare(`
       SELECT * FROM dag_actor_commands
-      WHERE run_id = ? AND status IN ('pending', 'delivered')
+      WHERE run_id = ? AND (? IS NULL OR actor_id = ?) AND status IN ('pending', 'delivered')
       ORDER BY created_at, command_id
-    `).all(runId) as DagActorCommandRow[];
+    `).all(runId, actorId ?? null, actorId ?? null) as DagActorCommandRow[];
     if (candidates.length === 0) return [];
     if (candidates.some((command) => completedAt < Number(command.created_at))) {
       throw new Error("completed_at must not precede command creation");
@@ -653,12 +657,12 @@ export function cancelUnclaimedDagActorCommands(
         status = 'cancelled',
         completed_at = ?,
         failure_json = ?
-      WHERE run_id = ? AND status IN ('pending', 'delivered')
-    `).run(completedAt, reasonJson, runId);
+      WHERE run_id = ? AND (? IS NULL OR actor_id = ?) AND status IN ('pending', 'delivered')
+    `).run(completedAt, reasonJson, runId, actorId ?? null, actorId ?? null);
     if (changed.changes !== candidates.length) {
       throw new DagActorConflictError(
         "command_status_conflict",
-        `Unclaimed DAG actor commands for run ${runId} changed concurrently`,
+        `Unclaimed DAG actor commands for ${actorId ? `actor ${runId}/${actorId}` : `run ${runId}`} changed concurrently`,
       );
     }
     return candidates.map((candidate) => requireCommand(candidate.command_id));

--- a/homerail_manager/src/persistence/db.ts
+++ b/homerail_manager/src/persistence/db.ts
@@ -34,6 +34,7 @@ const CLEARABLE_TABLES = new Set([
   "dag_chats",
   "dag_handoffs",
   "dag_artifacts",
+  "dag_actor_dispatch_exclusions",
   "dag_surface_generation_snapshots",
   "dag_actor_interventions",
   "dag_run_rounds",
@@ -1442,6 +1443,50 @@ function validateDagActorInterventionSchemaV26(db: SqliteDatabase): void {
   if (!(db.prepare("PRAGMA foreign_key_list(dag_actor_interventions)").all() as Array<{ table: string }>)
     .some((entry) => entry.table === "dag_actors")) {
     throw new Error("Schema migration 26 is incomplete: intervention actor ownership constraint is invalid");
+  }
+}
+
+function validateDagActorDispatchExclusionSchemaV27(db: SqliteDatabase): void {
+  if (!hasTable(db, "dag_actor_dispatch_exclusions")) {
+    throw new Error("Schema migration 27 is incomplete: missing table dag_actor_dispatch_exclusions");
+  }
+  const requiredColumns = [
+    "run_id",
+    "actor_id",
+    "node_id",
+    "target_type",
+    "target_id",
+    "intervention_id",
+    "created_at",
+  ];
+  const actualColumns = new Set(
+    (db.prepare("PRAGMA table_info(dag_actor_dispatch_exclusions)").all() as Array<{ name: string }>)
+      .map((row) => row.name),
+  );
+  const missing = requiredColumns.filter((name) => !actualColumns.has(name));
+  if (missing.length > 0) {
+    throw new Error(`Schema migration 27 is incomplete: dag_actor_dispatch_exclusions is missing ${missing.join(", ")}`);
+  }
+  const targetIndex = (db.prepare("PRAGMA index_list(dag_actor_dispatch_exclusions)").all() as Array<{
+    name: string;
+    unique: number;
+  }>).find((entry) => entry.name === "idx_dag_actor_dispatch_exclusions_target");
+  if (!targetIndex || targetIndex.unique !== 0) {
+    throw new Error("Schema migration 27 is incomplete: dispatch exclusion target index is missing or invalid");
+  }
+  const targetColumns = (db.prepare("PRAGMA index_info(idx_dag_actor_dispatch_exclusions_target)").all() as Array<{
+    seqno: number;
+    name: string;
+  }>).sort((left, right) => left.seqno - right.seqno).map((entry) => entry.name);
+  if (targetColumns.join(",") !== "target_type,target_id") {
+    throw new Error("Schema migration 27 is incomplete: dispatch exclusion target index has invalid columns");
+  }
+  const foreignKeyTables = new Set(
+    (db.prepare("PRAGMA foreign_key_list(dag_actor_dispatch_exclusions)").all() as Array<{ table: string }>)
+      .map((entry) => entry.table),
+  );
+  if (!foreignKeyTables.has("dag_actors") || !foreignKeyTables.has("dag_actor_interventions")) {
+    throw new Error("Schema migration 27 is incomplete: dispatch exclusion ownership constraints are invalid");
   }
 }
 
@@ -3159,6 +3204,30 @@ const SCHEMA_MIGRATIONS: readonly SchemaMigration[] = [
       END;
     `),
     validate: validateDagActorInterventionSchemaV26,
+  },
+  {
+    version: 27,
+    up: (db) => db.exec(`
+      CREATE TABLE IF NOT EXISTS dag_actor_dispatch_exclusions (
+        run_id TEXT NOT NULL CHECK(length(run_id) BETWEEN 1 AND 256),
+        actor_id TEXT NOT NULL CHECK(length(actor_id) BETWEEN 1 AND 256),
+        node_id TEXT NOT NULL CHECK(length(node_id) BETWEEN 1 AND 256),
+        target_type TEXT NOT NULL CHECK(target_type IN ('worker', 'node')),
+        target_id TEXT NOT NULL CHECK(length(target_id) BETWEEN 1 AND 256),
+        intervention_id TEXT NOT NULL CHECK(length(intervention_id) BETWEEN 1 AND 256),
+        created_at INTEGER NOT NULL CHECK(created_at >= 0),
+        PRIMARY KEY(run_id, node_id),
+        UNIQUE(intervention_id),
+        FOREIGN KEY(run_id, actor_id) REFERENCES dag_actors(run_id, actor_id)
+          ON UPDATE RESTRICT ON DELETE CASCADE,
+        FOREIGN KEY(intervention_id, run_id, actor_id)
+          REFERENCES dag_actor_interventions(intervention_id, run_id, actor_id)
+          ON UPDATE RESTRICT ON DELETE CASCADE
+      );
+      CREATE INDEX IF NOT EXISTS idx_dag_actor_dispatch_exclusions_target
+        ON dag_actor_dispatch_exclusions(target_type, target_id);
+    `),
+    validate: validateDagActorDispatchExclusionSchemaV27,
   },
 ];
 

--- a/homerail_manager/src/persistence/db.ts
+++ b/homerail_manager/src/persistence/db.ts
@@ -34,6 +34,8 @@ const CLEARABLE_TABLES = new Set([
   "dag_chats",
   "dag_handoffs",
   "dag_artifacts",
+  "dag_surface_generation_snapshots",
+  "dag_actor_interventions",
   "dag_run_rounds",
   "dag_actor_provisioned_workers",
   "dag_actor_checkpoints",
@@ -1340,6 +1342,107 @@ function validateDagLiveSurfaceQueueTriggersV22(db: SqliteDatabase): void {
     "trg_dag_surface_projection_queue_identity_immutable",
     DAG_SURFACE_QUEUE_IMMUTABLE_IDENTITY_TRIGGER_V22,
   );
+}
+
+function validateDagActorInterventionSchemaV26(db: SqliteDatabase): void {
+  const requiredColumns: Record<string, readonly string[]> = {
+    dag_actor_interventions: [
+      "intervention_id", "run_id", "actor_id", "operation", "status", "idempotency_key",
+      "payload_digest", "payload_json", "expected_actor_generation", "expected_actor_version",
+      "checkpoint_version", "from_generation", "to_generation", "resulting_actor_version",
+      "created_at", "started_at", "completed_at", "failure_json",
+    ],
+    dag_surface_generation_snapshots: [
+      "run_id", "actor_id", "generation", "node_id", "surface_id", "document_id",
+      "node_revision", "document_revision", "surface_revision", "activity_state",
+      "visibility_state", "last_event_id", "node_snapshot_sha256", "node_snapshot_json",
+      "superseded_by_generation", "intervention_id", "created_at",
+    ],
+  };
+  for (const [table, names] of Object.entries(requiredColumns)) {
+    if (!hasTable(db, table)) {
+      throw new Error(`Schema migration 26 is incomplete: missing table ${table}`);
+    }
+    const actual = new Set((db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>)
+      .map((row) => row.name));
+    const missing = names.filter((name) => !actual.has(name));
+    if (missing.length > 0) {
+      throw new Error(`Schema migration 26 is incomplete: ${table} is missing ${missing.join(", ")}`);
+    }
+  }
+  const requireIndex = (
+    table: string,
+    name: string,
+    expectedColumns: readonly string[],
+    unique: number,
+    partial: number,
+  ): void => {
+    const index = (db.prepare(`PRAGMA index_list(${table})`).all() as Array<{
+      name: string;
+      unique: number;
+      partial: number;
+    }>).find((entry) => entry.name === name);
+    if (!index || index.unique !== unique || index.partial !== partial) {
+      throw new Error(`Schema migration 26 is incomplete: index ${name} is missing or invalid`);
+    }
+    const columns = (db.prepare(`PRAGMA index_info(${name})`).all() as Array<{ seqno: number; name: string }>)
+      .sort((left, right) => left.seqno - right.seqno)
+      .map((entry) => entry.name);
+    if (columns.length !== expectedColumns.length || columns.some((column, indexPosition) => column !== expectedColumns[indexPosition])) {
+      throw new Error(`Schema migration 26 is incomplete: index ${name} has invalid columns`);
+    }
+  };
+  requireIndex(
+    "dag_actor_interventions",
+    "idx_dag_actor_interventions_idempotency",
+    ["run_id", "actor_id", "idempotency_key"],
+    1,
+    0,
+  );
+  requireIndex(
+    "dag_actor_interventions",
+    "idx_dag_actor_interventions_active_actor",
+    ["run_id", "actor_id"],
+    1,
+    1,
+  );
+  requireIndex(
+    "dag_actor_interventions",
+    "idx_dag_actor_interventions_actor_created",
+    ["run_id", "actor_id", "created_at", "intervention_id"],
+    0,
+    0,
+  );
+  requireIndex(
+    "dag_surface_generation_snapshots",
+    "idx_dag_surface_generation_snapshots_actor_created",
+    ["run_id", "actor_id", "created_at", "generation"],
+    0,
+    0,
+  );
+  const activeSql = normalizedSchemaSql((db.prepare(
+    "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'idx_dag_actor_interventions_active_actor'",
+  ).get() as { sql?: string } | undefined)?.sql ?? "");
+  if (!activeSql.includes("where status in ('queued', 'applying')")) {
+    throw new Error("Schema migration 26 is incomplete: active intervention index predicate is invalid");
+  }
+  const triggerSql = normalizedSchemaSql((db.prepare(
+    "SELECT sql FROM sqlite_master WHERE type = 'trigger' AND name = 'trg_dag_surface_generation_snapshots_no_update'",
+  ).get() as { sql?: string } | undefined)?.sql ?? "");
+  if (!triggerSql.includes("dag surface generation snapshots are append-only")) {
+    throw new Error("Schema migration 26 is incomplete: generation snapshot append-only trigger is missing or invalid");
+  }
+  const foreignKeyTables = new Set(
+    (db.prepare("PRAGMA foreign_key_list(dag_surface_generation_snapshots)").all() as Array<{ table: string }>)
+      .map((entry) => entry.table),
+  );
+  if (!foreignKeyTables.has("dag_actors") || !foreignKeyTables.has("dag_actor_interventions")) {
+    throw new Error("Schema migration 26 is incomplete: generation snapshot ownership constraints are invalid");
+  }
+  if (!(db.prepare("PRAGMA foreign_key_list(dag_actor_interventions)").all() as Array<{ table: string }>)
+    .some((entry) => entry.table === "dag_actors")) {
+    throw new Error("Schema migration 26 is incomplete: intervention actor ownership constraint is invalid");
+  }
 }
 
 function validateGenerativeUiSchemaV3(db: SqliteDatabase): void {
@@ -2966,6 +3069,96 @@ const SCHEMA_MIGRATIONS: readonly SchemaMigration[] = [
         ON dag_activity_events(run_id, round_id, actor_id, generation, activity_type, seq);
     `),
     validate: validateDagActivityRoundIndexV25,
+  },
+  {
+    version: 26,
+    up: (db) => db.exec(`
+      CREATE TABLE IF NOT EXISTS dag_actor_interventions (
+        intervention_id TEXT PRIMARY KEY CHECK(length(intervention_id) BETWEEN 1 AND 256),
+        run_id TEXT NOT NULL CHECK(length(run_id) BETWEEN 1 AND 256),
+        actor_id TEXT NOT NULL CHECK(length(actor_id) BETWEEN 1 AND 256),
+        operation TEXT NOT NULL CHECK(operation IN ('interrupt', 'cancel', 'retry', 'reassign', 'checkpoint_fork')),
+        status TEXT NOT NULL CHECK(status IN ('queued', 'applying', 'applied', 'failed')),
+        idempotency_key TEXT NOT NULL CHECK(length(idempotency_key) BETWEEN 1 AND 256),
+        payload_digest TEXT NOT NULL CHECK(
+          length(payload_digest) = 64 AND payload_digest NOT GLOB '*[^0-9a-f]*'
+        ),
+        payload_json TEXT NOT NULL CHECK(length(payload_json) BETWEEN 2 AND 65536),
+        expected_actor_generation INTEGER NOT NULL CHECK(expected_actor_generation >= 1),
+        expected_actor_version INTEGER NOT NULL CHECK(expected_actor_version >= 1),
+        checkpoint_version INTEGER CHECK(checkpoint_version IS NULL OR checkpoint_version >= 1),
+        from_generation INTEGER CHECK(from_generation IS NULL OR from_generation >= 1),
+        to_generation INTEGER CHECK(to_generation IS NULL OR to_generation >= 1),
+        resulting_actor_version INTEGER CHECK(resulting_actor_version IS NULL OR resulting_actor_version >= 1),
+        created_at INTEGER NOT NULL CHECK(created_at >= 0),
+        started_at INTEGER CHECK(started_at IS NULL OR started_at >= created_at),
+        completed_at INTEGER CHECK(completed_at IS NULL OR completed_at >= created_at),
+        failure_json TEXT CHECK(failure_json IS NULL OR length(failure_json) BETWEEN 2 AND 65536),
+        UNIQUE(intervention_id, run_id, actor_id),
+        CHECK(
+          (operation = 'checkpoint_fork' AND checkpoint_version IS NOT NULL)
+          OR (operation <> 'checkpoint_fork' AND checkpoint_version IS NULL)
+        ),
+        CHECK(to_generation IS NULL OR (from_generation IS NOT NULL AND to_generation = from_generation + 1)),
+        CHECK(
+          (status = 'queued' AND started_at IS NULL AND completed_at IS NULL AND failure_json IS NULL
+            AND from_generation IS NULL AND to_generation IS NULL AND resulting_actor_version IS NULL)
+          OR (status = 'applying' AND started_at IS NOT NULL AND completed_at IS NULL AND failure_json IS NULL
+            AND to_generation IS NULL AND resulting_actor_version IS NULL)
+          OR (status = 'applied' AND started_at IS NOT NULL AND completed_at IS NOT NULL AND failure_json IS NULL
+            AND from_generation IS NOT NULL AND to_generation IS NOT NULL AND resulting_actor_version IS NOT NULL)
+          OR (status = 'failed' AND completed_at IS NOT NULL AND failure_json IS NOT NULL
+            AND to_generation IS NULL AND resulting_actor_version IS NULL)
+        ),
+        UNIQUE(run_id, actor_id, idempotency_key),
+        FOREIGN KEY(run_id, actor_id) REFERENCES dag_actors(run_id, actor_id)
+          ON UPDATE RESTRICT ON DELETE CASCADE
+      );
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_dag_actor_interventions_idempotency
+        ON dag_actor_interventions(run_id, actor_id, idempotency_key);
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_dag_actor_interventions_active_actor
+        ON dag_actor_interventions(run_id, actor_id)
+        WHERE status IN ('queued', 'applying');
+      CREATE INDEX IF NOT EXISTS idx_dag_actor_interventions_actor_created
+        ON dag_actor_interventions(run_id, actor_id, created_at, intervention_id);
+
+      CREATE TABLE IF NOT EXISTS dag_surface_generation_snapshots (
+        run_id TEXT NOT NULL,
+        actor_id TEXT NOT NULL,
+        generation INTEGER NOT NULL CHECK(generation >= 1),
+        node_id TEXT NOT NULL CHECK(length(node_id) BETWEEN 1 AND 256),
+        surface_id TEXT NOT NULL CHECK(length(surface_id) BETWEEN 1 AND 512),
+        document_id TEXT NOT NULL CHECK(length(document_id) BETWEEN 1 AND 256),
+        node_revision INTEGER NOT NULL CHECK(node_revision >= 1),
+        document_revision INTEGER NOT NULL CHECK(document_revision >= 1),
+        surface_revision INTEGER NOT NULL CHECK(surface_revision >= 1),
+        activity_state TEXT NOT NULL CHECK(activity_state IN ('started', 'progress', 'finding', 'blocked', 'completed', 'failed')),
+        visibility_state TEXT NOT NULL CHECK(visibility_state IN ('visible', 'focused', 'removed')),
+        last_event_id TEXT CHECK(last_event_id IS NULL OR length(last_event_id) BETWEEN 1 AND 256),
+        node_snapshot_sha256 TEXT NOT NULL CHECK(
+          length(node_snapshot_sha256) = 64 AND node_snapshot_sha256 NOT GLOB '*[^0-9a-f]*'
+        ),
+        node_snapshot_json TEXT NOT NULL CHECK(length(node_snapshot_json) BETWEEN 2 AND 262144),
+        superseded_by_generation INTEGER NOT NULL CHECK(superseded_by_generation = generation + 1),
+        intervention_id TEXT NOT NULL CHECK(length(intervention_id) BETWEEN 1 AND 256),
+        created_at INTEGER NOT NULL CHECK(created_at >= 0),
+        PRIMARY KEY(run_id, actor_id, generation),
+        UNIQUE(intervention_id),
+        FOREIGN KEY(run_id, actor_id) REFERENCES dag_actors(run_id, actor_id)
+          ON UPDATE RESTRICT ON DELETE CASCADE,
+        FOREIGN KEY(intervention_id, run_id, actor_id)
+          REFERENCES dag_actor_interventions(intervention_id, run_id, actor_id)
+          ON UPDATE RESTRICT ON DELETE CASCADE
+      );
+      CREATE INDEX IF NOT EXISTS idx_dag_surface_generation_snapshots_actor_created
+        ON dag_surface_generation_snapshots(run_id, actor_id, created_at, generation);
+      CREATE TRIGGER IF NOT EXISTS trg_dag_surface_generation_snapshots_no_update
+      BEFORE UPDATE ON dag_surface_generation_snapshots
+      BEGIN
+        SELECT RAISE(ABORT, 'DAG surface generation snapshots are append-only');
+      END;
+    `),
+    validate: validateDagActorInterventionSchemaV26,
   },
 ];
 

--- a/homerail_manager/src/runtime/active-runs.ts
+++ b/homerail_manager/src/runtime/active-runs.ts
@@ -24,7 +24,12 @@ import {
 import type { DAGAgentConfig, DAGArtifactDeclaration, DAGEdge, DAGGatewayConfig, DAGGraphNode, DAGOutputRoute, DAGPatternInstanceMeta, ParsedDAG, ScorecardPolicyConfig } from "../orchestration/graph.js";
 import { _normalizeOutputsToEdges } from "../orchestration/yaml-loader.js";
 import { assertGraphValid } from "../orchestration/graph-validator.js";
-import { findDispatchTarget } from "../orchestration/dispatch-tracker.js";
+import {
+  clearDispatchTarget,
+  excludeCurrentDispatchTarget,
+  findDispatchTarget,
+  type DispatchTarget,
+} from "../orchestration/dispatch-tracker.js";
 import { deprovisionProvisionedForRun } from "../orchestration/provisioned-cleanup.js";
 import { getWorker } from "../worker/registry.js";
 import { getNode } from "../node/registry.js";
@@ -93,6 +98,7 @@ import {
   claimDagActorCommand,
   createDagActorCommand,
   DagActorConflictError,
+  getDagActor,
   getDagActorCommand,
   getDagActorByNode,
   listDagActors,
@@ -105,12 +111,28 @@ import {
 import {
   acquireDagActorLease,
   ensureDagActorLease,
+  getDagActorCheckpoint,
   getDagActorLease,
   getLatestDagActorCheckpoint,
+  releaseDagActorLease,
   retireDagActorLease,
   writeDagActorCheckpoint,
 } from "../persistence/dag-actor-leases.js";
-import { buildRunActorCheckpoints } from "./dag-actor-checkpoint-builder.js";
+import {
+  createDagActorIntervention,
+  DagActorInterventionConflictError,
+  failDagActorIntervention,
+  findDagActorInterventionByKey,
+  getDagActorIntervention,
+  listDagActorInterventions,
+  markDagActorInterventionApplying,
+  completeDagActorIntervention,
+  type DagActorInterventionOperation,
+  type DagActorInterventionRecord,
+} from "../persistence/dag-actor-interventions.js";
+import { supersedeDagLiveSurfaceForIntervention } from "../generative-ui/dag-live-surface-projector.js";
+import { buildDagActorCheckpoint, buildRunActorCheckpoints } from "./dag-actor-checkpoint-builder.js";
+import { getDagActorControlState, type DagActorControlStateName } from "./dag-actor-control-state.js";
 
 export interface InjectResult {
   runId: string;
@@ -122,6 +144,48 @@ export interface InjectResult {
   deliveryTargetType?: "worker" | "node";
   deliveryTargetId?: string;
   deliveryGap?: string;
+}
+
+export interface InterveneDagActorRequest {
+  actor_id: string;
+  operation: DagActorInterventionOperation;
+  expected_state_token: string;
+  idempotency_key: string;
+  instruction?: string;
+  checkpoint_version?: number;
+}
+
+export interface InterveneDagActorResult {
+  intervention_id: string;
+  run_id: string;
+  actor_id: string;
+  operation: DagActorInterventionOperation;
+  status: DagActorInterventionRecord["status"];
+  actor_state: DagActorControlStateName;
+  state_token: string;
+  deduplicated: boolean;
+  created_at: number;
+  updated_at: number;
+}
+
+export class DagActorInterventionRuntimeError extends Error {
+  constructor(
+    public readonly code:
+      | "run_not_active"
+      | "actor_not_found"
+      | "state_token_conflict"
+      | "intervention_recovery_failed",
+    message: string,
+  ) {
+    super(message);
+    this.name = "DagActorInterventionRuntimeError";
+  }
+}
+
+export interface DagActorInterventionRecoverySummary {
+  applied: string[];
+  failed: string[];
+  skipped: string[];
 }
 
 export interface ActiveRun {
@@ -862,8 +926,14 @@ function _rebuildDagRunFromPersisted(metadata: PersistedRunMetadata, graphData: 
 }
 
 function _applyOrphanedNodeDemotion(run: ActiveRun): string[] {
+  const interventionProtectedNodeIds = new Set(
+    listDagActorInterventions({ run_id: run.runId, limit: 500 })
+      .filter((intervention) => intervention.status === "queued" || intervention.status === "applying")
+      .map((intervention) => getDagActor(run.runId, intervention.actor_id)?.node_id)
+      .filter((nodeId): nodeId is string => Boolean(nodeId)),
+  );
   const demotedFromRunning = Array.from(run.dagRun.nodeStates.entries())
-    .filter(([, state]) => state === "RUNNING")
+    .filter(([nodeId, state]) => state === "RUNNING" && !interventionProtectedNodeIds.has(nodeId))
     .map(([nodeId]) => nodeId);
 
   // Apply RUNNING→FAILED demotion: mark sessions and emit the standard
@@ -2284,6 +2354,365 @@ export function injectActiveRun(
   return result;
 }
 
+function _interventionId(runId: string, actorId: string, idempotencyKey: string): string {
+  return `intervention-${createHash("sha256")
+    .update(`${runId}\0${actorId}\0${idempotencyKey}`)
+    .digest("hex")}`;
+}
+
+function _interventionInstruction(intervention: DagActorInterventionRecord): string {
+  if (intervention.instruction) return intervention.instruction;
+  switch (intervention.operation) {
+    case "retry": return "Retry the same objective from the durable actor checkpoint.";
+    case "reassign": return "Continue the same objective from the durable actor checkpoint on another available executor.";
+    case "checkpoint_fork": return "Continue the same objective from the selected durable actor checkpoint.";
+    case "interrupt": return "Stop the current attempt and retain its durable evidence.";
+    case "cancel": return "Cancel this actor branch and retain its durable evidence.";
+  }
+}
+
+function _interventionResult(
+  intervention: DagActorInterventionRecord,
+  deduplicated: boolean,
+): InterveneDagActorResult {
+  const control = getDagActorControlState(intervention.run_id, intervention.actor_id);
+  return {
+    intervention_id: intervention.intervention_id,
+    run_id: intervention.run_id,
+    actor_id: intervention.actor_id,
+    operation: intervention.operation,
+    status: intervention.status,
+    actor_state: control.actor_state,
+    state_token: control.state_token,
+    deduplicated,
+    created_at: intervention.created_at,
+    updated_at: intervention.completed_at ?? intervention.started_at ?? intervention.created_at,
+  };
+}
+
+function _sendInterventionInterrupt(
+  target: DispatchTarget | undefined,
+  runId: string,
+  nodeId: string,
+  intervention: DagActorInterventionRecord,
+): void {
+  if (target?.state !== "dispatched" || !target.targetType || !target.targetId) return;
+  const registryEntry = target.targetType === "worker"
+    ? getWorker(target.targetId)
+    : getNode(target.targetId);
+  const socket = registryEntry?.socket;
+  if (!socket || socket.readyState !== WebSocket.OPEN) return;
+  try {
+    socket.send(JSON.stringify({
+      type: "inject",
+      data: {
+        runId,
+        nodeId,
+        mode: "interrupt",
+        instruction: _interventionInstruction(intervention),
+      },
+    }));
+  } catch (error) {
+    console.warn(
+      `[homerail_manager] failed to interrupt previous DAG actor attempt: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+function _releaseActorLeaseForIntervention(
+  actor: DagActorRecord,
+  operation: DagActorInterventionOperation,
+  now: number,
+): void {
+  const lease = getDagActorLease({ run_id: actor.run_id, actor_id: actor.actor_id });
+  if (!lease) return;
+  let current = lease;
+  if (current.state === "leased") {
+    current = releaseDagActorLease({
+      run_id: current.run_id,
+      actor_id: current.actor_id,
+      lease_generation: current.lease_generation,
+      target_type: current.target_type!,
+      target_id: current.target_id!,
+      expected_version: current.version,
+      now,
+    });
+  }
+  if (operation === "cancel" && current.state !== "retired") {
+    retireDagActorLease({
+      run_id: current.run_id,
+      actor_id: current.actor_id,
+      expected_version: current.version,
+      now,
+    });
+  }
+}
+
+function _applyPersistedDagActorIntervention(
+  requested: DagActorInterventionRecord,
+): DagActorInterventionRecord {
+  if (requested.status === "applied" || requested.status === "failed") return requested;
+  const run = store.get(requested.run_id);
+  if (!run || run.status !== "active") {
+    throw new DagActorInterventionRuntimeError(
+      "run_not_active",
+      `DAG run ${requested.run_id} is not active for actor intervention`,
+    );
+  }
+  const actor = getDagActor(requested.run_id, requested.actor_id);
+  if (!actor) {
+    throw new DagActorInterventionRuntimeError(
+      "actor_not_found",
+      `Unknown DAG actor: ${requested.run_id}/${requested.actor_id}`,
+    );
+  }
+  if (
+    actor.generation !== requested.expected_actor_generation
+    || actor.version !== requested.expected_actor_version
+  ) {
+    throw new DagActorInterventionConflictError(
+      actor.generation !== requested.expected_actor_generation
+        ? "actor_generation_conflict"
+        : "actor_version_conflict",
+      `DAG actor ${requested.run_id}/${requested.actor_id} changed before the queued intervention could apply`,
+    );
+  }
+
+  const applying = requested.status === "queued"
+    ? markDagActorInterventionApplying({
+        intervention_id: requested.intervention_id,
+        from_generation: actor.generation,
+      }).intervention
+    : requested;
+  const before = _snapshotMutableRun(run);
+  const beforeStates = _snapshotNodeStates(run);
+  const oldTarget = findDispatchTarget(run.runId, actor.node_id);
+  const now = Math.max(Date.now(), applying.created_at, actor.updated_at);
+
+  let completed: DagActorInterventionRecord;
+  try {
+    completed = getDb().transaction(() => {
+      const current = getDagActor(applying.run_id, applying.actor_id);
+      if (!current) throw new Error(`Unknown DAG actor: ${applying.run_id}/${applying.actor_id}`);
+      if (
+        current.generation !== applying.expected_actor_generation
+        || current.version !== applying.expected_actor_version
+      ) {
+        throw new DagActorInterventionConflictError(
+          current.generation !== applying.expected_actor_generation
+            ? "actor_generation_conflict"
+            : "actor_version_conflict",
+          `DAG actor ${applying.run_id}/${applying.actor_id} changed while applying intervention`,
+        );
+      }
+
+      const checkpoint = applying.operation === "checkpoint_fork"
+        ? getDagActorCheckpoint({
+            run_id: current.run_id,
+            actor_id: current.actor_id,
+            checkpoint_version: applying.checkpoint_version!,
+          })
+        : writeDagActorCheckpoint({
+            run_id: current.run_id,
+            actor_id: current.actor_id,
+            checkpoint: buildDagActorCheckpoint({
+              runId: run.runId,
+              actor: current,
+              roundId: run.currentRound.round_id,
+              capturedAt: now,
+            }),
+            expected_checkpoint_version: getLatestDagActorCheckpoint({
+              run_id: current.run_id,
+              actor_id: current.actor_id,
+            })?.checkpoint_version ?? 0,
+            now,
+          });
+      if (!checkpoint) {
+        throw new Error(
+          `Portable checkpoint ${applying.checkpoint_version} is unavailable for actor ${applying.actor_id}`,
+        );
+      }
+
+      cancelUnclaimedDagActorCommands({
+        run_id: current.run_id,
+        actor_id: current.actor_id,
+        completed_at: now,
+        reason: { code: "actor_intervention", operation: applying.operation },
+      });
+      _releaseActorLeaseForIntervention(current, applying.operation, now);
+
+      const nextSession: NodeSessionState = {
+        sessionId: _newSessionId(run.runId, current.node_id),
+        attempt: current.attempt + 1,
+        ...(current.session_id ? { parentSessionId: current.session_id } : {}),
+        resumeInstruction: _interventionInstruction(applying),
+        status: applying.operation === "interrupt" || applying.operation === "cancel"
+          ? "cancelled"
+          : "active",
+      };
+      const nextActor = advanceDagActorGeneration({
+        run_id: current.run_id,
+        actor_id: current.actor_id,
+        expected_generation: current.generation,
+        expected_version: current.version,
+        session_id: nextSession.sessionId,
+        attempt: nextSession.attempt,
+        checkpoint_ref: `portable:${checkpoint.checkpoint_version}`,
+      });
+      _persistNodeSession(run, nextActor.node_id, nextSession);
+
+      if (applying.operation === "interrupt" || applying.operation === "cancel") {
+        failNode(run.dagRun, nextActor.node_id, {
+          code: "actor_intervention",
+          operation: applying.operation,
+        });
+        run.dagRun.nodeStates.set(nextActor.node_id, "CANCELLED");
+      } else {
+        _resetActorBranchForIntervention({
+          run,
+          actor: nextActor,
+          intervention_id: applying.intervention_id,
+          operation: applying.operation,
+          instruction: _interventionInstruction(applying),
+        });
+      }
+
+      supersedeDagLiveSurfaceForIntervention({
+        run_id: run.runId,
+        actor_id: nextActor.actor_id,
+        intervention_id: applying.intervention_id,
+        created_at: now,
+      });
+      writeRunMetadata(run.runId, serializeRunMetadata(run));
+      return completeDagActorIntervention({
+        intervention_id: applying.intervention_id,
+        from_generation: current.generation,
+        to_generation: nextActor.generation,
+        resulting_actor_version: nextActor.version,
+        completed_at: now,
+      }).intervention;
+    }).immediate();
+  } catch (error) {
+    _restoreMutableRun(run, before);
+    try {
+      failDagActorIntervention({
+        intervention_id: applying.intervention_id,
+        failure: { message: error instanceof Error ? error.message : String(error) },
+      });
+    } catch {
+      // Preserve the original failure; a concurrent recovery may have completed the intervention.
+    }
+    throw error;
+  }
+
+  if (completed.operation === "reassign") excludeCurrentDispatchTarget(run.runId, actor.node_id);
+  else clearDispatchTarget(run.runId, actor.node_id);
+  _sendInterventionInterrupt(oldTarget, run.runId, actor.node_id, completed);
+  _emitNodeStateChanges(run, beforeStates);
+  emit("dag:actor_intervention_applied", {
+    runId: run.runId,
+    actorId: actor.actor_id,
+    operation: completed.operation,
+    interventionId: completed.intervention_id,
+  });
+  return completed;
+}
+
+/** Queue and apply a branch-local Actor intervention without exposing physical execution identity. */
+export function interveneActiveRunActor(
+  runId: string,
+  request: InterveneDagActorRequest,
+): InterveneDagActorResult {
+  const existing = findDagActorInterventionByKey({
+    run_id: runId,
+    actor_id: request.actor_id,
+    idempotency_key: request.idempotency_key,
+  });
+  if (existing) {
+    const verified = createDagActorIntervention({
+      intervention_id: existing.intervention_id,
+      run_id: existing.run_id,
+      actor_id: existing.actor_id,
+      operation: request.operation,
+      instruction: request.instruction,
+      expected_actor_generation: existing.expected_actor_generation,
+      expected_actor_version: existing.expected_actor_version,
+      idempotency_key: request.idempotency_key,
+      checkpoint_version: request.checkpoint_version,
+    }).intervention;
+    const current = verified.status === "queued" || verified.status === "applying"
+      ? _applyPersistedDagActorIntervention(verified)
+      : verified;
+    return _interventionResult(current, true);
+  }
+
+  const run = store.get(runId);
+  if (!run || run.status !== "active") {
+    throw new DagActorInterventionRuntimeError("run_not_active", `DAG run ${runId} is not active`);
+  }
+  const actor = getDagActor(runId, request.actor_id);
+  if (!actor) {
+    throw new DagActorInterventionRuntimeError("actor_not_found", `Unknown DAG actor: ${runId}/${request.actor_id}`);
+  }
+  const control = getDagActorControlState(runId, actor.actor_id);
+  if (control.state_token !== request.expected_state_token.trim()) {
+    throw new DagActorInterventionRuntimeError(
+      "state_token_conflict",
+      `DAG actor ${runId}/${actor.actor_id} state changed before intervention`,
+    );
+  }
+  const queued = createDagActorIntervention({
+    intervention_id: _interventionId(runId, actor.actor_id, request.idempotency_key),
+    run_id: runId,
+    actor_id: actor.actor_id,
+    operation: request.operation,
+    instruction: request.instruction,
+    expected_actor_generation: actor.generation,
+    expected_actor_version: actor.version,
+    idempotency_key: request.idempotency_key,
+    checkpoint_version: request.checkpoint_version,
+  });
+  const applied = _applyPersistedDagActorIntervention(queued.intervention);
+  return _interventionResult(applied, queued.deduplicated);
+}
+
+/** Resume interventions durably queued before a Manager crash. */
+export function recoverDagActorInterventions(): DagActorInterventionRecoverySummary {
+  const summary: DagActorInterventionRecoverySummary = { applied: [], failed: [], skipped: [] };
+  const rows = getDb().prepare(`
+    SELECT intervention_id, run_id FROM dag_actor_interventions
+    WHERE status IN ('queued', 'applying')
+    ORDER BY created_at, intervention_id
+  `).all() as Array<{ intervention_id: string; run_id: string }>;
+  for (const row of rows) {
+    if (!store.has(row.run_id)) {
+      summary.skipped.push(row.intervention_id);
+      continue;
+    }
+    try {
+      const record = getDagActorIntervention(row.intervention_id);
+      if (!record) {
+        summary.skipped.push(row.intervention_id);
+        continue;
+      }
+      const applied = _applyPersistedDagActorIntervention(record);
+      if (applied.status === "applied") summary.applied.push(applied.intervention_id);
+      else summary.failed.push(applied.intervention_id);
+    } catch (error) {
+      try {
+        failDagActorIntervention({
+          intervention_id: row.intervention_id,
+          failure: { message: error instanceof Error ? error.message : String(error) },
+        });
+      } catch {
+        // The apply path may already have recorded a bounded failure.
+      }
+      summary.failed.push(row.intervention_id);
+    }
+  }
+  return summary;
+}
+
 function _nodeInputs(
   run: DAGRun,
   nodeId: string,
@@ -2368,6 +2797,58 @@ function _roundCarryoverInputs(
     carryover.set(edge.to_node, inputs);
   }
   return carryover;
+}
+
+function _branchInterventionResetNodeIds(run: ActiveRun, actorNodeId: string): string[] {
+  const reset = new Set([actorNodeId]);
+  const queue = [actorNodeId];
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    for (const edge of run.dagRun.graph.edges) {
+      if (edge.from_node !== current || !edge.to_node || reset.has(edge.to_node)) continue;
+      const target = run.dagRun.graph.nodes.find((node) => node.node_id === edge.to_node);
+      if (!target || !_isGatewayNode(target)) continue;
+      reset.add(target.node_id);
+      queue.push(target.node_id);
+    }
+  }
+  return Array.from(reset).sort();
+}
+
+function _resetActorBranchForIntervention(input: {
+  run: ActiveRun;
+  actor: DagActorRecord;
+  intervention_id: string;
+  operation: string;
+  instruction: string;
+}): { resetNodeIds: string[]; readyNodeIds: string[] } {
+  const resetNodeIds = _branchInterventionResetNodeIds(input.run, input.actor.node_id);
+  const resetSet = new Set(resetNodeIds);
+  const carryover = _roundCarryoverInputs(input.run, resetSet);
+  const previousMailbox = input.run.dagRun.mailboxes.get(input.actor.node_id);
+  if (previousMailbox) {
+    const actorCarryover = carryover.get(input.actor.node_id) ?? [];
+    for (const [port, values] of previousMailbox.entries()) {
+      if (port === "intervention" || port === "checkpoint_resume") continue;
+      for (const value of values) {
+        actorCarryover.push({ fromNode: "__previous_actor_input__", port, value });
+      }
+    }
+    if (actorCarryover.length > 0) carryover.set(input.actor.node_id, actorCarryover);
+  }
+  const reset = resetNodesForRound(input.run.dagRun, {
+    resetNodeIds,
+    carryoverInputs: carryover,
+    commandInputs: new Map([[input.actor.node_id, {
+      port: "intervention",
+      value: {
+        intervention_id: input.intervention_id,
+        operation: input.operation,
+        instruction: input.instruction,
+      },
+    }]]),
+  });
+  return { resetNodeIds, readyNodeIds: reset.readyNodes };
 }
 
 function _firstInputValue(inputs: Record<string, unknown[]>): unknown {
@@ -3334,15 +3815,27 @@ function _buildDispatchEnvelope(run: ActiveRun, nodeId: string): DispatchEnvelop
   const actorId = actor.actor_id;
   const generation = actor.generation;
   const surfaceId = actor.surface_id;
-  const actorCheckpoint = getLatestDagActorCheckpoint({
-    run_id: run.runId,
-    actor_id: actorId,
-  })?.checkpoint;
+  const requestedCheckpointVersion = actor.checkpoint_ref?.match(/^portable:(\d+)$/)?.[1];
+  const actorCheckpointRecord = requestedCheckpointVersion
+    ? getDagActorCheckpoint({
+        run_id: run.runId,
+        actor_id: actorId,
+        checkpoint_version: Number(requestedCheckpointVersion),
+      })
+    : getLatestDagActorCheckpoint({ run_id: run.runId, actor_id: actorId });
+  if (requestedCheckpointVersion && !actorCheckpointRecord) {
+    return { ok: false, reason: `portable checkpoint ${requestedCheckpointVersion} is unavailable for actor ${actorId}` };
+  }
+  const actorCheckpoint = actorCheckpointRecord?.checkpoint;
   const roundCommand = listDagActorCommands({
     run_id: run.runId,
     actor_id: actorId,
     round_id: run.currentRound.round_id,
-  }).find((command) => command.status !== "cancelled" && command.status !== "failed");
+  }).find((command) =>
+    command.target_generation === generation
+    && command.status !== "cancelled"
+    && command.status !== "failed"
+  );
   const dispatchInputs = nodeSession.resumeInstruction
     ? { ...inputs, checkpoint_resume: [nodeSession.resumeInstruction] }
     : inputs;

--- a/homerail_manager/src/runtime/active-runs.ts
+++ b/homerail_manager/src/runtime/active-runs.ts
@@ -28,6 +28,7 @@ import {
   clearDispatchTarget,
   excludeCurrentDispatchTarget,
   findDispatchTarget,
+  restoreDispatchExclusion,
   type DispatchTarget,
 } from "../orchestration/dispatch-tracker.js";
 import { deprovisionProvisionedForRun } from "../orchestration/provisioned-cleanup.js";
@@ -127,6 +128,9 @@ import {
   listDagActorInterventions,
   markDagActorInterventionApplying,
   completeDagActorIntervention,
+  clearDagActorDispatchExclusion,
+  listDagActorDispatchExclusions,
+  upsertDagActorDispatchExclusion,
   type DagActorInterventionOperation,
   type DagActorInterventionRecord,
 } from "../persistence/dag-actor-interventions.js";
@@ -173,6 +177,7 @@ export class DagActorInterventionRuntimeError extends Error {
     public readonly code:
       | "run_not_active"
       | "actor_not_found"
+      | "actor_retired"
       | "state_token_conflict"
       | "intervention_recovery_failed",
     message: string,
@@ -2488,6 +2493,7 @@ function _applyPersistedDagActorIntervention(
   const beforeStates = _snapshotNodeStates(run);
   const oldTarget = findDispatchTarget(run.runId, actor.node_id);
   const now = Math.max(Date.now(), applying.created_at, actor.updated_at);
+  let terminalizedRun = false;
 
   let completed: DagActorInterventionRecord;
   try {
@@ -2577,13 +2583,42 @@ function _applyPersistedDagActorIntervention(
         });
       }
 
+      if (
+        applying.operation === "reassign"
+        && oldTarget?.state === "dispatched"
+        && oldTarget.targetType
+        && oldTarget.targetId
+      ) {
+        upsertDagActorDispatchExclusion({
+          run_id: run.runId,
+          actor_id: nextActor.actor_id,
+          node_id: nextActor.node_id,
+          target_type: oldTarget.targetType,
+          target_id: oldTarget.targetId,
+          intervention_id: applying.intervention_id,
+          created_at: now,
+        });
+      } else if (applying.operation !== "reassign") {
+        clearDagActorDispatchExclusion({ run_id: run.runId, node_id: nextActor.node_id });
+      }
+
       supersedeDagLiveSurfaceForIntervention({
         run_id: run.runId,
         actor_id: nextActor.actor_id,
         intervention_id: applying.intervention_id,
         created_at: now,
       });
-      writeRunMetadata(run.runId, serializeRunMetadata(run));
+      if (
+        (applying.operation === "interrupt" || applying.operation === "cancel")
+        && isRunTerminal(run.dagRun)
+      ) {
+        run.status = "cancelled";
+        run.completedAt = now;
+        _persistTerminalRun(run, "cancelled");
+        terminalizedRun = true;
+      } else {
+        writeRunMetadata(run.runId, serializeRunMetadata(run));
+      }
       return completeDagActorIntervention({
         intervention_id: applying.intervention_id,
         from_generation: current.generation,
@@ -2615,6 +2650,11 @@ function _applyPersistedDagActorIntervention(
     operation: completed.operation,
     interventionId: completed.intervention_id,
   });
+  if (terminalizedRun) {
+    _emitStatusUpdate(run);
+    emit("dag:run_cancelled", { runId: run.runId });
+    deprovisionProvisionedForRun(run.runId);
+  }
   return completed;
 }
 
@@ -2654,6 +2694,12 @@ export function interveneActiveRunActor(
   if (!actor) {
     throw new DagActorInterventionRuntimeError("actor_not_found", `Unknown DAG actor: ${runId}/${request.actor_id}`);
   }
+  if (getDagActorLease({ run_id: runId, actor_id: actor.actor_id })?.state === "retired") {
+    throw new DagActorInterventionRuntimeError(
+      "actor_retired",
+      `DAG actor ${runId}/${actor.actor_id} is retired and cannot accept another intervention`,
+    );
+  }
   const control = getDagActorControlState(runId, actor.actor_id);
   if (control.state_token !== request.expected_state_token.trim()) {
     throw new DagActorInterventionRuntimeError(
@@ -2661,17 +2707,38 @@ export function interveneActiveRunActor(
       `DAG actor ${runId}/${actor.actor_id} state changed before intervention`,
     );
   }
-  const queued = createDagActorIntervention({
-    intervention_id: _interventionId(runId, actor.actor_id, request.idempotency_key),
-    run_id: runId,
-    actor_id: actor.actor_id,
-    operation: request.operation,
-    instruction: request.instruction,
-    expected_actor_generation: actor.generation,
-    expected_actor_version: actor.version,
-    idempotency_key: request.idempotency_key,
-    checkpoint_version: request.checkpoint_version,
-  });
+  const oldTarget = request.operation === "reassign"
+    ? findDispatchTarget(runId, actor.node_id)
+    : undefined;
+  const queued = getDb().transaction(() => {
+    const created = createDagActorIntervention({
+      intervention_id: _interventionId(runId, actor.actor_id, request.idempotency_key),
+      run_id: runId,
+      actor_id: actor.actor_id,
+      operation: request.operation,
+      instruction: request.instruction,
+      expected_actor_generation: actor.generation,
+      expected_actor_version: actor.version,
+      idempotency_key: request.idempotency_key,
+      checkpoint_version: request.checkpoint_version,
+    });
+    if (
+      created.changed
+      && oldTarget?.state === "dispatched"
+      && oldTarget.targetType
+      && oldTarget.targetId
+    ) {
+      upsertDagActorDispatchExclusion({
+        run_id: runId,
+        actor_id: actor.actor_id,
+        node_id: actor.node_id,
+        target_type: oldTarget.targetType,
+        target_id: oldTarget.targetId,
+        intervention_id: created.intervention.intervention_id,
+      });
+    }
+    return created;
+  }).immediate();
   const applied = _applyPersistedDagActorIntervention(queued.intervention);
   return _interventionResult(applied, queued.deduplicated);
 }
@@ -2679,6 +2746,7 @@ export function interveneActiveRunActor(
 /** Resume interventions durably queued before a Manager crash. */
 export function recoverDagActorInterventions(): DagActorInterventionRecoverySummary {
   const summary: DagActorInterventionRecoverySummary = { applied: [], failed: [], skipped: [] };
+  const runsNeedingOrphanDemotion = new Set<string>();
   const rows = getDb().prepare(`
     SELECT intervention_id, run_id FROM dag_actor_interventions
     WHERE status IN ('queued', 'applying')
@@ -2697,7 +2765,10 @@ export function recoverDagActorInterventions(): DagActorInterventionRecoverySumm
       }
       const applied = _applyPersistedDagActorIntervention(record);
       if (applied.status === "applied") summary.applied.push(applied.intervention_id);
-      else summary.failed.push(applied.intervention_id);
+      else {
+        summary.failed.push(applied.intervention_id);
+        runsNeedingOrphanDemotion.add(row.run_id);
+      }
     } catch (error) {
       try {
         failDagActorIntervention({
@@ -2708,7 +2779,40 @@ export function recoverDagActorInterventions(): DagActorInterventionRecoverySumm
         // The apply path may already have recorded a bounded failure.
       }
       summary.failed.push(row.intervention_id);
+      runsNeedingOrphanDemotion.add(row.run_id);
     }
+  }
+  for (const runId of runsNeedingOrphanDemotion) {
+    const run = store.get(runId);
+    if (!run || run.status !== "active") continue;
+    const demoted = _applyOrphanedNodeDemotion(run);
+    if (demoted.length === 0) continue;
+    writeRunMetadata(run.runId, serializeRunMetadata(run));
+    _emitStatusUpdate(run);
+  }
+  for (const exclusion of listDagActorDispatchExclusions()) {
+    const run = store.get(exclusion.run_id);
+    const actor = getDagActor(exclusion.run_id, exclusion.actor_id);
+    const intervention = getDagActorIntervention(exclusion.intervention_id);
+    if (
+      !run
+      || run.status !== "active"
+      || !actor
+      || actor.node_id !== exclusion.node_id
+      || run.dagRun.nodeStates.get(actor.node_id) !== "READY"
+      || intervention?.status !== "applied"
+      || intervention.operation !== "reassign"
+      || intervention.to_generation !== actor.generation
+    ) {
+      clearDagActorDispatchExclusion({ run_id: exclusion.run_id, node_id: exclusion.node_id });
+      continue;
+    }
+    restoreDispatchExclusion(
+      exclusion.run_id,
+      exclusion.node_id,
+      exclusion.target_type,
+      exclusion.target_id,
+    );
   }
   return summary;
 }

--- a/homerail_manager/src/runtime/dag-actor-control-state.ts
+++ b/homerail_manager/src/runtime/dag-actor-control-state.ts
@@ -1,0 +1,80 @@
+import { createHash } from "node:crypto";
+import { getDagLiveSurfaceProjection } from "../generative-ui/dag-live-surface-projector.js";
+import { getDagActorLease } from "../persistence/dag-actor-leases.js";
+import { getDagActor } from "../persistence/dag-actors.js";
+import { getCurrentDagRunRound } from "../persistence/dag-run-rounds.js";
+import { loadRunMetadata } from "../persistence/store.js";
+
+export type DagActorControlStateName =
+  | "pending"
+  | "ready"
+  | "running"
+  | "waiting"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+export interface DagActorControlState {
+  run_id: string;
+  actor_id: string;
+  actor_state: DagActorControlStateName;
+  state_token: string;
+}
+
+function assertIdentifier(value: string, label: string): string {
+  const normalized = value.trim();
+  if (!normalized || normalized.length > 256 || /[\u0000-\u001f\u007f]/.test(normalized)) {
+    throw new Error(`${label} must be between 1 and 256 printable characters`);
+  }
+  return normalized;
+}
+
+function controlStateName(nodeState: string | undefined): DagActorControlStateName {
+  switch (nodeState) {
+    case "READY": return "ready";
+    case "RUNNING": return "running";
+    case "WAITING_FOR_COMMAND":
+    case "WAITING_FOR_APPROVAL": return "waiting";
+    case "COMPLETED": return "completed";
+    case "FAILED": return "failed";
+    case "CANCELLED":
+    case "SKIPPED": return "cancelled";
+    default: return "pending";
+  }
+}
+
+/** Build an opaque CAS token from every durable fence that controls one logical Actor. */
+export function getDagActorControlState(runId: string, actorId: string): DagActorControlState {
+  const normalizedRunId = assertIdentifier(runId, "run_id");
+  const normalizedActorId = assertIdentifier(actorId, "actor_id");
+  const actor = getDagActor(normalizedRunId, normalizedActorId);
+  if (!actor) throw new Error(`Unknown DAG actor: ${normalizedRunId}/${normalizedActorId}`);
+  const metadata = loadRunMetadata(normalizedRunId);
+  if (!metadata) throw new Error(`Run not found: ${normalizedRunId}`);
+  const round = getCurrentDagRunRound(normalizedRunId);
+  const lease = getDagActorLease({ run_id: normalizedRunId, actor_id: normalizedActorId });
+  const projection = getDagLiveSurfaceProjection(normalizedRunId, normalizedActorId);
+  const nodeState = metadata.nodeStates[actor.node_id];
+  const tokenPayload = {
+    schema_version: 1,
+    run_id: normalizedRunId,
+    actor_id: normalizedActorId,
+    actor_generation: actor.generation,
+    actor_version: actor.version,
+    node_state: nodeState ?? "PENDING",
+    round_id: round?.round_id ?? null,
+    round_status: round?.status ?? null,
+    lease_state: lease?.state ?? null,
+    lease_generation: lease?.lease_generation ?? 0,
+    lease_version: lease?.version ?? 0,
+    projection_generation: projection?.generation ?? 0,
+    surface_revision: projection?.surface_revision ?? 0,
+    visibility_state: projection?.visibility_state ?? null,
+  };
+  return {
+    run_id: normalizedRunId,
+    actor_id: normalizedActorId,
+    actor_state: controlStateName(nodeState),
+    state_token: createHash("sha256").update(JSON.stringify(tokenPayload)).digest("hex"),
+  };
+}

--- a/homerail_manager/src/runtime/dag-manager-supervisor.ts
+++ b/homerail_manager/src/runtime/dag-manager-supervisor.ts
@@ -13,12 +13,18 @@ import {
   type DagActivityJournalEntry,
 } from "../persistence/dag-activity-journal.js";
 import { listDagActorCommands, listDagActors } from "../persistence/dag-actors.js";
+import {
+  listDagActorInterventions,
+  type DagActorInterventionOperation,
+  type DagActorInterventionStatus,
+} from "../persistence/dag-actor-interventions.js";
 import { getDagState, updateDagState } from "../persistence/dag-runtime-primitives.js";
 import { getCurrentDagRunRound, listDagRunRounds, type DagRunRoundRecord } from "../persistence/dag-run-rounds.js";
 import { loadRunMetadata } from "../persistence/store.js";
+import { getDagActorControlState, type DagActorControlStateName } from "./dag-actor-control-state.js";
 
-const SUPERVISOR_CURSOR_NAMESPACE = "manager_supervisor_cursor_v1";
-const SUPERVISOR_CURSOR_SCHEMA_VERSION = 1;
+const SUPERVISOR_CURSOR_NAMESPACE = "manager_supervisor_cursor_v2";
+const SUPERVISOR_CURSOR_SCHEMA_VERSION = 2;
 const MAX_SUPERVISOR_ACTORS = 64;
 const MAX_MILESTONES = 12;
 const MAX_PENDING_TOOLS_PER_ACTOR = 8;
@@ -31,6 +37,8 @@ const TERMINAL_ACTIVITY_TYPES = new Set<DagActivityType>(["blocked", "completed"
 export interface DagSupervisorActorSummary {
   actor_id: string;
   role: string;
+  actor_state: DagActorControlStateName;
+  state_token: string;
   activity_state: string;
   visibility_state: string;
   round_targeted: boolean;
@@ -41,6 +49,23 @@ export interface DagSupervisorActorSummary {
     retained_until?: number;
   };
   commands: Record<string, number>;
+  latest_intervention?: DagSupervisorInterventionSummary;
+}
+
+export interface DagSupervisorInterventionSummary {
+  intervention_id: string;
+  operation: DagActorInterventionOperation;
+  status: DagActorInterventionStatus;
+  summary: string;
+  created_at: number;
+  completed_at?: number;
+}
+
+export interface DagSupervisorInterventionMilestone extends DagSupervisorInterventionSummary {
+  milestone_id: string;
+  actor_id: string;
+  role: string;
+  timestamp: number;
 }
 
 export interface DagSupervisorMilestone {
@@ -106,16 +131,18 @@ export interface DagSupervisionSnapshot {
     has_more: boolean;
     suppressed_progress_events: number;
     milestones: DagSupervisorMilestone[];
+    intervention_milestones: DagSupervisorInterventionMilestone[];
     commentary: string[];
   };
 }
 
-interface SupervisorCursorV1 {
-  schema_version: 1;
+interface SupervisorCursorV2 {
+  schema_version: 2;
   run_id: string;
   consumer_digest: string;
   next_after_seq: number;
   pending_tools: Record<string, string[]>;
+  seen_intervention_ids: string[];
 }
 
 function assertIdentifier(value: string, label: string, maxLength = 256): string {
@@ -189,7 +216,7 @@ function cursorKey(runId: string, consumerId: string): { key: string; digest: st
   return { key: `${runId}:${digest.slice(0, 32)}`, digest };
 }
 
-function decodeCursor(value: unknown, runId: string, consumerDigest: string): SupervisorCursorV1 {
+function decodeCursor(value: unknown, runId: string, consumerDigest: string): SupervisorCursorV2 {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return {
       schema_version: SUPERVISOR_CURSOR_SCHEMA_VERSION,
@@ -197,9 +224,10 @@ function decodeCursor(value: unknown, runId: string, consumerDigest: string): Su
       consumer_digest: consumerDigest,
       next_after_seq: 0,
       pending_tools: {},
+      seen_intervention_ids: [],
     };
   }
-  const candidate = value as Partial<SupervisorCursorV1>;
+  const candidate = value as Partial<SupervisorCursorV2>;
   if (
     candidate.schema_version !== SUPERVISOR_CURSOR_SCHEMA_VERSION
     || candidate.run_id !== runId
@@ -224,6 +252,11 @@ function decodeCursor(value: unknown, runId: string, consumerDigest: string): Su
     consumer_digest: consumerDigest,
     next_after_seq: Number(candidate.next_after_seq),
     pending_tools: pendingTools,
+    seen_intervention_ids: Array.isArray(candidate.seen_intervention_ids)
+      ? Array.from(new Set(candidate.seen_intervention_ids
+          .filter((id): id is string => typeof id === "string" && id.length > 0 && id.length <= 256)))
+          .slice(-500)
+      : [],
   };
 }
 
@@ -268,6 +301,29 @@ function commentaryFor(milestones: DagSupervisorMilestone[]): string[] {
     : `${commentary.slice(0, MAX_COMMENTARY_LENGTH - 1)}…`];
 }
 
+function interventionSummary(operation: DagActorInterventionOperation, status: DagActorInterventionStatus): string {
+  if (status === "failed") return "干预未能应用，原有证据仍保留";
+  switch (operation) {
+    case "retry": return "已从持久检查点开始新的重试";
+    case "reassign": return "已换用其他可用执行资源继续任务";
+    case "checkpoint_fork": return "已从指定检查点开启新的执行分支";
+    case "interrupt": return "当前尝试已中断，证据已保留";
+    case "cancel": return "当前 Actor 分支已取消，证据已保留";
+  }
+}
+
+function interventionCommentary(milestones: DagSupervisorInterventionMilestone[]): string[] {
+  if (milestones.length === 0) return [];
+  const text = milestones.slice(0, 3)
+    .map((milestone) => `${milestone.role || milestone.actor_id}：${milestone.summary}`)
+    .join("；");
+  const overflow = milestones.length > 3 ? `；另有 ${milestones.length - 3} 项干预` : "";
+  const commentary = `${text}${overflow}`;
+  return [commentary.length <= MAX_COMMENTARY_LENGTH
+    ? commentary
+    : `${commentary.slice(0, MAX_COMMENTARY_LENGTH - 1)}…`];
+}
+
 function buildActorSummaries(runId: string, round?: DagRunRoundRecord): {
   actor_count: number;
   actors_truncated: boolean;
@@ -276,15 +332,23 @@ function buildActorSummaries(runId: string, round?: DagRunRoundRecord): {
   const allActors = listDagActors(runId);
   const projections = new Map(listDagLiveSurfaceProjections(runId).map((projection) => [projection.actor_id, projection]));
   const actors = allActors.slice(0, MAX_SUPERVISOR_ACTORS).map((actor): DagSupervisorActorSummary => {
+    const controlState = getDagActorControlState(runId, actor.actor_id);
     const projection = projections.get(actor.actor_id);
     const lease = getDagActorLease({ run_id: runId, actor_id: actor.actor_id });
     const commandCounts: Record<string, number> = {};
     for (const command of listDagActorCommands({ run_id: runId, actor_id: actor.actor_id, limit: 500 })) {
       commandCounts[command.status] = (commandCounts[command.status] ?? 0) + 1;
     }
+    const latestIntervention = listDagActorInterventions({
+      run_id: runId,
+      actor_id: actor.actor_id,
+      limit: 1,
+    })[0];
     return {
       actor_id: actor.actor_id,
       role: actor.role,
+      actor_state: controlState.actor_state,
+      state_token: controlState.state_token,
       activity_state: projection?.activity_state ?? "pending",
       visibility_state: projection?.visibility_state ?? "unprojected",
       round_targeted: round?.target_actor_ids.includes(actor.actor_id) ?? false,
@@ -299,6 +363,20 @@ function buildActorSummaries(runId: string, round?: DagRunRoundRecord): {
         }
         : {}),
       commands: commandCounts,
+      ...(latestIntervention
+        ? {
+          latest_intervention: {
+            intervention_id: latestIntervention.intervention_id,
+            operation: latestIntervention.operation,
+            status: latestIntervention.status,
+            summary: interventionSummary(latestIntervention.operation, latestIntervention.status),
+            created_at: latestIntervention.created_at,
+            ...(latestIntervention.completed_at === undefined
+              ? {}
+              : { completed_at: latestIntervention.completed_at }),
+          },
+        }
+        : {}),
     };
   });
   return {
@@ -387,6 +465,8 @@ function consumeMilestones(input: {
   const page = listDagActivityEvents({ run_id: runId, after_seq: cursor.next_after_seq, limit: 500 });
   const pendingTools = structuredClone(cursor.pending_tools);
   const milestones: DagSupervisorMilestone[] = [];
+  const seenInterventionIds = new Set(cursor.seen_intervention_ids);
+  const interventionMilestones: DagSupervisorInterventionMilestone[] = [];
   let nextAfterSeq = cursor.next_after_seq;
   let suppressedProgressEvents = 0;
   let stoppedEarly = false;
@@ -394,6 +474,8 @@ function consumeMilestones(input: {
   for (const entry of page.events) {
     nextAfterSeq = entry.seq;
     const event = entry.event;
+    const actor = actorsById.get(event.actor_id);
+    if (!actor || event.generation !== actor.generation) continue;
     if (event.type === "tool_used") {
       const tools = new Set([...(pendingTools[event.actor_id] ?? []), ...eventToolNames(event)]);
       pendingTools[event.actor_id] = [...tools].sort().slice(0, MAX_PENDING_TOOLS_PER_ACTOR);
@@ -404,8 +486,6 @@ function consumeMilestones(input: {
       continue;
     }
     if (!MILESTONE_TYPES.has(event.type)) continue;
-    const actor = actorsById.get(event.actor_id);
-    if (!actor) continue;
     const tools = pendingTools[event.actor_id] ?? [];
     milestones.push(milestoneFromEntry(entry, actor.role, tools));
     delete pendingTools[event.actor_id];
@@ -415,7 +495,42 @@ function consumeMilestones(input: {
     }
   }
 
-  if (nextAfterSeq !== cursor.next_after_seq || JSON.stringify(pendingTools) !== JSON.stringify(cursor.pending_tools)) {
+  const pendingInterventions = listDagActorInterventions({ run_id: runId, limit: 500 })
+    .reverse()
+    .filter((intervention) => (
+      (intervention.status === "applied" || intervention.status === "failed")
+      && !seenInterventionIds.has(intervention.intervention_id)
+    ));
+  const remainingMilestoneBudget = Math.max(0, maxMilestones - milestones.length);
+  for (const intervention of pendingInterventions.slice(0, remainingMilestoneBudget)) {
+    const actor = actorsById.get(intervention.actor_id);
+    if (!actor) continue;
+    const summary = interventionSummary(intervention.operation, intervention.status);
+    interventionMilestones.push({
+      milestone_id: createHash("sha256")
+        .update(`intervention\0${intervention.intervention_id}`)
+        .digest("hex"),
+      intervention_id: intervention.intervention_id,
+      actor_id: intervention.actor_id,
+      role: actor.role,
+      operation: intervention.operation,
+      status: intervention.status,
+      summary,
+      created_at: intervention.created_at,
+      ...(intervention.completed_at === undefined ? {} : { completed_at: intervention.completed_at }),
+      timestamp: intervention.completed_at ?? intervention.started_at ?? intervention.created_at,
+    });
+    seenInterventionIds.add(intervention.intervention_id);
+    delete pendingTools[intervention.actor_id];
+  }
+  const interventionsHaveMore = pendingInterventions.length > interventionMilestones.length;
+  const nextSeenInterventionIds = Array.from(seenInterventionIds).slice(-500);
+
+  if (
+    nextAfterSeq !== cursor.next_after_seq
+    || JSON.stringify(pendingTools) !== JSON.stringify(cursor.pending_tools)
+    || JSON.stringify(nextSeenInterventionIds) !== JSON.stringify(cursor.seen_intervention_ids)
+  ) {
     const updated = updateDagState({
       namespace: SUPERVISOR_CURSOR_NAMESPACE,
       key: stateKey,
@@ -427,7 +542,8 @@ function consumeMilestones(input: {
         consumer_digest: identity.digest,
         next_after_seq: nextAfterSeq,
         pending_tools: pendingTools,
-      } satisfies SupervisorCursorV1,
+        seen_intervention_ids: nextSeenInterventionIds,
+      } satisfies SupervisorCursorV2,
     });
     if (!updated.updated) throw new Error("Manager Supervisor cursor changed concurrently; retry status query");
   }
@@ -436,10 +552,11 @@ function consumeMilestones(input: {
     consumer_digest: identity.digest,
     after_seq: cursor.next_after_seq,
     next_after_seq: nextAfterSeq,
-    has_more: stoppedEarly || (nextAfterSeq >= page.next_after_seq && page.has_more),
+    has_more: stoppedEarly || (nextAfterSeq >= page.next_after_seq && page.has_more) || interventionsHaveMore,
     suppressed_progress_events: suppressedProgressEvents,
     milestones,
-    commentary: commentaryFor(milestones),
+    intervention_milestones: interventionMilestones,
+    commentary: [...commentaryFor(milestones), ...interventionCommentary(interventionMilestones)],
   };
 }
 

--- a/homerail_manager/src/server/host-codex-manager-agent.ts
+++ b/homerail_manager/src/server/host-codex-manager-agent.ts
@@ -31,6 +31,7 @@ import {
   matchingManagerAgentSkillViewToolDefinition,
   materializeManagerAgentSkillViewInput,
   mergeManagerAgentPluginSkillCatalog,
+  normalizeManagerAgentDagActorInterventionInput,
   executeHomerailPluginTool,
   homerailPluginTurnContextDigestInput,
   resolvePrCloseout,
@@ -1304,6 +1305,30 @@ export function createManagerTools(state: {
           }
         }
         return { content: [{ type: "text", text: short(body, 40000) }] };
+      },
+    },
+    {
+      ...managerAgentToolSpec("intervene_dag_actor"),
+      async handler(args) {
+        const input = normalizeManagerAgentDagActorInterventionInput(args);
+        const body = await requestManager(
+          state.restUrl,
+          `/runs/${encodeURIComponent(input.run_id)}/actors/${encodeURIComponent(input.actor_id)}/interventions`,
+          {
+            method: "POST",
+            body: JSON.stringify({
+              operation: input.operation,
+              ...(input.instruction === undefined ? {} : { instruction: input.instruction }),
+              expected_state_token: input.expected_state_token,
+              idempotency_key: input.idempotency_key,
+              ...(input.checkpoint_version === undefined
+                ? {}
+                : { checkpoint_version: input.checkpoint_version }),
+            }),
+          },
+        );
+        state.objectiveToolCalls.push({ name: "intervene_dag_actor", success: true });
+        return { content: [{ type: "text", text: short(body, 20000) }] };
       },
     },
     {

--- a/homerail_manager/src/server/mutations.ts
+++ b/homerail_manager/src/server/mutations.ts
@@ -538,12 +538,20 @@ export function mutationRoutesHandler(
       const idempotencyKey = typeof body.idempotency_key === "string" ? body.idempotency_key.trim() : "";
       if (!expectedStateToken) throw new Error("expected_state_token is required");
       if (!idempotencyKey) throw new Error("idempotency_key is required");
-      const instruction = typeof body.instruction === "string" ? body.instruction : undefined;
-      const checkpointVersion = body.checkpoint_version === undefined
-        ? undefined
-        : Number(body.checkpoint_version);
-      if (checkpointVersion !== undefined && (!Number.isSafeInteger(checkpointVersion) || checkpointVersion < 1)) {
-        throw new Error("checkpoint_version must be a positive integer");
+      if (body.instruction !== undefined && typeof body.instruction !== "string") {
+        throw new Error("instruction must be a string when provided");
+      }
+      const instruction = body.instruction as string | undefined;
+      let checkpointVersion: number | undefined;
+      if (body.checkpoint_version !== undefined) {
+        if (
+          typeof body.checkpoint_version !== "number"
+          || !Number.isSafeInteger(body.checkpoint_version)
+          || body.checkpoint_version < 1
+        ) {
+          throw new Error("checkpoint_version must be a positive integer");
+        }
+        checkpointVersion = body.checkpoint_version;
       }
       const result = changeOrchestrator.interveneActor(runId, {
         actor_id: actorId,

--- a/homerail_manager/src/server/mutations.ts
+++ b/homerail_manager/src/server/mutations.ts
@@ -29,6 +29,8 @@ import {
   focusDagSupervisorActor,
   getDagSupervisionSnapshot,
 } from "../runtime/dag-manager-supervisor.js";
+import { DagActorInterventionConflictError } from "../persistence/dag-actor-interventions.js";
+import { DagActorInterventionRuntimeError } from "../runtime/active-runs.js";
 
 interface BaseResponse {
   success: boolean;
@@ -68,6 +70,10 @@ function _unavailable(res: http.ServerResponse, message: string, data?: unknown)
 
 function _created(res: http.ServerResponse, message: string, data: unknown) {
   json(res, 201, { success: true, message, data });
+}
+
+function _accepted(res: http.ServerResponse, message: string, data: unknown) {
+  json(res, 202, { success: true, message, data });
 }
 
 function _runCreationError(res: http.ServerResponse, error: unknown): void {
@@ -501,6 +507,73 @@ export function mutationRoutesHandler(
       else if (message.includes("conflict") || message.includes("reused with different input")) {
         json(res, 409, { success: false, message, error: message });
       } else _badRequest(res, message);
+    });
+    return true;
+  }
+
+  // POST /api/runs/:run_id/actors/:actor_id/interventions
+  const actorInterventionMatch = pathname.match(/^\/api\/runs\/([^/]+)\/actors\/([^/]+)\/interventions$/);
+  if (actorInterventionMatch && req.method === "POST") {
+    const runId = decodeURIComponent(actorInterventionMatch[1]);
+    const actorId = decodeURIComponent(actorInterventionMatch[2]);
+    void _readJsonBody(req).then((raw) => {
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) throw new Error("request body must be an object");
+      const body = raw as Record<string, unknown>;
+      const allowed = new Set([
+        "operation",
+        "instruction",
+        "expected_state_token",
+        "idempotency_key",
+        "checkpoint_version",
+      ]);
+      const unknown = Object.keys(body).filter((key) => !allowed.has(key));
+      if (unknown.length > 0) throw new Error(`unsupported intervention fields: ${unknown.sort().join(", ")}`);
+      const operation = typeof body.operation === "string" ? body.operation.trim() : "";
+      if (!["interrupt", "cancel", "retry", "reassign", "checkpoint_fork"].includes(operation)) {
+        throw new Error("operation must be interrupt, cancel, retry, reassign, or checkpoint_fork");
+      }
+      const expectedStateToken = typeof body.expected_state_token === "string"
+        ? body.expected_state_token.trim()
+        : "";
+      const idempotencyKey = typeof body.idempotency_key === "string" ? body.idempotency_key.trim() : "";
+      if (!expectedStateToken) throw new Error("expected_state_token is required");
+      if (!idempotencyKey) throw new Error("idempotency_key is required");
+      const instruction = typeof body.instruction === "string" ? body.instruction : undefined;
+      const checkpointVersion = body.checkpoint_version === undefined
+        ? undefined
+        : Number(body.checkpoint_version);
+      if (checkpointVersion !== undefined && (!Number.isSafeInteger(checkpointVersion) || checkpointVersion < 1)) {
+        throw new Error("checkpoint_version must be a positive integer");
+      }
+      const result = changeOrchestrator.interveneActor(runId, {
+        actor_id: actorId,
+        operation: operation as "interrupt" | "cancel" | "retry" | "reassign" | "checkpoint_fork",
+        expected_state_token: expectedStateToken,
+        idempotency_key: idempotencyKey,
+        ...(instruction === undefined ? {} : { instruction }),
+        ...(checkpointVersion === undefined ? {} : { checkpoint_version: checkpointVersion }),
+      });
+      if (result.deduplicated) _ok(res, "DAG Actor intervention already applied", result);
+      else _accepted(res, "DAG Actor intervention applied", result);
+    }).catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      if (
+        (error instanceof DagActorInterventionRuntimeError
+          && error.code === "actor_not_found")
+        || message.includes("Unknown DAG actor")
+        || message.includes("Run not found")
+      ) {
+        _notFound(res, message);
+      } else if (
+        error instanceof DagActorInterventionConflictError
+        || error instanceof DagActorInterventionRuntimeError
+        || message.includes("conflict")
+        || message.includes("not active")
+      ) {
+        json(res, 409, { success: false, message, error: message });
+      } else {
+        _badRequest(res, message);
+      }
     });
     return true;
   }

--- a/homerail_manager/src/server/routes.ts
+++ b/homerail_manager/src/server/routes.ts
@@ -27,10 +27,16 @@ import { getDagState, listPendingApprovals } from "../persistence/dag-runtime-pr
 import { listDagTriggers } from "../persistence/dag-triggers.js";
 import { listDagActivityEvents } from "../persistence/dag-activity-journal.js";
 import { listDagActorCommands, type DagActorCommandStatus } from "../persistence/dag-actors.js";
+import {
+  getDagActorIntervention,
+  listDagActorInterventions,
+  type DagActorInterventionRecord,
+} from "../persistence/dag-actor-interventions.js";
 import { listDagRunRounds } from "../persistence/dag-run-rounds.js";
 import {
   getDagLiveSurfaceDocument,
   isDagLiveSurfaceProjectionNode,
+  listDagLiveSurfaceGenerationHistory,
   listDagLiveSurfaceProjections,
 } from "../generative-ui/dag-live-surface-projector.js";
 import {
@@ -56,6 +62,21 @@ function _notFound(res: http.ServerResponse, message: string) {
 
 function _ok(res: http.ServerResponse, message: string, data?: unknown) {
   json(res, 200, { success: true, message, data });
+}
+
+function _publicIntervention(intervention: DagActorInterventionRecord) {
+  return {
+    intervention_id: intervention.intervention_id,
+    run_id: intervention.run_id,
+    actor_id: intervention.actor_id,
+    operation: intervention.operation,
+    status: intervention.status,
+    ...(intervention.instruction === undefined ? {} : { instruction: intervention.instruction }),
+    created_at: intervention.created_at,
+    ...(intervention.started_at === undefined ? {} : { started_at: intervention.started_at }),
+    ...(intervention.completed_at === undefined ? {} : { completed_at: intervention.completed_at }),
+    ...(intervention.failure === undefined ? {} : { failure: intervention.failure }),
+  };
 }
 
 function _sseHeaders(res: http.ServerResponse): void {
@@ -645,6 +666,83 @@ export function inspectionRoutesHandler(
     return true;
   }
 
+  const actorInterventionDetailMatch = pathname.match(
+    /^\/api\/runs\/([^/]+)\/actors\/([^/]+)\/interventions\/([^/]+)$/,
+  );
+  if (actorInterventionDetailMatch && req.method === "GET") {
+    const runId = decodeURIComponent(actorInterventionDetailMatch[1]);
+    const actorId = decodeURIComponent(actorInterventionDetailMatch[2]);
+    const interventionId = decodeURIComponent(actorInterventionDetailMatch[3]);
+    if (!loadRunMetadata(runId)) {
+      _notFound(res, `Run not found: ${runId}`);
+      return true;
+    }
+    const intervention = getDagActorIntervention(interventionId);
+    if (!intervention || intervention.run_id !== runId || intervention.actor_id !== actorId) {
+      _notFound(res, `DAG Actor intervention not found: ${interventionId}`);
+      return true;
+    }
+    _ok(res, "DAG Actor intervention retrieved", _publicIntervention(intervention));
+    return true;
+  }
+
+  const actorInterventionsMatch = pathname.match(/^\/api\/runs\/([^/]+)\/actors\/([^/]+)\/interventions$/);
+  if (actorInterventionsMatch && req.method === "GET") {
+    const runId = decodeURIComponent(actorInterventionsMatch[1]);
+    const actorId = decodeURIComponent(actorInterventionsMatch[2]);
+    if (!loadRunMetadata(runId)) {
+      _notFound(res, `Run not found: ${runId}`);
+      return true;
+    }
+    try {
+      const url = new URL(req.url || "/", "http://localhost");
+      const interventions = listDagActorInterventions({
+        run_id: runId,
+        actor_id: actorId,
+        limit: url.searchParams.get("limit") ? Number(url.searchParams.get("limit")) : undefined,
+      }).map(_publicIntervention);
+      _ok(res, `Found ${interventions.length} intervention(s)`, {
+        run_id: runId,
+        actor_id: actorId,
+        interventions,
+        total: interventions.length,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      json(res, 400, { success: false, message, error: message });
+    }
+    return true;
+  }
+
+  const actorSurfaceHistoryMatch = pathname.match(/^\/api\/runs\/([^/]+)\/actors\/([^/]+)\/surface-history$/);
+  if (actorSurfaceHistoryMatch && req.method === "GET") {
+    const runId = decodeURIComponent(actorSurfaceHistoryMatch[1]);
+    const actorId = decodeURIComponent(actorSurfaceHistoryMatch[2]);
+    if (!loadRunMetadata(runId)) {
+      _notFound(res, `Run not found: ${runId}`);
+      return true;
+    }
+    try {
+      const url = new URL(req.url || "/", "http://localhost");
+      const history = listDagLiveSurfaceGenerationHistory({
+        run_id: runId,
+        actor_id: actorId,
+        limit: url.searchParams.get("limit") ? Number(url.searchParams.get("limit")) : undefined,
+      });
+      _ok(res, `Found ${history.length} superseded surface generation(s)`, {
+        run_id: runId,
+        actor_id: actorId,
+        generation_state: "superseded",
+        history,
+        total: history.length,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      json(res, 400, { success: false, message, error: message });
+    }
+    return true;
+  }
+
   // GET /api/runs/:run_id/live-surfaces
   if (pathname.match(/^\/api\/runs\/[^/]+\/live-surfaces$/) && req.method === "GET") {
     let runId = "";
@@ -661,9 +759,29 @@ export function inspectionRoutesHandler(
     const projections = listDagLiveSurfaceProjections(runId);
     const projectionBySurface = new Map(projections.map((projection) => [projection.surface_id, projection]));
     const document = getDagLiveSurfaceDocument(runId);
+    const surfaceStates = projections.map((projection) => {
+      const latestIntervention = listDagActorInterventions({
+        run_id: runId,
+        actor_id: projection.actor_id,
+        limit: 1,
+      })[0];
+      const supersededCount = listDagLiveSurfaceGenerationHistory({
+        run_id: runId,
+        actor_id: projection.actor_id,
+        limit: 100,
+      }).length;
+      return {
+        actor_id: projection.actor_id,
+        surface_id: projection.surface_id,
+        generation_state: "current" as const,
+        superseded_count: supersededCount,
+        ...(latestIntervention ? { latest_intervention: _publicIntervention(latestIntervention) } : {}),
+      };
+    });
     _ok(res, `Live surfaces retrieved (${projections.length} actors)`, {
       run_id: runId,
       projections,
+      surface_states: surfaceStates,
       document: document
         ? {
             ...document,

--- a/homerail_manager/tests/dag-actor-branch-intervention.test.ts
+++ b/homerail_manager/tests/dag-actor-branch-intervention.test.ts
@@ -20,6 +20,7 @@ import type {
 } from "../src/orchestration/dag-dispatcher.js";
 import {
   _clearAllDispatches,
+  clearByTargetId,
   findDispatchExclusion,
   recordDispatch,
 } from "../src/orchestration/dispatch-tracker.js";
@@ -309,12 +310,12 @@ describe("runtime-backed DAG actor branch intervention", () => {
   });
 
   it.each([
-    ["retry", "READY", "dormant"],
-    ["reassign", "READY", "dormant"],
-    ["checkpoint_fork", "READY", "dormant"],
-    ["interrupt", "CANCELLED", "dormant"],
-    ["cancel", "CANCELLED", "retired"],
-  ] as const)("enforces %s branch state, checkpoint, and lease semantics", (operation, nodeState, leaseState) => {
+    ["retry", "READY", "dormant", "active"],
+    ["reassign", "READY", "dormant", "active"],
+    ["checkpoint_fork", "READY", "dormant", "active"],
+    ["interrupt", "CANCELLED", "retired", "cancelled"],
+    ["cancel", "CANCELLED", "retired", "cancelled"],
+  ] as const)("enforces %s branch state, checkpoint, and lease semantics", (operation, nodeState, leaseState, runStatus) => {
     const runId = `operation-${operation}`;
     const dispatcher = new ActorDispatcher();
     createActiveRun(runId, oneActorDag());
@@ -344,6 +345,8 @@ describe("runtime-backed DAG actor branch intervention", () => {
 
     expect(result.status).toBe("applied");
     expect(getActiveRun(runId)?.dagRun.nodeStates.get("research")).toBe(nodeState);
+    expect(getActiveRun(runId)?.status).toBe(runStatus);
+    if (runStatus === "cancelled") expect(getActiveRun(runId)?.completedAt).toEqual(expect.any(Number));
     expect(getDagActor(runId, "research")).toMatchObject({
       generation: 2,
       checkpoint_ref: `portable:${operation === "checkpoint_fork" ? checkpointVersion : 1}`,
@@ -358,6 +361,65 @@ describe("runtime-backed DAG actor branch intervention", () => {
     } else {
       expect(findDispatchExclusion(runId, "research")).toBeUndefined();
     }
+  });
+
+  it("keeps a reassign exclusion across target disconnect and Manager restart until replacement dispatch", () => {
+    const runId = "durable-reassign-exclusion";
+    const dispatcher = new ActorDispatcher();
+    createActiveRun(runId, oneActorDag());
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+
+    interveneActiveRunActor(runId, {
+      actor_id: "research",
+      operation: "reassign",
+      expected_state_token: getDagActorControlState(runId, "research").state_token,
+      idempotency_key: "durable-reassign-once",
+    });
+    expect(findDispatchExclusion(runId, "research")).toEqual({
+      targetType: "worker",
+      targetId: "worker-research",
+    });
+    clearByTargetId("worker-research");
+    expect(findDispatchExclusion(runId, "research")?.targetId).toBe("worker-research");
+
+    _clearActiveRuns();
+    _clearAllDispatches();
+    closeDb();
+    expect(recoverAllActiveRuns().recovered).toContain(runId);
+    expect(recoverDagActorInterventions()).toEqual({ applied: [], failed: [], skipped: [] });
+    expect(findDispatchExclusion(runId, "research")?.targetId).toBe("worker-research");
+
+    recordDispatch(runId, "research", "worker", "replacement-worker");
+    expect(findDispatchExclusion(runId, "research")).toBeUndefined();
+    _clearActiveRuns();
+    _clearAllDispatches();
+    closeDb();
+    expect(recoverAllActiveRuns().recovered).toContain(runId);
+    recoverDagActorInterventions();
+    expect(findDispatchExclusion(runId, "research")).toBeUndefined();
+  });
+
+  it("rejects new interventions after an actor branch is retired", () => {
+    const runId = "retired-actor-intervention";
+    const dispatcher = new ActorDispatcher();
+    createActiveRun(runId, threeActorDag());
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(3);
+
+    interveneActiveRunActor(runId, {
+      actor_id: "research",
+      operation: "cancel",
+      expected_state_token: getDagActorControlState(runId, "research").state_token,
+      idempotency_key: "cancel-research",
+    });
+    expect(getActiveRun(runId)?.status).toBe("active");
+    expect(getDagActorLease({ run_id: runId, actor_id: "research" })?.state).toBe("retired");
+    expect(() => interveneActiveRunActor(runId, {
+      actor_id: "research",
+      operation: "retry",
+      expected_state_token: getDagActorControlState(runId, "research").state_token,
+      idempotency_key: "retry-retired-research",
+    })).toThrow("is retired and cannot accept another intervention");
+    expect(listDagActorInterventions({ run_id: runId, actor_id: "research" })).toHaveLength(1);
   });
 
   it("recovers a durable queued intervention before orphaned running-node demotion", () => {
@@ -400,5 +462,37 @@ describe("runtime-backed DAG actor branch intervention", () => {
     expect(getActiveRun(runId)?.dagRun.nodeStates.get("research")).toBe("READY");
     expect(listDagLiveSurfaceGenerationHistory({ run_id: runId, actor_id: "research" })).toHaveLength(1);
     expect(recoverDagActorInterventions()).toEqual({ applied: [], failed: [], skipped: [] });
+  });
+
+  it("demotes an orphaned running node when its queued intervention cannot recover", () => {
+    const runId = "recover-failed-intervention";
+    const dispatcher = new ActorDispatcher();
+    createActiveRun(runId, oneActorDag());
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+    const actor = getDagActor(runId, "research")!;
+    createDagActorIntervention({
+      intervention_id: "recover-missing-checkpoint",
+      run_id: runId,
+      actor_id: actor.actor_id,
+      operation: "checkpoint_fork",
+      checkpoint_version: 999,
+      expected_actor_generation: actor.generation,
+      expected_actor_version: actor.version,
+      idempotency_key: "recover-missing-checkpoint-once",
+    });
+
+    _clearActiveRuns();
+    _clearAllDispatches();
+    closeDb();
+    expect(recoverAllActiveRuns()).toMatchObject({ recovered: [runId], failed: [] });
+    expect(getActiveRun(runId)?.dagRun.nodeStates.get("research")).toBe("RUNNING");
+    expect(recoverDagActorInterventions()).toEqual({
+      applied: [],
+      failed: ["recover-missing-checkpoint"],
+      skipped: [],
+    });
+    expect(getDagActorIntervention("recover-missing-checkpoint")?.status).toBe("failed");
+    expect(getActiveRun(runId)?.dagRun.nodeStates.get("research")).toBe("FAILED");
+    expect(getActiveRun(runId)).toMatchObject({ status: "failed", completedAt: expect.any(Number) });
   });
 });

--- a/homerail_manager/tests/dag-actor-branch-intervention.test.ts
+++ b/homerail_manager/tests/dag-actor-branch-intervention.test.ts
@@ -1,0 +1,404 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  DAG_ACTIVITY_EVENT_SCHEMA_VERSION,
+  type DagActivityEventV1,
+} from "homerail-protocol";
+
+import {
+  getDagLiveSurfaceDocument,
+  getDagLiveSurfaceProjection,
+  listDagLiveSurfaceGenerationHistory,
+  projectDagActivityJournalEntry,
+} from "../src/generative-ui/dag-live-surface-projector.js";
+import type {
+  DAGDispatcher,
+  DispatchEnvelope,
+  DispatchResult,
+} from "../src/orchestration/dag-dispatcher.js";
+import {
+  _clearAllDispatches,
+  findDispatchExclusion,
+  recordDispatch,
+} from "../src/orchestration/dispatch-tracker.js";
+import { parseDAGYaml } from "../src/orchestration/yaml-loader.js";
+import { appendDagActivityEvent } from "../src/persistence/dag-activity-journal.js";
+import {
+  createDagActorIntervention,
+  getDagActorIntervention,
+  listDagActorInterventions,
+} from "../src/persistence/dag-actor-interventions.js";
+import { getDagActor, listDagActors } from "../src/persistence/dag-actors.js";
+import {
+  acquireDagActorLease,
+  getDagActorLease,
+  writeDagActorCheckpoint,
+} from "../src/persistence/dag-actor-leases.js";
+import { closeDb } from "../src/persistence/db.js";
+import { _clearAllPersistence } from "../src/persistence/store.js";
+import {
+  _clearActiveRuns,
+  createActiveRun,
+  dispatchReadyNodes,
+  getActiveRun,
+  handoffActiveRun,
+  interveneActiveRunActor,
+  recoverAllActiveRuns,
+  recoverDagActorInterventions,
+} from "../src/runtime/active-runs.js";
+import { buildDagActorCheckpoint } from "../src/runtime/dag-actor-checkpoint-builder.js";
+import { getDagActorControlState } from "../src/runtime/dag-actor-control-state.js";
+
+class ActorDispatcher implements DAGDispatcher {
+  readonly dispatched: DispatchEnvelope[] = [];
+
+  dispatch(envelope: DispatchEnvelope): DispatchResult {
+    if (!envelope.activity) throw new Error("test dispatch is missing durable actor identity");
+    const targetId = `worker-${envelope.activity.actorId}`;
+    const lease = acquireDagActorLease({
+      run_id: envelope.runId,
+      actor_id: envelope.activity.actorId,
+      target_type: "worker",
+      target_id: targetId,
+    });
+    const dispatched = structuredClone({
+      ...envelope,
+      activity: {
+        ...envelope.activity,
+        leaseGeneration: lease.lease_generation,
+      },
+    });
+    this.dispatched.push(dispatched);
+    recordDispatch(envelope.runId, envelope.nodeId, "worker", targetId);
+    return { status: "dispatched", targetType: "worker", targetId };
+  }
+}
+
+function threeActorDag() {
+  return parseDAGYaml(`
+name: branch-intervention
+workflow_id: branch-intervention
+agents:
+  worker: { agent_type: deterministic }
+nodes:
+  research:
+    agent: worker
+    extra:
+      agent_runtime:
+        actor_id: research
+        role: Research
+        surface_id: surface:research
+    outputs:
+      result: { to: join.in:research }
+  build:
+    agent: worker
+    extra:
+      agent_runtime:
+        actor_id: build
+        role: Build
+        surface_id: surface:build
+    outputs:
+      result: { to: join.in:build }
+  verify:
+    agent: worker
+    extra:
+      agent_runtime:
+        actor_id: verify
+        role: Verify
+        surface_id: surface:verify
+    outputs:
+      result: { to: join.in:verify }
+  join:
+    type: join_gateway
+    after: [research, build, verify]
+    gateway_config:
+      mode: all
+      passed_port: merged
+      failed_port: failed
+`);
+}
+
+function oneActorDag() {
+  return parseDAGYaml(`
+name: recover-intervention
+workflow_id: recover-intervention
+agents:
+  worker: { agent_type: deterministic }
+nodes:
+  research:
+    agent: worker
+    extra:
+      agent_runtime:
+        actor_id: research
+        role: Research
+        surface_id: surface:research
+`);
+}
+
+function activity(input: {
+  runId: string;
+  actorId: string;
+  generation?: number;
+  sequence: number;
+  type: DagActivityEventV1["type"];
+  payload?: DagActivityEventV1["payload"];
+}): DagActivityEventV1 {
+  const generation = input.generation ?? 1;
+  return {
+    schema_version: DAG_ACTIVITY_EVENT_SCHEMA_VERSION,
+    event_id: `${input.runId}-${input.actorId}-g${generation}-s${input.sequence}-${input.type}`,
+    run_id: input.runId,
+    round_id: "round-0001",
+    node_id: input.actorId,
+    actor_id: input.actorId,
+    generation,
+    surface_id: `surface:${input.actorId}`,
+    sequence: input.sequence,
+    timestamp: Date.now() + input.sequence,
+    type: input.type,
+    payload: input.payload ?? { message: `${input.actorId} ${input.type}` },
+  };
+}
+
+function appendAndProject(event: DagActivityEventV1): void {
+  projectDagActivityJournalEntry(appendDagActivityEvent(event));
+}
+
+function projectInitialEvidence(runId: string, actorIds: readonly string[]): void {
+  for (const actorId of actorIds) {
+    appendAndProject(activity({ runId, actorId, sequence: 1, type: "started" }));
+    appendAndProject(activity({
+      runId,
+      actorId,
+      sequence: 2,
+      type: "finding",
+      payload: { title: `${actorId} evidence`, detail: `durable ${actorId} result` },
+    }));
+  }
+}
+
+function nodeById(runId: string, nodeId: string) {
+  return getDagLiveSurfaceDocument(runId)?.nodes.find((node) => node.id === nodeId);
+}
+
+describe("runtime-backed DAG actor branch intervention", () => {
+  let home: string;
+  let previousHome: string | undefined;
+
+  beforeEach(() => {
+    previousHome = process.env.HOMERAIL_HOME;
+    home = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-branch-intervention-"));
+    process.env.HOMERAIL_HOME = home;
+    closeDb();
+    _clearActiveRuns();
+    _clearAllPersistence();
+    _clearAllDispatches();
+  });
+
+  afterEach(() => {
+    _clearActiveRuns();
+    _clearAllPersistence();
+    _clearAllDispatches();
+    closeDb();
+    if (previousHome === undefined) delete process.env.HOMERAIL_HOME;
+    else process.env.HOMERAIL_HOME = previousHome;
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it("retries only the selected branch, preserves other surfaces, and fences the old generation", () => {
+    const runId = "intervene-one-of-three";
+    const dispatcher = new ActorDispatcher();
+    createActiveRun(runId, threeActorDag());
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(3);
+    projectInitialEvidence(runId, ["research", "build", "verify"]);
+
+    const actorsBefore = new Map(listDagActors(runId).map((actor) => [actor.actor_id, actor]));
+    const researchBefore = actorsBefore.get("research")!;
+    const oldEnvelope = dispatcher.dispatched.find((entry) => entry.activity?.actorId === "research")!;
+    const buildSurfaceBefore = structuredClone(nodeById(runId, "surface:build"));
+    const verifySurfaceBefore = structuredClone(nodeById(runId, "surface:verify"));
+    const researchSurfaceBefore = structuredClone(nodeById(runId, "surface:research"));
+    const oldToken = getDagActorControlState(runId, "research").state_token;
+
+    const result = interveneActiveRunActor(runId, {
+      actor_id: "research",
+      operation: "retry",
+      expected_state_token: oldToken,
+      idempotency_key: "retry-research-once",
+      instruction: "Use the retained evidence and verify the corrected claim.",
+    });
+
+    expect(result).toMatchObject({
+      run_id: runId,
+      actor_id: "research",
+      operation: "retry",
+      status: "applied",
+      actor_state: "ready",
+      deduplicated: false,
+    });
+    const actorsAfter = new Map(listDagActors(runId).map((actor) => [actor.actor_id, actor]));
+    expect(actorsAfter.get("research")).toMatchObject({
+      generation: researchBefore.generation + 1,
+      attempt: researchBefore.attempt + 1,
+      checkpoint_ref: "portable:1",
+    });
+    expect(actorsAfter.get("build")).toEqual(actorsBefore.get("build"));
+    expect(actorsAfter.get("verify")).toEqual(actorsBefore.get("verify"));
+    expect(getActiveRun(runId)?.dagRun.nodeStates.get("research")).toBe("READY");
+    expect(getActiveRun(runId)?.dagRun.nodeStates.get("build")).toBe("RUNNING");
+    expect(getActiveRun(runId)?.dagRun.nodeStates.get("verify")).toBe("RUNNING");
+
+    expect(nodeById(runId, "surface:build")).toEqual(buildSurfaceBefore);
+    expect(nodeById(runId, "surface:verify")).toEqual(verifySurfaceBefore);
+    expect(nodeById(runId, "surface:research")).toMatchObject({
+      id: researchSurfaceBefore?.id,
+      revision: (researchSurfaceBefore?.revision ?? 0) + 1,
+      content: {
+        data: {
+          actor: { id: "research", generation: 2 },
+          intervention: {
+            operation: "retry",
+            generation_state: "current",
+            supersedes_generation: 1,
+          },
+          findings: [],
+        },
+      },
+    });
+    const history = listDagLiveSurfaceGenerationHistory({ run_id: runId, actor_id: "research" });
+    expect(history).toHaveLength(1);
+    expect(history[0]).toMatchObject({ generation: 1, superseded_by_generation: 2 });
+    expect(history[0]?.node_snapshot).toMatchObject({
+      content: { data: { findings: [{ title: "research evidence" }] } },
+    });
+    expect(listDagLiveSurfaceGenerationHistory({ run_id: runId, actor_id: "build" })).toEqual([]);
+    expect(getDagLiveSurfaceProjection(runId, "research")).toMatchObject({
+      generation: 2,
+      visibility_state: "focused",
+    });
+    expect(getDagActorLease({ run_id: runId, actor_id: "research" })?.state).toBe("dormant");
+
+    expect(() => handoffActiveRun(runId, "research", "result", { ok: true }, {
+      transport: true,
+      roundId: oldEnvelope.activity!.roundId,
+      actorId: oldEnvelope.activity!.actorId,
+      generation: oldEnvelope.activity!.generation,
+      leaseGeneration: oldEnvelope.activity!.leaseGeneration,
+    })).toThrow("DAG_HANDOFF_GENERATION_CONFLICT");
+
+    expect(interveneActiveRunActor(runId, {
+      actor_id: "research",
+      operation: "retry",
+      expected_state_token: oldToken,
+      idempotency_key: "retry-research-once",
+      instruction: "Use the retained evidence and verify the corrected claim.",
+    })).toMatchObject({
+      intervention_id: result.intervention_id,
+      deduplicated: true,
+      state_token: result.state_token,
+    });
+    expect(() => interveneActiveRunActor(runId, {
+      actor_id: "research",
+      operation: "retry",
+      expected_state_token: oldToken,
+      idempotency_key: "retry-research-again",
+    })).toThrow("state changed before intervention");
+    expect(listDagActorInterventions({ run_id: runId, actor_id: "research" })).toHaveLength(1);
+  });
+
+  it.each([
+    ["retry", "READY", "dormant"],
+    ["reassign", "READY", "dormant"],
+    ["checkpoint_fork", "READY", "dormant"],
+    ["interrupt", "CANCELLED", "dormant"],
+    ["cancel", "CANCELLED", "retired"],
+  ] as const)("enforces %s branch state, checkpoint, and lease semantics", (operation, nodeState, leaseState) => {
+    const runId = `operation-${operation}`;
+    const dispatcher = new ActorDispatcher();
+    createActiveRun(runId, oneActorDag());
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+    projectInitialEvidence(runId, ["research"]);
+    const actor = getDagActor(runId, "research")!;
+    let checkpointVersion: number | undefined;
+    if (operation === "checkpoint_fork") {
+      checkpointVersion = writeDagActorCheckpoint({
+        run_id: runId,
+        actor_id: "research",
+        checkpoint: buildDagActorCheckpoint({
+          runId,
+          actor,
+          roundId: "round-0001",
+        }),
+        expected_checkpoint_version: 0,
+      }).checkpoint_version;
+    }
+    const result = interveneActiveRunActor(runId, {
+      actor_id: "research",
+      operation,
+      expected_state_token: getDagActorControlState(runId, "research").state_token,
+      idempotency_key: `key-${operation}`,
+      ...(checkpointVersion === undefined ? {} : { checkpoint_version: checkpointVersion }),
+    });
+
+    expect(result.status).toBe("applied");
+    expect(getActiveRun(runId)?.dagRun.nodeStates.get("research")).toBe(nodeState);
+    expect(getDagActor(runId, "research")).toMatchObject({
+      generation: 2,
+      checkpoint_ref: `portable:${operation === "checkpoint_fork" ? checkpointVersion : 1}`,
+    });
+    expect(getDagActorLease({ run_id: runId, actor_id: "research" })?.state).toBe(leaseState);
+    expect(listDagLiveSurfaceGenerationHistory({ run_id: runId, actor_id: "research" })).toHaveLength(1);
+    if (operation === "reassign") {
+      expect(findDispatchExclusion(runId, "research")).toEqual({
+        targetType: "worker",
+        targetId: "worker-research",
+      });
+    } else {
+      expect(findDispatchExclusion(runId, "research")).toBeUndefined();
+    }
+  });
+
+  it("recovers a durable queued intervention before orphaned running-node demotion", () => {
+    const runId = "recover-queued-intervention";
+    const dispatcher = new ActorDispatcher();
+    createActiveRun(runId, oneActorDag());
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+    projectInitialEvidence(runId, ["research"]);
+    const actor = getDagActor(runId, "research")!;
+    createDagActorIntervention({
+      intervention_id: "recover-intervention",
+      run_id: runId,
+      actor_id: actor.actor_id,
+      operation: "retry",
+      expected_actor_generation: actor.generation,
+      expected_actor_version: actor.version,
+      idempotency_key: "recover-once",
+    });
+
+    _clearActiveRuns();
+    _clearAllDispatches();
+    closeDb();
+
+    expect(recoverAllActiveRuns()).toMatchObject({
+      recovered: [runId],
+      failed: [],
+    });
+    expect(getActiveRun(runId)?.dagRun.nodeStates.get("research")).toBe("RUNNING");
+    expect(recoverDagActorInterventions()).toEqual({
+      applied: ["recover-intervention"],
+      failed: [],
+      skipped: [],
+    });
+    expect(getDagActorIntervention("recover-intervention")).toMatchObject({
+      status: "applied",
+      from_generation: 1,
+      to_generation: 2,
+    });
+    expect(getDagActor(runId, "research")).toMatchObject({ generation: 2, checkpoint_ref: "portable:1" });
+    expect(getActiveRun(runId)?.dagRun.nodeStates.get("research")).toBe("READY");
+    expect(listDagLiveSurfaceGenerationHistory({ run_id: runId, actor_id: "research" })).toHaveLength(1);
+    expect(recoverDagActorInterventions()).toEqual({ applied: [], failed: [], skipped: [] });
+  });
+});

--- a/homerail_manager/tests/dag-actor-intervention-api.test.ts
+++ b/homerail_manager/tests/dag-actor-intervention-api.test.ts
@@ -1,0 +1,263 @@
+import * as fs from "node:fs";
+import * as http from "node:http";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  DAG_ACTIVITY_EVENT_SCHEMA_VERSION,
+  type DagActivityEventV1,
+} from "homerail-protocol";
+
+import { projectDagActivityJournalEntry } from "../src/generative-ui/dag-live-surface-projector.js";
+import type {
+  DAGDispatcher,
+  DispatchEnvelope,
+  DispatchResult,
+} from "../src/orchestration/dag-dispatcher.js";
+import { _clearAllDispatches, recordDispatch } from "../src/orchestration/dispatch-tracker.js";
+import { parseDAGYaml } from "../src/orchestration/yaml-loader.js";
+import { appendDagActivityEvent } from "../src/persistence/dag-activity-journal.js";
+import { acquireDagActorLease } from "../src/persistence/dag-actor-leases.js";
+import { closeDb } from "../src/persistence/db.js";
+import { _clearAllPersistence } from "../src/persistence/store.js";
+import {
+  _clearActiveRuns,
+  createActiveRun,
+  dispatchReadyNodes,
+} from "../src/runtime/active-runs.js";
+import { getDagActorControlState } from "../src/runtime/dag-actor-control-state.js";
+import { createServer } from "../src/server/http.js";
+
+class ApiDispatcher implements DAGDispatcher {
+  readonly dispatched: DispatchEnvelope[] = [];
+
+  dispatch(envelope: DispatchEnvelope): DispatchResult {
+    if (!envelope.activity) throw new Error("test dispatch is missing actor identity");
+    const targetId = `worker-${envelope.activity.actorId}-${this.dispatched.length + 1}`;
+    const lease = acquireDagActorLease({
+      run_id: envelope.runId,
+      actor_id: envelope.activity.actorId,
+      target_type: "worker",
+      target_id: targetId,
+    });
+    this.dispatched.push(structuredClone({
+      ...envelope,
+      activity: { ...envelope.activity, leaseGeneration: lease.lease_generation },
+    }));
+    recordDispatch(envelope.runId, envelope.nodeId, "worker", targetId);
+    return { status: "dispatched", targetType: "worker", targetId };
+  }
+}
+
+function oneActorDag() {
+  return parseDAGYaml(`
+name: intervention-api
+workflow_id: intervention-api
+agents:
+  worker: { agent_type: deterministic }
+nodes:
+  research:
+    agent: worker
+    extra:
+      agent_runtime:
+        actor_id: research
+        role: Research
+        surface_id: surface:research
+`);
+}
+
+function activity(sequence: number, type: DagActivityEventV1["type"]): DagActivityEventV1 {
+  return {
+    schema_version: DAG_ACTIVITY_EVENT_SCHEMA_VERSION,
+    event_id: `api-research-${sequence}-${type}`,
+    run_id: "intervention-api-run",
+    round_id: "round-0001",
+    node_id: "research",
+    actor_id: "research",
+    generation: 1,
+    surface_id: "surface:research",
+    sequence,
+    timestamp: Date.now() + sequence,
+    type,
+    payload: type === "finding"
+      ? { title: "Original result", detail: "Retain this evidence" }
+      : { message: "Research started" },
+  };
+}
+
+async function listen(server: http.Server): Promise<number> {
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address !== "object") throw new Error("server did not bind");
+  return address.port;
+}
+
+async function closeServer(server: http.Server | undefined): Promise<void> {
+  if (!server?.listening) return;
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+async function jsonResponse(url: string, init?: RequestInit): Promise<{
+  status: number;
+  body: Record<string, unknown>;
+}> {
+  const response = await fetch(url, init);
+  return { status: response.status, body: await response.json() as Record<string, unknown> };
+}
+
+function jsonPost(body: unknown, token?: string): RequestInit {
+  return {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { "X-Homerail-Dag-Token": token } : {}),
+    },
+    body: JSON.stringify(body),
+  };
+}
+
+describe("DAG actor intervention HTTP API", () => {
+  let home: string;
+  let previousHome: string | undefined;
+  let previousMutationToken: string | undefined;
+  let server: http.Server | undefined;
+
+  beforeEach(() => {
+    previousHome = process.env.HOMERAIL_HOME;
+    previousMutationToken = process.env.HOMERAIL_DAG_MUTATION_TOKEN;
+    home = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-intervention-api-"));
+    process.env.HOMERAIL_HOME = home;
+    process.env.HOMERAIL_DAG_MUTATION_TOKEN = "test-mutation-token";
+    closeDb();
+    _clearActiveRuns();
+    _clearAllPersistence();
+    _clearAllDispatches();
+  });
+
+  afterEach(async () => {
+    await closeServer(server);
+    server = undefined;
+    _clearActiveRuns();
+    _clearAllPersistence();
+    _clearAllDispatches();
+    closeDb();
+    if (previousHome === undefined) delete process.env.HOMERAIL_HOME;
+    else process.env.HOMERAIL_HOME = previousHome;
+    if (previousMutationToken === undefined) delete process.env.HOMERAIL_DAG_MUTATION_TOKEN;
+    else process.env.HOMERAIL_DAG_MUTATION_TOKEN = previousMutationToken;
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it("authenticates, applies, observes, and deduplicates a sanitized actor-only intervention", async () => {
+    const runId = "intervention-api-run";
+    const dispatcher = new ApiDispatcher();
+    createActiveRun(runId, oneActorDag());
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+    projectDagActivityJournalEntry(appendDagActivityEvent(activity(1, "started")));
+    projectDagActivityJournalEntry(appendDagActivityEvent(activity(2, "finding")));
+    const stateToken = getDagActorControlState(runId, "research").state_token;
+    server = createServer(0, undefined, dispatcher, false, { autoDetectCodex: false });
+    const baseUrl = `http://127.0.0.1:${await listen(server)}`;
+    const endpoint = `${baseUrl}/api/runs/${runId}/actors/research/interventions`;
+    const request = {
+      operation: "retry",
+      instruction: "Recheck the conclusion without exposing token=private-value.",
+      expected_state_token: stateToken,
+      idempotency_key: "api-retry-once",
+    };
+
+    expect(await jsonResponse(endpoint, jsonPost(request))).toMatchObject({
+      status: 403,
+      body: { success: false },
+    });
+    const applied = await jsonResponse(endpoint, jsonPost(request, "test-mutation-token"));
+    expect(applied).toMatchObject({
+      status: 202,
+      body: {
+        success: true,
+        data: {
+          run_id: runId,
+          actor_id: "research",
+          operation: "retry",
+          status: "applied",
+          actor_state: "ready",
+          deduplicated: false,
+          redispatched: true,
+        },
+      },
+    });
+    const appliedData = (applied.body.data ?? {}) as Record<string, unknown>;
+    const interventionId = String(appliedData.intervention_id);
+    expect(interventionId).toMatch(/^intervention-[0-9a-f]{64}$/);
+    expect(JSON.stringify(applied.body)).not.toMatch(/worker-|target_id|lease_generation|node_id|checkpoint_ref/);
+
+    const repeated = await jsonResponse(endpoint, jsonPost(request, "test-mutation-token"));
+    expect(repeated).toMatchObject({
+      status: 200,
+      body: { data: { intervention_id: interventionId, deduplicated: true, redispatched: false } },
+    });
+    const list = await jsonResponse(endpoint);
+    expect(list).toMatchObject({
+      status: 200,
+      body: {
+        data: {
+          total: 1,
+          interventions: [{
+            intervention_id: interventionId,
+            actor_id: "research",
+            operation: "retry",
+            status: "applied",
+          }],
+        },
+      },
+    });
+    const detail = await jsonResponse(`${endpoint}/${interventionId}`);
+    expect(detail).toMatchObject({
+      status: 200,
+      body: { data: { intervention_id: interventionId, status: "applied" } },
+    });
+    expect(JSON.stringify(list.body)).not.toMatch(/expected_actor|from_generation|to_generation|resulting_actor_version/);
+    expect(JSON.stringify(detail.body)).not.toContain("private-value");
+
+    const history = await jsonResponse(`${baseUrl}/api/runs/${runId}/actors/research/surface-history`);
+    expect(history).toMatchObject({
+      status: 200,
+      body: {
+        data: {
+          generation_state: "superseded",
+          total: 1,
+          history: [{ generation: 1, superseded_by_generation: 2 }],
+        },
+      },
+    });
+    const live = await jsonResponse(`${baseUrl}/api/runs/${runId}/live-surfaces`);
+    expect(live).toMatchObject({
+      status: 200,
+      body: {
+        data: {
+          surface_states: [{
+            actor_id: "research",
+            surface_id: "surface:research",
+            generation_state: "current",
+            superseded_count: 1,
+            latest_intervention: { intervention_id: interventionId, status: "applied" },
+          }],
+        },
+      },
+    });
+
+    expect(await jsonResponse(endpoint, jsonPost({
+      ...request,
+      idempotency_key: "physical-target-injection",
+      target_id: "worker-private",
+    }, "test-mutation-token"))).toMatchObject({ status: 400 });
+    expect(await jsonResponse(endpoint, jsonPost({
+      ...request,
+      idempotency_key: "stale-token",
+    }, "test-mutation-token"))).toMatchObject({ status: 409 });
+    expect(await jsonResponse(
+      `${baseUrl}/api/runs/${runId}/actors/missing/interventions`,
+      jsonPost({ ...request, idempotency_key: "missing-actor" }, "test-mutation-token"),
+    )).toMatchObject({ status: 404 });
+  });
+});

--- a/homerail_manager/tests/dag-actor-intervention-api.test.ts
+++ b/homerail_manager/tests/dag-actor-intervention-api.test.ts
@@ -170,6 +170,23 @@ describe("DAG actor intervention HTTP API", () => {
       status: 403,
       body: { success: false },
     });
+    expect(await jsonResponse(endpoint, jsonPost({
+      ...request,
+      instruction: { text: "not a string" },
+      idempotency_key: "invalid-instruction-type",
+    }, "test-mutation-token"))).toMatchObject({
+      status: 400,
+      body: { error: "instruction must be a string when provided" },
+    });
+    expect(await jsonResponse(endpoint, jsonPost({
+      ...request,
+      operation: "checkpoint_fork",
+      checkpoint_version: "1",
+      idempotency_key: "invalid-checkpoint-type",
+    }, "test-mutation-token"))).toMatchObject({
+      status: 400,
+      body: { error: "checkpoint_version must be a positive integer" },
+    });
     const applied = await jsonResponse(endpoint, jsonPost(request, "test-mutation-token"));
     expect(applied).toMatchObject({
       status: 202,

--- a/homerail_manager/tests/dag-actor-interventions.test.ts
+++ b/homerail_manager/tests/dag-actor-interventions.test.ts
@@ -43,21 +43,34 @@ describe("DAG actor intervention persistence", () => {
     fs.rmSync(home, { recursive: true, force: true });
   });
 
-  it("creates and validates the strict v26 schema on fresh and upgraded databases", () => {
-    expect(getDb().prepare("SELECT MAX(version) AS version FROM schema_migrations").get()).toEqual({ version: 26 });
+  it("creates and validates the strict intervention and dispatch-fence schemas on fresh and upgraded databases", () => {
+    expect(getDb().prepare("SELECT MAX(version) AS version FROM schema_migrations").get()).toEqual({ version: 27 });
     expect(getDb().prepare("PRAGMA foreign_key_check").all()).toEqual([]);
     getDb().exec(`
+      DROP TABLE dag_actor_dispatch_exclusions;
+      DELETE FROM schema_migrations WHERE version = 27;
+    `);
+    closeDb();
+    expect(getDb().prepare("SELECT version FROM schema_migrations WHERE version = 27").get()).toEqual({ version: 27 });
+    expect(getDb().prepare(`
+      SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'dag_actor_dispatch_exclusions'
+    `).get()).toEqual({ name: "dag_actor_dispatch_exclusions" });
+    getDb().exec(`
+      DROP TABLE dag_actor_dispatch_exclusions;
       DROP TABLE dag_surface_generation_snapshots;
       DROP TABLE dag_actor_interventions;
-      DELETE FROM schema_migrations WHERE version = 26;
+      DELETE FROM schema_migrations WHERE version IN (26, 27);
     `);
     closeDb();
     expect(getDb().prepare("SELECT version FROM schema_migrations WHERE version = 26").get()).toEqual({ version: 26 });
+    expect(getDb().prepare("SELECT version FROM schema_migrations WHERE version = 27").get()).toEqual({ version: 27 });
     expect(getDb().prepare("PRAGMA foreign_key_check").all()).toEqual([]);
     closeDb();
     expect(getDb().prepare("SELECT COUNT(*) AS count FROM schema_migrations WHERE version = 25").get())
       .toEqual({ count: 1 });
     expect(getDb().prepare("SELECT COUNT(*) AS count FROM schema_migrations WHERE version = 26").get())
+      .toEqual({ count: 1 });
+    expect(getDb().prepare("SELECT COUNT(*) AS count FROM schema_migrations WHERE version = 27").get())
       .toEqual({ count: 1 });
   });
 

--- a/homerail_manager/tests/dag-actor-interventions.test.ts
+++ b/homerail_manager/tests/dag-actor-interventions.test.ts
@@ -1,0 +1,186 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  completeDagActorIntervention,
+  createDagActorIntervention,
+  createDagSurfaceGenerationSnapshot,
+  DagActorInterventionConflictError,
+  failDagActorIntervention,
+  getDagActorIntervention,
+  listDagActorInterventions,
+  listDagSurfaceGenerationSnapshots,
+  markDagActorInterventionApplying,
+} from "../src/persistence/dag-actor-interventions.js";
+import { registerDagActor } from "../src/persistence/dag-actors.js";
+import { closeDb, getDb } from "../src/persistence/db.js";
+import { ensureRunDir } from "../src/persistence/store.js";
+
+describe("DAG actor intervention persistence", () => {
+  let home: string;
+  let previousHome: string | undefined;
+
+  beforeEach(() => {
+    closeDb();
+    previousHome = process.env.HOMERAIL_HOME;
+    home = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-dag-interventions-"));
+    process.env.HOMERAIL_HOME = home;
+    ensureRunDir("run-1");
+    registerDagActor({
+      run_id: "run-1",
+      actor_id: "research",
+      node_id: "research-node",
+      role: "research",
+      surface_id: "surface:research",
+    });
+  });
+
+  afterEach(() => {
+    closeDb();
+    if (previousHome === undefined) delete process.env.HOMERAIL_HOME;
+    else process.env.HOMERAIL_HOME = previousHome;
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it("creates and validates the strict v26 schema on fresh and upgraded databases", () => {
+    expect(getDb().prepare("SELECT MAX(version) AS version FROM schema_migrations").get()).toEqual({ version: 26 });
+    expect(getDb().prepare("PRAGMA foreign_key_check").all()).toEqual([]);
+    getDb().exec(`
+      DROP TABLE dag_surface_generation_snapshots;
+      DROP TABLE dag_actor_interventions;
+      DELETE FROM schema_migrations WHERE version = 26;
+    `);
+    closeDb();
+    expect(getDb().prepare("SELECT version FROM schema_migrations WHERE version = 26").get()).toEqual({ version: 26 });
+    expect(getDb().prepare("PRAGMA foreign_key_check").all()).toEqual([]);
+    closeDb();
+    expect(getDb().prepare("SELECT COUNT(*) AS count FROM schema_migrations WHERE version = 25").get())
+      .toEqual({ count: 1 });
+    expect(getDb().prepare("SELECT COUNT(*) AS count FROM schema_migrations WHERE version = 26").get())
+      .toEqual({ count: 1 });
+  });
+
+  it("persists the Inbox before applying, deduplicates retries, and enforces Actor CAS", () => {
+    const request = {
+      intervention_id: "intervention-1",
+      run_id: "run-1",
+      actor_id: "research",
+      operation: "retry" as const,
+      instruction: "Retry with token=secret-value",
+      expected_actor_generation: 1,
+      expected_actor_version: 1,
+      idempotency_key: "retry-1",
+      created_at: 100,
+    };
+    const created = createDagActorIntervention(request);
+    expect(created).toMatchObject({ changed: true, deduplicated: false, intervention: { status: "queued" } });
+    expect(JSON.stringify(getDagActorIntervention("intervention-1"))).not.toContain("secret-value");
+    expect(createDagActorIntervention(request)).toMatchObject({ changed: false, deduplicated: true });
+    expect(() => createDagActorIntervention({ ...request, intervention_id: "other", instruction: "different" }))
+      .toThrowError(expect.objectContaining<DagActorInterventionConflictError>({ code: "intervention_identity_conflict" }));
+    expect(() => createDagActorIntervention({
+      ...request,
+      intervention_id: "intervention-2",
+      idempotency_key: "retry-2",
+    })).toThrowError(expect.objectContaining<DagActorInterventionConflictError>({ code: "intervention_in_progress" }));
+  });
+
+  it("enforces transition order and retains applied audit plus immutable Surface history", () => {
+    createDagActorIntervention({
+      intervention_id: "intervention-1",
+      run_id: "run-1",
+      actor_id: "research",
+      operation: "checkpoint_fork",
+      instruction: "Continue from the selected checkpoint",
+      expected_actor_generation: 1,
+      expected_actor_version: 1,
+      idempotency_key: "fork-1",
+      checkpoint_version: 3,
+      created_at: 100,
+    });
+    markDagActorInterventionApplying({ intervention_id: "intervention-1", from_generation: 1, started_at: 110 });
+    createDagSurfaceGenerationSnapshot({
+      run_id: "run-1",
+      actor_id: "research",
+      generation: 1,
+      node_id: "research-node",
+      surface_id: "surface:research",
+      document_id: "document-1",
+      node_revision: 2,
+      document_revision: 4,
+      surface_revision: 2,
+      activity_state: "finding",
+      visibility_state: "visible",
+      last_event_id: "event-1",
+      node_snapshot: { content: { api_key: "sk-private", summary: "old result" } },
+      superseded_by_generation: 2,
+      intervention_id: "intervention-1",
+      created_at: 115,
+    });
+    const completed = completeDagActorIntervention({
+      intervention_id: "intervention-1",
+      from_generation: 1,
+      to_generation: 2,
+      resulting_actor_version: 2,
+      completed_at: 120,
+    });
+    expect(completed.intervention).toMatchObject({ status: "applied", from_generation: 1, to_generation: 2 });
+    const history = listDagSurfaceGenerationSnapshots({ run_id: "run-1", actor_id: "research" });
+    expect(history).toHaveLength(1);
+    expect(JSON.stringify(history)).not.toContain("sk-private");
+    expect(() => getDb().prepare(`
+      UPDATE dag_surface_generation_snapshots SET surface_revision = 9
+      WHERE run_id = 'run-1' AND actor_id = 'research' AND generation = 1
+    `).run()).toThrow(/append-only/);
+    expect(listDagActorInterventions({ run_id: "run-1", actor_id: "research" })).toHaveLength(1);
+  });
+
+  it("records bounded failures without opening a second active intervention", () => {
+    createDagActorIntervention({
+      intervention_id: "intervention-fail",
+      run_id: "run-1",
+      actor_id: "research",
+      operation: "interrupt",
+      expected_actor_generation: 1,
+      expected_actor_version: 1,
+      idempotency_key: "interrupt-1",
+      created_at: 100,
+    });
+    const failed = failDagActorIntervention({
+      intervention_id: "intervention-fail",
+      failure: { message: "transport failed", api_key: "sk-private" },
+      completed_at: 120,
+    });
+    expect(failed.intervention.status).toBe("failed");
+    expect(JSON.stringify(failed.intervention)).not.toContain("sk-private");
+    expect(() => completeDagActorIntervention({
+      intervention_id: "intervention-fail",
+      from_generation: 1,
+      to_generation: 2,
+      resulting_actor_version: 2,
+    })).toThrowError(expect.objectContaining<DagActorInterventionConflictError>({ code: "intervention_status_conflict" }));
+  });
+
+  it("requires checkpoint_version only for checkpoint_fork", () => {
+    expect(() => createDagActorIntervention({
+      intervention_id: "invalid-retry",
+      run_id: "run-1",
+      actor_id: "research",
+      operation: "retry",
+      expected_actor_generation: 1,
+      expected_actor_version: 1,
+      idempotency_key: "invalid-retry",
+      checkpoint_version: 1,
+    })).toThrow("checkpoint_version is required only for checkpoint_fork");
+    expect(() => createDagActorIntervention({
+      intervention_id: "invalid-fork",
+      run_id: "run-1",
+      actor_id: "research",
+      operation: "checkpoint_fork",
+      expected_actor_generation: 1,
+      expected_actor_version: 1,
+      idempotency_key: "invalid-fork",
+    })).toThrow("checkpoint_version is required only for checkpoint_fork");
+  });
+});

--- a/homerail_manager/tests/dag-actor-leases.test.ts
+++ b/homerail_manager/tests/dag-actor-leases.test.ts
@@ -100,7 +100,7 @@ describe("DAG actor lease persistence", () => {
   it("creates and revalidates the strict actor lease schema on a fresh database", () => {
     const db = getDb();
     expect(db.prepare("SELECT MAX(version) AS version FROM schema_migrations").get())
-      .toEqual({ version: 26 });
+      .toEqual({ version: 27 });
     expect(db.prepare(`
       SELECT name FROM sqlite_master
       WHERE type = 'table' AND name IN (

--- a/homerail_manager/tests/dag-actor-leases.test.ts
+++ b/homerail_manager/tests/dag-actor-leases.test.ts
@@ -9,6 +9,7 @@ import {
   DagActorLeaseConflictError,
   deleteExpiredDagActorRuntime,
   ensureDagActorLease,
+  getDagActorCheckpoint,
   getDagActorLease,
   getLatestDagActorCheckpoint,
   listDagProvisionedWorkers,
@@ -78,10 +79,28 @@ describe("DAG actor lease persistence", () => {
     fs.rmSync(home, { recursive: true, force: true });
   });
 
+  it("reads an exact portable checkpoint version without changing the latest pointer", () => {
+    const first = writeDagActorCheckpoint({ run_id: "run-1", actor_id: "researcher", checkpoint: checkpoint(), now: 100 });
+    const second = writeDagActorCheckpoint({
+      run_id: "run-1",
+      actor_id: "researcher",
+      checkpoint: checkpoint({ captured_at: 110, context_summary: "Second checkpoint" }),
+      expected_checkpoint_version: 1,
+      now: 120,
+    });
+
+    expect(getDagActorCheckpoint({ run_id: "run-1", actor_id: "researcher", checkpoint_version: 1 }))
+      .toEqual(first);
+    expect(getLatestDagActorCheckpoint({ run_id: "run-1", actor_id: "researcher" }))
+      .toEqual(second);
+    expect(getDagActorCheckpoint({ run_id: "run-1", actor_id: "researcher", checkpoint_version: 99 }))
+      .toBeUndefined();
+  });
+
   it("creates and revalidates the strict actor lease schema on a fresh database", () => {
     const db = getDb();
     expect(db.prepare("SELECT MAX(version) AS version FROM schema_migrations").get())
-      .toEqual({ version: 25 });
+      .toEqual({ version: 26 });
     expect(db.prepare(`
       SELECT name FROM sqlite_master
       WHERE type = 'table' AND name IN (

--- a/homerail_manager/tests/dag-actors.test.ts
+++ b/homerail_manager/tests/dag-actors.test.ts
@@ -403,6 +403,30 @@ nodes:
     })).toThrowError(expect.objectContaining<DagActorConflictError>({ code: "command_status_conflict" }));
   });
 
+  it("cancels unclaimed commands for only the intervened actor", () => {
+    registerActor();
+    registerActor({
+      actor_id: "writer",
+      node_id: "writer-node",
+      role: "write",
+      surface_id: "surface-writer",
+    });
+    createCommand();
+    createCommand({
+      command_id: "writer-command",
+      actor_id: "writer",
+      idempotency_key: "writer-round-1",
+    });
+
+    expect(cancelUnclaimedDagActorCommands({
+      run_id: "run-1",
+      actor_id: "researcher",
+      reason: { operation: "retry" },
+    }).map((command) => command.command_id)).toEqual(["command-1"]);
+    expect(getDagActorCommand("command-1")?.status).toBe("cancelled");
+    expect(getDagActorCommand("writer-command")?.status).toBe("pending");
+  });
+
   it("allows only the current generation to claim and complete a command", () => {
     const actor = registerActor().actor;
     const generationTwo = advanceDagActorGeneration({

--- a/homerail_manager/tests/dag-live-surface-projector.test.ts
+++ b/homerail_manager/tests/dag-live-surface-projector.test.ts
@@ -13,15 +13,22 @@ import {
   getDagLiveSurfaceDocument,
   getDagLiveSurfaceProjection,
   isDagLiveSurfaceProjectionNode,
+  listDagLiveSurfaceGenerationHistory,
   listDagLiveSurfaceProjections,
   listDagLiveSurfaceQueue,
   projectDagActivityJournalEntry,
   recoverDagLiveSurfaceProjections,
+  supersedeDagLiveSurfaceForIntervention,
 } from "../src/generative-ui/dag-live-surface-projector.js";
 import {
   appendDagActivityEvent,
   type DagActivityJournalEntry,
 } from "../src/persistence/dag-activity-journal.js";
+import {
+  createDagActorIntervention,
+  markDagActorInterventionApplying,
+  type DagActorInterventionOperation,
+} from "../src/persistence/dag-actor-interventions.js";
 import {
   advanceDagActorGeneration,
   getDagActor,
@@ -71,6 +78,40 @@ function activity(input: {
 
 function appendAndProject(event: DagActivityEventV1): ReturnType<typeof projectDagActivityJournalEntry> {
   return projectDagActivityJournalEntry(appendDagActivityEvent(event));
+}
+
+function advanceForIntervention(input: {
+  run_id: string;
+  actor_id: string;
+  intervention_id: string;
+  operation?: DagActorInterventionOperation;
+  instruction?: string;
+}): void {
+  const actor = getDagActor(input.run_id, input.actor_id)!;
+  const operation = input.operation ?? "retry";
+  createDagActorIntervention({
+    intervention_id: input.intervention_id,
+    run_id: input.run_id,
+    actor_id: input.actor_id,
+    operation,
+    ...(input.instruction === undefined ? {} : { instruction: input.instruction }),
+    expected_actor_generation: actor.generation,
+    expected_actor_version: actor.version,
+    idempotency_key: `key:${input.intervention_id}`,
+    ...(operation === "checkpoint_fork" ? { checkpoint_version: 1 } : {}),
+    created_at: BASE_TIME + 100,
+  });
+  markDagActorInterventionApplying({
+    intervention_id: input.intervention_id,
+    from_generation: actor.generation,
+    started_at: BASE_TIME + 101,
+  });
+  advanceDagActorGeneration({
+    run_id: input.run_id,
+    actor_id: input.actor_id,
+    expected_generation: actor.generation,
+    expected_version: actor.version,
+  });
 }
 
 function contentData(runId: string, actorId: string): Record<string, unknown> {
@@ -468,6 +509,273 @@ describe("DAG Live Surface Projector", () => {
     expect(JSON.stringify(node.content)).not.toContain("untrusted-199");
     expect(Buffer.byteLength(JSON.stringify(node.content), "utf8")).toBeLessThanOrEqual(32 * 1024);
     expect(listDagLiveSurfaceQueue({ run_id: runId }).every((entry) => entry.status === "applied")).toBe(true);
+  });
+
+  it("supersedes one Actor generation in place while retaining its old evidence", () => {
+    const runId = "intervention-supersession";
+    ensureRunDir(runId);
+    register(runId, "alpha");
+    register(runId, "beta");
+    appendAndProject(activity({
+      run_id: runId,
+      actor_id: "alpha",
+      sequence: 1,
+      type: "started",
+      payload: { title: "Alpha task", message: "alpha started" },
+    }));
+    appendAndProject(activity({
+      run_id: runId,
+      actor_id: "alpha",
+      sequence: 2,
+      type: "finding",
+      payload: { title: "Old evidence", detail: "keep this audit evidence" },
+    }));
+    appendAndProject(activity({
+      run_id: runId,
+      actor_id: "beta",
+      sequence: 1,
+      type: "started",
+      payload: { title: "Beta task", message: "beta remains unchanged" },
+    }));
+    expect(appendAndProject(activity({
+      run_id: runId,
+      actor_id: "alpha",
+      sequence: 4,
+      payload: { message: "old queued progress" },
+    }))).toMatchObject({ applied_count: 0, queue: { status: "pending" } });
+    const before = getDagLiveSurfaceDocument(runId)!;
+    const alphaBefore = before.nodes.find((node) => node.id === "surface:alpha")!;
+    const betaBefore = before.nodes.find((node) => node.id === "surface:beta")!;
+    const alphaProjectionBefore = getDagLiveSurfaceProjection(runId, "alpha")!;
+
+    advanceForIntervention({
+      run_id: runId,
+      actor_id: "alpha",
+      intervention_id: "retry-alpha",
+      instruction: "Retry with token=do-not-expose and verify the result",
+    });
+    const transitioned = supersedeDagLiveSurfaceForIntervention({
+      run_id: runId,
+      actor_id: "alpha",
+      intervention_id: "retry-alpha",
+      created_at: BASE_TIME + 200,
+    });
+
+    expect(transitioned).toMatchObject({
+      deduplicated: false,
+      operation: "retry",
+      from_generation: 1,
+      to_generation: 2,
+      projection: {
+        generation: 2,
+        surface_id: "surface:alpha",
+        surface_revision: alphaProjectionBefore.surface_revision + 1,
+        visibility_state: "focused",
+        focused_until: BASE_TIME + 15_200,
+      },
+      snapshot: {
+        generation: 1,
+        superseded_by_generation: 2,
+        intervention_id: "retry-alpha",
+        node_revision: alphaBefore.revision,
+        document_revision: before.revision,
+      },
+    });
+    const after = getDagLiveSurfaceDocument(runId)!;
+    const alphaAfter = after.nodes.find((node) => node.id === "surface:alpha")!;
+    const betaAfter = after.nodes.find((node) => node.id === "surface:beta")!;
+    expect(after.nodes).toHaveLength(2);
+    expect(after.revision).toBe(before.revision + 1);
+    expect(alphaAfter.id).toBe(alphaBefore.id);
+    expect(alphaAfter.revision).toBe(alphaBefore.revision + 1);
+    expect(betaAfter).toEqual(betaBefore);
+    expect(alphaAfter.content.data).toMatchObject({
+      actor: { id: "alpha", generation: 2 },
+      state: {
+        activity: "started",
+        visibility: "focused",
+        surface_revision: alphaProjectionBefore.surface_revision + 1,
+        focused_until: BASE_TIME + 15_200,
+      },
+      intervention: {
+        intervention_id: "retry-alpha",
+        operation: "retry",
+        generation_state: "current",
+        supersedes_generation: 1,
+        generation: 2,
+      },
+      findings: [],
+    });
+    expect(JSON.stringify(alphaAfter.content)).not.toContain("do-not-expose");
+
+    const history = listDagLiveSurfaceGenerationHistory({ run_id: runId, actor_id: "alpha" });
+    expect(history).toHaveLength(1);
+    const oldNode = history[0]!.node_snapshot as typeof alphaBefore;
+    expect(oldNode.id).toBe(alphaBefore.id);
+    expect(oldNode.content.data).toMatchObject({
+      actor: { id: "alpha", generation: 1 },
+      findings: [{ title: "Old evidence", detail: "keep this audit evidence" }],
+    });
+    expect(listDagLiveSurfaceGenerationHistory({ run_id: runId, actor_id: "beta" })).toEqual([]);
+    expect(listDagLiveSurfaceQueue({ run_id: runId, actor_id: "alpha" })).toEqual(expect.arrayContaining([
+      expect.objectContaining({ generation: 1, activity_sequence: 4, status: "stale" }),
+    ]));
+
+    const repeated = supersedeDagLiveSurfaceForIntervention({
+      run_id: runId,
+      actor_id: "alpha",
+      intervention_id: "retry-alpha",
+      created_at: BASE_TIME + 999,
+    });
+    expect(repeated).toMatchObject({ deduplicated: true, projection: { surface_revision: 3 } });
+    expect(getDagLiveSurfaceDocument(runId)).toEqual(after);
+    expect(listDagLiveSurfaceGenerationHistory({ run_id: runId, actor_id: "alpha" })).toHaveLength(1);
+
+    appendAndProject(activity({
+      run_id: runId,
+      actor_id: "alpha",
+      generation: 2,
+      sequence: 1,
+      payload: { message: "new attempt is running", progress: 20 },
+    }));
+    expect(contentData(runId, "alpha")).toMatchObject({
+      actor: { generation: 2 },
+      state: { summary: "new attempt is running" },
+      intervention: {
+        intervention_id: "retry-alpha",
+        operation: "retry",
+        generation_state: "current",
+        generation: 2,
+      },
+    });
+  });
+
+  it("creates a current-generation placeholder without inventing old history when no node exists", () => {
+    const runId = "intervention-placeholder";
+    ensureRunDir(runId);
+    register(runId, "worker");
+    advanceForIntervention({
+      run_id: runId,
+      actor_id: "worker",
+      intervention_id: "cancel-before-output",
+      operation: "cancel",
+    });
+
+    const transitioned = supersedeDagLiveSurfaceForIntervention({
+      run_id: runId,
+      actor_id: "worker",
+      intervention_id: "cancel-before-output",
+      created_at: BASE_TIME + 300,
+    });
+    expect(transitioned.snapshot).toBeUndefined();
+    expect(transitioned).toMatchObject({
+      deduplicated: false,
+      operation: "cancel",
+      from_generation: 1,
+      to_generation: 2,
+      projection: {
+        generation: 2,
+        surface_id: "surface:worker",
+        surface_revision: 1,
+        visibility_state: "focused",
+      },
+    });
+    const document = getDagLiveSurfaceDocument(runId)!;
+    expect(document).toMatchObject({
+      revision: 1,
+      nodes: [{
+        id: "surface:worker",
+        revision: 1,
+        status: { phase: "cancelled", label: "Cancelled" },
+        content: {
+          data: {
+            actor: { id: "worker", generation: 2 },
+            state: { activity: "blocked", visibility: "focused" },
+            intervention: {
+              intervention_id: "cancel-before-output",
+              operation: "cancel",
+              generation_state: "current",
+              supersedes_generation: 1,
+              generation: 2,
+            },
+            findings: [],
+          },
+        },
+      }],
+    });
+    expect(listDagLiveSurfaceGenerationHistory({ run_id: runId, actor_id: "worker" })).toEqual([]);
+    expect(supersedeDagLiveSurfaceForIntervention({
+      run_id: runId,
+      actor_id: "worker",
+      intervention_id: "cancel-before-output",
+    })).toMatchObject({ deduplicated: true, projection: { surface_revision: 1 } });
+  });
+
+  it("fails closed if the durable Actor has not advanced to the intervention generation", () => {
+    const runId = "intervention-generation-conflict";
+    ensureRunDir(runId);
+    register(runId, "worker");
+    const actor = getDagActor(runId, "worker")!;
+    createDagActorIntervention({
+      intervention_id: "retry-too-early",
+      run_id: runId,
+      actor_id: "worker",
+      operation: "retry",
+      expected_actor_generation: actor.generation,
+      expected_actor_version: actor.version,
+      idempotency_key: "retry-too-early",
+    });
+    markDagActorInterventionApplying({
+      intervention_id: "retry-too-early",
+      from_generation: actor.generation,
+    });
+
+    expect(() => supersedeDagLiveSurfaceForIntervention({
+      run_id: runId,
+      actor_id: "worker",
+      intervention_id: "retry-too-early",
+    })).toThrowError(expect.objectContaining<DagLiveSurfaceProjectionError>({ code: "generation_conflict" }));
+    expect(getDagLiveSurfaceDocument(runId)).toBeUndefined();
+    expect(listDagLiveSurfaceGenerationHistory({ run_id: runId, actor_id: "worker" })).toEqual([]);
+  });
+
+  it("rolls back the snapshot and A2UI patch together when projection bookkeeping fails", () => {
+    const runId = "intervention-atomicity";
+    ensureRunDir(runId);
+    register(runId, "worker");
+    appendAndProject(activity({ run_id: runId, actor_id: "worker", sequence: 1, type: "started" }));
+    const before = getDagLiveSurfaceDocument(runId)!;
+    advanceForIntervention({
+      run_id: runId,
+      actor_id: "worker",
+      intervention_id: "retry-atomically",
+    });
+    getDb().exec(`
+      CREATE TRIGGER reject_intervention_projection_commit
+      BEFORE UPDATE OF surface_revision ON dag_surface_projections
+      WHEN NEW.surface_revision > OLD.surface_revision
+      BEGIN
+        SELECT RAISE(ABORT, 'forced intervention bookkeeping failure');
+      END
+    `);
+
+    expect(() => supersedeDagLiveSurfaceForIntervention({
+      run_id: runId,
+      actor_id: "worker",
+      intervention_id: "retry-atomically",
+    })).toThrow("forced intervention bookkeeping failure");
+    expect(getDagLiveSurfaceDocument(runId)).toEqual(before);
+    expect(getDagLiveSurfaceProjection(runId, "worker")).toMatchObject({ generation: 1, surface_revision: 1 });
+    expect(listDagLiveSurfaceGenerationHistory({ run_id: runId, actor_id: "worker" })).toEqual([]);
+
+    getDb().exec("DROP TRIGGER reject_intervention_projection_commit");
+    const transitioned = getDb().transaction(() => supersedeDagLiveSurfaceForIntervention({
+      run_id: runId,
+      actor_id: "worker",
+      intervention_id: "retry-atomically",
+    })).immediate();
+    expect(transitioned).toMatchObject({ deduplicated: false, projection: { generation: 2, surface_revision: 2 } });
+    expect(listDagLiveSurfaceGenerationHistory({ run_id: runId, actor_id: "worker" })).toHaveLength(1);
   });
 
   it("accepts a trusted control immediately after an actor generation advances", () => {

--- a/homerail_manager/tests/dag-manager-supervisor.test.ts
+++ b/homerail_manager/tests/dag-manager-supervisor.test.ts
@@ -7,7 +7,10 @@ import {
   DAG_ACTIVITY_EVENT_SCHEMA_VERSION,
   type DagActivityEventV1,
 } from "homerail-protocol";
-import { projectDagActivityJournalEntry } from "../src/generative-ui/dag-live-surface-projector.js";
+import {
+  projectDagActivityJournalEntry,
+  supersedeDagLiveSurfaceForIntervention,
+} from "../src/generative-ui/dag-live-surface-projector.js";
 import { appendDagActivityEvent } from "../src/persistence/dag-activity-journal.js";
 import { acquireDagActorLease } from "../src/persistence/dag-actor-leases.js";
 import {
@@ -15,6 +18,11 @@ import {
   getDagActor,
   registerDagActor,
 } from "../src/persistence/dag-actors.js";
+import {
+  completeDagActorIntervention,
+  createDagActorIntervention,
+  markDagActorInterventionApplying,
+} from "../src/persistence/dag-actor-interventions.js";
 import { closeDb, getDb } from "../src/persistence/db.js";
 import { createInitialDagRunRound } from "../src/persistence/dag-run-rounds.js";
 import { ensureRunDir } from "../src/persistence/store.js";
@@ -37,14 +45,15 @@ function event(input: {
   round_id?: string;
   generation?: number;
 }): DagActivityEventV1 {
+  const generation = input.generation ?? 1;
   return {
     schema_version: DAG_ACTIVITY_EVENT_SCHEMA_VERSION,
-    event_id: `${input.run_id}-${input.actor_id}-${input.sequence}-${input.type}`,
+    event_id: `${input.run_id}-${input.actor_id}-g${generation}-${input.sequence}-${input.type}`,
     run_id: input.run_id,
     round_id: input.round_id ?? "round-0001",
     node_id: `node-${input.actor_id}`,
     actor_id: input.actor_id,
-    generation: input.generation ?? 1,
+    generation,
     surface_id: `surface:${input.actor_id}`,
     sequence: input.sequence,
     timestamp: BASE_TIME + input.sequence,
@@ -352,6 +361,112 @@ describe("DAG Manager Supervisor", () => {
       complete: true,
     });
     expect(snapshot.round_summary?.accepted_results).toHaveLength(64);
+  });
+
+  it("ignores superseded generation events and explains an applied intervention once", () => {
+    const runId = "supervisor-intervention-generation";
+    setupRun(runId, ["research"]);
+    append({
+      run_id: runId,
+      actor_id: "research",
+      sequence: 2,
+      type: "tool_used",
+      payload: { tool_name: "old.private.tool" },
+    });
+    append({
+      run_id: runId,
+      actor_id: "research",
+      sequence: 3,
+      type: "finding",
+      payload: { summary: "superseded result must not reach Manager" },
+    });
+    const actor = getDagActor(runId, "research")!;
+    createDagActorIntervention({
+      intervention_id: "supervisor-retry-research",
+      run_id: runId,
+      actor_id: "research",
+      operation: "retry",
+      expected_actor_generation: actor.generation,
+      expected_actor_version: actor.version,
+      idempotency_key: "supervisor-retry-research",
+      created_at: BASE_TIME + 10,
+    });
+    markDagActorInterventionApplying({
+      intervention_id: "supervisor-retry-research",
+      from_generation: 1,
+      started_at: BASE_TIME + 11,
+    });
+    const advanced = advanceDagActorGeneration({
+      run_id: runId,
+      actor_id: "research",
+      expected_generation: actor.generation,
+      expected_version: actor.version,
+    });
+    supersedeDagLiveSurfaceForIntervention({
+      run_id: runId,
+      actor_id: "research",
+      intervention_id: "supervisor-retry-research",
+      created_at: BASE_TIME + 12,
+    });
+    completeDagActorIntervention({
+      intervention_id: "supervisor-retry-research",
+      from_generation: 1,
+      to_generation: 2,
+      resulting_actor_version: advanced.version,
+      completed_at: BASE_TIME + 13,
+    });
+    append({
+      run_id: runId,
+      actor_id: "research",
+      generation: 2,
+      sequence: 1,
+      type: "finding",
+      payload: { summary: "current corrected result" },
+    });
+
+    const snapshot = getDagSupervisionSnapshot({
+      run_id: runId,
+      consumer_id: "intervention-observer",
+    });
+    expect(snapshot.actors).toMatchObject([{
+      actor_id: "research",
+      latest_intervention: {
+        intervention_id: "supervisor-retry-research",
+        operation: "retry",
+        status: "applied",
+      },
+    }]);
+    expect(snapshot.milestone_digest.milestones).toMatchObject([{
+      actor_id: "research",
+      type: "finding",
+      summary: "current corrected result",
+      tools_used: [],
+    }]);
+    expect(snapshot.milestone_digest.intervention_milestones).toMatchObject([{
+      intervention_id: "supervisor-retry-research",
+      actor_id: "research",
+      operation: "retry",
+      status: "applied",
+    }]);
+    expect(snapshot.round_summary?.accepted_results).toMatchObject([{
+      actor_id: "research",
+      outcome: "finding",
+      summary: "current corrected result",
+    }]);
+    const serialized = JSON.stringify(snapshot);
+    expect(serialized).not.toContain("superseded result must not reach Manager");
+    expect(serialized).not.toContain("old.private.tool");
+    expect(serialized).not.toMatch(/private-worker-|node-research|lease_generation|\"generation\"/);
+
+    const repeated = getDagSupervisionSnapshot({
+      run_id: runId,
+      consumer_id: "intervention-observer",
+    });
+    expect(repeated.milestone_digest).toMatchObject({
+      milestones: [],
+      intervention_milestones: [],
+      commentary: [],
+    });
   });
 
   it("suppresses high-frequency progress instead of flooding commentary", () => {

--- a/homerail_manager/tests/dag-run-rounds.test.ts
+++ b/homerail_manager/tests/dag-run-rounds.test.ts
@@ -135,7 +135,14 @@ describe("DAG run round persistence", () => {
 
     const migrated = getDb();
     expect(migrated.prepare("SELECT version FROM schema_migrations WHERE version >= 21 ORDER BY version").all())
-      .toEqual([{ version: 21 }, { version: 22 }, { version: 23 }, { version: 24 }, { version: 25 }]);
+      .toEqual([
+        { version: 21 },
+        { version: 22 },
+        { version: 23 },
+        { version: 24 },
+        { version: 25 },
+        { version: 26 },
+      ]);
     expect(migrated.prepare("SELECT * FROM dag_actor_commands ORDER BY command_id").all())
       .toEqual(expectedRows);
     expect(migrated.prepare("PRAGMA foreign_key_check").all()).toEqual([]);

--- a/homerail_manager/tests/dag-run-rounds.test.ts
+++ b/homerail_manager/tests/dag-run-rounds.test.ts
@@ -142,6 +142,7 @@ describe("DAG run round persistence", () => {
         { version: 24 },
         { version: 25 },
         { version: 26 },
+        { version: 27 },
       ]);
     expect(migrated.prepare("SELECT * FROM dag_actor_commands ORDER BY command_id").all())
       .toEqual(expectedRows);

--- a/homerail_manager/tests/dispatch-capabilities.test.ts
+++ b/homerail_manager/tests/dispatch-capabilities.test.ts
@@ -6,7 +6,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DAG_TRANSPORT_FENCE_CAPABILITY } from "homerail-protocol";
 
 import type { DispatchEnvelope } from "../src/orchestration/dag-dispatcher.js";
-import { _clearAllDispatches, recordDispatch, recordProvisioning } from "../src/orchestration/dispatch-tracker.js";
+import {
+  _clearAllDispatches,
+  excludeCurrentDispatchTarget,
+  recordDispatch,
+  recordProvisioning,
+} from "../src/orchestration/dispatch-tracker.js";
 import { normalizeAgentBackend, WsDispatchAdapter } from "../src/orchestration/ws-dispatch-adapter.js";
 import { parseDAGYaml } from "../src/orchestration/yaml-loader.js";
 import { _clearListeners, subscribe } from "../src/events/bus.js";
@@ -264,6 +269,43 @@ nodes:
     });
     expect(hotSocket.send).toHaveBeenCalledTimes(1);
     expect(otherSocket.send).not.toHaveBeenCalled();
+  });
+
+  it("reassigns an actor without allowing the next dispatch to reuse its previous Worker", () => {
+    const replacementSocket = makeSocket();
+    const previousSocket = makeSocket();
+    registerWorker({
+      worker_id: "replacement-worker",
+      project_id: "p1",
+      socket: replacementSocket,
+      status: "idle",
+      capabilities: ["browser"],
+      registered_at: Date.now(),
+      last_heartbeat: Date.now(),
+    });
+    registerWorker({
+      worker_id: "previous-worker",
+      project_id: "p1",
+      socket: previousSocket,
+      status: "idle",
+      capabilities: ["browser"],
+      registered_at: Date.now(),
+      last_heartbeat: Date.now(),
+    });
+    recordDispatch("run-capabilities", "diagnose", "worker", "previous-worker");
+    excludeCurrentDispatchTarget("run-capabilities", "diagnose");
+
+    const result = new WsDispatchAdapter({ provisioner: false }).dispatch(
+      makeEnvelope({ requiredCapabilities: ["browser"] }),
+    );
+
+    expect(result).toMatchObject({
+      status: "dispatched",
+      targetType: "worker",
+      targetId: "replacement-worker",
+    });
+    expect(replacementSocket.send).toHaveBeenCalledTimes(1);
+    expect(previousSocket.send).not.toHaveBeenCalled();
   });
 
   it("mirrors dispatched prompts into the manager-side session store", () => {

--- a/homerail_manager/tests/generative-ui-persistent-document-service.test.ts
+++ b/homerail_manager/tests/generative-ui-persistent-document-service.test.ts
@@ -187,7 +187,7 @@ describe("PersistentGenerativeUiDocumentService", () => {
     legacy.close();
 
     expect(getDb().prepare("SELECT version FROM schema_migrations ORDER BY version").all())
-      .toEqual(Array.from({ length: 25 }, (_, index) => ({ version: index + 1 })));
+      .toEqual(Array.from({ length: 26 }, (_, index) => ({ version: index + 1 })));
     expect(getDb().prepare("SELECT data FROM voice_agent_sessions WHERE session_id = ?").get("legacy-v2"))
       .toEqual({ data: legacyPayload });
     expect(getDb().prepare(`
@@ -269,7 +269,7 @@ describe("PersistentGenerativeUiDocumentService", () => {
     mainDb.close();
 
     expect(getDb().prepare("SELECT version FROM schema_migrations ORDER BY version").all())
-      .toEqual(Array.from({ length: 25 }, (_, index) => ({ version: index + 1 })));
+      .toEqual(Array.from({ length: 26 }, (_, index) => ({ version: index + 1 })));
     expect(getDb().prepare(`
       SELECT name FROM sqlite_master
       WHERE type = 'table' AND name IN ('generative_ui_documents', 'generative_ui_user_overrides')

--- a/homerail_manager/tests/generative-ui-persistent-document-service.test.ts
+++ b/homerail_manager/tests/generative-ui-persistent-document-service.test.ts
@@ -187,7 +187,7 @@ describe("PersistentGenerativeUiDocumentService", () => {
     legacy.close();
 
     expect(getDb().prepare("SELECT version FROM schema_migrations ORDER BY version").all())
-      .toEqual(Array.from({ length: 26 }, (_, index) => ({ version: index + 1 })));
+      .toEqual(Array.from({ length: 27 }, (_, index) => ({ version: index + 1 })));
     expect(getDb().prepare("SELECT data FROM voice_agent_sessions WHERE session_id = ?").get("legacy-v2"))
       .toEqual({ data: legacyPayload });
     expect(getDb().prepare(`
@@ -269,7 +269,7 @@ describe("PersistentGenerativeUiDocumentService", () => {
     mainDb.close();
 
     expect(getDb().prepare("SELECT version FROM schema_migrations ORDER BY version").all())
-      .toEqual(Array.from({ length: 26 }, (_, index) => ({ version: index + 1 })));
+      .toEqual(Array.from({ length: 27 }, (_, index) => ({ version: index + 1 })));
     expect(getDb().prepare(`
       SELECT name FROM sqlite_master
       WHERE type = 'table' AND name IN ('generative_ui_documents', 'generative_ui_user_overrides')

--- a/homerail_manager/tests/manager-agent-tool-parity.test.ts
+++ b/homerail_manager/tests/manager-agent-tool-parity.test.ts
@@ -1,19 +1,25 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  HOMERAIL_MANAGER_TURN_HEADER,
+  managerAgentTurnScopeFromPayload,
   managerAgentCommonToolCatalog,
   type AgentToolDefinition,
   type GenerativeUiCanvasContextV1,
   type ManagerAgentResponseMode,
   type ManagerAgentPromptSkill,
+  type ManagerAgentTurnEnvelopeV1,
   type HomerailPluginToolExecutionEnvelopeV1,
   type HomerailPluginTurnContextV1,
 } from "homerail-protocol";
 import { createManagerTools as createHostCodexManagerTools } from "../src/server/host-codex-manager-agent.js";
-import { createManagerTools as createWorkerManagerTools } from "../../homerail_worker/src/manager-agent/server.js";
+import {
+  _withManagerTurnEnvelopeForTest,
+  createManagerTools as createWorkerManagerTools,
+} from "../../homerail_worker/src/manager-agent/server.js";
 import { closeDb } from "../src/persistence/db.js";
 import { assemblePluginTurnContext } from "../src/plugins/context-assembler.js";
 import { syncBuiltinPlugins } from "../src/plugins/registry.js";
@@ -108,6 +114,8 @@ beforeEach(() => {
 
 afterEach(() => {
   closeDb();
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
   if (previousHome === undefined) delete process.env.HOMERAIL_HOME;
   else process.env.HOMERAIL_HOME = previousHome;
   fs.rmSync(tmpHome, { recursive: true, force: true });
@@ -302,6 +310,175 @@ describe("Manager Agent deterministic result envelope parity", () => {
 
     expect(hostState.finalNotes).toEqual(workerState.finalNotes);
     expect(hostState.voiceSurface).toEqual(workerState.voiceSurface);
+  });
+
+  it("maps DAG Actor intervention identically while preserving harness authentication", async () => {
+    const { hostState, workerState, hostTools, workerTools } = createHarnessTools("chat");
+    const restUrl = "https://manager.test/api";
+    hostState.restUrl = restUrl;
+    vi.stubEnv("MANAGER_REST_URL", restUrl);
+    vi.stubEnv("HOMERAIL_MANAGER_ADMIN_TOKEN", "A".repeat(32));
+    vi.stubEnv("HOMERAIL_DAG_MUTATION_TOKEN", "mutation-parity-token");
+
+    const observed: Array<{
+      method: string;
+      pathname: string;
+      body: Record<string, unknown>;
+      authorization: string | null;
+      managerTurn: string | null;
+      mutationToken: string | null;
+    }> = [];
+    vi.stubGlobal("fetch", async (request: string | URL | Request, init?: RequestInit) => {
+      const rawUrl = typeof request === "string"
+        ? request
+        : request instanceof URL
+          ? request.toString()
+          : request.url;
+      const headers = new Headers(init?.headers);
+      const body = typeof init?.body === "string"
+        ? JSON.parse(init.body) as Record<string, unknown>
+        : {};
+      observed.push({
+        method: init?.method ?? "GET",
+        pathname: new URL(rawUrl).pathname,
+        body,
+        authorization: headers.get("authorization"),
+        managerTurn: headers.get(HOMERAIL_MANAGER_TURN_HEADER),
+        mutationToken: headers.get("x-homerail-dag-token"),
+      });
+      const conflict = body.idempotency_key === "conflict-intervention";
+      return new Response(JSON.stringify(conflict
+        ? { success: false, error: "state token conflict" }
+        : { success: true, data: { intervention_id: "intervention-parity" } }), {
+        status: conflict ? 409 : 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const input = {
+      run_id: "run /?# supervised",
+      actor_id: "research /?#",
+      operation: "checkpoint_fork",
+      instruction: "Resume from the verified checkpoint with the corrected constraint.",
+      expected_state_token: "opaque-state-token",
+      idempotency_key: "intervention-parity-1",
+      checkpoint_version: 3,
+    };
+    const workerPayload = {
+      project_id: "project-parity",
+      session_id: "session-parity",
+      response_mode: "chat",
+      manager_api_scopes: ["POST:/api/runs/*/actors/*/interventions"],
+    };
+    const workerTurn: ManagerAgentTurnEnvelopeV1 = {
+      claims: {
+        turn_envelope_version: 1,
+        issuer: "homerail-manager",
+        audience: "homerail-manager-agent-worker",
+        key_id: "manager-parity-key",
+        turn_id: "turn-parity",
+        issued_at: "2026-07-15T00:00:00.000Z",
+        expires_at: "2026-07-15T00:05:00.000Z",
+        payload_digest: "a".repeat(64),
+        scope: managerAgentTurnScopeFromPayload(workerPayload, {
+          runtime_placement: "container",
+          worker_id: "worker-parity",
+        }),
+      },
+      signature: "A".repeat(86),
+    };
+
+    const hostResult = await requireTool(hostTools, "intervene_dag_actor").handler(input);
+    const workerResult = await _withManagerTurnEnvelopeForTest(
+      workerTurn,
+      () => requireTool(workerTools, "intervene_dag_actor").handler(input),
+    );
+    expect(hostResult).toEqual(workerResult);
+    expect(observed.map(({ method, pathname, body }) => ({ method, pathname, body }))).toEqual([
+      {
+        method: "POST",
+        pathname: "/api/runs/run%20%2F%3F%23%20supervised/actors/research%20%2F%3F%23/interventions",
+        body: {
+          operation: "checkpoint_fork",
+          instruction: input.instruction,
+          expected_state_token: "opaque-state-token",
+          idempotency_key: "intervention-parity-1",
+          checkpoint_version: 3,
+        },
+      },
+      {
+        method: "POST",
+        pathname: "/api/runs/run%20%2F%3F%23%20supervised/actors/research%20%2F%3F%23/interventions",
+        body: {
+          operation: "checkpoint_fork",
+          instruction: input.instruction,
+          expected_state_token: "opaque-state-token",
+          idempotency_key: "intervention-parity-1",
+          checkpoint_version: 3,
+        },
+      },
+    ]);
+    expect(observed[0]).toMatchObject({
+      authorization: `Bearer ${"A".repeat(32)}`,
+      managerTurn: null,
+      mutationToken: "mutation-parity-token",
+    });
+    expect(observed[1]).toMatchObject({
+      authorization: null,
+      managerTurn: Buffer.from(JSON.stringify(workerTurn), "utf8").toString("base64url"),
+      mutationToken: "mutation-parity-token",
+    });
+    expect(hostState.objectiveToolCalls).toEqual([{ name: "intervene_dag_actor", success: true }]);
+    expect(workerState.objectiveToolCalls).toEqual([{ name: "intervene_dag_actor", success: true }]);
+
+    const conflictInput = { ...input, idempotency_key: "conflict-intervention" };
+    const errors = await Promise.all([
+      requireTool(hostTools, "intervene_dag_actor").handler(conflictInput)
+        .then(() => "", (error: unknown) => error instanceof Error ? error.message : String(error)),
+      _withManagerTurnEnvelopeForTest(
+        workerTurn,
+        () => requireTool(workerTools, "intervene_dag_actor").handler(conflictInput),
+      ).then(() => "", (error: unknown) => error instanceof Error ? error.message : String(error)),
+    ]);
+    expect(errors[0]).toBe(errors[1]);
+    expect(errors[0]).toContain("Manager API 409");
+    expect(errors[0]).toContain("state token conflict");
+  });
+
+  it("rejects physical target and arbitrary intervention fields before either harness sends HTTP", async () => {
+    const { hostTools, workerTools } = createHarnessTools("chat");
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const input = {
+      run_id: "run-supervised",
+      actor_id: "research",
+      operation: "retry",
+      expected_state_token: "opaque-state-token",
+      idempotency_key: "intervention-parity-2",
+    };
+    const forbiddenFields = [
+      "node_id",
+      "worker_id",
+      "container_id",
+      "session_id",
+      "lease_id",
+      "lease_generation",
+      "generation",
+      "revision",
+      "target_id",
+      "target_generation",
+      "unexpected",
+    ];
+
+    for (const tools of [hostTools, workerTools]) {
+      for (const field of forbiddenFields) {
+        await expect(requireTool(tools, "intervene_dag_actor").handler({
+          ...input,
+          [field]: "forbidden",
+        })).rejects.toThrow(new RegExp(`additional properties: ${field}`));
+      }
+    }
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("executes the same enabled plugin projection through both voice harnesses", async () => {

--- a/homerail_manager/tests/plugin-distribution.test.ts
+++ b/homerail_manager/tests/plugin-distribution.test.ts
@@ -149,6 +149,6 @@ describe("plugin publisher trust persistence", () => {
     expect(listPluginPublisherTrustEvents()).toHaveLength(1);
     expect(getDb().prepare(
       "SELECT MAX(version) AS version FROM schema_migrations",
-    ).get()).toEqual({ version: 25 });
+    ).get()).toEqual({ version: 26 });
   });
 });

--- a/homerail_manager/tests/plugin-distribution.test.ts
+++ b/homerail_manager/tests/plugin-distribution.test.ts
@@ -149,6 +149,6 @@ describe("plugin publisher trust persistence", () => {
     expect(listPluginPublisherTrustEvents()).toHaveLength(1);
     expect(getDb().prepare(
       "SELECT MAX(version) AS version FROM schema_migrations",
-    ).get()).toEqual({ version: 26 });
+    ).get()).toEqual({ version: 27 });
   });
 });

--- a/homerail_manager/tests/plugin-package-lifecycle.test.ts
+++ b/homerail_manager/tests/plugin-package-lifecycle.test.ts
@@ -260,7 +260,7 @@ describe("external plugin package lifecycle", () => {
       expect.objectContaining({ plugin_version: "1.1.0", active: false, enabled: false }),
       expect.objectContaining({ plugin_version: "1.2.0", active: false, enabled: false }),
     ]));
-    expect(getDb().prepare("SELECT MAX(version) AS version FROM schema_migrations").get()).toEqual({ version: 26 });
+    expect(getDb().prepare("SELECT MAX(version) AS version FROM schema_migrations").get()).toEqual({ version: 27 });
     expect(inspectInstalledPlugin("com.example.release-notes")).toMatchObject({ healthy: true, issues: [] });
   });
 
@@ -455,7 +455,7 @@ describe("external plugin package lifecycle", () => {
 
     expect(getPluginRegistryState().revision).toBe(101);
     expect(getDb().prepare("SELECT MAX(version) AS version FROM schema_migrations").get())
-      .toEqual({ version: 26 });
+      .toEqual({ version: 27 });
   });
 
   it("rejects a stale uninstall when an inactive version was installed concurrently", () => {

--- a/homerail_manager/tests/plugin-package-lifecycle.test.ts
+++ b/homerail_manager/tests/plugin-package-lifecycle.test.ts
@@ -260,7 +260,7 @@ describe("external plugin package lifecycle", () => {
       expect.objectContaining({ plugin_version: "1.1.0", active: false, enabled: false }),
       expect.objectContaining({ plugin_version: "1.2.0", active: false, enabled: false }),
     ]));
-    expect(getDb().prepare("SELECT MAX(version) AS version FROM schema_migrations").get()).toEqual({ version: 25 });
+    expect(getDb().prepare("SELECT MAX(version) AS version FROM schema_migrations").get()).toEqual({ version: 26 });
     expect(inspectInstalledPlugin("com.example.release-notes")).toMatchObject({ healthy: true, issues: [] });
   });
 
@@ -455,7 +455,7 @@ describe("external plugin package lifecycle", () => {
 
     expect(getPluginRegistryState().revision).toBe(101);
     expect(getDb().prepare("SELECT MAX(version) AS version FROM schema_migrations").get())
-      .toEqual({ version: 25 });
+      .toEqual({ version: 26 });
   });
 
   it("rejects a stale uninstall when an inactive version was installed concurrently", () => {

--- a/homerail_manager/tests/plugin-remote-registry.test.ts
+++ b/homerail_manager/tests/plugin-remote-registry.test.ts
@@ -236,7 +236,7 @@ describe("signed remote plugin registry", () => {
     expect(listPluginRegistryUpdateAttempts("stable.example").filter((attempt) => attempt.status === "failed"))
       .toHaveLength(3);
     expect(getDb().prepare("SELECT MAX(version) AS version FROM schema_migrations").get())
-      .toEqual({ version: 25 });
+      .toEqual({ version: 26 });
   });
 
   it("rejects signed catalog releases whose payload or publisher digest disagrees with the HRP", () => {

--- a/homerail_manager/tests/plugin-remote-registry.test.ts
+++ b/homerail_manager/tests/plugin-remote-registry.test.ts
@@ -236,7 +236,7 @@ describe("signed remote plugin registry", () => {
     expect(listPluginRegistryUpdateAttempts("stable.example").filter((attempt) => attempt.status === "failed"))
       .toHaveLength(3);
     expect(getDb().prepare("SELECT MAX(version) AS version FROM schema_migrations").get())
-      .toEqual({ version: 26 });
+      .toEqual({ version: 27 });
   });
 
   it("rejects signed catalog releases whose payload or publisher digest disagrees with the HRP", () => {

--- a/homerail_manager/vitest.config.ts
+++ b/homerail_manager/vitest.config.ts
@@ -1,9 +1,19 @@
 import { defineConfig } from "vitest/config";
 
+function timeoutFromEnv(name: string): number | undefined {
+  const value = process.env[name];
+  if (value === undefined) return undefined;
+
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
 export default defineConfig({
   test: {
     include: ["tests/**/*.test.ts"],
     exclude: ["node_modules/**", "dist/**"],
     setupFiles: ["./tests/setup.ts"],
+    testTimeout: timeoutFromEnv("VITEST_TEST_TIMEOUT"),
+    hookTimeout: timeoutFromEnv("VITEST_HOOK_TIMEOUT"),
   },
 });

--- a/homerail_protocol/src/manager-agent-tools.ts
+++ b/homerail_protocol/src/manager-agent-tools.ts
@@ -18,6 +18,27 @@ export type ManagerAgentWidgetFileType = (typeof MANAGER_AGENT_WIDGET_FILE_TYPES
 
 export type ManagerAgentResponseMode = "chat" | "voice";
 
+export const MANAGER_AGENT_DAG_ACTOR_INTERVENTION_OPERATIONS = [
+  "interrupt",
+  "cancel",
+  "retry",
+  "reassign",
+  "checkpoint_fork",
+] as const;
+
+export type ManagerAgentDagActorInterventionOperation =
+  (typeof MANAGER_AGENT_DAG_ACTOR_INTERVENTION_OPERATIONS)[number];
+
+export interface ManagerAgentDagActorInterventionInput {
+  run_id: string;
+  actor_id: string;
+  operation: ManagerAgentDagActorInterventionOperation;
+  instruction?: string;
+  expected_state_token: string;
+  idempotency_key: string;
+  checkpoint_version?: number;
+}
+
 export const MANAGER_AGENT_COMMON_TOOL_NAMES = [
   "list_projects",
   "list_skills",
@@ -41,6 +62,7 @@ export const MANAGER_AGENT_COMMON_TOOL_NAMES = [
   "start_supervised_dag",
   "list_dag_actors",
   "get_dag_supervision",
+  "intervene_dag_actor",
   "send_dag_actor_command",
   "focus_dag_actor",
   "cancel_dag_run",
@@ -251,6 +273,112 @@ export interface HomeRailPromptHandoff {
   port: string;
   content: unknown;
   summary?: string;
+}
+
+const INTERVENE_DAG_ACTOR_ALLOWED_KEYS = new Set([
+  "run_id",
+  "actor_id",
+  "operation",
+  "instruction",
+  "expected_state_token",
+  "idempotency_key",
+  "checkpoint_version",
+]);
+const INTERVENE_DAG_ACTOR_INSTRUCTION_MAX_LENGTH = 4096;
+const INTERVENE_DAG_ACTOR_STATE_TOKEN_MAX_LENGTH = 256;
+const INTERVENE_DAG_ACTOR_IDEMPOTENCY_KEY_MAX_LENGTH = 256;
+const INTERVENE_DAG_ACTOR_IDENTIFIER_MAX_LENGTH = 256;
+const INTERVENE_DAG_ACTOR_IDENTIFIER_PATTERN = "^(?=[^\\u0000-\\u001f\\u007f]*\\S)[^\\u0000-\\u001f\\u007f]+$";
+
+function interventionIdentifier(value: unknown, field: "run_id" | "actor_id"): string {
+  const normalized = typeof value === "string" ? value.trim() : "";
+  if (
+    !normalized
+    || normalized.length > INTERVENE_DAG_ACTOR_IDENTIFIER_MAX_LENGTH
+    || /[\u0000-\u001f\u007f]/.test(normalized)
+  ) {
+    throw new Error(
+      `intervene_dag_actor ${field} must be between 1 and ${INTERVENE_DAG_ACTOR_IDENTIFIER_MAX_LENGTH} printable characters`,
+    );
+  }
+  return normalized;
+}
+
+function boundedNonEmptyInterventionString(
+  value: unknown,
+  field: string,
+  maxLength: number,
+): string {
+  if (
+    typeof value !== "string"
+    || !value.trim()
+    || value.length > maxLength
+  ) {
+    throw new Error(
+      `intervene_dag_actor ${field} must be a non-empty string of at most ${maxLength} characters`,
+    );
+  }
+  return value;
+}
+
+export function normalizeManagerAgentDagActorInterventionInput(
+  args: Record<string, unknown>,
+): ManagerAgentDagActorInterventionInput {
+  const extraKeys = Object.keys(args)
+    .filter((key) => !INTERVENE_DAG_ACTOR_ALLOWED_KEYS.has(key))
+    .sort();
+  if (extraKeys.length > 0) {
+    throw new Error(`intervene_dag_actor does not accept additional properties: ${extraKeys.join(", ")}`);
+  }
+
+  const runId = interventionIdentifier(args.run_id, "run_id");
+  const actorId = interventionIdentifier(args.actor_id, "actor_id");
+  if (!MANAGER_AGENT_DAG_ACTOR_INTERVENTION_OPERATIONS.includes(
+    args.operation as ManagerAgentDagActorInterventionOperation,
+  )) {
+    throw new Error(
+      `intervene_dag_actor operation must be one of ${MANAGER_AGENT_DAG_ACTOR_INTERVENTION_OPERATIONS.join(", ")}`,
+    );
+  }
+
+  const operation = args.operation as ManagerAgentDagActorInterventionOperation;
+  const instruction = args.instruction === undefined
+    ? undefined
+    : boundedNonEmptyInterventionString(
+      args.instruction,
+      "instruction",
+      INTERVENE_DAG_ACTOR_INSTRUCTION_MAX_LENGTH,
+    );
+  const expectedStateToken = boundedNonEmptyInterventionString(
+    args.expected_state_token,
+    "expected_state_token",
+    INTERVENE_DAG_ACTOR_STATE_TOKEN_MAX_LENGTH,
+  );
+  const idempotencyKey = boundedNonEmptyInterventionString(
+    args.idempotency_key,
+    "idempotency_key",
+    INTERVENE_DAG_ACTOR_IDEMPOTENCY_KEY_MAX_LENGTH,
+  );
+  const checkpointVersion = args.checkpoint_version;
+  if (operation === "checkpoint_fork") {
+    if (!Number.isSafeInteger(checkpointVersion) || Number(checkpointVersion) < 1) {
+      throw new Error(
+        "intervene_dag_actor checkpoint_version is required and must be a positive integer for checkpoint_fork",
+      );
+    }
+  } else if (checkpointVersion !== undefined) {
+    throw new Error("intervene_dag_actor checkpoint_version is only accepted for checkpoint_fork");
+  }
+
+  return {
+    run_id: runId,
+    actor_id: actorId,
+    operation,
+    ...(instruction === undefined ? {} : { instruction }),
+    expected_state_token: expectedStateToken,
+    idempotency_key: idempotencyKey,
+    ...(checkpointVersion === undefined ? {} : { checkpoint_version: Number(checkpointVersion) }),
+  };
 }
 
 const emptyObjectSchema = { type: "object", properties: {}, additionalProperties: false };
@@ -603,6 +731,62 @@ export const MANAGER_AGENT_TOOL_SPECS: Record<ManagerAgentToolName, AgentToolDef
         max_milestones: { type: "integer", minimum: 1, maximum: 12 },
       },
       required: ["run_id"],
+      additionalProperties: false,
+    },
+  },
+  intervene_dag_actor: {
+    name: "intervene_dag_actor",
+    description: "Intervene in one supervised DAG Actor by stable actor_id. Obtain the current expected_state_token from get_dag_supervision immediately before calling this tool and treat it as opaque. Never infer physical execution targets, including Worker or container IDs, and never supply node, session, lease, generation, revision, or target identifiers.",
+    input_schema: {
+      type: "object",
+      properties: {
+        run_id: {
+          type: "string",
+          minLength: 1,
+          maxLength: INTERVENE_DAG_ACTOR_IDENTIFIER_MAX_LENGTH,
+          pattern: INTERVENE_DAG_ACTOR_IDENTIFIER_PATTERN,
+        },
+        actor_id: {
+          type: "string",
+          minLength: 1,
+          maxLength: INTERVENE_DAG_ACTOR_IDENTIFIER_MAX_LENGTH,
+          pattern: INTERVENE_DAG_ACTOR_IDENTIFIER_PATTERN,
+        },
+        operation: { type: "string", enum: MANAGER_AGENT_DAG_ACTOR_INTERVENTION_OPERATIONS },
+        instruction: {
+          type: "string",
+          minLength: 1,
+          maxLength: INTERVENE_DAG_ACTOR_INSTRUCTION_MAX_LENGTH,
+        },
+        expected_state_token: {
+          type: "string",
+          minLength: 1,
+          maxLength: INTERVENE_DAG_ACTOR_STATE_TOKEN_MAX_LENGTH,
+        },
+        idempotency_key: {
+          type: "string",
+          minLength: 1,
+          maxLength: INTERVENE_DAG_ACTOR_IDEMPOTENCY_KEY_MAX_LENGTH,
+        },
+        checkpoint_version: { type: "integer", minimum: 1 },
+      },
+      required: ["run_id", "actor_id", "operation", "expected_state_token", "idempotency_key"],
+      allOf: [{
+        if: {
+          properties: { operation: { const: "checkpoint_fork" } },
+          required: ["operation"],
+        },
+        then: {
+          properties: { checkpoint_version: { type: "integer", minimum: 1 } },
+          required: ["checkpoint_version"],
+        },
+        else: {
+          not: {
+            properties: { checkpoint_version: {} },
+            required: ["checkpoint_version"],
+          },
+        },
+      }],
       additionalProperties: false,
     },
   },

--- a/homerail_protocol/tests/manager-agent.test.ts
+++ b/homerail_protocol/tests/manager-agent.test.ts
@@ -1,3 +1,4 @@
+import Ajv from "ajv";
 import { describe, expect, it } from "vitest";
 import {
   DEFAULT_MANAGER_AGENT_HARNESS,
@@ -15,6 +16,7 @@ import { buildManagerAgentSystemPrompt } from "../src/manager-agent-prompt.js";
 import {
   MANAGER_AGENT_COMMON_TOOL_NAMES,
   MANAGER_AGENT_COMMON_VOICE_TOOL_NAMES,
+  MANAGER_AGENT_DAG_ACTOR_INTERVENTION_OPERATIONS,
   MANAGER_AGENT_HOST_VOICE_TOOL_NAMES,
   MANAGER_AGENT_WIDGET_FILE_TYPES,
   formatHomeRailPromptHandoff,
@@ -22,6 +24,7 @@ import {
   managerAgentDagCommandResult,
   managerAgentCommonToolCatalog,
   managerAgentToolSpec,
+  normalizeManagerAgentDagActorInterventionInput,
   parseHomeRailPromptHandoff,
   parseHomeRailPromptToolCalls,
   stripHomeRailPromptMarkers,
@@ -155,6 +158,7 @@ describe("Manager Agent harness contract", () => {
       "start_supervised_dag",
       "list_dag_actors",
       "get_dag_supervision",
+      "intervene_dag_actor",
       "send_dag_actor_command",
       "focus_dag_actor",
       "cancel_dag_run",
@@ -196,6 +200,46 @@ describe("Manager Agent harness contract", () => {
           max_milestones: { type: "integer", minimum: 1, maximum: 12 },
         },
         required: ["run_id"],
+        additionalProperties: false,
+      },
+      intervene_dag_actor: {
+        type: "object",
+        properties: {
+          run_id: {
+            type: "string",
+            minLength: 1,
+            maxLength: 256,
+            pattern: "^(?=[^\\u0000-\\u001f\\u007f]*\\S)[^\\u0000-\\u001f\\u007f]+$",
+          },
+          actor_id: {
+            type: "string",
+            minLength: 1,
+            maxLength: 256,
+            pattern: "^(?=[^\\u0000-\\u001f\\u007f]*\\S)[^\\u0000-\\u001f\\u007f]+$",
+          },
+          operation: { type: "string", enum: MANAGER_AGENT_DAG_ACTOR_INTERVENTION_OPERATIONS },
+          instruction: { type: "string", minLength: 1, maxLength: 4096 },
+          expected_state_token: { type: "string", minLength: 1, maxLength: 256 },
+          idempotency_key: { type: "string", minLength: 1, maxLength: 256 },
+          checkpoint_version: { type: "integer", minimum: 1 },
+        },
+        required: ["run_id", "actor_id", "operation", "expected_state_token", "idempotency_key"],
+        allOf: [{
+          if: {
+            properties: { operation: { const: "checkpoint_fork" } },
+            required: ["operation"],
+          },
+          then: {
+            properties: { checkpoint_version: { type: "integer", minimum: 1 } },
+            required: ["checkpoint_version"],
+          },
+          else: {
+            not: {
+              properties: { checkpoint_version: {} },
+              required: ["checkpoint_version"],
+            },
+          },
+        }],
         additionalProperties: false,
       },
       send_dag_actor_command: {
@@ -244,6 +288,111 @@ describe("Manager Agent harness contract", () => {
       expect(spec.description).toContain("stable actor_id");
       expect(spec.description).toContain("Worker or container IDs");
     }
+
+    const intervention = managerAgentToolSpec("intervene_dag_actor");
+    expect(intervention.description).toContain("get_dag_supervision");
+    expect(intervention.description).toContain("expected_state_token");
+    expect(intervention.description).toContain("Never infer physical execution targets");
+  });
+
+  it("rejects invalid and physical-target inputs for DAG Actor intervention", () => {
+    const validate = new Ajv({ strict: true }).compile(
+      managerAgentToolSpec("intervene_dag_actor").input_schema,
+    );
+    const valid = {
+      run_id: "run-supervised",
+      actor_id: "research",
+      operation: "checkpoint_fork",
+      instruction: "Retry from the verified checkpoint with the corrected constraint.",
+      expected_state_token: "a".repeat(64),
+      idempotency_key: "intervention-research-1",
+      checkpoint_version: 3,
+    };
+
+    expect(validate(valid)).toBe(true);
+    expect(validate({
+      run_id: valid.run_id,
+      actor_id: valid.actor_id,
+      operation: "cancel",
+      expected_state_token: valid.expected_state_token,
+      idempotency_key: valid.idempotency_key,
+    })).toBe(true);
+
+    const invalidInputs = [
+      { ...valid, operation: "restart" },
+      {
+        run_id: valid.run_id,
+        actor_id: valid.actor_id,
+        operation: "checkpoint_fork",
+        expected_state_token: valid.expected_state_token,
+        idempotency_key: valid.idempotency_key,
+      },
+      { ...valid, operation: "retry" },
+      { ...valid, run_id: "" },
+      { ...valid, run_id: "   " },
+      { ...valid, run_id: "x".repeat(257) },
+      { ...valid, run_id: "run\nbad" },
+      { ...valid, actor_id: "" },
+      { ...valid, actor_id: "x".repeat(257) },
+      { ...valid, actor_id: "actor\u007fbad" },
+      { ...valid, instruction: "" },
+      { ...valid, instruction: "x".repeat(4097) },
+      { ...valid, expected_state_token: "" },
+      { ...valid, expected_state_token: "x".repeat(257) },
+      { ...valid, idempotency_key: "" },
+      { ...valid, idempotency_key: "x".repeat(257) },
+      { ...valid, checkpoint_version: 0 },
+      { ...valid, checkpoint_version: 1.5 },
+      ...[
+        "node_id",
+        "worker_id",
+        "container_id",
+        "session_id",
+        "lease_id",
+        "generation",
+        "revision",
+        "target_id",
+        "unexpected",
+      ].map((field) => ({ ...valid, [field]: "forbidden" })),
+    ];
+    for (const input of invalidInputs) expect(validate(input), JSON.stringify(input)).toBe(false);
+  });
+
+  it("normalizes bounded identifiers and enforces checkpoint-only version semantics", () => {
+    const base = {
+      run_id: "  run-supervised  ",
+      actor_id: "  research  ",
+      operation: "retry",
+      expected_state_token: "opaque-state-token",
+      idempotency_key: "intervention-research-1",
+    };
+    expect(normalizeManagerAgentDagActorInterventionInput(base)).toEqual({
+      ...base,
+      run_id: "run-supervised",
+      actor_id: "research",
+    });
+    expect(normalizeManagerAgentDagActorInterventionInput({
+      ...base,
+      operation: "checkpoint_fork",
+      checkpoint_version: 2,
+    })).toMatchObject({ operation: "checkpoint_fork", checkpoint_version: 2 });
+
+    expect(() => normalizeManagerAgentDagActorInterventionInput({
+      ...base,
+      operation: "checkpoint_fork",
+    })).toThrow(/checkpoint_version is required/);
+    expect(() => normalizeManagerAgentDagActorInterventionInput({
+      ...base,
+      checkpoint_version: 2,
+    })).toThrow(/only accepted for checkpoint_fork/);
+    expect(() => normalizeManagerAgentDagActorInterventionInput({
+      ...base,
+      run_id: "x".repeat(257),
+    })).toThrow(/run_id must be between 1 and 256 printable characters/);
+    expect(() => normalizeManagerAgentDagActorInterventionInput({
+      ...base,
+      actor_id: "actor\nbad",
+    })).toThrow(/actor_id must be between 1 and 256 printable characters/);
   });
 
   it("projects command responses onto the stable Actor-only contract", () => {

--- a/homerail_worker/src/__tests__/manager-agent-server.test.ts
+++ b/homerail_worker/src/__tests__/manager-agent-server.test.ts
@@ -12,6 +12,7 @@ const SUPERVISOR_TOOL_NAMES = [
   "start_supervised_dag",
   "list_dag_actors",
   "get_dag_supervision",
+  "intervene_dag_actor",
   "send_dag_actor_command",
   "focus_dag_actor",
   "cancel_dag_run",
@@ -1240,9 +1241,17 @@ describe("manager-agent server", () => {
           input_schema: tool.input_schema,
         }).toEqual(managerAgentToolSpec(name));
         expect(tool.input_schema).toMatchObject({ additionalProperties: false });
-        expect(JSON.stringify(tool.input_schema)).not.toContain("worker_id");
-        expect(JSON.stringify(tool.input_schema)).not.toContain("container_id");
-        expect(JSON.stringify(tool.input_schema)).not.toContain("generation");
+        const schema = JSON.stringify(tool.input_schema);
+        for (const forbidden of [
+          "node_id",
+          "worker_id",
+          "container_id",
+          "session_id",
+          "lease_id",
+          "generation",
+          "revision",
+          "target_id",
+        ]) expect(schema).not.toContain(forbidden);
       }
     }
   });
@@ -1270,6 +1279,24 @@ describe("manager-agent server", () => {
       results.push(await requireManagerTool(tools, "get_dag_supervision").handler({
         run_id: runId,
         max_milestones: 5,
+      }));
+      const interventionTool = requireManagerTool(tools, "intervene_dag_actor");
+      await expect(interventionTool.handler({
+        run_id: runId,
+        actor_id: "research /?#",
+        operation: "retry",
+        expected_state_token: "a".repeat(64),
+        idempotency_key: "intervention-research-2",
+        node_id: "forbidden-node",
+      })).rejects.toThrow(/does not accept additional properties: node_id/);
+      results.push(await interventionTool.handler({
+        run_id: runId,
+        actor_id: "research /?#",
+        operation: "checkpoint_fork",
+        instruction: "Resume from the verified checkpoint with the corrected constraint.",
+        expected_state_token: "a".repeat(64),
+        idempotency_key: "intervention-research-2",
+        checkpoint_version: 3,
       }));
       results.push(await requireManagerTool(tools, "send_dag_actor_command").handler({
         run_id: runId,
@@ -1317,6 +1344,18 @@ describe("manager-agent server", () => {
         },
         {
           method: "POST",
+          pathname: `/api/runs/${encodedRunId}/actors/research%20%2F%3F%23/interventions`,
+          query: {},
+          body: {
+            operation: "checkpoint_fork",
+            instruction: "Resume from the verified checkpoint with the corrected constraint.",
+            expected_state_token: "a".repeat(64),
+            idempotency_key: "intervention-research-2",
+            checkpoint_version: 3,
+          },
+        },
+        {
+          method: "POST",
           pathname: `/api/runs/${encodedRunId}/commands`,
           query: {},
           body: {
@@ -1349,6 +1388,7 @@ describe("manager-agent server", () => {
       expect(state.createdRunIds).toEqual(["run-supervised-123"]);
       expect(state.objectiveToolCalls).toEqual([
         { name: "start_supervised_dag", success: true },
+        { name: "intervene_dag_actor", success: true },
         { name: "send_dag_actor_command", success: true },
         { name: "focus_dag_actor", success: true },
         { name: "cancel_dag_run", success: true },

--- a/homerail_worker/src/manager-agent/server.ts
+++ b/homerail_worker/src/manager-agent/server.ts
@@ -26,6 +26,7 @@ import {
   matchingManagerAgentSkillViewToolDefinition,
   materializeManagerAgentSkillViewInput,
   mergeManagerAgentPluginSkillCatalog,
+  normalizeManagerAgentDagActorInterventionInput,
   executeHomerailPluginTool,
   validateHomerailPluginTurnContext,
   homerailPluginTurnContextDigestInput,
@@ -1170,6 +1171,29 @@ export function createManagerTools(state: {
         );
         appendSupervisionCommentary(state.voiceSurface, body);
         return { content: [{ type: "text", text: short(body, 40000) }] };
+      },
+    },
+    {
+      ...managerAgentToolSpec("intervene_dag_actor"),
+      async handler(args) {
+        const input = normalizeManagerAgentDagActorInterventionInput(args);
+        const body = await requestManager(
+          `/runs/${encodeURIComponent(input.run_id)}/actors/${encodeURIComponent(input.actor_id)}/interventions`,
+          {
+            method: "POST",
+            body: JSON.stringify({
+              operation: input.operation,
+              ...(input.instruction === undefined ? {} : { instruction: input.instruction }),
+              expected_state_token: input.expected_state_token,
+              idempotency_key: input.idempotency_key,
+              ...(input.checkpoint_version === undefined
+                ? {}
+                : { checkpoint_version: input.checkpoint_version }),
+            }),
+          },
+        );
+        state.objectiveToolCalls.push({ name: "intervene_dag_actor", success: true });
+        return { content: [{ type: "text", text: short(body, 20000) }] };
       },
     },
     {


### PR DESCRIPTION
Closes #44

## Summary
- add one actor-scoped Manager tool for interrupt, cancel, retry, reassign, and checkpoint fork
- persist every request in an intervention Inbox before applying it, with generation/version CAS, idempotency, cold recovery, and stale-output fences
- advance only the selected logical Actor generation while preserving unaffected Actor state and Surface identity
- retain superseded A2UI snapshots as read-only history and update the stable current Surface in place
- emit sanitized Manager milestones without exposing node IDs, Worker IDs, lease generations, or physical targets
- add migration v26 for interventions and append-only Surface generation history

## Base
- rebased directly onto `main@305afffe` after #53 was merged
- current HEAD: `556c6172`
- merge state: clean

## Runtime guarantees
- stale Actor generations cannot submit handoffs or overwrite the current Surface
- duplicate intervention requests return the original result
- concurrent or stale requests fail with an explicit conflict
- at most one queued or applying intervention exists per Actor
- cold recovery applies queued Inbox rows before orphaned running nodes are demoted
- retry, reassign, and checkpoint fork reset only the selected branch
- interrupt and cancel retire only the selected branch
- historical Surface content is read-only and never replaces the stable current Surface ID

## Verification
- full local `npm run ci`: 2161 passed, 0 failed
- post-rebase root typecheck passed
- focused Protocol catalog: 18/18 passed
- focused intervention, branch isolation, API, projection, Supervisor, and tool-parity suites: 56/56 passed
- Worker Manager Agent suite: 22/22 passed
- Manager full suite: 900 passed, 2 skipped
- Chromium visual verification passed at 1920x1080 and 390x844, including Surface history and reduced-motion behavior
- GitHub CI passed on Linux Node 20/24, Windows Node 24, Agent UI, and Docker

The live-model DAG job remains an explicit manual validation path and is intentionally skipped by the normal pull-request trigger. No credentials or machine-local configuration are included.

## Review notes
- the reported intervention CAS, stale-output fence, cold-recovery ordering, and branch isolation guarantees were rechecked against the current HEAD
- this PR does not merge itself
