### PR TITLE
feat: add built-in Edge TTS and streamline voice setup

### DIFF
--- a/agent-ui/src/components/agent/AgentSettingsPage.vue
+++ b/agent-ui/src/components/agent/AgentSettingsPage.vue
@@ -681,7 +681,7 @@ function isQwen3Tts(model: string): boolean {
   return model === 'qwen3-tts'
 }
 
-function applyTtsDefaultsFor(model: string, baseUrl: string): void {
+function applyTtsDefaultsFor(model: string, baseUrl: string, configuredVoice?: string | null): void {
   if (isMimoTts(model, baseUrl)) {
     voiceForm.value.tts_voice = 'mimo_default'
     voiceForm.value.tts_speed = null
@@ -692,7 +692,11 @@ function applyTtsDefaultsFor(model: string, baseUrl: string): void {
     voiceForm.value.tts_voice = 'serena'
     voiceForm.value.tts_speed = null
     voiceForm.value.tts_stream = false
+    return
   }
+  voiceForm.value.tts_voice = configuredVoice || 'alloy'
+  voiceForm.value.tts_speed = null
+  voiceForm.value.tts_stream = false
 }
 
 function setTtsSpeed(event: Event): void {
@@ -1331,7 +1335,7 @@ function selectVoiceModelSetting(service: 'omni' | 'llm' | 'asr' | 'tts', event:
   voiceForm.value.tts_llm_setting_id = setting.id
   voiceForm.value.tts_model = setting.model_name
   voiceForm.value.tts_base_url = setting.provider_base_url || voiceForm.value.tts_base_url
-  applyTtsDefaultsFor(voiceForm.value.tts_model, voiceForm.value.tts_base_url)
+  applyTtsDefaultsFor(voiceForm.value.tts_model, voiceForm.value.tts_base_url, setting.tts_voice)
 }
 
 async function fetchVoiceModels(service: 'omni' | 'llm' | 'asr' | 'tts'): Promise<void> {

--- a/agent-ui/src/components/agent/AgentVoiceCockpit.vue
+++ b/agent-ui/src/components/agent/AgentVoiceCockpit.vue
@@ -140,18 +140,16 @@ import {
   SlidersHorizontal,
   Sparkles,
   Volume2,
+  VolumeX,
   X
 } from 'lucide-vue-next'
 
 const store = useAgentStore()
 const { t, te } = useI18n()
 const { planLabel } = createProtocolLabels(t)
-// 新手引导配置状态检测（用于"模型配置"按钮的缺配提示）
+// 新手引导配置状态检测（作为独立状态入口，不阻断模型选择）
 const { status: onboardingStatus, refresh: refreshOnboarding } = useOnboardingStatus()
 const needsOnboardingHint = computed(() => onboardingStatus.value.needsOnboarding)
-const modelConfigButtonLabel = computed(() =>
-  needsOnboardingHint.value ? t('voice.model.incomplete') : t('voice.model.configuration')
-)
 const devOnboardingEntryVisible =
   import.meta.env.DEV && flagEnabled(import.meta.env.VITE_HOMERAIL_DEV_ONBOARDING_ENTRY)
 const generativeUiShadowPreviewRequested =
@@ -272,6 +270,8 @@ const codexTextSubmitting = ref(false)
 // 'assist' = ASR 流式转写填入 composer，由用户改完手动发送。
 const VOICE_INPUT_ASSIST_KEY = 'homerail.voice.input-assist'
 const voiceInputAssist = ref(loadBooleanSetting(VOICE_INPUT_ASSIST_KEY, false))
+const VOICE_OUTPUT_ENABLED_KEY = 'homerail.voice.output-enabled'
+const voiceOutputEnabled = ref(loadBooleanSetting(VOICE_OUTPUT_ENABLED_KEY, true))
 const composerRef = ref<HTMLTextAreaElement | null>(null)
 const fullscreenPromptVisible = ref(false)
 const fullscreenPromptDismissed = ref(false)
@@ -1095,15 +1095,15 @@ function isKimiCodeCompatibleSetting(setting: LLMSetting): boolean {
 }
 
 function toggleModelMenu(): void {
-  if (needsOnboardingHint.value) {
-    modelMenuOpen.value = false
-    store.openOnboarding()
-    return
-  }
   modelMenuOpen.value = !modelMenuOpen.value
   if (modelMenuOpen.value) {
     void loadCodexModelCatalog()
   }
+}
+
+function openRequiredOnboarding(): void {
+  modelMenuOpen.value = false
+  store.openOnboarding()
 }
 
 function closeModelMenuOnOutside(event: PointerEvent): void {
@@ -3014,6 +3014,12 @@ function toggleVoiceInputAssist(): void {
   saveBooleanSetting(VOICE_INPUT_ASSIST_KEY, voiceInputAssist.value)
 }
 
+function toggleVoiceOutput(): void {
+  voiceOutputEnabled.value = !voiceOutputEnabled.value
+  saveBooleanSetting(VOICE_OUTPUT_ENABLED_KEY, voiceOutputEnabled.value)
+  if (!voiceOutputEnabled.value) cancelLocalSpeech('voice_output_disabled')
+}
+
 function submitComposerDraft(): void {
   if (composerSubmitDisabled.value) return
   void submitCodexTextDraft()
@@ -3141,6 +3147,10 @@ async function submitDraft(force = false): Promise<void> {
 async function speak(text: string): Promise<void> {
   const clean = text.trim()
   if (!clean) return
+  if (!voiceOutputEnabled.value) {
+    recordTtsDebug('tts_output_disabled', `跳过已关闭的语音输出：${previewSpeechText(clean)}`)
+    return
+  }
   if (!tabCanUseVoiceOutput()) {
     recordTtsDebug('tts_tab_inactive', `跳过不可见标签页语音输出：${previewSpeechText(clean)}`, 'warning')
     return
@@ -3204,6 +3214,13 @@ async function speakText(text: string): Promise<void> {
 function enqueueSpeechEvent(event: VoiceSpeechEvent, source = 'stream'): boolean {
   const text = event.text?.trim()
   if (!text) return false
+  if (!voiceOutputEnabled.value) {
+    recordTtsDebug(
+      'tts_enqueue_skipped',
+      `source=${source} reason=output_disabled channel=${event.channel} text="${previewSpeechText(text)}"`
+    )
+    return false
+  }
   if (!tabCanUseVoiceOutput()) {
     recordTtsDebug(
       'tts_enqueue_skipped',
@@ -4654,20 +4671,15 @@ function summarizeTask(value: string): string {
         <div ref="modelMenuRef" class="voice-model-menu">
           <button
             class="voice-model-menu__button"
-            :class="{
-              'voice-model-menu__button--alert': needsOnboardingHint
-            }"
             type="button"
             data-testid="voice-model-config-button"
             :aria-expanded="modelMenuOpen"
             aria-haspopup="menu"
             @click="toggleModelMenu"
           >
-            <AlertTriangle v-if="needsOnboardingHint" class="h-4 w-4" />
-            <SlidersHorizontal v-else class="h-4 w-4" />
-            <span>{{ modelConfigButtonLabel }}</span>
+            <SlidersHorizontal class="h-4 w-4" />
+            <span>{{ t('voice.model.configuration') }}</span>
             <ChevronDown
-              v-if="!needsOnboardingHint"
               class="h-4 w-4 transition-transform"
               :class="modelMenuOpen ? 'rotate-180' : ''"
             />
@@ -4884,6 +4896,17 @@ function summarizeTask(value: string): string {
             </div>
           </div>
         </div>
+        <button
+          v-if="needsOnboardingHint"
+          class="voice-model-menu__button voice-model-menu__button--alert"
+          type="button"
+          data-testid="voice-onboarding-status-button"
+          :title="t('voice.state.onboardingRequired')"
+          @click="openRequiredOnboarding"
+        >
+          <AlertTriangle class="h-4 w-4" />
+          <span>{{ t('voice.model.incomplete') }}</span>
+        </button>
         <button
           v-if="devOnboardingEntryVisible"
           class="voice-runtime-pill voice-runtime-pill--dev-onboarding flex h-9 items-center gap-2 rounded-full border border-amber-300/24 bg-amber-300/10 px-3 text-xs text-amber-100 transition-colors hover:bg-amber-300/16 hover:text-white"
@@ -5377,26 +5400,45 @@ function summarizeTask(value: string): string {
               data-testid="voice-composer"
               @submit.prevent="submitComposerDraft"
             >
-              <div class="voice-composer__mode" role="group" :aria-label="t('voice.composer.modeLabel')">
+              <div class="voice-composer__preferences">
+                <div class="voice-composer__mode" role="group" :aria-label="t('voice.composer.modeLabel')">
+                  <button
+                    type="button"
+                    class="voice-composer__mode-btn"
+                    :class="{ 'voice-composer__mode-btn--active': !voiceInputAssist }"
+                    :disabled="!voiceInputAssist"
+                    :title="t('voice.composer.realtimeTitle')"
+                    @click="voiceInputAssist ? toggleVoiceInputAssist() : undefined"
+                  >
+                    {{ t('voice.composer.realtime') }}
+                  </button>
+                  <button
+                    type="button"
+                    class="voice-composer__mode-btn"
+                    :class="{ 'voice-composer__mode-btn--active': voiceInputAssist }"
+                    :disabled="voiceInputAssist"
+                    :title="t('voice.composer.assistTitle')"
+                    @click="voiceInputAssist ? undefined : toggleVoiceInputAssist()"
+                  >
+                    {{ t('voice.composer.assist') }}
+                  </button>
+                </div>
                 <button
                   type="button"
-                  class="voice-composer__mode-btn"
-                  :class="{ 'voice-composer__mode-btn--active': !voiceInputAssist }"
-                  :disabled="!voiceInputAssist"
-                  :title="t('voice.composer.realtimeTitle')"
-                  @click="voiceInputAssist ? toggleVoiceInputAssist() : undefined"
+                  class="voice-composer__output-toggle"
+                  :class="{
+                    'voice-composer__output-toggle--enabled': voiceOutputEnabled
+                  }"
+                  data-testid="voice-output-toggle"
+                  :data-state="voiceOutputEnabled ? 'on' : 'off'"
+                  :aria-pressed="voiceOutputEnabled"
+                  :aria-label="t('voice.composer.voice')"
+                  :title="t('voice.composer.voice')"
+                  @click="toggleVoiceOutput"
                 >
-                  {{ t('voice.composer.realtime') }}
-                </button>
-                <button
-                  type="button"
-                  class="voice-composer__mode-btn"
-                  :class="{ 'voice-composer__mode-btn--active': voiceInputAssist }"
-                  :disabled="voiceInputAssist"
-                  :title="t('voice.composer.assistTitle')"
-                  @click="voiceInputAssist ? undefined : toggleVoiceInputAssist()"
-                >
-                  {{ t('voice.composer.assist') }}
+                  <Volume2 v-if="voiceOutputEnabled" class="h-3.5 w-3.5" />
+                  <VolumeX v-else class="h-3.5 w-3.5" />
+                  <span>{{ t('voice.composer.voice') }}</span>
                 </button>
               </div>
               <div class="voice-composer__row">
@@ -7790,6 +7832,13 @@ function summarizeTask(value: string): string {
   background: rgba(255, 255, 255, 0.04);
 }
 
+.voice-composer__preferences {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
 .voice-composer__mode-btn {
   min-width: 56px;
   padding: 5px 14px;
@@ -7813,6 +7862,36 @@ function summarizeTask(value: string): string {
 
 .voice-composer__mode-btn:disabled {
   cursor: default;
+}
+
+.voice-composer__output-toggle {
+  display: inline-flex;
+  min-height: 34px;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.035);
+  padding: 5px 11px;
+  color: rgba(236, 254, 255, 0.48);
+  font-size: 12px;
+  font-weight: 720;
+  transition:
+    border-color 160ms ease,
+    background 160ms ease,
+    color 160ms ease;
+}
+
+.voice-composer__output-toggle:hover {
+  border-color: rgba(103, 232, 249, 0.28);
+  background: rgba(103, 232, 249, 0.08);
+  color: rgba(236, 254, 255, 0.86);
+}
+
+.voice-composer__output-toggle--enabled {
+  border-color: rgba(45, 212, 191, 0.3);
+  background: rgba(13, 148, 136, 0.16);
+  color: rgba(204, 251, 241, 0.94);
 }
 
 .voice-composer__row {

--- a/agent-ui/src/components/agent/AgentVoiceCockpit.vue
+++ b/agent-ui/src/components/agent/AgentVoiceCockpit.vue
@@ -102,6 +102,11 @@ import {
   isAndroidTvShell,
   isMobileVoiceUserAgent
 } from '@/utils/voice-host-platform'
+import {
+  BUILTIN_EDGE_TTS_OPTION_ID,
+  builtinEdgeTtsUpdate,
+  isBuiltinEdgeTtsSettings
+} from '@/components/agent/builtin-tts'
 import { createVoiceMediaStream } from '@/utils/voice-audio-input'
 import {
   NATIVE_GAMEPAD_ANALOG_EVENT,
@@ -573,6 +578,7 @@ const selectedAsrModelId = computed(() => {
 })
 const selectedTtsModelId = computed(() => {
   if (!voiceSettings.value) return ''
+  if (isBuiltinEdgeTtsSettings(voiceSettings.value)) return BUILTIN_EDGE_TTS_OPTION_ID
   if (voiceSettings.value.tts_llm_setting_id) return voiceSettings.value.tts_llm_setting_id
   return (
     ttsModelOptions.value.find(setting => setting.model_name === voiceSettings.value?.tts_model)
@@ -653,6 +659,9 @@ const asrModelLabel = computed(() => {
   return modelSettingLabel(setting, asrModelOptions.value) || voiceSettings.value?.asr_model || t('voice.model.asrUnconfigured')
 })
 const ttsModelLabel = computed(() => {
+  if (selectedTtsModelId.value === BUILTIN_EDGE_TTS_OPTION_ID) {
+    return t('voice.model.edgeTts')
+  }
   const setting = ttsModelOptions.value.find(item => item.id === selectedTtsModelId.value)
   return modelSettingLabel(setting, ttsModelOptions.value) || voiceSettings.value?.tts_model || t('voice.model.ttsUnconfigured')
 })
@@ -2557,7 +2566,11 @@ function ttsDefaultsFor(setting: {
   if (isQwen3Tts(setting.model_name)) {
     return { tts_voice: 'serena', tts_speed: null, tts_stream: false }
   }
-  return {}
+  return {
+    tts_voice: setting.tts_voice || 'alloy',
+    tts_speed: null,
+    tts_stream: false
+  }
 }
 
 async function changeOmniModel(event: Event): Promise<void> {
@@ -2816,17 +2829,24 @@ async function changeAsrModel(event: Event): Promise<void> {
 async function changeTtsModel(event: Event): Promise<void> {
   const settingId = (event.target as HTMLSelectElement).value
   const setting = ttsModelOptions.value.find(item => item.id === settingId)
-  if (!voiceSettings.value || !setting || settingId === selectedTtsModelId.value) return
+  if (
+    !voiceSettings.value ||
+    settingId === selectedTtsModelId.value ||
+    (settingId !== BUILTIN_EDGE_TTS_OPTION_ID && !setting)
+  ) return
   ttsSaving.value = true
   voiceConfigError.value = ''
   try {
+    const ttsUpdate = settingId === BUILTIN_EDGE_TTS_OPTION_ID
+      ? builtinEdgeTtsUpdate()
+      : {
+          tts_base_url: setting!.provider_base_url || voiceSettings.value.tts_base_url,
+          tts_model: setting!.model_name,
+          tts_llm_setting_id: setting!.id,
+          ...ttsDefaultsFor(setting!)
+        }
     const res = await updateVoiceSettings(
-      voiceSettingsPayload({
-        tts_base_url: setting.provider_base_url || voiceSettings.value.tts_base_url,
-        tts_model: setting.model_name,
-        tts_llm_setting_id: setting.id,
-        ...ttsDefaultsFor(setting)
-      })!
+      voiceSettingsPayload(ttsUpdate)!
     )
     voiceSettings.value = res.data
   } catch (err: any) {
@@ -4827,12 +4847,22 @@ function summarizeTask(value: string): string {
               </span>
               <select
                 :value="selectedTtsModelId"
-                :disabled="asrLoading || ttsSaving || !voiceSettings || !ttsModelOptions.length"
+                :disabled="asrLoading || ttsSaving || !voiceSettings"
                 :title="t('voice.model.tts')"
                 @change="changeTtsModel"
               >
-                <option v-if="!ttsModelOptions.length" value="" class="bg-[#111315] text-white">
+                <option
+                  v-if="selectedTtsModelId === '' && voiceSettings?.tts_model"
+                  value=""
+                  class="bg-[#111315] text-white"
+                >
                   {{ voiceSettings?.tts_model || t('voice.model.ttsUnconfigured') }}
+                </option>
+                <option
+                  :value="BUILTIN_EDGE_TTS_OPTION_ID"
+                  class="bg-[#111315] text-white"
+                >
+                  {{ t('voice.model.edgeTts') }}
                 </option>
                 <option
                   v-for="setting in ttsModelOptions"

--- a/agent-ui/src/components/agent/AgentVoiceCockpitLayout.test.ts
+++ b/agent-ui/src/components/agent/AgentVoiceCockpitLayout.test.ts
@@ -10,4 +10,40 @@ describe('AgentVoiceCockpit responsive layout', () => {
     )
     expect(cockpitSource).toContain('padding-top: 44px;')
   })
+
+  it('keeps model selection independent from incomplete onboarding status', () => {
+    expect(cockpitSource).toContain('data-testid="voice-model-config-button"')
+    expect(cockpitSource).toContain('data-testid="voice-onboarding-status-button"')
+    expect(cockpitSource).toContain("<span>{{ t('voice.model.configuration') }}</span>")
+    expect(cockpitSource).toContain('@click="openRequiredOnboarding"')
+
+    const toggleModelMenu = cockpitSource.match(
+      /function toggleModelMenu\(\): void \{([\s\S]*?)\n\}/,
+    )?.[1]
+    expect(toggleModelMenu).toContain('modelMenuOpen.value = !modelMenuOpen.value')
+    expect(toggleModelMenu).not.toContain('needsOnboardingHint')
+    expect(toggleModelMenu).not.toContain('openOnboarding')
+  })
+
+  it('keeps voice output independently controllable and disabled before TTS requests', () => {
+    expect(cockpitSource).toContain("const VOICE_OUTPUT_ENABLED_KEY = 'homerail.voice.output-enabled'")
+    expect(cockpitSource).toContain('data-testid="voice-output-toggle"')
+    expect(cockpitSource).toContain("cancelLocalSpeech('voice_output_disabled')")
+
+    const speak = cockpitSource.slice(
+      cockpitSource.indexOf('async function speak(text: string)'),
+      cockpitSource.indexOf('async function speakText(text: string)'),
+    )
+    expect(speak).toContain('if (!voiceOutputEnabled.value)')
+    expect(speak.indexOf('if (!voiceOutputEnabled.value)')).toBeLessThan(
+      speak.indexOf('speechStream(clean'),
+    )
+
+    const enqueue = cockpitSource.slice(
+      cockpitSource.indexOf('function enqueueSpeechEvent('),
+      cockpitSource.indexOf('async function drainSpeechQueue()'),
+    )
+    expect(enqueue).toContain('if (!voiceOutputEnabled.value)')
+    expect(enqueue).toContain('reason=output_disabled')
+  })
 })

--- a/agent-ui/src/components/agent/builtin-tts.test.ts
+++ b/agent-ui/src/components/agent/builtin-tts.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  BUILTIN_EDGE_TTS_MODEL,
+  BUILTIN_EDGE_TTS_OPTION_ID,
+  BUILTIN_EDGE_TTS_VOICE,
+  builtinEdgeTtsUpdate,
+  isBuiltinEdgeTtsSettings
+} from './builtin-tts'
+
+describe('built-in Edge TTS option', () => {
+  it('recognizes only the keyless built-in runtime, not a stored model setting', () => {
+    expect(isBuiltinEdgeTtsSettings({
+      tts_model: BUILTIN_EDGE_TTS_MODEL,
+      tts_llm_setting_id: null
+    })).toBe(true)
+    expect(isBuiltinEdgeTtsSettings({
+      tts_model: BUILTIN_EDGE_TTS_MODEL,
+      tts_llm_setting_id: 'user-edge-setting'
+    })).toBe(false)
+    expect(BUILTIN_EDGE_TTS_OPTION_ID).toBe('builtin:microsoft-edge')
+  })
+
+  it('produces a canonical update without creating an LLM setting', () => {
+    expect(builtinEdgeTtsUpdate()).toEqual({
+      tts_base_url: '',
+      tts_model: BUILTIN_EDGE_TTS_MODEL,
+      tts_llm_setting_id: null,
+      tts_voice: BUILTIN_EDGE_TTS_VOICE,
+      tts_speed: null,
+      tts_stream: false
+    })
+  })
+})

--- a/agent-ui/src/components/agent/builtin-tts.ts
+++ b/agent-ui/src/components/agent/builtin-tts.ts
@@ -1,0 +1,26 @@
+import type { UpdateVoiceSettingsRequest, VoiceSettings } from '@/api/services/voice-api'
+
+export const BUILTIN_EDGE_TTS_OPTION_ID = 'builtin:microsoft-edge'
+export const BUILTIN_EDGE_TTS_MODEL = 'edge-tts'
+export const BUILTIN_EDGE_TTS_VOICE = 'en-US-MichelleNeural'
+
+export function isBuiltinEdgeTtsSettings(
+  settings: Pick<VoiceSettings, 'tts_llm_setting_id' | 'tts_model'> | null | undefined
+): boolean {
+  return Boolean(
+    settings &&
+    !settings.tts_llm_setting_id &&
+    settings.tts_model === BUILTIN_EDGE_TTS_MODEL
+  )
+}
+
+export function builtinEdgeTtsUpdate(): Partial<UpdateVoiceSettingsRequest> {
+  return {
+    tts_base_url: '',
+    tts_model: BUILTIN_EDGE_TTS_MODEL,
+    tts_llm_setting_id: null,
+    tts_voice: BUILTIN_EDGE_TTS_VOICE,
+    tts_speed: null,
+    tts_stream: false
+  }
+}

--- a/agent-ui/src/components/agent/onboarding/OnboardingWizard.vue
+++ b/agent-ui/src/components/agent/onboarding/OnboardingWizard.vue
@@ -11,7 +11,7 @@
  * （其判断已并入 needsOnboarding），所以这里不需要直接操作麦克风。
  */
 
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { Check, Sparkles, ArrowRight, Terminal, Mic, Volume2, X, FolderCheck, RefreshCw } from 'lucide-vue-next'
 import { useAgentStore } from '@/stores/agent-store'
@@ -23,6 +23,7 @@ import { isKimiProviderId } from '@/lib/model-runtime'
 import type { Provider } from '@/api/types/orchestration-v2.types'
 import type { LLMSetting } from '@/api/services/llm-settings-api'
 import OnboardingStepForm from './OnboardingStepForm.vue'
+import { dockerWorkspaceGuidance } from './docker-workspace-status'
 
 const props = withDefaults(defineProps<{
   manualDebug?: boolean
@@ -46,11 +47,13 @@ const dockerProbeResult = ref<DockerWorkspaceProbeResult | null>(null)
 const applyingExistingAgentId = ref<string | null>(null)
 
 onMounted(async () => {
-  await Promise.all([
-    refresh(),
-    loadProviders(),
-    loadExistingSettings(),
-  ])
+  const providersPromise = loadProviders()
+  const settingsPromise = loadExistingSettings()
+  await refresh()
+  const dockerProbePromise = status.value.dockerWorkspace?.required
+    ? checkDockerWorkspace()
+    : Promise.resolve()
+  await Promise.all([providersPromise, settingsPromise, dockerProbePromise])
   // 初始推进到第一个未完成阶段（例如 Codex 已可用时直接跳到 ASR）
   if (!props.manualDebug) advanceIfDone()
 })
@@ -198,7 +201,15 @@ const environmentNeedsAttention = computed(() => !hostShellReady.value || (docke
 const dockerWorkspaceMessage = computed(() => {
   if (dockerProbeRunning.value) return t('onboarding.environmentCheck.checkingDocker')
   if (dockerProbeResult.value?.available) return t('onboarding.environmentCheck.dockerReady')
-  if (dockerProbeResult.value?.error) return dockerProbeResult.value.error
+  const guidance = dockerWorkspaceGuidance(dockerProbeResult.value)
+  if (guidance === 'install') return t('onboarding.environmentCheck.dockerInstallRequired')
+  if (guidance === 'start') return t('onboarding.environmentCheck.dockerStartRequired')
+  if (guidance === 'permission') return t('onboarding.environmentCheck.dockerPermissionRequired')
+  if (dockerProbeResult.value?.error) {
+    return t('onboarding.environmentCheck.dockerCheckFailed', {
+      error: dockerProbeResult.value.error,
+    })
+  }
   return dockerWorkspaceHostPath.value
     ? t('onboarding.environmentCheck.dockerSharePath', { path: dockerWorkspaceHostPath.value })
     : t('onboarding.environmentCheck.dockerShareHomeRail')
@@ -256,6 +267,15 @@ async function checkDockerWorkspace(): Promise<void> {
     dockerProbeRunning.value = false
   }
 }
+
+function ensureDockerWorkspaceChecked(): void {
+  if (!dockerWorkspaceRequired.value || dockerProbeRunning.value || dockerProbeResult.value) return
+  void checkDockerWorkspace()
+}
+
+watch(activePane, (pane) => {
+  if (pane === 'environment') ensureDockerWorkspaceChecked()
+})
 </script>
 
 <template>
@@ -403,7 +423,7 @@ async function checkDockerWorkspace(): Promise<void> {
             <em>{{ t('onboarding.environmentCheck.description') }}</em>
           </div>
 
-          <div class="onboarding-wizard__docker-check">
+          <div v-if="hostShellRequired" class="onboarding-wizard__docker-check">
             <Terminal :class="cn('h-5 w-5', hostShellReady ? 'text-emerald-400' : 'text-cyan-300')" />
             <div class="onboarding-wizard__docker-check-copy">
               <div class="onboarding-wizard__docker-check-title">Git Bash / host-shell</div>
@@ -420,7 +440,14 @@ async function checkDockerWorkspace(): Promise<void> {
               <div class="onboarding-wizard__docker-check-title">{{ t('onboarding.environmentCheck.dockerTitle') }}</div>
               <div class="onboarding-wizard__docker-check-hint">{{ dockerWorkspaceMessage }}</div>
             </div>
+            <span
+              v-if="dockerWorkspaceReady"
+              class="onboarding-wizard__check-pill onboarding-wizard__check-pill--ready"
+            >
+              {{ t('onboarding.environmentCheck.passed') }}
+            </span>
             <button
+              v-else
               type="button"
               class="onboarding-wizard__docker-check-button"
               :disabled="dockerProbeRunning"
@@ -428,7 +455,13 @@ async function checkDockerWorkspace(): Promise<void> {
               @click="checkDockerWorkspace"
             >
               <RefreshCw :class="cn('h-3.5 w-3.5', dockerProbeRunning && 'animate-spin')" />
-              <span>{{ dockerProbeRunning ? t('onboarding.environmentCheck.checking') : t('onboarding.environmentCheck.check') }}</span>
+              <span>{{
+                dockerProbeRunning
+                  ? t('onboarding.environmentCheck.checking')
+                  : dockerProbeResult
+                    ? t('onboarding.environmentCheck.recheck')
+                    : t('onboarding.environmentCheck.check')
+              }}</span>
             </button>
           </div>
 

--- a/agent-ui/src/components/agent/onboarding/OnboardingWizardBehavior.test.ts
+++ b/agent-ui/src/components/agent/onboarding/OnboardingWizardBehavior.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import wizardSource from './OnboardingWizard.vue?raw'
+
+describe('OnboardingWizard environment checks', () => {
+  it('automatically probes Docker and keeps manual interaction as retry only', () => {
+    expect(wizardSource).toContain('const dockerProbePromise = status.value.dockerWorkspace?.required')
+    expect(wizardSource).toContain('? checkDockerWorkspace()')
+    expect(wizardSource).toContain("if (pane === 'environment') ensureDockerWorkspaceChecked()")
+    expect(wizardSource).toContain("t('onboarding.environmentCheck.recheck')")
+    expect(wizardSource).toContain('v-if="dockerWorkspaceReady"')
+  })
+
+  it('renders the Git Bash host-shell check only when the runtime requires it', () => {
+    expect(wizardSource).toContain('v-if="hostShellRequired" class="onboarding-wizard__docker-check"')
+  })
+})

--- a/agent-ui/src/components/agent/onboarding/docker-workspace-status.test.ts
+++ b/agent-ui/src/components/agent/onboarding/docker-workspace-status.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { dockerWorkspaceGuidance } from './docker-workspace-status'
+
+describe('Docker workspace guidance', () => {
+  it('does not add guidance before probing or after success', () => {
+    expect(dockerWorkspaceGuidance(null)).toBeNull()
+    expect(dockerWorkspaceGuidance({ available: true, host_path: '/workspace' })).toBeNull()
+  })
+
+  it('prompts installation when no Docker-capable Node can be started', () => {
+    expect(dockerWorkspaceGuidance({
+      available: false,
+      host_path: '/workspace',
+      code: 'docker_node_unavailable',
+      error: 'No connected docker-capable node available',
+    })).toBe('install')
+  })
+
+  it('distinguishes a stopped daemon from a permission problem', () => {
+    expect(dockerWorkspaceGuidance({
+      available: false,
+      host_path: '/workspace',
+      error: 'Cannot connect to the Docker daemon. Is Docker running?',
+    })).toBe('start')
+    expect(dockerWorkspaceGuidance({
+      available: false,
+      host_path: '/workspace',
+      error: 'permission denied while trying to connect to the Docker daemon; add the user to the docker group',
+    })).toBe('permission')
+  })
+})

--- a/agent-ui/src/components/agent/onboarding/docker-workspace-status.ts
+++ b/agent-ui/src/components/agent/onboarding/docker-workspace-status.ts
@@ -1,0 +1,29 @@
+import type { DockerWorkspaceProbeResult } from '@/api/services/voice-agent-api'
+
+export type DockerWorkspaceGuidance = 'install' | 'start' | 'permission' | null
+
+export function dockerWorkspaceGuidance(
+  result: DockerWorkspaceProbeResult | null,
+): DockerWorkspaceGuidance {
+  if (!result || result.available) return null
+  const message = (result.error || '').toLowerCase()
+
+  if (
+    result.code === 'docker_node_unavailable' ||
+    message.includes('command not found') ||
+    message.includes('is docker installed') ||
+    message.includes('enoent')
+  ) {
+    return 'install'
+  }
+  if (
+    message.includes('cannot connect to the docker daemon') ||
+    message.includes('is the docker daemon running')
+  ) {
+    return 'start'
+  }
+  if (message.includes('permission denied') || message.includes('docker group')) {
+    return 'permission'
+  }
+  return null
+}

--- a/agent-ui/src/locales/en-US/onboarding.json
+++ b/agent-ui/src/locales/en-US/onboarding.json
@@ -34,12 +34,17 @@
     "dockerReady": "Docker workspace access confirmed",
     "dockerSharePath": "Allow Docker Desktop to share {path}",
     "dockerShareHomeRail": "Allow Docker Desktop to share the HomeRail workspace",
+    "dockerInstallRequired": "Docker was not detected. Install and start Docker, then check again.",
+    "dockerStartRequired": "Docker is installed but not running. Start Docker, then check again.",
+    "dockerPermissionRequired": "The current user cannot access Docker. Grant Docker access, then check again.",
+    "dockerCheckFailed": "Docker workspace check failed: {error}",
     "passed": "Passed",
     "needsAttention": "Action needed",
     "dockerTitle": "Docker workspace access",
     "checkTitle": "Check Docker workspace access",
     "checking": "Checking",
-    "check": "Check"
+    "check": "Check",
+    "recheck": "Check again"
   },
   "actions": {
     "skipTts": "Skip TTS",

--- a/agent-ui/src/locales/en-US/voice.json
+++ b/agent-ui/src/locales/en-US/voice.json
@@ -17,6 +17,7 @@
     "asrUnconfigured": "ASR not configured",
     "asrModelUnconfigured": "ASR model not configured",
     "ttsUnconfigured": "TTS not configured",
+    "edgeTts": "Microsoft Edge (online, no API key)",
     "omniUnconfigured": "Omni model not configured",
     "saving": "Saving",
     "noAvailableCodex": "No Codex models are available for this account",

--- a/agent-ui/src/locales/en-US/voice.json
+++ b/agent-ui/src/locales/en-US/voice.json
@@ -184,6 +184,7 @@
     "realtimeTitle": "Live mode: send automatically after speaking",
     "assist": "Assist",
     "assistTitle": "Assist mode: transcribe, edit, then send manually",
+    "voice": "Voice",
     "voiceInput": "Voice input",
     "send": "Send",
     "cleared": "Pending input cleared"

--- a/agent-ui/src/locales/zh-Hans/onboarding.json
+++ b/agent-ui/src/locales/zh-Hans/onboarding.json
@@ -17,7 +17,7 @@
   "runtime": {
     "ready": "主 Agent 运行时已就绪",
     "currentHarness": "当前 Harness：{harness}",
-    "notReady": "主 Agent 运行时未就绪。模型凭证在这里配置，本机依赖和 Docker 授权请到环境检查页处理。",
+    "notReady": "主 Agent 运行时未就绪。模型凭证在这里配置，本机依赖和 Docker 访问请到环境检查页处理。",
     "existing": "已有主 Agent 配置",
     "switching": "切换中...",
     "use": "使用",
@@ -25,21 +25,26 @@
     "nextAvailable": "可以进入下一步"
   },
   "environmentCheck": {
-    "description": "确认本机运行依赖和 Docker 工作区授权",
+    "description": "确认本机运行依赖和 Docker 工作区访问",
     "hostNotRequired": "当前 Manager Agent 不需要 Git Bash host-shell 环境",
     "gitBashReadyPath": "Git Bash 已就绪：{path}",
     "gitBashReady": "Git Bash host-shell 环境已就绪",
     "gitBashRequired": "请安装 Git Bash，并确认 packaged shell 包内 worker 运行文件可用",
-    "checkingDocker": "正在检查 Docker 工作区授权...",
-    "dockerReady": "Docker 工作区授权已确认",
+    "checkingDocker": "正在检查 Docker 工作区访问...",
+    "dockerReady": "Docker 工作区访问已确认",
     "dockerSharePath": "请确认 Docker Desktop 已允许共享 {path}",
     "dockerShareHomeRail": "请确认 Docker Desktop 已允许共享 HomeRail 工作区",
+    "dockerInstallRequired": "未检测到可用 Docker。请安装并启动 Docker 后重新检查。",
+    "dockerStartRequired": "Docker 已安装但未运行。请启动 Docker 后重新检查。",
+    "dockerPermissionRequired": "当前用户无法访问 Docker。请授予 Docker 访问权限后重新检查。",
+    "dockerCheckFailed": "Docker 工作区检查失败：{error}",
     "passed": "已通过",
     "needsAttention": "需处理",
-    "dockerTitle": "Docker 工作区授权",
-    "checkTitle": "检查 Docker 工作区授权",
+    "dockerTitle": "Docker 工作区访问",
+    "checkTitle": "检查 Docker 工作区访问",
     "checking": "检查中",
-    "check": "检查"
+    "check": "检查",
+    "recheck": "重新检查"
   },
   "actions": {
     "skipTts": "跳过 TTS",

--- a/agent-ui/src/locales/zh-Hans/voice.json
+++ b/agent-ui/src/locales/zh-Hans/voice.json
@@ -184,6 +184,7 @@
     "realtimeTitle": "实时模式：说话后自动发送",
     "assist": "辅助",
     "assistTitle": "辅助模式：语音转文字后手动发送",
+    "voice": "语音",
     "voiceInput": "语音输入",
     "send": "发送",
     "cleared": "已清空待发送内容"

--- a/agent-ui/src/locales/zh-Hans/voice.json
+++ b/agent-ui/src/locales/zh-Hans/voice.json
@@ -17,6 +17,7 @@
     "asrUnconfigured": "未配置 ASR",
     "asrModelUnconfigured": "未配置 ASR 模型",
     "ttsUnconfigured": "未配置 TTS",
+    "edgeTts": "Microsoft Edge（在线、无需 Key）",
     "omniUnconfigured": "未配置 Omni 模型",
     "saving": "保存中",
     "noAvailableCodex": "当前账号没有可用的 Codex 模型",

--- a/agent-ui/src/locales/zh-Hant/onboarding.json
+++ b/agent-ui/src/locales/zh-Hant/onboarding.json
@@ -17,7 +17,7 @@
   "runtime": {
     "ready": "主 Agent 運行時已就緒",
     "currentHarness": "當前 Harness：{harness}",
-    "notReady": "主 Agent 運行時未就緒。模型憑證在這裏配置，本機依賴和 Docker 授權請到環境檢查頁處理。",
+    "notReady": "主 Agent 運行時未就緒。模型憑證在這裏配置，本機依賴和 Docker 存取請到環境檢查頁處理。",
     "existing": "已有主 Agent 配置",
     "switching": "切換中...",
     "use": "使用",
@@ -25,21 +25,26 @@
     "nextAvailable": "可以進入下一步"
   },
   "environmentCheck": {
-    "description": "確認本機運行依賴和 Docker 工作區授權",
+    "description": "確認本機運行依賴和 Docker 工作區存取",
     "hostNotRequired": "當前 Manager Agent 不需要 Git Bash host-shell 環境",
     "gitBashReadyPath": "Git Bash 已就緒：{path}",
     "gitBashReady": "Git Bash host-shell 環境已就緒",
     "gitBashRequired": "請安裝 Git Bash，並確認 packaged shell 包內 worker 運行文件可用",
-    "checkingDocker": "正在檢查 Docker 工作區授權...",
-    "dockerReady": "Docker 工作區授權已確認",
+    "checkingDocker": "正在檢查 Docker 工作區存取...",
+    "dockerReady": "Docker 工作區存取已確認",
     "dockerSharePath": "請確認 Docker Desktop 已允許共享 {path}",
     "dockerShareHomeRail": "請確認 Docker Desktop 已允許共享 HomeRail 工作區",
+    "dockerInstallRequired": "未偵測到可用的 Docker。請安裝並啟動 Docker 後重新檢查。",
+    "dockerStartRequired": "Docker 已安裝但未執行。請啟動 Docker 後重新檢查。",
+    "dockerPermissionRequired": "目前使用者無法存取 Docker。請授予 Docker 存取權限後重新檢查。",
+    "dockerCheckFailed": "Docker 工作區檢查失敗：{error}",
     "passed": "已通過",
     "needsAttention": "需處理",
-    "dockerTitle": "Docker 工作區授權",
-    "checkTitle": "檢查 Docker 工作區授權",
+    "dockerTitle": "Docker 工作區存取",
+    "checkTitle": "檢查 Docker 工作區存取",
     "checking": "檢查中",
-    "check": "檢查"
+    "check": "檢查",
+    "recheck": "重新檢查"
   },
   "actions": {
     "skipTts": "跳過 TTS",

--- a/agent-ui/src/locales/zh-Hant/voice.json
+++ b/agent-ui/src/locales/zh-Hant/voice.json
@@ -184,6 +184,7 @@
     "realtimeTitle": "實時模式：說話後自動發送",
     "assist": "輔助",
     "assistTitle": "輔助模式：語音轉文字後手動發送",
+    "voice": "語音",
     "voiceInput": "語音輸入",
     "send": "發送",
     "cleared": "已清空待發送內容"

--- a/agent-ui/src/locales/zh-Hant/voice.json
+++ b/agent-ui/src/locales/zh-Hant/voice.json
@@ -17,6 +17,7 @@
     "asrUnconfigured": "未配置 ASR",
     "asrModelUnconfigured": "未配置 ASR 模型",
     "ttsUnconfigured": "未配置 TTS",
+    "edgeTts": "Microsoft Edge（在線、無需 Key）",
     "omniUnconfigured": "未配置 Omni 模型",
     "saving": "保存中",
     "noAvailableCodex": "當前賬號沒有可用的 Codex 模型",

--- a/homerail_cli/src/commands/config.ts
+++ b/homerail_cli/src/commands/config.ts
@@ -171,15 +171,10 @@ async function runConfigWizard(_globalOpts: GlobalOpts): Promise<void> {
     const projectId = await promptText(rl, "Project ID", next.node?.projectId || "p1");
     const nodeId = await promptText(rl, "Node ID", next.node?.nodeId || "local-docker-node");
     const provider = await promptChoice(rl, "Node provider", ["docker-cli", "docker-api", "mock"], next.node?.provider || "docker-cli");
-    const capsDefault = (next.node?.capabilities && next.node.capabilities.length > 0)
-      ? next.node.capabilities.join(",")
-      : provider;
-    const capabilities = await promptText(rl, "Node capabilities (comma separated)", capsDefault);
     next.node = {
       projectId,
       nodeId,
       provider,
-      capabilities: capabilities.split(",").map((c) => c.trim()).filter(Boolean),
     };
 
     next.ui = next.ui ?? {};

--- a/homerail_cli/src/commands/runtime.ts
+++ b/homerail_cli/src/commands/runtime.ts
@@ -603,7 +603,6 @@ async function startRuntime(globalOpts: GlobalOpts, opts: StartOpts): Promise<nu
       HOMERAIL_PROJECT_ID: cfg.node?.projectId || "p1",
       HOMERAIL_NODE_ID: nodeId,
       HOMERAIL_NODE_PROVIDER: cfg.node?.provider || "docker-cli",
-      HOMERAIL_NODE_CAPABILITIES: (cfg.node?.capabilities || ["docker-cli"]).join(","),
       ...assetEnv,
     };
     const pid = startService("node", "homerail_node/dist/cli.js", env);

--- a/homerail_cli/src/local-config.ts
+++ b/homerail_cli/src/local-config.ts
@@ -13,7 +13,6 @@ export interface LocalHomeRailConfig {
     projectId?: string;
     nodeId?: string;
     provider?: string;
-    capabilities?: string[];
   };
   ui?: {
     host?: string;
@@ -73,7 +72,6 @@ export function defaultLocalConfig(): LocalHomeRailConfig {
       projectId: "p1",
       nodeId: "local-docker-node",
       provider: "docker-cli",
-      capabilities: ["docker-cli"],
     },
     ui: {
       host: DEFAULT_UI_HOST,
@@ -323,9 +321,15 @@ export function setConfigPathValue(config: LocalHomeRailConfig, key: string, val
 }
 
 function mergeConfig(defaults: LocalHomeRailConfig, raw: LocalHomeRailConfig): LocalHomeRailConfig {
+  const rawNode = raw.node ?? {};
   return {
     manager: { ...defaults.manager, ...(raw.manager ?? {}) },
-    node: { ...defaults.node, ...(raw.node ?? {}) },
+    node: {
+      ...defaults.node,
+      ...(rawNode.projectId !== undefined ? { projectId: rawNode.projectId } : {}),
+      ...(rawNode.nodeId !== undefined ? { nodeId: rawNode.nodeId } : {}),
+      ...(rawNode.provider !== undefined ? { provider: rawNode.provider } : {}),
+    },
     ui: { ...defaults.ui, ...(raw.ui ?? {}) },
     model: { ...defaults.model, ...(raw.model ?? {}) },
     runtime: { ...defaults.runtime, ...(raw.runtime ?? {}) },

--- a/homerail_cli/tests/config.test.ts
+++ b/homerail_cli/tests/config.test.ts
@@ -6,6 +6,7 @@ import { createProgram } from "../src/index.js";
 import {
   configuredUiHttpPublicUrl,
   configuredUiPublicUrl,
+  defaultLocalConfig,
   detectedMachineHost,
   getConfigPath,
   getSecretsPath,
@@ -50,6 +51,29 @@ afterEach(() => {
 });
 
 describe("config command", () => {
+  it("keeps Docker capability implicit for the managed local Node", () => {
+    expect(defaultLocalConfig().node).toEqual({
+      projectId: "p1",
+      nodeId: "local-docker-node",
+      provider: "docker-cli",
+    });
+
+    fs.writeFileSync(getConfigPath(), JSON.stringify({
+      node: {
+        projectId: "legacy-project",
+        nodeId: "legacy-node",
+        provider: "docker-cli",
+        capabilities: ["browser"],
+      },
+    }));
+
+    expect(loadLocalConfig().node).toEqual({
+      projectId: "legacy-project",
+      nodeId: "legacy-node",
+      provider: "docker-cli",
+    });
+  });
+
   it("routes regular config to config.json and secrets to the secrets file", async () => {
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const program = createProgram();

--- a/homerail_manager/package-lock.json
+++ b/homerail_manager/package-lock.json
@@ -14,6 +14,7 @@
         "better-sqlite3": "^12.11.1",
         "homerail-plugin-sdk": "file:../homerail_plugin_sdk",
         "homerail-protocol": "file:../homerail_protocol",
+        "node-edge-tts": "1.2.10",
         "ws": "^8.18.0",
         "yaml": "^2.4.2"
       },
@@ -1071,6 +1072,15 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -1085,6 +1095,30 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/assertion-error": {
@@ -1191,12 +1225,61 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -1230,6 +1313,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -1287,6 +1376,15 @@
         "@esbuild/win32-arm64": "0.28.1",
         "@esbuild/win32-ia32": "0.28.1",
         "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/estree-walker": {
@@ -1385,6 +1483,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmmirror.com/github-from-package/-/github-from-package-0.0.0.tgz",
@@ -1398,6 +1505,19 @@
     "node_modules/homerail-protocol": {
       "resolved": "../homerail_protocol",
       "link": true
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -1430,6 +1550,15 @@
       "resolved": "https://registry.npmmirror.com/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -1735,6 +1864,12 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
@@ -1770,6 +1905,20 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/node-edge-tts": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/node-edge-tts/-/node-edge-tts-1.2.10.tgz",
+      "integrity": "sha512-bV2i4XU54D45+US0Zm1HcJRkifuB3W438dWyuJEHLQdKxnuqlI1kim2MOvR6Q3XUQZvfF9PoDyR1Rt7aeXhPdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "https-proxy-agent": "^7.0.1",
+        "ws": "^8.13.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "node-edge-tts": "bin.js"
       }
     },
     "node_modules/obug": {
@@ -1914,6 +2063,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/require-from-string": {
@@ -2074,6 +2232,32 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -2408,6 +2592,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmmirror.com/wrappy/-/wrappy-1.0.2.tgz",
@@ -2435,6 +2636,15 @@
         }
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yaml": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
@@ -2448,6 +2658,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     }
   }

--- a/homerail_manager/package.json
+++ b/homerail_manager/package.json
@@ -26,6 +26,7 @@
     "better-sqlite3": "^12.11.1",
     "homerail-plugin-sdk": "file:../homerail_plugin_sdk",
     "homerail-protocol": "file:../homerail_protocol",
+    "node-edge-tts": "1.2.10",
     "ws": "^8.18.0",
     "yaml": "^2.4.2"
   },

--- a/homerail_manager/src/server/edge-tts.ts
+++ b/homerail_manager/src/server/edge-tts.ts
@@ -1,0 +1,126 @@
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+export const BUILTIN_EDGE_TTS_MODEL = "edge-tts";
+export const DEFAULT_EDGE_TTS_VOICE = "en-US-MichelleNeural";
+export const DEFAULT_EDGE_TTS_OUTPUT_FORMAT = "audio-24khz-48kbitrate-mono-mp3";
+
+const DEFAULT_CHINESE_EDGE_TTS_VOICE = "zh-CN-XiaoxiaoNeural";
+const DEFAULT_EDGE_TTS_TIMEOUT_MS = 30_000;
+const MAX_EDGE_TTS_TEXT_LENGTH = 4_096;
+const EDGE_VOICE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+
+type EdgeTtsClient = {
+  ttsPromise(text: string, outputPath: string): Promise<unknown>;
+};
+
+export type EdgeTtsClientConfig = {
+  voice: string;
+  lang: string;
+  outputFormat: string;
+  saveSubtitles: boolean;
+  rate?: string;
+  timeout: number;
+};
+
+export type EdgeTtsClientFactory = (
+  config: EdgeTtsClientConfig,
+) => EdgeTtsClient | Promise<EdgeTtsClient>;
+
+export class EdgeTtsInputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "EdgeTtsInputError";
+  }
+}
+
+function isCjkDominant(text: string): boolean {
+  const compact = text.replace(/\s+/g, "");
+  if (!compact) return false;
+  let cjk = 0;
+  for (const character of compact) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    if (
+      (codePoint >= 0x3400 && codePoint <= 0x4dbf) ||
+      (codePoint >= 0x4e00 && codePoint <= 0x9fff) ||
+      (codePoint >= 0x3000 && codePoint <= 0x303f) ||
+      (codePoint >= 0xff00 && codePoint <= 0xffef)
+    ) {
+      cjk += 1;
+    }
+  }
+  return cjk / compact.length > 0.3;
+}
+
+function resolveVoice(text: string, requestedVoice: string | undefined): { voice: string; lang: string } {
+  const configuredVoice = requestedVoice?.trim() || DEFAULT_EDGE_TTS_VOICE;
+  const voice = configuredVoice === DEFAULT_EDGE_TTS_VOICE && isCjkDominant(text)
+    ? DEFAULT_CHINESE_EDGE_TTS_VOICE
+    : configuredVoice;
+  if (!EDGE_VOICE_PATTERN.test(voice) || !voice.endsWith("Neural")) {
+    throw new EdgeTtsInputError(`Invalid Edge TTS voice '${voice}'`);
+  }
+  const [language, region] = voice.split("-");
+  if (!/^[a-z]{2,3}$/.test(language ?? "") || !/^[A-Z]{2}$/.test(region ?? "")) {
+    throw new EdgeTtsInputError(`Invalid Edge TTS voice '${voice}'`);
+  }
+  return { voice, lang: `${language}-${region}` };
+}
+
+function resolveRate(speed: number | null | undefined): string | undefined {
+  if (speed === null || speed === undefined) return undefined;
+  if (!Number.isFinite(speed) || speed < 0.5 || speed > 2) {
+    throw new EdgeTtsInputError("Edge TTS speed must be between 0.5 and 2");
+  }
+  const percentage = Math.round((speed - 1) * 100);
+  return `${percentage >= 0 ? "+" : ""}${percentage}%`;
+}
+
+async function createEdgeTtsClient(config: EdgeTtsClientConfig): Promise<EdgeTtsClient> {
+  const { EdgeTTS } = await import("node-edge-tts");
+  return new EdgeTTS(config);
+}
+
+export async function synthesizeEdgeTts(
+  params: {
+    text: string;
+    voice?: string;
+    speed?: number | null;
+    timeoutMs?: number;
+  },
+  createClient: EdgeTtsClientFactory = createEdgeTtsClient,
+): Promise<Buffer> {
+  const text = params.text.trim();
+  if (!text) throw new EdgeTtsInputError("Missing required field: text");
+  if (text.length > MAX_EDGE_TTS_TEXT_LENGTH) {
+    throw new EdgeTtsInputError(`Edge TTS text exceeds ${MAX_EDGE_TTS_TEXT_LENGTH} characters`);
+  }
+  const { voice, lang } = resolveVoice(text, params.voice);
+  const timeout = params.timeoutMs ?? DEFAULT_EDGE_TTS_TIMEOUT_MS;
+  if (!Number.isFinite(timeout) || timeout < 1_000 || timeout > 120_000) {
+    throw new EdgeTtsInputError("Edge TTS timeout must be between 1000 and 120000 ms");
+  }
+  const client = await createClient({
+    voice,
+    lang,
+    outputFormat: DEFAULT_EDGE_TTS_OUTPUT_FORMAT,
+    saveSubtitles: false,
+    rate: resolveRate(params.speed),
+    timeout,
+  });
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "homerail-edge-tts-"));
+  const outputPath = path.join(tempDir, "speech.mp3");
+  try {
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      await writeFile(outputPath, "");
+      await client.ttsPromise(text, outputPath);
+      if ((await stat(outputPath)).size > 0) {
+        return await readFile(outputPath);
+      }
+    }
+    throw new Error("Edge TTS produced empty audio after retry");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 });
+  }
+}

--- a/homerail_manager/src/server/http.ts
+++ b/homerail_manager/src/server/http.ts
@@ -259,6 +259,11 @@ export function createServer(
           image: process.env.HOMERAIL_MANAGER_AGENT_IMAGE || workerImage,
           env: resolveManagerAgentRuntimeEnv(),
           extraHosts: resolveManagerWorkerExtraHosts(),
+          localManagerUrl: () => {
+            const addr = server?.address();
+            const actualPort = typeof addr === "object" && addr ? addr.port : port;
+            return `http://127.0.0.1:${actualPort}`;
+          },
           managerRestUrl: () => {
             const addr = server?.address();
             const actualPort = typeof addr === "object" && addr ? addr.port : port;

--- a/homerail_manager/src/server/manager-agent-container.ts
+++ b/homerail_manager/src/server/manager-agent-container.ts
@@ -33,6 +33,8 @@ export interface ManagerAgentRuntimeConfig {
 
 export interface ManagerAgentContainerOptions {
   managerRestUrl: string | (() => string);
+  /** Manager URL reachable from a host-side managed Node. */
+  localManagerUrl?: string | (() => string);
   image?: string;
   env?: Record<string, string>;
   extraHosts?: string[];
@@ -91,6 +93,11 @@ function baseUrl(projectId?: string): string {
 function managerRestUrl(options: ManagerAgentContainerOptions): string {
   const raw = typeof options.managerRestUrl === "function" ? options.managerRestUrl() : options.managerRestUrl;
   return raw.replace(/\/+$/, "").endsWith("/api") ? raw.replace(/\/+$/, "") : `${raw.replace(/\/+$/, "")}/api`;
+}
+
+function localManagerUrl(options: ManagerAgentContainerOptions): string {
+  const source = options.localManagerUrl ?? options.managerRestUrl;
+  return typeof source === "function" ? source() : source;
 }
 
 function resolveProjectWorkspace(projectId?: string): string | undefined {
@@ -156,6 +163,10 @@ function restUrlToWsUrl(raw: string): string {
   return url.toString().replace(/\/$/, "");
 }
 
+export function resolveLocalNodeManagerWsUrl(options: ManagerAgentContainerOptions): string {
+  return restUrlToWsUrl(localManagerUrl(options));
+}
+
 function localNodeAutostartEnabled(): boolean {
   const raw = process.env.HOMERAIL_LOCAL_NODE_AUTOSTART;
   return raw === undefined || !["0", "false", "no", "off"].includes(raw.trim().toLowerCase());
@@ -171,7 +182,7 @@ async function waitForDockerNode(timeoutMs: number): Promise<string | undefined>
   return undefined;
 }
 
-async function ensureLocalDockerNode(options: ManagerAgentContainerOptions, projectId?: string): Promise<string | undefined> {
+export async function ensureLocalDockerNode(options: ManagerAgentContainerOptions, projectId?: string): Promise<string | undefined> {
   const existing = selectDockerNode();
   if (existing) return existing;
   if (!localNodeAutostartEnabled()) return undefined;
@@ -185,7 +196,7 @@ async function ensureLocalDockerNode(options: ManagerAgentContainerOptions, proj
     const out = fs.openSync(path.join(logDir, "local-node.log"), "a");
     const err = fs.openSync(path.join(logDir, "local-node.err.log"), "a");
     const nodeId = process.env.HOMERAIL_NODE_ID || LOCAL_NODE_ID;
-    const managerUrl = restUrlToWsUrl(managerRestUrl(options));
+    const managerUrl = resolveLocalNodeManagerWsUrl(options);
     const child = spawn(process.execPath, [cliPath], {
       cwd: runtimeRoot(),
       detached: true,
@@ -199,7 +210,6 @@ async function ensureLocalDockerNode(options: ManagerAgentContainerOptions, proj
         HOMERAIL_PROJECT_ID: projectId || process.env.HOMERAIL_PROJECT_ID || "p1",
         HOMERAIL_NODE_ID: nodeId,
         HOMERAIL_NODE_PROVIDER: process.env.HOMERAIL_NODE_PROVIDER || "docker-cli",
-        HOMERAIL_NODE_CAPABILITIES: process.env.HOMERAIL_NODE_CAPABILITIES || "docker-cli",
       },
     });
     fs.closeSync(out);

--- a/homerail_manager/src/server/manager-agent-readiness.ts
+++ b/homerail_manager/src/server/manager-agent-readiness.ts
@@ -7,6 +7,7 @@ import { readManagerAgentConfig, type ManagerAgentConfig } from "../persistence/
 import { sendLifecycleRequest } from "../node/lifecycle-request.js";
 import { getHomerailHome } from "../config/env.js";
 import {
+  ensureLocalDockerNode,
   resolveManagerAgentConfig,
   type ManagerAgentContainerOptions,
 } from "./manager-agent-container.js";
@@ -118,7 +119,8 @@ function errorMessage(error: unknown): string {
 async function probeDockerWorkspaceMount(
   managerAgentOptions?: ManagerAgentContainerOptions,
 ): Promise<Record<string, unknown>> {
-  const nodeId = dockerCapableNodeIds()[0];
+  const nodeId = dockerCapableNodeIds()[0]
+    ?? (managerAgentOptions ? await ensureLocalDockerNode(managerAgentOptions) : undefined);
   const workspaceRoot = dockerWorkspaceRoot();
   fs.mkdirSync(workspaceRoot, { recursive: true });
 

--- a/homerail_manager/src/server/voice.ts
+++ b/homerail_manager/src/server/voice.ts
@@ -14,6 +14,12 @@ import {
   synthesizeArkTtsHttp,
   transcribeArkAsr,
 } from "./ark-voice.js";
+import {
+  BUILTIN_EDGE_TTS_MODEL,
+  DEFAULT_EDGE_TTS_VOICE,
+  EdgeTtsInputError,
+  synthesizeEdgeTts,
+} from "./edge-tts.js";
 
 interface BaseResponse {
   success: boolean;
@@ -197,6 +203,9 @@ function _resolveTtsSetting(settings?: Record<string, unknown>): LLMSetting | un
     const setting = getSetting(settingId);
     if (setting?.is_active && setting.supports_tts) return setting;
   }
+  if (!settingId && _stringField(settings?.tts_model) === BUILTIN_EDGE_TTS_MODEL) {
+    return undefined;
+  }
   return _findActiveCapabilitySetting("supports_tts");
 }
 
@@ -206,6 +215,7 @@ function _resolveLlmSettingForDefaults(): LLMSetting | undefined {
 }
 
 function _defaultTtsVoiceFor(runtime: { baseUrl: string; model: string }): string {
+  if (runtime.model === BUILTIN_EDGE_TTS_MODEL) return DEFAULT_EDGE_TTS_VOICE;
   return _isMimoTts(runtime) ? DEFAULT_MIMO_TTS_VOICE : DEFAULT_OPENAI_TTS_VOICE;
 }
 
@@ -213,6 +223,7 @@ function _isGenericDefaultTtsVoice(voice: string | undefined): boolean {
   return !voice ||
     voice === DEFAULT_MIMO_TTS_VOICE ||
     voice === DEFAULT_OPENAI_TTS_VOICE ||
+    voice === DEFAULT_EDGE_TTS_VOICE ||
     voice === LEGACY_ARK_TTS_DEFAULT_VOICE;
 }
 
@@ -231,7 +242,7 @@ function _defaultVoiceSettings() {
   const llmSetting = _resolveLlmSettingForDefaults();
   const ttsSetting = _resolveTtsSetting();
   const ttsBaseUrl = ttsSetting?.base_url ?? (ttsSetting ? _providerBaseUrl(ttsSetting.provider_id) : undefined) ?? "";
-  const ttsModel = ttsSetting?.model_name ?? "";
+  const ttsModel = ttsSetting?.model_name ?? BUILTIN_EDGE_TTS_MODEL;
   return {
     recognition_mode: "asr",
     omni_base_url: "",
@@ -250,9 +261,7 @@ function _defaultVoiceSettings() {
     tts_base_url: ttsBaseUrl,
     tts_model: ttsModel,
     tts_llm_setting_id: ttsSetting?.id ?? "",
-    tts_voice: ttsModel
-      ? _defaultTtsVoiceForSetting(ttsSetting, { baseUrl: ttsBaseUrl, model: ttsModel })
-      : DEFAULT_MIMO_TTS_VOICE,
+    tts_voice: _defaultTtsVoiceForSetting(ttsSetting, { baseUrl: ttsBaseUrl, model: ttsModel }),
     tts_speed: null,
     tts_token_set: Boolean(ttsSetting?.api_key || process.env.HOMERAIL_TTS_API_KEY),
     tts_stream: false,
@@ -284,6 +293,7 @@ function _voiceSettingsWithCapabilityDefaults(settings?: Record<string, unknown>
   const ttsSetting = _resolveTtsSetting(data);
   const hasStoredTtsSettingId = Boolean(_stringField(settings?.tts_llm_setting_id));
   const storedTtsModel = _stringField(settings?.tts_model);
+  const hasStoredTtsRuntime = hasStoredTtsSettingId || Boolean(storedTtsModel);
   const shouldApplyTtsSetting = Boolean(ttsSetting) &&
     (!hasStoredSettings || hasStoredTtsSettingId || !storedTtsModel || !storedTtsModel.toLowerCase().includes("tts"));
   if (ttsSetting && shouldApplyTtsSetting) {
@@ -297,8 +307,17 @@ function _voiceSettingsWithCapabilityDefaults(settings?: Record<string, unknown>
         model: String(data.tts_model ?? ""),
       });
     }
+  } else if (!ttsSetting && !hasStoredTtsRuntime) {
+    data.tts_base_url = "";
+    data.tts_model = BUILTIN_EDGE_TTS_MODEL;
+    data.tts_llm_setting_id = "";
+    data.tts_voice = DEFAULT_EDGE_TTS_VOICE;
+    data.tts_speed = null;
+    data.tts_stream = false;
   }
-  data.tts_token_set = Boolean(ttsSetting?.api_key || process.env.HOMERAIL_TTS_API_KEY);
+  data.tts_token_set = _stringField(data.tts_model) === BUILTIN_EDGE_TTS_MODEL
+    ? false
+    : Boolean(ttsSetting?.api_key || process.env.HOMERAIL_TTS_API_KEY);
   data.tts_output_channels = _normalizeTtsOutputChannels(data.tts_output_channels);
   delete data.omni_token;
   delete data.llm_token;
@@ -352,6 +371,16 @@ function _mergeVoiceSettingsUpdate(body: Record<string, unknown>): Record<string
         model: nextTtsSetting.model_name,
       });
     }
+  }
+  if (
+    _stringField(merged.tts_model) === BUILTIN_EDGE_TTS_MODEL &&
+    !_stringField(merged.tts_llm_setting_id)
+  ) {
+    merged.tts_base_url = "";
+    merged.tts_llm_setting_id = "";
+    merged.tts_voice = DEFAULT_EDGE_TTS_VOICE;
+    merged.tts_speed = null;
+    merged.tts_stream = false;
   }
   for (const field of ["omni_token", "llm_token", "asr_token", "tts_token"]) {
     delete merged[field];
@@ -622,6 +651,10 @@ function _isMimoTts(runtime: { baseUrl: string; model: string }): boolean {
     || (runtime.baseUrl.includes("xiaomimimo.com") && runtime.model.includes("tts"));
 }
 
+function _isBuiltinEdgeTts(runtime: { model: string; setting?: LLMSetting }): boolean {
+  return !runtime.setting && runtime.model === BUILTIN_EDGE_TTS_MODEL;
+}
+
 function _resolveTtsRuntime(settings?: Record<string, unknown>): {
   baseUrl: string;
   model: string;
@@ -799,14 +832,27 @@ export function voiceRoutesHandler(
     _readJsonBody(req)
       .then(async (body) => {
         const runtime = _resolveTtsRuntime(_loadVoiceSettings());
+        const speechBody = body as VoiceSpeechBody;
+        if (_isBuiltinEdgeTts(runtime)) {
+          const text = _stringField(speechBody.text);
+          if (!text) throw new EdgeTtsInputError("Missing required field: text");
+          const audio = await synthesizeEdgeTts({
+            text,
+            voice: _stringField(speechBody.voice) ?? runtime.voice,
+            speed: typeof speechBody.speed === "number" ? speechBody.speed : runtime.speed,
+          });
+          res.writeHead(200, { "Content-Type": "audio/mpeg", "Cache-Control": "no-store" });
+          res.end(audio);
+          return;
+        }
         const configuredSpeechUrl = _stringField(runtime.setting?.tts_http_url);
         if (!runtime.apiKey) throw new Error("Missing TTS API key");
         if (isArkVoiceSetting(runtime.setting)) {
-          const text = _stringField((body as VoiceSpeechBody).text);
+          const text = _stringField(speechBody.text);
           if (!text) throw new Error("Missing required field: text");
           const result = await synthesizeArkTtsHttp(arkVoiceRuntimeFromSetting(runtime.setting, "tts"), {
             text,
-            voice: _stringField((body as VoiceSpeechBody).voice) ?? runtime.voice,
+            voice: _stringField(speechBody.voice) ?? runtime.voice,
           });
           res.writeHead(200, {
             "Content-Type": result.contentType,
@@ -815,7 +861,7 @@ export function voiceRoutesHandler(
           res.end(result.audio);
           return;
         }
-        const payload = _buildTtsPayload(runtime, body as VoiceSpeechBody);
+        const payload = _buildTtsPayload(runtime, speechBody);
         if (_isMimoTts(runtime)) {
           const data = await _requestJson(runtime.baseUrl, "/v1/chat/completions", runtime.apiKey, payload);
           const audio = _extractMimoAudio(data);
@@ -855,7 +901,7 @@ export function voiceRoutesHandler(
       })
       .catch((err) => {
         const message = err instanceof Error ? err.message : String(err);
-        if (message.startsWith("Missing required field")) {
+        if (err instanceof EdgeTtsInputError || message.startsWith("Missing required field")) {
           _badRequest(res, message);
           return;
         }

--- a/homerail_manager/tests/edge-tts.test.ts
+++ b/homerail_manager/tests/edge-tts.test.ts
@@ -1,0 +1,86 @@
+import { existsSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import * as path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  DEFAULT_EDGE_TTS_OUTPUT_FORMAT,
+  EdgeTtsInputError,
+  synthesizeEdgeTts,
+  type EdgeTtsClientConfig,
+} from "../src/server/edge-tts.js";
+
+describe("built-in Edge TTS", () => {
+  it("uses the Chinese neural voice for CJK-dominant text and cleans its workspace", async () => {
+    let receivedConfig: EdgeTtsClientConfig | undefined;
+    let receivedOutputPath = "";
+    const audio = Buffer.from("ID3-edge-audio");
+
+    const result = await synthesizeEdgeTts(
+      { text: "你好，这是 HomeRail 的语音播报。", speed: 1.25 },
+      async (config) => {
+        receivedConfig = config;
+        return {
+          ttsPromise: async (_text, outputPath) => {
+            receivedOutputPath = outputPath;
+            await writeFile(outputPath, audio);
+          },
+        };
+      },
+    );
+
+    expect(result).toEqual(audio);
+    expect(receivedConfig).toMatchObject({
+      voice: "zh-CN-XiaoxiaoNeural",
+      lang: "zh-CN",
+      outputFormat: DEFAULT_EDGE_TTS_OUTPUT_FORMAT,
+      saveSubtitles: false,
+      rate: "+25%",
+      timeout: 30_000,
+    });
+    expect(existsSync(path.dirname(receivedOutputPath))).toBe(false);
+  });
+
+  it("retries one empty output before returning audio", async () => {
+    let attempts = 0;
+    const result = await synthesizeEdgeTts(
+      { text: "HomeRail voice output" },
+      async () => ({
+        ttsPromise: async (_text, outputPath) => {
+          attempts += 1;
+          if (attempts === 2) await writeFile(outputPath, Buffer.from("ID3-retry"));
+        },
+      }),
+    );
+
+    expect(attempts).toBe(2);
+    expect(result.toString()).toBe("ID3-retry");
+  });
+
+  it("rejects unsafe voice names and out-of-range speed before creating a client", async () => {
+    const createClient = vi.fn();
+
+    await expect(synthesizeEdgeTts({
+      text: "hello",
+      voice: 'en-US-JennyNeural\"/><break time="10s"/>',
+    }, createClient)).rejects.toBeInstanceOf(EdgeTtsInputError);
+    await expect(synthesizeEdgeTts({ text: "hello", speed: 2.1 }, createClient))
+      .rejects.toThrow("speed must be between 0.5 and 2");
+    expect(createClient).not.toHaveBeenCalled();
+  });
+
+  it("cleans its workspace when synthesis fails", async () => {
+    let receivedOutputPath = "";
+    await expect(synthesizeEdgeTts(
+      { text: "network failure" },
+      async () => ({
+        ttsPromise: async (_text, outputPath) => {
+          receivedOutputPath = outputPath;
+          throw new Error("Edge service unavailable");
+        },
+      }),
+    )).rejects.toThrow("Edge service unavailable");
+
+    expect(existsSync(path.dirname(receivedOutputPath))).toBe(false);
+  });
+});

--- a/homerail_manager/tests/manager-agent-container.test.ts
+++ b/homerail_manager/tests/manager-agent-container.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveLocalNodeManagerWsUrl } from "../src/server/manager-agent-container.js";
+
+describe("managed local Docker Node", () => {
+  it("uses the host-reachable Manager URL instead of the container URL", () => {
+    expect(resolveLocalNodeManagerWsUrl({
+      managerRestUrl: "http://host.docker.internal:19191/api",
+      localManagerUrl: "http://127.0.0.1:19191/api",
+    })).toBe("ws://127.0.0.1:19191");
+  });
+
+  it("keeps managerRestUrl as the compatibility fallback", () => {
+    expect(resolveLocalNodeManagerWsUrl({
+      managerRestUrl: "http://127.0.0.1:29191/api",
+    })).toBe("ws://127.0.0.1:29191");
+  });
+});

--- a/homerail_manager/tests/voice-bootstrap.test.ts
+++ b/homerail_manager/tests/voice-bootstrap.test.ts
@@ -5,9 +5,18 @@ import * as path from "node:path";
 import { WebSocket, WebSocketServer } from "ws";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+vi.mock("../src/server/edge-tts.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/server/edge-tts.js")>();
+  return {
+    ...actual,
+    synthesizeEdgeTts: vi.fn(async () => Buffer.from("ID3-homerail-edge")),
+  };
+});
+
 import { _clearStoredConfig } from "../src/server/voice-agent-bootstrap.js";
 import { _clearStoredVoiceSettings } from "../src/server/voice.js";
-import { _clearAllSettings, createSetting, upsertProvider } from "../src/persistence/llm-settings.js";
+import { BUILTIN_EDGE_TTS_MODEL, synthesizeEdgeTts } from "../src/server/edge-tts.js";
+import { _clearAllSettings, createSetting, listSettings, upsertProvider } from "../src/persistence/llm-settings.js";
 import { createProject } from "../src/persistence/projects-changes.js";
 import { closeDb, getDb } from "../src/persistence/db.js";
 import { createServer } from "../src/server/http.js";
@@ -105,6 +114,7 @@ describe("voice bootstrap routes", () => {
     process.env.HOMERAIL_LOCAL_NODE_AUTOSTART = "0";
     process.env.HOMERAIL_MANAGER_AGENT_RUNTIME = "container";
     process.env.HOMERAIL_MANAGER_AGENT_PORT = String(await findAvailableManagerAgentPort());
+    vi.mocked(synthesizeEdgeTts).mockReset().mockResolvedValue(Buffer.from("ID3-homerail-edge"));
     _clearStoredConfig();
     _clearStoredVoiceSettings();
     _clearAllSettings();
@@ -1440,11 +1450,12 @@ describe("voice bootstrap routes", () => {
     expect(row.message_count).toBe(2);
   });
 
-  it("serves voice model and connection endpoints without requiring local defaults", async () => {
+  it("serves voice endpoints and built-in Edge TTS without requiring local defaults", async () => {
     const port = await listen(server);
+    const baseUrl = `http://127.0.0.1:${port}`;
 
     for (const endpoint of ["/api/voice/models", "/api/voice/test"]) {
-      const response = await fetch(`http://127.0.0.1:${port}${endpoint}`, {
+      const response = await fetch(`${baseUrl}${endpoint}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: "{}",
@@ -1456,13 +1467,75 @@ describe("voice bootstrap routes", () => {
       expect(body.data?.models).toEqual(expect.any(Array));
     }
 
-    const speech = await fetch(`http://127.0.0.1:${port}/api/voice/speech`, {
+    const settingsResponse = await fetch(`${baseUrl}/api/voice`);
+    const settingsBody = await settingsResponse.json() as {
+      data: { tts_model: string; tts_llm_setting_id: string; tts_token_set: boolean };
+    };
+    expect(settingsBody.data).toMatchObject({
+      tts_model: BUILTIN_EDGE_TTS_MODEL,
+      tts_llm_setting_id: "",
+      tts_token_set: false,
+    });
+
+    const speech = await fetch(`${baseUrl}/api/voice/speech`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ text: "hello" }),
     });
-    expect(speech.status).toBe(502);
-    expect(await speech.text()).toContain("Missing TTS API key");
+    expect(speech.status).toBe(200);
+    expect(speech.headers.get("content-type")).toContain("audio/mpeg");
+    expect(Buffer.from(await speech.arrayBuffer()).toString()).toBe("ID3-homerail-edge");
+    expect(synthesizeEdgeTts).toHaveBeenCalledWith(expect.objectContaining({
+      text: "hello",
+      voice: "en-US-MichelleNeural",
+    }));
+  });
+
+  it("keeps an explicit built-in Edge selection ahead of configured TTS settings", async () => {
+    createSetting({
+      provider_id: "xiaomi",
+      model_name: "mimo-v2.5-tts",
+      api_key: "tts-secret-12345678",
+      base_url: "https://api.xiaomimimo.com",
+      supports_llm: false,
+      supports_tts: true,
+      is_active: true,
+    });
+    const port = await listen(server);
+    const baseUrl = `http://127.0.0.1:${port}`;
+
+    const initial = await fetch(`${baseUrl}/api/voice`);
+    expect((await initial.json() as { data: { tts_model: string } }).data.tts_model)
+      .toBe("mimo-v2.5-tts");
+
+    const updated = await fetch(`${baseUrl}/api/voice`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        tts_base_url: "https://ignored.example/v1",
+        tts_model: BUILTIN_EDGE_TTS_MODEL,
+        tts_llm_setting_id: null,
+        tts_voice: "ignored-voice",
+      }),
+    });
+    const updatedBody = await updated.json() as {
+      data: { tts_base_url: string; tts_model: string; tts_llm_setting_id: string; tts_voice: string };
+    };
+    expect(updatedBody.data).toEqual(expect.objectContaining({
+      tts_base_url: "",
+      tts_model: BUILTIN_EDGE_TTS_MODEL,
+      tts_llm_setting_id: "",
+      tts_voice: "en-US-MichelleNeural",
+    }));
+    expect(listSettings().map((setting) => setting.model_name)).toEqual(["mimo-v2.5-tts"]);
+
+    const speech = await fetch(`${baseUrl}/api/voice/speech`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: "使用内置语音" }),
+    });
+    expect(speech.status).toBe(200);
+    expect(synthesizeEdgeTts).toHaveBeenCalledOnce();
   });
 
   it("forwards speech to a configured MiMo TTS setting instead of returning silent audio", async () => {


### PR DESCRIPTION
## Summary

- add built-in Microsoft Edge TTS as the default no-key speech output while keeping it outside editable provider settings
- separate model selection from incomplete onboarding and add a compact, persistent voice-output toggle in English, Simplified Chinese, and Traditional Chinese
- make local Docker Node capability implicit and automatically verify Docker workspace access with platform-aware status and remediation guidance

## Validation

- `npm run ci`
- browser smoke validation for empty settings, model selection, Docker auto-probe, and voice toggle persistence