### PR TITLE
fix: probe models with saved credentials

### DIFF
--- a/agent-ui/src/api/services/providers-api.test.ts
+++ b/agent-ui/src/api/services/providers-api.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { http } from '@/api/clients/http-client'
+import { probeModels } from './providers-api'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('providers api model probing', () => {
+  it('sends only the saved setting id when probing a reused credential', async () => {
+    const post = vi.spyOn(http, 'post').mockResolvedValue({
+      success: true,
+      data: { models: ['k3'] }
+    })
+
+    await expect(probeModels({ settingId: 'setting-1' })).resolves.toEqual({ models: ['k3'] })
+    expect(post).toHaveBeenCalledWith('/api/llm/models/probe', { setting_id: 'setting-1' })
+  })
+
+  it('keeps explicit credentials for unsaved model probes', async () => {
+    const post = vi.spyOn(http, 'post').mockResolvedValue({
+      success: true,
+      data: { models: ['model-1'] }
+    })
+
+    await probeModels({ baseUrl: 'https://provider.example/v1', apiKey: 'new-key' })
+    expect(post).toHaveBeenCalledWith('/api/llm/models/probe', {
+      base_url: 'https://provider.example/v1',
+      api_key: 'new-key'
+    })
+  })
+})

--- a/agent-ui/src/api/services/providers-api.ts
+++ b/agent-ui/src/api/services/providers-api.ts
@@ -86,13 +86,19 @@ export async function getProviderModels(
 
 /**
  * 动态探测供应商可用模型（后端代理调 /v1/models）
- * 用户填入 API Key 后调用，返回实际可用的模型 ID 列表。
+ * 已保存凭证只发送 settingId；新凭证发送 baseUrl + apiKey。
  */
+export type ProbeModelsInput =
+  | { settingId: string; baseUrl?: never; apiKey?: never }
+  | { settingId?: never; baseUrl: string; apiKey: string }
+
 export async function probeModels(
-  baseUrl: string,
-  apiKey: string
+  input: ProbeModelsInput
 ): Promise<{ models: string[]; error?: string }> {
-  const res = await http.post<any>('/api/llm/models/probe', { base_url: baseUrl, api_key: apiKey })
+  const body = input.settingId
+    ? { setting_id: input.settingId }
+    : { base_url: input.baseUrl, api_key: input.apiKey }
+  const res = await http.post<any>('/api/llm/models/probe', body)
   const data = res.data ?? res
   return {
     models: Array.isArray(data?.models) ? data.models : [],

--- a/agent-ui/src/components/agent/onboarding/OnboardingStepForm.test.ts
+++ b/agent-ui/src/components/agent/onboarding/OnboardingStepForm.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, nextTick, type App } from 'vue'
 import { i18n } from '@/plugins/i18n'
 import type { LLMSetting } from '@/api/services/llm-settings-api'
+import { probeModels } from '@/api/services/providers-api'
 import type { Provider } from '@/api/types/orchestration-v2.types'
 import OnboardingStepForm from './OnboardingStepForm.vue'
 
@@ -124,6 +125,32 @@ describe('OnboardingStepForm TTS persistence', () => {
       supports_tts: true
     }))
     expect(apiMocks.createLLMSetting.mock.calls[0]?.[0]).not.toHaveProperty('api_key')
+  })
+
+  it('probes preset models by saved setting id when onboarding reuses a credential', async () => {
+    vi.useFakeTimers()
+    try {
+      vi.mocked(probeModels).mockResolvedValueOnce({
+        models: ['mimo-v2.5-tts', 'mimo-v2.5-tts-latest']
+      })
+      const root = await mountForm({
+        capability: 'supports_tts',
+        providers: [ttsProvider],
+        existingSettings: [existingAsrSetting]
+      })
+
+      const credential = root.querySelector<HTMLSelectElement>('select')!
+      credential.value = 'xiaomi::api_billing'
+      credential.dispatchEvent(new Event('change'))
+      await nextTick()
+      await vi.advanceTimersByTimeAsync(600)
+      await nextTick()
+
+      expect(probeModels).toHaveBeenCalledWith({ settingId: existingAsrSetting.id })
+      expect(root.textContent).toContain('mimo-v2.5-tts-latest')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('creates a custom TTS provider before saving its model setting', async () => {

--- a/agent-ui/src/components/agent/onboarding/OnboardingStepForm.vue
+++ b/agent-ui/src/components/agent/onboarding/OnboardingStepForm.vue
@@ -128,13 +128,13 @@ const credentials = computed<CredentialOption[]>(() => {
 // ── credential 已有 key 检测 ───────────────────────────────────
 // Key 的复用边界是具体 credential/endpoint，不是 provider。
 // 例如 Xiaomi 的 API 计费和 Token Plan 是不同 credential，不能互相复用。
-function maskedKeyForCredential(
+function settingForCredential(
   credential: CredentialOption,
   endpoint?: ProviderEndpointPreset | null,
-): string | undefined {
+): LLMSetting | undefined {
   const existing = props.existingSettings ?? []
   const endpointIds = new Set((endpoint ? [endpoint] : credential.endpoints).map(ep => ep.id))
-  const hit = existing.find(s =>
+  return existing.find(s =>
     s.is_active &&
     s.provider_id === credential.provider.id &&
     s.api_key_display &&
@@ -143,7 +143,13 @@ function maskedKeyForCredential(
       (!s.endpoint_id && s.plan_type === credential.planType)
     )
   )
-  return hit?.api_key_display
+}
+
+function maskedKeyForCredential(
+  credential: CredentialOption,
+  endpoint?: ProviderEndpointPreset | null,
+): string | undefined {
+  return settingForCredential(credential, endpoint)?.api_key_display
 }
 
 // ── 表单状态 ──────────────────────────────────────────────────
@@ -164,7 +170,12 @@ const selectedCredential = computed<CredentialOption | null>(() => {
 const selectedCredentialHasKey = computed(() => {
   const cred = selectedCredential.value
   if (!cred) return false
-  return Boolean(maskedKeyForCredential(cred, selectedEndpoint.value))
+  return Boolean(settingForCredential(cred, selectedEndpoint.value))
+})
+const selectedCredentialSetting = computed(() => {
+  const cred = selectedCredential.value
+  if (!cred) return undefined
+  return settingForCredential(cred, selectedEndpoint.value)
 })
 const selectedMaskedKey = computed(() => {
   const cred = selectedCredential.value
@@ -280,23 +291,38 @@ watch(() => props.capability, () => {
 // ── 动态探测（内置模式，key 填入后）──────────────────────────
 async function runProbe(): Promise<void> {
   const ep = selectedEndpoint.value
-  if (!ep || !apiKey.value.trim()) return
+  if (!ep) return
+  const savedSetting = selectedCredentialSetting.value
+  const rawApiKey = apiKey.value.trim()
   const baseUrl = ep.chat_completions_base_url || ep.base_url
-  if (!baseUrl) return
+  if (!savedSetting && (!baseUrl || !rawApiKey)) return
   try {
-    const result = await probeModels(baseUrl, apiKey.value.trim())
+    const result = await probeModels(
+      savedSetting ? { settingId: savedSetting.id } : { baseUrl, apiKey: rawApiKey }
+    )
     probedModels.value = result.models
   } catch {
     probedModels.value = []
   }
 }
 
-watch([apiKey, selectedCredentialKey], () => {
-  if (probeTimer) window.clearTimeout(probeTimer)
-  probedModels.value = []
-  if (!apiKey.value.trim() || !selectedCredential.value) return
-  probeTimer = window.setTimeout(() => { void runProbe() }, 600)
-})
+watch(
+  [
+    apiKey,
+    selectedCredentialKey,
+    () => selectedEndpoint.value?.id,
+    () => selectedCredentialSetting.value?.id
+  ],
+  () => {
+    if (probeTimer) window.clearTimeout(probeTimer)
+    probedModels.value = []
+    if ((!apiKey.value.trim() && !selectedCredentialSetting.value) || !selectedCredential.value)
+      return
+    probeTimer = window.setTimeout(() => {
+      void runProbe()
+    }, 600)
+  }
+)
 
 // ── 校验 ──────────────────────────────────────────────────────
 // credential 已有 key 时只需选模型；否则需模型 + key

--- a/agent-ui/src/components/agent/settings/ModelForm.vue
+++ b/agent-ui/src/components/agent/settings/ModelForm.vue
@@ -358,6 +358,10 @@ const reusingCredential = computed(() => canReuseCredential.value && !useNewApiK
 const reusableCredentialDisplay = computed(
   () => reusableCredentialSettings.value[0]?.api_key_display || '****'
 )
+const reusableProbeSetting = computed(() => {
+  const endpoint = representativeEndpoint.value
+  return endpoint ? reusableSettingForEndpoint(endpoint) : undefined
+})
 
 const endpointUrlRows = computed(() => {
   const ep = representativeEndpoint.value
@@ -434,18 +438,22 @@ const selectedModelRows = computed(() =>
 // ── 动态探测模型 ──────────────────────────────────────────────
 async function runProbe(): Promise<void> {
   const ep = representativeEndpoint.value
-  if (!ep || !apiKey.value.trim()) return
+  if (!ep) return
   if (isArkVoiceEndpoint(ep)) {
     probedModels.value = []
     probeError.value = null
     return
   }
+  const savedSetting = reusingCredential.value ? reusableProbeSetting.value : undefined
+  const rawApiKey = apiKey.value.trim()
   const baseUrl = ep.chat_completions_base_url || ep.base_url
-  if (!baseUrl) return
+  if (!savedSetting && (!baseUrl || !rawApiKey)) return
   probing.value = true
   probeError.value = null
   try {
-    const result = await probeModels(baseUrl, apiKey.value.trim())
+    const result = await probeModels(
+      savedSetting ? { settingId: savedSetting.id } : { baseUrl, apiKey: rawApiKey }
+    )
     probedModels.value = result.models
     if (result.error) probeError.value = result.error
   } catch (e: any) {
@@ -456,16 +464,25 @@ async function runProbe(): Promise<void> {
   }
 }
 
-// 填 key 后 debounce 自动 probe（500ms）
-watch([apiKey, selectedEndpointId], ([key]) => {
-  if (probeTimer) window.clearTimeout(probeTimer)
-  probedModels.value = []
-  probeError.value = null
-  if (!key?.trim() || isArkVoiceCredential.value) return
-  probeTimer = window.setTimeout(() => {
-    void runProbe()
-  }, 600)
-})
+const canProbeModels = computed(
+  () =>
+    !isArkVoiceCredential.value &&
+    Boolean(reusingCredential.value ? reusableProbeSetting.value : apiKey.value.trim())
+)
+
+// 填入新 key 或选择可复用凭证后 debounce 自动 probe。
+watch(
+  [apiKey, selectedEndpointId, reusingCredential, () => reusableProbeSetting.value?.id],
+  () => {
+    if (probeTimer) window.clearTimeout(probeTimer)
+    probedModels.value = []
+    probeError.value = null
+    if (!canProbeModels.value) return
+    probeTimer = window.setTimeout(() => {
+      void runProbe()
+    }, 600)
+  }
+)
 
 function endpointDefaultCapabilities(ep?: ProviderEndpointPreset | null): ModelCapabilities {
   return {
@@ -794,7 +811,7 @@ async function submit(): Promise<void> {
               {{ t('settings.models.form.probedCount', { count: probedModels.length }) }}
             </span>
             <button
-              v-if="apiKey && !probing && !isArkVoiceCredential"
+              v-if="canProbeModels && !probing"
               type="button"
               class="flex items-center gap-1 text-[11px] text-gray-500 transition-colors hover:text-cyan-300"
               :title="t('settings.models.form.reprobe')"

--- a/agent-ui/src/components/agent/settings/ModelForms.test.ts
+++ b/agent-ui/src/components/agent/settings/ModelForms.test.ts
@@ -4,6 +4,7 @@ import { i18n } from '@/plugins/i18n'
 import type { LLMSetting } from '@/api/services/llm-settings-api'
 import type { Provider } from '@/api/types/orchestration-v2.types'
 import { agentSettingsApi } from '@/api/agent'
+import { probeModels } from '@/api/services/providers-api'
 import CustomProviderManager from './CustomProviderManager.vue'
 import EditModelForm, { type EditModelPayload } from './EditModelForm.vue'
 import ModelForm, { type ModelFormPayload } from './ModelForm.vue'
@@ -241,6 +242,34 @@ describe('model purpose forms', () => {
     expect(submitted?.modelName).toBe('second-chat-model')
     expect(submitted?.apiKey).toBe('')
     expect(submitted?.reuseExistingApiKey).toBe(true)
+  })
+
+  it('probes new models by saved setting id when reusing a credential', async () => {
+    vi.useFakeTimers()
+    try {
+      vi.mocked(probeModels).mockResolvedValueOnce({ models: ['chat-model', 'k3'] })
+      const root = await mount(ModelForm, {
+        providers: [provider],
+        settings: [setting],
+        purpose: 'llm'
+      })
+
+      const credential = Array.from(root.querySelectorAll('button')).find(button =>
+        button.textContent?.includes('API 计费')
+      )!
+      credential.click()
+      await nextTick()
+      await vi.advanceTimersByTimeAsync(600)
+      await nextTick()
+
+      expect(probeModels).toHaveBeenCalledWith({ settingId: setting.id })
+      expect(probeModels).not.toHaveBeenCalledWith(
+        expect.objectContaining({ apiKey: expect.anything() })
+      )
+      expect(root.textContent).toContain('k3')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('uses a separate edit form with a read-only provider binding', async () => {

--- a/homerail_manager/src/server/llm-settings.ts
+++ b/homerail_manager/src/server/llm-settings.ts
@@ -64,6 +64,15 @@ function _catalogModelsForBaseUrl(baseUrl: string): string[] | undefined {
   return endpoint?.models.map((model) => model.id) ?? [];
 }
 
+function _modelProbeBaseUrlForSetting(setting: LLMSetting): string {
+  const provider = getProvider(setting.provider_id);
+  const endpoint = provider?.endpoints?.find((candidate) => candidate.id === setting.endpoint_id);
+  const baseUrl = setting.chat_completions_base_url ?? setting.base_url ??
+    endpoint?.chat_completions_base_url ?? endpoint?.base_url ??
+    provider?.chat_completions_base_url ?? provider?.base_url ?? "";
+  return _normalizedBaseUrl(baseUrl);
+}
+
 function _created(res: http.ServerResponse, message: string, data: unknown) {
   json(res, 201, { success: true, message, data });
 }
@@ -303,20 +312,32 @@ export function llmSettingsRoutesHandler(
   }
 
   // POST /api/llm/models/probe — 动态探测供应商可用模型
-  // 后端代理调用供应商的 /v1/models 端点（避免浏览器 CORS），
-  // 返回实际可用的模型 ID 列表。用于"填 Key 后自动拉取模型"。
+  // 已保存的凭证只传 setting_id，由 Manager 解密；新凭证仍可传 base_url + api_key。
+  // API key 始终由后端代理调用供应商，不回传浏览器。
   if (pathname === "/api/llm/models/probe" && req.method === "POST") {
     _readJsonBody(req)
       .then(async (body) => {
         const b = body as Record<string, unknown>;
-        const baseUrl = typeof b.base_url === "string" ? b.base_url.trim().replace(/\/+$/, "") : "";
-        const apiKey = typeof b.api_key === "string" ? b.api_key.trim() : "";
+        const settingId = typeof b.setting_id === "string" ? b.setting_id.trim() : "";
+        const setting = settingId ? getSetting(settingId) : undefined;
+        if (settingId && !setting) {
+          _notFound(res, `LLM setting not found: ${settingId}`);
+          return;
+        }
+        const baseUrl = setting
+          ? _modelProbeBaseUrlForSetting(setting)
+          : typeof b.base_url === "string" ? _normalizedBaseUrl(b.base_url) : "";
+        const apiKey = setting?.api_key ?? (typeof b.api_key === "string" ? b.api_key.trim() : "");
         if (!baseUrl) {
-          _badRequest(res, "Missing required field: base_url");
+          _badRequest(res, setting
+            ? `No model probe URL configured for LLM setting: ${setting.id}`
+            : "Missing required field: base_url");
           return;
         }
         if (!apiKey) {
-          _badRequest(res, "Missing required field: api_key");
+          _badRequest(res, setting
+            ? `No API key configured for LLM setting: ${setting.id}`
+            : "Missing required field: api_key");
           return;
         }
         const catalogModels = _catalogModelsForBaseUrl(baseUrl);

--- a/homerail_manager/tests/llm-providers.test.ts
+++ b/homerail_manager/tests/llm-providers.test.ts
@@ -12,6 +12,7 @@ import {
   listProviders,
   listSettings,
   resolveClaudeSdkBaseUrlForSetting,
+  upsertProvider,
   updateSetting,
 } from "../src/persistence/llm-settings.js";
 import { closeDb, getDb } from "../src/persistence/db.js";
@@ -370,6 +371,91 @@ describe("custom LLM providers", () => {
     ]));
     expect(body.data?.models).toHaveLength(3);
     expect(body.data?.error).toBeUndefined();
+  });
+
+  it("probes upstream models with a saved encrypted setting credential", async () => {
+    const upstreamRequests: Array<{
+      url?: string;
+      authorization?: string;
+      apiKey?: string;
+    }> = [];
+    const upstream = http.createServer((req, res) => {
+      upstreamRequests.push({
+        url: req.url,
+        authorization: req.headers.authorization,
+        apiKey: typeof req.headers["x-api-key"] === "string"
+          ? req.headers["x-api-key"]
+          : undefined,
+      });
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({
+        data: [
+          { id: "kimi-for-coding" },
+          { id: "k3" },
+        ],
+      }));
+    });
+    const upstreamPort = await listen(upstream);
+
+    try {
+      upsertProvider({
+        id: "saved-probe-provider",
+        name: "Saved probe provider",
+        default_model: "kimi-for-coding",
+        base_url: `http://127.0.0.1:${upstreamPort}/v1`,
+        supports_llm: true,
+        supports_asr: false,
+        supports_tts: false,
+        supports_audio_input: false,
+        supports_image_input: false,
+        supports_video_input: false,
+      });
+      const setting = createSetting({
+        provider_id: "saved-probe-provider",
+        endpoint_id: "saved-probe-provider_custom",
+        model_name: "kimi-for-coding",
+        api_key: "saved-probe-secret",
+        is_active: true,
+        is_default: false,
+        supports_llm: true,
+        supports_asr: false,
+        supports_tts: false,
+        supports_audio_input: false,
+        supports_image_input: false,
+        supports_video_input: false,
+      });
+      expect(storedLlmSettingsText()).not.toContain("saved-probe-secret");
+
+      const port = await listen(server);
+      const response = await fetch(`http://127.0.0.1:${port}/api/llm/models/probe`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ setting_id: setting.id }),
+      });
+      const body = await response.json() as { data?: { models?: string[]; error?: string } };
+
+      expect(response.status).toBe(200);
+      expect(body.data).toEqual({ models: ["k3", "kimi-for-coding"] });
+      expect(JSON.stringify(body)).not.toContain("saved-probe-secret");
+      expect(upstreamRequests).toEqual([{
+        url: "/v1/models",
+        authorization: "Bearer saved-probe-secret",
+        apiKey: "saved-probe-secret",
+      }]);
+    } finally {
+      await close(upstream);
+    }
+  });
+
+  it("rejects model probes for unknown saved settings", async () => {
+    const port = await listen(server);
+    const response = await fetch(`http://127.0.0.1:${port}/api/llm/models/probe`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ setting_id: "missing-setting" }),
+    });
+
+    expect(response.status).toBe(404);
   });
 
   it("migrates legacy plaintext DB settings to Manager-encrypted storage", () => {


### PR DESCRIPTION
## Summary

- let the Manager probe provider models from an encrypted saved LLM setting
- automatically probe reused credentials in model settings and onboarding
- keep explicit base URL and API key probing for newly entered credentials
- keep saved API keys server-side so they are never returned to the browser

## Why

When a credential was reused, the frontend had only a masked key and skipped dynamic model discovery. Providers such as Kimi Coding Plan therefore showed only the static catalog and omitted account-visible models such as `k3`.

## Validation

- `npm run ci`
- Manager model-provider tests: 17 passed
- focused Agent UI model-probe tests: 13 passed
