### PR TITLE
fix: ignore IME confirmation in voice composer

### DIFF
--- a/agent-ui/src/components/agent/AgentVoiceCockpit.vue
+++ b/agent-ui/src/components/agent/AgentVoiceCockpit.vue
@@ -31,6 +31,7 @@ import VoiceSessionProjectSidebar from '@/components/agent/VoiceSessionProjectSi
 import AgentModeTopBar from '@/components/agent/AgentModeTopBar.vue'
 import DagResourceStatusPill from '@/components/agent/DagResourceStatusPill.vue'
 import VoiceDynamicWidget from '@/components/agent/VoiceDynamicWidget.vue'
+import { shouldSubmitVoiceComposer } from '@/components/agent/voice-composer-keyboard'
 import {
   resolveVoiceSessionProjectRestore,
   VoiceSessionTransitionGuard,
@@ -3026,7 +3027,7 @@ function submitComposerDraft(): void {
 }
 
 function handleComposerKeydown(event: KeyboardEvent): void {
-  if (event.key === 'Enter' && !event.shiftKey) {
+  if (shouldSubmitVoiceComposer(event)) {
     event.preventDefault()
     submitComposerDraft()
   }

--- a/agent-ui/src/components/agent/voice-composer-keyboard.test.ts
+++ b/agent-ui/src/components/agent/voice-composer-keyboard.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { shouldSubmitVoiceComposer } from './voice-composer-keyboard'
+
+function keyEvent(
+  overrides: Partial<Pick<KeyboardEvent, 'isComposing' | 'key' | 'keyCode' | 'shiftKey'>> = {}
+) {
+  return {
+    isComposing: false,
+    key: 'Enter',
+    keyCode: 13,
+    shiftKey: false,
+    ...overrides
+  }
+}
+
+describe('shouldSubmitVoiceComposer', () => {
+  it('submits a regular Enter key', () => {
+    expect(shouldSubmitVoiceComposer(keyEvent())).toBe(true)
+  })
+
+  it('keeps Shift+Enter as a newline', () => {
+    expect(shouldSubmitVoiceComposer(keyEvent({ shiftKey: true }))).toBe(false)
+  })
+
+  it('does not submit while an IME composition is active', () => {
+    expect(shouldSubmitVoiceComposer(keyEvent({ isComposing: true }))).toBe(false)
+  })
+
+  it('does not submit legacy IME keydown events', () => {
+    expect(shouldSubmitVoiceComposer(keyEvent({ keyCode: 229 }))).toBe(false)
+  })
+
+  it('ignores non-Enter keys', () => {
+    expect(shouldSubmitVoiceComposer(keyEvent({ key: 'Process', keyCode: 229 }))).toBe(false)
+    expect(shouldSubmitVoiceComposer(keyEvent({ key: 'a', keyCode: 65 }))).toBe(false)
+  })
+})

--- a/agent-ui/src/components/agent/voice-composer-keyboard.ts
+++ b/agent-ui/src/components/agent/voice-composer-keyboard.ts
@@ -1,0 +1,11 @@
+type VoiceComposerKeyboardEvent = Pick<
+  KeyboardEvent,
+  'isComposing' | 'key' | 'keyCode' | 'shiftKey'
+>
+
+export function shouldSubmitVoiceComposer(event: VoiceComposerKeyboardEvent): boolean {
+  // Some IMEs report keyCode 229 while confirming a candidate even when
+  // isComposing is false, so keep both guards.
+  if (event.isComposing || event.keyCode === 229) return false
+  return event.key === 'Enter' && !event.shiftKey
+}


### PR DESCRIPTION
## Summary
- prevent IME candidate confirmation from submitting the voice composer
- retain Enter-to-send and Shift+Enter newline behavior
- cover modern composition events and legacy keyCode 229 events

## Validation
- Agent UI tests: 321 passed
- Agent UI typecheck passed
- Agent UI production build passed
- local HomeRail UI restarted and doctor passed