### PR TITLE
fix: reconcile runtime upgrade readiness

### DIFF
--- a/homerail_cli/src/commands/doctor.ts
+++ b/homerail_cli/src/commands/doctor.ts
@@ -5,6 +5,7 @@ import type { BaseResponse } from "../client.js";
 import { dockerNotFoundDetail, resolveDockerBinary } from "../docker-bin.js";
 import {
   DEFAULT_MANAGER_AGENT_HARNESS,
+  isKimiCodeCompatibleModelSetting,
   normalizeManagerAgentHarness,
 } from "homerail-protocol";
 
@@ -41,7 +42,13 @@ interface LlmSettingSummary {
   providerId?: unknown;
   model_name?: unknown;
   modelName?: unknown;
+  plan_type?: unknown;
+  planType?: unknown;
   protocol?: unknown;
+  endpoint_id?: unknown;
+  endpointId?: unknown;
+  endpoint_name?: unknown;
+  endpointName?: unknown;
   base_url?: unknown;
   baseUrl?: unknown;
   anthropic_base_url?: unknown;
@@ -135,6 +142,16 @@ function anthropicCompatibleBaseUrl(setting: LlmSettingSummary): string {
 
 function modelRuntimeBaseUrl(setting: LlmSettingSummary): string {
   return stringValue(setting.base_url ?? setting.baseUrl);
+}
+
+function isKimiCodeCompatibleSetting(setting: LlmSettingSummary): boolean {
+  return isKimiCodeCompatibleModelSetting({
+    providerId: providerId(setting),
+    planType: setting.plan_type ?? setting.planType,
+    protocol: setting.protocol,
+    endpointId: setting.endpoint_id ?? setting.endpointId,
+    endpointName: setting.endpoint_name ?? setting.endpointName,
+  });
 }
 
 const defaultCommandRunner: CommandRunner = (file, args, options) => spawnSync(file, args, {
@@ -263,11 +280,11 @@ export function managerAgentReadiness(
     };
   }
   if (harness === "kimi_code") {
-    if (!KIMI_PROVIDER_IDS.has(providerId(selected))) {
+    if (!isKimiCodeCompatibleSetting(selected)) {
       return {
         name: "manager-agent",
         ok: false,
-        detail: `${settingLabel(selected)} is not a Kimi setting for kimi_code`,
+        detail: `${settingLabel(selected)} is not Kimi Code-compatible`,
       };
     }
     if (!modelRuntimeBaseUrl(selected)) {

--- a/homerail_cli/tests/doctor.test.ts
+++ b/homerail_cli/tests/doctor.test.ts
@@ -142,6 +142,33 @@ describe("doctor readiness helpers", () => {
     });
   });
 
+  it("accepts an explicitly selected custom setting for the Kimi Code manager agent", () => {
+    const resp = settings([
+      {
+        id: "qwen36-local-setting",
+        provider_id: "qwen36-local",
+        model_name: "qwen3.6",
+        plan_type: "custom",
+        endpoint_id: "qwen36-local_custom",
+        is_active: true,
+        is_default: true,
+        supports_llm: true,
+        protocol: "openai_compatible",
+        base_url: "http://192.0.2.10:5000/v1",
+      },
+    ]);
+
+    const check = managerAgentReadiness({
+      harness: "kimi_code",
+      llm_setting_id: "qwen36-local-setting",
+    }, resp);
+    expect(check).toMatchObject({
+      name: "manager-agent",
+      ok: true,
+      detail: "qwen36-local/qwen3.6 via kimi_code",
+    });
+  });
+
   it("reports Docker CLI absence for Docker-backed DAG readiness", () => {
     const checks = dockerReadiness(runnerFor([
       { status: null, error: Object.assign(new Error("spawn docker ENOENT"), { code: "ENOENT" }) },

--- a/homerail_manager/src/persistence/db.ts
+++ b/homerail_manager/src/persistence/db.ts
@@ -470,6 +470,27 @@ function legacyMainMigrationVersions(db: SqliteDatabase): number[] {
   return versions;
 }
 
+/**
+ * The durable-Actor PR stack originally used ids 27-29 for live commands,
+ * pinned Skill context, and Surface patches. After interventions were inserted,
+ * those schemas moved to 28-30 and id 27 became dispatch exclusions. Detect
+ * that exact pre-merge physical chain so the current idempotent migrations can
+ * record the canonical order without dropping persisted data.
+ */
+function legacyDurableActorMigrationVersions(db: SqliteDatabase): number[] {
+  if (!hasTable(db, "schema_migrations")) return [];
+  const hasVersion = (version: number) => Boolean(db.prepare(
+    "SELECT 1 FROM schema_migrations WHERE version = ?",
+  ).get(version));
+  const shiftedChain =
+    hasVersion(27) && hasVersion(28) && hasVersion(29) && !hasVersion(30) &&
+    !hasTable(db, "dag_actor_dispatch_exclusions") &&
+    hasTable(db, "dag_actor_live_commands") &&
+    hasTable(db, "dag_run_skill_contexts") &&
+    hasTable(db, "dag_actor_surface_patch_journal");
+  return shiftedChain ? [27, 28, 29] : [];
+}
+
 function validateDagWorkflowSchemaV15(db: SqliteDatabase): void {
   if (!hasTable(db, "dag_workflow_revisions")) {
     throw new Error("Schema migration 15 is incomplete: missing table dag_workflow_revisions");
@@ -3909,7 +3930,10 @@ function initializeSchema(db: SqliteDatabase, filePath: string): void {
   db.pragma("journal_mode = WAL");
   db.pragma("foreign_keys = ON");
   db.pragma("busy_timeout = 5000");
-  const collidingMainVersions = legacyMainMigrationVersions(db);
+  const collidingMigrationVersions = [
+    ...legacyMainMigrationVersions(db),
+    ...legacyDurableActorMigrationVersions(db),
+  ];
   db.exec(`
     CREATE TABLE IF NOT EXISTS schema_migrations (
       version INTEGER PRIMARY KEY,
@@ -4677,10 +4701,10 @@ function initializeSchema(db: SqliteDatabase, filePath: string): void {
   ensureExpandedColumns(db);
   seedBuiltinProviderCatalog(db);
   db.prepare("INSERT OR IGNORE INTO schema_migrations(version, applied_at) VALUES (?, ?)").run(2, nowIso());
-  if (collidingMainVersions.length > 0) {
+  if (collidingMigrationVersions.length > 0) {
     const remove = db.prepare("DELETE FROM schema_migrations WHERE version = ?");
     db.transaction(() => {
-      for (const version of collidingMainVersions) remove.run(version);
+      for (const version of collidingMigrationVersions) remove.run(version);
     })();
   }
   runSchemaMigrations(db, SCHEMA_MIGRATIONS);

--- a/homerail_manager/src/runtime/agent-runtime-resolver.ts
+++ b/homerail_manager/src/runtime/agent-runtime-resolver.ts
@@ -18,6 +18,7 @@ import {
   DEFAULT_MANAGER_AGENT_RUNTIME_AGENT_TYPE,
   ManagerAgentRuntimePlacement,
   isDisabledDirectLlmAgentType,
+  isKimiCodeCompatibleModelSetting,
   managerAgentHarnessDefinition,
   normalizeManagerAgentHarness,
   normalizeManagerAgentRuntimeAgentType,
@@ -81,20 +82,15 @@ function requestedAgentType(input: AgentRuntimeResolutionInput): string | undefi
   return normalizeManagerAgentRuntimeAgentType(input.agentType);
 }
 
-function isCustomModelSetting(setting: LLMSetting): boolean {
-  const provider = getProvider(setting.provider_id);
-  if (provider?.source === "builtin") return false;
-  if (provider?.source === "custom") return true;
-  return (
-    setting.plan_type === "custom" ||
-    setting.protocol === "custom" ||
-    setting.endpoint_id === "custom" ||
-    setting.endpoint_name === "custom"
-  );
-}
-
 function isKimiCodeCompatibleSetting(setting: LLMSetting): boolean {
-  return isKimiProviderId(setting.provider_id) || isCustomModelSetting(setting);
+  return isKimiCodeCompatibleModelSetting({
+    providerId: setting.provider_id,
+    providerSource: getProvider(setting.provider_id)?.source,
+    planType: setting.plan_type,
+    protocol: setting.protocol,
+    endpointId: setting.endpoint_id,
+    endpointName: setting.endpoint_name,
+  });
 }
 
 function findActiveKimiSetting(modelName?: string): LLMSetting | undefined {

--- a/homerail_manager/tests/dag-actor-interventions.test.ts
+++ b/homerail_manager/tests/dag-actor-interventions.test.ts
@@ -80,6 +80,46 @@ describe("DAG actor intervention persistence", () => {
       .toEqual({ count: 1 });
   });
 
+  it("reconciles the shifted pre-merge migration 27-29 chain without losing persisted data", () => {
+    getDb().prepare(`
+      INSERT INTO dag_run_skill_contexts(
+        run_id, agent_id, context_version, context_digest, total_bytes,
+        skill_count, context_json, created_at
+      ) VALUES (?, ?, 1, ?, 0, 0, '{}', ?)
+    `).run("run-1", "legacy-agent", "a".repeat(64), 100);
+    getDb().exec(`
+      DROP TABLE dag_actor_dispatch_exclusions;
+      DELETE FROM schema_migrations WHERE version IN (27, 28, 29, 30);
+      INSERT INTO schema_migrations(version, applied_at) VALUES
+        (27, 'legacy-live-commands'),
+        (28, 'legacy-skill-context'),
+        (29, 'legacy-surface-patches');
+    `);
+    closeDb();
+
+    const migrated = getDb();
+    expect(migrated.prepare(
+      "SELECT version FROM schema_migrations WHERE version >= 27 ORDER BY version",
+    ).all()).toEqual([
+      { version: 27 },
+      { version: 28 },
+      { version: 29 },
+      { version: 30 },
+    ]);
+    expect(migrated.prepare(`
+      SELECT agent_id, context_json FROM dag_run_skill_contexts
+      WHERE run_id = ? AND agent_id = ?
+    `).get("run-1", "legacy-agent")).toEqual({
+      agent_id: "legacy-agent",
+      context_json: "{}",
+    });
+    expect(migrated.prepare(`
+      SELECT name FROM sqlite_master
+      WHERE type = 'table' AND name = 'dag_actor_dispatch_exclusions'
+    `).get()).toEqual({ name: "dag_actor_dispatch_exclusions" });
+    expect(migrated.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
+  });
+
   it("persists the Inbox before applying, deduplicates retries, and enforces Actor CAS", () => {
     const request = {
       intervention_id: "intervention-1",

--- a/homerail_protocol/src/manager-agent.ts
+++ b/homerail_protocol/src/manager-agent.ts
@@ -73,6 +73,34 @@ function normalizedString(value: unknown): string {
   return typeof value === "string" ? value.trim().toLowerCase() : "";
 }
 
+export interface KimiCodeModelSettingDescriptor {
+  providerId?: unknown;
+  providerSource?: unknown;
+  planType?: unknown;
+  protocol?: unknown;
+  endpointId?: unknown;
+  endpointName?: unknown;
+}
+
+const KIMI_CODE_PROVIDER_IDS = new Set(["kimi", "kimi_cn"]);
+
+/** Keep Kimi Code setting compatibility consistent across runtime and setup checks. */
+export function isKimiCodeCompatibleModelSetting(
+  setting: KimiCodeModelSettingDescriptor,
+): boolean {
+  const providerId = normalizedString(setting.providerId);
+  if (KIMI_CODE_PROVIDER_IDS.has(providerId)) return true;
+
+  const providerSource = normalizedString(setting.providerSource);
+  if (providerSource === "builtin") return false;
+  if (providerSource === "custom") return true;
+
+  return normalizedString(setting.planType) === "custom" ||
+    normalizedString(setting.protocol) === "custom" ||
+    normalizedString(setting.endpointId) === "custom" ||
+    normalizedString(setting.endpointName) === "custom";
+}
+
 export function isManagerAgentHarness(value: unknown): value is ManagerAgentHarness {
   return value === ManagerAgentHarness.CLAUDE_AGENT_SDK ||
     value === ManagerAgentHarness.CODEX_APPSERVER ||

--- a/homerail_protocol/tests/manager-agent.test.ts
+++ b/homerail_protocol/tests/manager-agent.test.ts
@@ -5,6 +5,7 @@ import {
   MANAGER_AGENT_PRODUCTION_RUNTIME_AGENT_TYPES,
   ManagerAgentRuntimePlacement,
   isDisabledDirectLlmAgentType,
+  isKimiCodeCompatibleModelSetting,
   isManagerAgentHarness,
   managerAgentHarnessDefinition,
   managerAgentRuntimeAgentTypeForHarness,
@@ -108,6 +109,27 @@ describe("Manager Agent DAG context", () => {
 });
 
 describe("Manager Agent harness contract", () => {
+  it("accepts official Kimi providers and explicitly custom model settings", () => {
+    expect(isKimiCodeCompatibleModelSetting({ providerId: "kimi_cn" })).toBe(true);
+    expect(isKimiCodeCompatibleModelSetting({
+      providerId: "qwen36-local",
+      providerSource: "custom",
+    })).toBe(true);
+    expect(isKimiCodeCompatibleModelSetting({
+      providerId: "qwen36-local",
+      planType: "custom",
+      protocol: "openai_compatible",
+    })).toBe(true);
+  });
+
+  it("rejects unrelated builtin providers even if their metadata is malformed", () => {
+    expect(isKimiCodeCompatibleModelSetting({
+      providerId: "deepseek",
+      providerSource: "builtin",
+      planType: "custom",
+    })).toBe(false);
+  });
+
   it("keeps canonical public harness ids explicit", () => {
     expect(DEFAULT_MANAGER_AGENT_HARNESS).toBe("claude_agent_sdk");
     expect(isManagerAgentHarness("claude_agent_sdk")).toBe(true);


### PR DESCRIPTION
## Summary

- reconcile the shifted pre-merge migration 27-29 chain with the canonical 27-30 schema
- preserve existing durable Actor, Skill context, and Surface patch data while replaying idempotent migrations
- move Kimi Code/custom-model compatibility into the shared protocol contract
- make Manager runtime resolution and `hr doctor` use the same compatibility rule

## Why

A real existing HomeRail database could contain migration markers 27-29 from the durable-Actor branch order while missing the table now owned by migration 27. Current main treated the marker as proof and failed Manager startup.

Separately, Kimi Code can run an explicitly configured custom OpenAI-compatible model, but `hr doctor` rejected that working configuration unless its provider id was `kimi` or `kimi_cn`.

## Verification

- `npm run ci`
  - Protocol: 292 passed
  - Plugin SDK: 34 passed
  - Manager: 963 passed, 2 skipped
  - Node: 187 passed, 2 skipped
  - Worker: 293 passed, 1 skipped
  - CLI: 249 passed
  - Agent UI: 329 passed
  - live validator: 28 passed, 2 skipped
- migrated the original database copy that reproduced the startup failure
  - schema advanced to version 30
  - `dag_actor_dispatch_exclusions` was created
  - `PRAGMA foreign_key_check` returned no violations
  - sampled configuration, 45 voice sessions, 5 DAG runs, 6 Skill contexts, and 36 Surface patches retained identical row counts
  - reopening the migrated database was idempotent
- ran the rebuilt CLI against the real default local Qwen configuration
  - `hr doctor` changed from a false failure to `ok=true`
  - Manager Agent: `qwen36-local/qwen3.6 via kimi_code`

## Scope

This is the Core dependency for the subsequent Desktop packaging and Worker-image freshness milestone. It does not change Desktop code or generated-UI behavior.
