### PR TITLE
feat: render trusted Skill views natively

### DIFF
--- a/agent-ui/src/components/generative-ui/GenerativeUiSurfaceHost.vue
+++ b/agent-ui/src/components/generative-ui/GenerativeUiSurfaceHost.vue
@@ -10,7 +10,11 @@ import {
   emptyGenerativeUiActionRegistry,
   GenerativeUiActionRegistry,
 } from '@/generative-ui/action-registry'
-import { resolveGenerativeUiFocusIndex, type GenerativeUiFocusDirection } from '@/generative-ui/focus-navigation'
+import {
+  focusGenerativeUiNode,
+  resolveGenerativeUiFocusIndex,
+  type GenerativeUiFocusDirection,
+} from '@/generative-ui/focus-navigation'
 import {
   emptyGenerativeUiRendererRegistry,
   GenerativeUiRendererRegistry,
@@ -161,14 +165,7 @@ function focus(direction: GenerativeUiFocusDirection): void {
 function focusNode(nodeId: string): boolean {
   const target = focusableNodes().find(element => element.dataset.generativeUiNode === nodeId)
   if (!target) return false
-  target.focus({ preventScroll: true })
-  target.scrollIntoView?.({
-    behavior: reducedMotionPreferred() ? 'auto' : 'smooth',
-    block: 'nearest',
-    inline: 'start',
-  })
-  const body = target.querySelector<HTMLElement>('.generative-ui-node-host__body')
-  body?.scrollTo?.({ top: body.scrollHeight, behavior: reducedMotionPreferred() ? 'auto' : 'smooth' })
+  focusGenerativeUiNode(target, reducedMotionPreferred() ? 'auto' : 'smooth')
   emit('focus-node', { node_id: nodeId })
   return true
 }

--- a/agent-ui/src/generative-ui/focus-navigation.test.ts
+++ b/agent-ui/src/generative-ui/focus-navigation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { resolveGenerativeUiFocusIndex } from './focus-navigation'
+import { focusGenerativeUiNode, resolveGenerativeUiFocusIndex } from './focus-navigation'
 
 describe('Generative UI focus navigation', () => {
   it('supports keyboard and Gamepad next/previous wrapping', () => {
@@ -13,5 +13,23 @@ describe('Generative UI focus navigation', () => {
     expect(resolveGenerativeUiFocusIndex(1, 3, 'first')).toBe(0)
     expect(resolveGenerativeUiFocusIndex(1, 3, 'last')).toBe(2)
     expect(resolveGenerativeUiFocusIndex(0, 0, 'next')).toBe(-1)
+  })
+
+  it('focuses the card without changing its internal reading position', () => {
+    const target = document.createElement('article')
+    const body = document.createElement('div')
+    body.className = 'generative-ui-node-host__body'
+    body.scrollTop = 72
+    target.appendChild(body)
+    const focusOptions: FocusOptions[] = []
+    const scrollOptions: ScrollIntoViewOptions[] = []
+    target.focus = options => { focusOptions.push(options ?? {}) }
+    target.scrollIntoView = options => { scrollOptions.push(options ?? {}) }
+
+    focusGenerativeUiNode(target, 'auto')
+
+    expect(focusOptions).toEqual([{ preventScroll: true }])
+    expect(scrollOptions).toEqual([{ behavior: 'auto', block: 'nearest', inline: 'start' }])
+    expect(body.scrollTop).toBe(72)
   })
 })

--- a/agent-ui/src/generative-ui/focus-navigation.ts
+++ b/agent-ui/src/generative-ui/focus-navigation.ts
@@ -1,5 +1,17 @@
 export type GenerativeUiFocusDirection = 'next' | 'previous' | 'first' | 'last'
 
+export function focusGenerativeUiNode(
+  target: HTMLElement,
+  behavior: ScrollBehavior,
+): void {
+  target.focus({ preventScroll: true })
+  target.scrollIntoView?.({
+    behavior,
+    block: 'nearest',
+    inline: 'start',
+  })
+}
+
 export function resolveGenerativeUiFocusIndex(
   currentIndex: number,
   itemCount: number,

--- a/homerail_manager/src/server/host-codex-manager-agent.ts
+++ b/homerail_manager/src/server/host-codex-manager-agent.ts
@@ -20,6 +20,7 @@ import type { ManagerAgentRuntimeConfig } from "./manager-agent-runtime-config.j
 import {
   buildManagerAgentSystemPrompt,
   canonicalManagerAgentToolCallName,
+  compactManagerAgentSkillViewPresentResult,
   createManagerAgentWidgetFileTools,
   DEFAULT_PR_REVIEW_EXPECTED_USAGE,
   defaultPrReviewBudgetKey,
@@ -32,6 +33,8 @@ import {
   managerAgentPluginToolCallName,
   managerAgentOutcomeObjectivePrompt,
   managerAgentRequiredToolObjectivePrompt,
+  managerAgentSkillViewPresentToolDefinition,
+  managerAgentSkillViewRenderToolDefinition,
   managerAgentSkillViewToolDefinitions,
   matchingManagerAgentSkillViewToolDefinition,
   materializeManagerAgentSkillViewInput,
@@ -1700,6 +1703,66 @@ export function createManagerTools(state: {
     );
   };
   if (generatedViewDescriptor) {
+    tools.push({
+      ...managerAgentSkillViewPresentToolDefinition(),
+      async handler(args, context) {
+        const skillId = String(args.skill_id || "").trim();
+        if (!skillId) throw new Error("skill_view_present requires skill_id");
+        const body = await requestManager(
+          state.restUrl,
+          `/skills/${encodeURIComponent(skillId)}/views/present`,
+          {
+            method: "POST",
+            body: JSON.stringify({ argv: args.argv }),
+          },
+        );
+        const data = managerData(body);
+        const input = data.input;
+        if (!input || typeof input !== "object" || Array.isArray(input)) {
+          throw new Error("Manager returned an invalid presented Skill view");
+        }
+        const result = await invokePluginTool(generatedViewDescriptor, input as Record<string, unknown>, context);
+        const responseText = typeof data.response_text === "string" ? data.response_text.trim() : "";
+        const rawResult = result.content.map((item) => item.text).join("");
+        let resultBody: Record<string, unknown>;
+        try {
+          const parsed = JSON.parse(rawResult) as unknown;
+          if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error("invalid");
+          resultBody = parsed as Record<string, unknown>;
+        } catch {
+          throw new Error("Generated view Tool returned an invalid result");
+        }
+        return { content: [{
+          type: "text",
+          text: JSON.stringify(compactManagerAgentSkillViewPresentResult(resultBody, responseText)),
+        }] };
+      },
+    });
+    tools.push({
+      ...managerAgentSkillViewRenderToolDefinition(),
+      async handler(args, context) {
+        const skillId = String(args.skill_id || "").trim();
+        const templateId = String(args.template_id || "").trim();
+        if (!skillId || !templateId) throw new Error("skill_view_render requires skill_id and template_id");
+        const body = await requestManager(
+          state.restUrl,
+          `/skills/${encodeURIComponent(skillId)}/views/${encodeURIComponent(templateId)}/materialize`,
+          {
+            method: "POST",
+            body: JSON.stringify({
+              id: args.id,
+              data: args.data,
+              ...(args.canvas_size === undefined ? {} : { canvas_size: args.canvas_size }),
+            }),
+          },
+        );
+        const input = managerData(body).input;
+        if (!input || typeof input !== "object" || Array.isArray(input)) {
+          throw new Error("Manager returned an invalid materialized Skill view");
+        }
+        return invokePluginTool(generatedViewDescriptor, input as Record<string, unknown>, context);
+      },
+    });
     for (const definition of skillViewDefinitions) {
       if (tools.some((tool) => tool.name === definition.name)) {
         throw new Error(`Skill view Tool collides with an existing Tool: ${definition.name}`);

--- a/homerail_manager/src/server/manager-agent-outcomes.ts
+++ b/homerail_manager/src/server/manager-agent-outcomes.ts
@@ -1,5 +1,7 @@
 import {
   canonicalManagerAgentToolCallName,
+  MANAGER_AGENT_SKILL_VIEW_PRESENT_TOOL_NAME,
+  MANAGER_AGENT_SKILL_VIEW_RENDER_TOOL_NAME,
   managerAgentPluginToolCallName,
   managerAgentSkillViewToolDefinitions,
   normalizeManagerAgentOutcomeCapabilities,
@@ -59,7 +61,11 @@ export function resolveManagerAgentOutcomeContracts(input: {
         ? input.plugin_context.tools.find((tool) => tool.qualified_id === CORE_GENERATED_VIEW_TOOL_ID)
         : undefined;
       if (!descriptor) return { capability, tool_names: [] };
-      const names = [managerAgentPluginToolCallName(descriptor, input.plugin_context.tools)];
+      const names = [
+        managerAgentPluginToolCallName(descriptor, input.plugin_context.tools),
+        MANAGER_AGENT_SKILL_VIEW_PRESENT_TOOL_NAME,
+        MANAGER_AGENT_SKILL_VIEW_RENDER_TOOL_NAME,
+      ];
       names.push(...managerAgentSkillViewToolDefinitions(input.manager_skills).map((definition) => definition.name));
       const selected = input.canvas_context?.selected_node_id
         ? input.canvas_context.nodes.find((node) => node.id === input.canvas_context?.selected_node_id)

--- a/homerail_manager/src/server/manager-agent-turn-envelope.ts
+++ b/homerail_manager/src/server/manager-agent-turn-envelope.ts
@@ -35,6 +35,8 @@ export const DEFAULT_MANAGER_AGENT_API_SCOPES = Object.freeze([
   "POST:/api/dag/patterns/*/instantiate",
   "POST:/api/dag/workflows/sync",
   "POST:/api/plugins/tools/invoke",
+  "POST:/api/skills/*/views/*/materialize",
+  "POST:/api/skills/*/views/present",
   "POST:/api/projects/*/changes",
   "POST:/api/runs/*/supervision",
   "POST:/api/runs/*/actors/*/interventions",

--- a/homerail_manager/src/server/manager-skills.ts
+++ b/homerail_manager/src/server/manager-skills.ts
@@ -1,3 +1,4 @@
+import { execFile } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import YAML from "yaml";
@@ -40,9 +41,20 @@ export interface ManagerSkillInstallResult {
   errors: Array<{ id: string; message: string }>;
 }
 
+export interface ManagerSkillViewPresenter {
+  skill_root: string;
+  command: string;
+  args: string[];
+  timeout_ms: number;
+}
+
 const MAX_SKILL_BYTES = 256 * 1024;
 const MAX_SKILL_VIEW_MANIFEST_BYTES = 256 * 1024;
 const MAX_SKILL_VIEW_TEMPLATES = 8;
+const MAX_SKILL_VIEW_PRESENTER_ARGUMENTS = 32;
+const MAX_SKILL_VIEW_PRESENTER_ARGUMENT_BYTES = 512;
+const MAX_SKILL_VIEW_PRESENTER_ARGUMENT_TOTAL_BYTES = 8 * 1024;
+const MAX_SKILL_VIEW_PRESENTER_OUTPUT_BYTES = 1024 * 1024;
 const SKILL_VIEW_MANIFEST = path.join("assets", "homerail", "view-templates.json");
 const VIEW_SURFACES = new Set(["task", "execution", "result", "ambient"]);
 const VIEW_IMPORTANCE = new Set(["critical", "primary", "secondary", "ambient"]);
@@ -140,30 +152,148 @@ function localSkillRoot(id: string): string | undefined {
   return undefined;
 }
 
-export function readManagerSkillViewTemplates(id: string): ManagerAgentSkillViewTemplateV1[] {
+function readSkillViewManifest(id: string): {
+  skill_root: string;
+  manifest: Record<string, unknown>;
+} | undefined {
   const normalized = id.trim();
   if (!normalized || normalized.includes(":") || normalized.includes("/") || normalized.includes("\\") || normalized === "." || normalized === "..") {
-    return [];
+    return undefined;
   }
   ensureManagerSkillsInstalled();
   const skillRoot = localSkillRoot(normalized);
-  if (!skillRoot) return [];
+  if (!skillRoot) return undefined;
   const file = path.join(skillRoot, SKILL_VIEW_MANIFEST);
   try {
     const stat = fs.lstatSync(file);
-    if (!stat.isFile() || stat.size > MAX_SKILL_VIEW_MANIFEST_BYTES) return [];
-    const parsed = record(JSON.parse(fs.readFileSync(file, "utf8")));
-    if (parsed?.manifest_version !== 1 || !Array.isArray(parsed.templates) || parsed.templates.length > MAX_SKILL_VIEW_TEMPLATES) {
-      return [];
-    }
-    const templates = parsed.templates.map(parseSkillViewTemplate);
-    if (templates.some((template) => template === undefined)) return [];
-    const valid = templates as ManagerAgentSkillViewTemplateV1[];
-    if (new Set(valid.map((template) => template.id)).size !== valid.length) return [];
-    return valid;
+    if (!stat.isFile() || stat.size > MAX_SKILL_VIEW_MANIFEST_BYTES) return undefined;
+    const manifest = record(JSON.parse(fs.readFileSync(file, "utf8")));
+    if (manifest?.manifest_version !== 1) return undefined;
+    return { skill_root: fs.realpathSync(skillRoot), manifest };
   } catch {
+    return undefined;
+  }
+}
+
+export function readManagerSkillViewTemplates(id: string): ManagerAgentSkillViewTemplateV1[] {
+  const loaded = readSkillViewManifest(id);
+  if (!loaded || !Array.isArray(loaded.manifest.templates) || loaded.manifest.templates.length > MAX_SKILL_VIEW_TEMPLATES) {
     return [];
   }
+  const templates = loaded.manifest.templates.map(parseSkillViewTemplate);
+  if (templates.some((template) => template === undefined)) return [];
+  const valid = templates as ManagerAgentSkillViewTemplateV1[];
+  if (new Set(valid.map((template) => template.id)).size !== valid.length) return [];
+  return valid;
+}
+
+export function readManagerSkillViewPresenter(id: string): ManagerSkillViewPresenter | undefined {
+  const loaded = readSkillViewManifest(id);
+  const presenter = record(loaded?.manifest.presenter);
+  if (!loaded || !presenter) return undefined;
+  const command = typeof presenter.command === "string" ? presenter.command.trim() : "";
+  const args = Array.isArray(presenter.args) ? presenter.args : [];
+  const timeoutMs = presenter.timeout_ms === undefined ? 30_000 : Number(presenter.timeout_ms);
+  if (
+    !command
+    || command.length > 200
+    || path.isAbsolute(command)
+    || command.includes("/")
+    || command.includes("\\")
+    || /[\u0000-\u001f\u007f]/.test(command)
+    || args.length > 8
+    || !Number.isInteger(timeoutMs)
+    || timeoutMs < 1_000
+    || timeoutMs > 60_000
+  ) return undefined;
+  const normalizedArgs = args.map((item) => typeof item === "string" ? item : "");
+  if (normalizedArgs.some((item) => (
+    !item
+    || Buffer.byteLength(item, "utf8") > MAX_SKILL_VIEW_PRESENTER_ARGUMENT_BYTES
+    || /[\u0000\r\n]/.test(item)
+  ))) return undefined;
+  return {
+    skill_root: loaded.skill_root,
+    command,
+    args: normalizedArgs,
+    timeout_ms: timeoutMs,
+  };
+}
+
+function normalizeSkillViewPresenterArgv(value: unknown): string[] {
+  if (!Array.isArray(value) || value.length < 1 || value.length > MAX_SKILL_VIEW_PRESENTER_ARGUMENTS) {
+    throw new Error("Skill view presenter argv must contain 1 to 32 arguments");
+  }
+  const argv = value.map((item) => typeof item === "string" ? item : "");
+  if (argv.some((item) => (
+    !item
+    || Buffer.byteLength(item, "utf8") > MAX_SKILL_VIEW_PRESENTER_ARGUMENT_BYTES
+    || /[\u0000\r\n]/.test(item)
+  ))) throw new Error("Skill view presenter argv contains an invalid argument");
+  if (Buffer.byteLength(argv.join("\0"), "utf8") > MAX_SKILL_VIEW_PRESENTER_ARGUMENT_TOTAL_BYTES) {
+    throw new Error("Skill view presenter argv is too large");
+  }
+  return argv;
+}
+
+function skillViewPresenterEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { HOMERAIL_HOME: getHomerailHome() };
+  for (const key of [
+    "PATH",
+    "HOME",
+    "USERPROFILE",
+    "SystemRoot",
+    "WINDIR",
+    "PATHEXT",
+    "TMPDIR",
+    "TEMP",
+    "TMP",
+    "LANG",
+    "LC_ALL",
+  ]) {
+    if (process.env[key] !== undefined) env[key] = process.env[key];
+  }
+  return env;
+}
+
+export async function executeManagerSkillViewPresenter(
+  id: string,
+  argvValue: unknown,
+): Promise<Record<string, unknown>> {
+  const presenter = readManagerSkillViewPresenter(id);
+  if (!presenter) throw new Error("Skill view presenter not found");
+  const argv = normalizeSkillViewPresenterArgv(argvValue);
+  const stdout = await new Promise<string>((resolve, reject) => {
+    execFile(
+      presenter.command,
+      [...presenter.args, ...argv],
+      {
+        cwd: presenter.skill_root,
+        env: skillViewPresenterEnv(),
+        timeout: presenter.timeout_ms,
+        maxBuffer: MAX_SKILL_VIEW_PRESENTER_OUTPUT_BYTES,
+        windowsHide: true,
+        encoding: "utf8",
+      },
+      (error, value) => {
+        if (!error) {
+          resolve(value);
+          return;
+        }
+        const killed = (error as NodeJS.ErrnoException & { killed?: boolean }).killed;
+        reject(new Error(killed ? "Skill view presenter timed out" : "Skill view presenter failed"));
+      },
+    );
+  });
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout.trim());
+  } catch {
+    throw new Error("Skill view presenter returned invalid JSON");
+  }
+  const output = record(parsed);
+  if (!output) throw new Error("Skill view presenter returned an invalid result");
+  return output;
 }
 
 function scanSkills(root: string, source: ManagerSkillSummary["source"]): ManagerSkillDetail[] {

--- a/homerail_manager/src/server/settings-bootstrap.ts
+++ b/homerail_manager/src/server/settings-bootstrap.ts
@@ -7,10 +7,15 @@ import { listPersistedRunIds, loadRunMetadata } from "../persistence/store.js";
 import { repoRoot, resolveAssetDirectory, resolveAssetRoot } from "../assets/root.js";
 import {
   ensureManagerSkillsInstalled,
+  executeManagerSkillViewPresenter,
   listManagerSkills,
   readManagerSkill,
+  readManagerSkillViewTemplates,
 } from "./manager-skills.js";
-import { isCanonicalHomerailPluginSemver } from "homerail-protocol";
+import {
+  isCanonicalHomerailPluginSemver,
+  materializeManagerAgentSkillViewTemplateInput,
+} from "homerail-protocol";
 
 interface BaseResponse {
   success: boolean;
@@ -554,6 +559,81 @@ export function settingsBootstrapHandler(
     } else {
       _ok(res, "Skill retrieved", skill);
     }
+    return true;
+  }
+
+  const skillViewMaterializeMatch = pathname.match(/^\/api\/skills\/([^/]+)\/views\/([^/]+)\/materialize$/);
+  if (skillViewMaterializeMatch && req.method === "POST") {
+    let skillId = "";
+    let templateId = "";
+    try {
+      skillId = decodeURIComponent(skillViewMaterializeMatch[1]);
+      templateId = decodeURIComponent(skillViewMaterializeMatch[2]);
+    } catch {
+      json(res, 400, { success: false, message: "Invalid Skill view identity", error: "Invalid Skill view identity" });
+      return true;
+    }
+    const template = readManagerSkillViewTemplates(skillId).find((candidate) => candidate.id === templateId);
+    if (!template) {
+      json(res, 404, { success: false, message: "Skill view template not found", error: "Skill view template not found" });
+      return true;
+    }
+    readJsonBody(req)
+      .then((body) => {
+        const input = materializeManagerAgentSkillViewTemplateInput(skillId, template, body);
+        _ok(res, "Skill view materialized", { input });
+      })
+      .catch((err) => json(res, 400, {
+        success: false,
+        message: err instanceof Error ? err.message : "Invalid Skill view input",
+        error: err instanceof Error ? err.message : "Invalid Skill view input",
+      }));
+    return true;
+  }
+
+  const skillViewPresentMatch = pathname.match(/^\/api\/skills\/([^/]+)\/views\/present$/);
+  if (skillViewPresentMatch && req.method === "POST") {
+    let skillId = "";
+    try {
+      skillId = decodeURIComponent(skillViewPresentMatch[1]);
+    } catch {
+      json(res, 400, { success: false, message: "Invalid Skill view identity", error: "Invalid Skill view identity" });
+      return true;
+    }
+    readJsonBody(req)
+      .then(async (body) => {
+        const presented = await executeManagerSkillViewPresenter(skillId, body.argv);
+        const templateId = typeof presented.template === "string" ? presented.template.trim() : "";
+        const id = typeof presented.id === "string" ? presented.id.trim() : "";
+        const data = presented.data && typeof presented.data === "object" && !Array.isArray(presented.data)
+          ? presented.data as Record<string, unknown>
+          : undefined;
+        const responseText = presented.response_text === undefined
+          ? ""
+          : typeof presented.response_text === "string"
+            ? presented.response_text.trim()
+            : "";
+        if (!templateId || !id || !data || responseText.length > 2_000) {
+          throw new Error("Skill view presenter returned an invalid visual contract");
+        }
+        const template = readManagerSkillViewTemplates(skillId).find((candidate) => candidate.id === templateId);
+        if (!template) throw new Error("Skill view presenter returned an unknown template");
+        const input = materializeManagerAgentSkillViewTemplateInput(skillId, template, {
+          id,
+          data,
+          ...(presented.canvas_size === undefined ? {} : { canvas_size: presented.canvas_size }),
+        });
+        _ok(res, "Skill view presented", {
+          input,
+          template_id: templateId,
+          ...(responseText ? { response_text: responseText } : {}),
+        });
+      })
+      .catch((err) => json(res, 400, {
+        success: false,
+        message: err instanceof Error ? err.message : "Invalid Skill view presenter request",
+        error: err instanceof Error ? err.message : "Invalid Skill view presenter request",
+      }));
     return true;
   }
 

--- a/homerail_manager/tests/manager-agent-capability-routing.test.ts
+++ b/homerail_manager/tests/manager-agent-capability-routing.test.ts
@@ -256,7 +256,7 @@ describe("Manager Agent per-turn capability routing", () => {
     });
     expect(captured.host[0].outcome_contracts).toEqual([{
       capability: "canvas.view.committed",
-      tool_names: ["upsert_generated_view"],
+      tool_names: ["upsert_generated_view", "skill_view_present", "skill_view_render"],
     }]);
     expect(turn.result.objective).toMatchObject({
       required_outcomes: ["canvas.view.committed"],

--- a/homerail_manager/tests/manager-agent-outcomes.test.ts
+++ b/homerail_manager/tests/manager-agent-outcomes.test.ts
@@ -68,6 +68,8 @@ describe("Manager Agent stable outcomes", () => {
     });
     expect(contracts).toHaveLength(1);
     expect(contracts[0].tool_names).toContain("upsert_generated_view");
+    expect(contracts[0].tool_names).toContain("skill_view_render");
+    expect(contracts[0].tool_names).toContain("skill_view_present");
     expect(contracts[0].tool_names.some((name) => name.startsWith("skill_view_route-skill_route_"))).toBe(true);
     expect(() => assertManagerAgentOutcomeContractsResolvable(contracts)).not.toThrow();
   });

--- a/homerail_manager/tests/manager-agent-tool-parity.test.ts
+++ b/homerail_manager/tests/manager-agent-tool-parity.test.ts
@@ -231,13 +231,103 @@ describe("Manager Agent deterministic result envelope parity", () => {
       undefined,
       managerSkills,
     );
-    const hostSkillTools = hostTools.filter((tool) => tool.name.startsWith("skill_view_"));
-    const workerSkillTools = workerTools.filter((tool) => tool.name.startsWith("skill_view_"));
+    const hostSkillTools = hostTools.filter(
+      (tool) => tool.name.startsWith("skill_view_")
+        && tool.name !== "skill_view_render"
+        && tool.name !== "skill_view_present",
+    );
+    const workerSkillTools = workerTools.filter(
+      (tool) => tool.name.startsWith("skill_view_")
+        && tool.name !== "skill_view_render"
+        && tool.name !== "skill_view_present",
+    );
     expect(catalogProjection(hostSkillTools)).toEqual(catalogProjection(workerSkillTools));
     expect(hostSkillTools).toHaveLength(1);
 
     const input = { id: "profile-one", data: { title: "Profile", value: 4 } };
     expect(await hostSkillTools[0].handler(input)).toEqual(await workerSkillTools[0].handler(input));
+  });
+
+  it("materializes and executes a native Skill template identically in both harnesses", async () => {
+    const context = assemblePluginTurnContext(undefined, { modality: "voice" });
+    const { hostState, hostTools, workerTools } = createHarnessTools("voice", context);
+    hostState.restUrl = "https://manager.test/api";
+    vi.stubEnv("MANAGER_REST_URL", "https://manager.test/api");
+    const observed: Array<{ pathname: string; body: Record<string, unknown> }> = [];
+    const materialized = {
+      id: "route-one",
+      title: "Verified route",
+      surface: "result",
+      importance: "primary",
+      density: "summary",
+      canvas_size: "1x2",
+      persistence: "session",
+      content: { data: { title: "Verified route", steps: ["start", "finish"] } },
+      a2ui: {
+        version: "v1.0",
+        catalogId: "https://homerail.dev/a2ui/catalogs/core/v1",
+        components: [{ id: "root", component: "Text", text: { path: "/data/title" } }],
+      },
+    };
+    vi.stubGlobal("fetch", async (request: string | URL | Request, init?: RequestInit) => {
+      const rawUrl = typeof request === "string"
+        ? request
+        : request instanceof URL
+          ? request.toString()
+          : request.url;
+      observed.push({
+        pathname: new URL(rawUrl).pathname,
+        body: typeof init?.body === "string" ? JSON.parse(init.body) as Record<string, unknown> : {},
+      });
+      return new Response(JSON.stringify({
+        success: true,
+        data: { input: materialized, response_text: "Route ready." },
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const input = {
+      skill_id: "route skill /?#",
+      template_id: "route /?#",
+      id: "route-one",
+      data: { title: "Verified route", steps: ["start", "finish"] },
+      canvas_size: "1x2",
+    };
+    const hostResult = await requireTool(hostTools, "skill_view_render").handler(input);
+    const workerResult = await requireTool(workerTools, "skill_view_render").handler(input);
+    expect(hostResult).toEqual(workerResult);
+    const presenterInput = {
+      skill_id: "route skill /?#",
+      argv: ["present", "route", "start", "finish"],
+    };
+    const hostPresented = await requireTool(hostTools, "skill_view_present").handler(presenterInput);
+    const workerPresented = await requireTool(workerTools, "skill_view_present").handler(presenterInput);
+    expect(hostPresented).toEqual(workerPresented);
+    expect(JSON.parse(hostPresented.content[0]?.text || "{}") as Record<string, unknown>).toMatchObject({
+      status: "projected",
+      committed: false,
+      response_text: "Route ready.",
+    });
+    expect(observed).toEqual([
+      {
+        pathname: "/api/skills/route%20skill%20%2F%3F%23/views/route%20%2F%3F%23/materialize",
+        body: { id: "route-one", data: input.data, canvas_size: "1x2" },
+      },
+      {
+        pathname: "/api/skills/route%20skill%20%2F%3F%23/views/route%20%2F%3F%23/materialize",
+        body: { id: "route-one", data: input.data, canvas_size: "1x2" },
+      },
+      {
+        pathname: "/api/skills/route%20skill%20%2F%3F%23/views/present",
+        body: { argv: presenterInput.argv },
+      },
+      {
+        pathname: "/api/skills/route%20skill%20%2F%3F%23/views/present",
+        body: { argv: presenterInput.argv },
+      },
+    ]);
   });
 
   it("rejects raw generated-view submissions already owned by a loaded Skill template", async () => {

--- a/homerail_manager/tests/manager-agent-turn-envelope.test.ts
+++ b/homerail_manager/tests/manager-agent-turn-envelope.test.ts
@@ -106,6 +106,21 @@ describe("Manager Agent signed turn envelope", () => {
       method: "GET",
       pathname: "/api/runs/run-one/supervision",
     })).toBe(false);
+    expect(authority.authorizeApiRequest({
+      credential,
+      method: "POST",
+      pathname: "/api/skills/palquery/views/breed-route/materialize",
+    })).toBe(true);
+    expect(authority.authorizeApiRequest({
+      credential,
+      method: "POST",
+      pathname: "/api/skills/palquery/views/present",
+    })).toBe(true);
+    expect(authority.authorizeApiRequest({
+      credential,
+      method: "GET",
+      pathname: "/api/skills/palquery/views/breed-route/materialize",
+    })).toBe(false);
     for (const [method, pathname] of [
       ["POST", "/api/runs/run-one/actors/goal-scout/interventions"],
       ["POST", "/api/runs/run-one/cancel"],

--- a/homerail_manager/tests/manager-skills.test.ts
+++ b/homerail_manager/tests/manager-skills.test.ts
@@ -8,6 +8,7 @@ import {
   getManagerSkillsRoot,
   listManagerSkills,
   readManagerSkill,
+  readManagerSkillViewPresenter,
   readManagerSkillViewTemplates,
 } from "../src/server/manager-skills.js";
 
@@ -33,6 +34,11 @@ function writeA2uiTemplateManifest(root: string, id: string, overrides: Record<s
   const file = path.join(dir, "view-templates.json");
   fs.writeFileSync(file, JSON.stringify({
     manifest_version: 1,
+    presenter: {
+      command: "node",
+      args: ["presenter.js"],
+      timeout_ms: 5000,
+    },
     templates: [{
       id: "profile",
       description: "Compact entity profile.",
@@ -142,6 +148,12 @@ describe("Manager Agent skill discovery", () => {
     });
     expect(templates[0]).not.toHaveProperty("view");
     expect(templates[0]).not.toHaveProperty("allowed_canvas_sizes");
+    expect(readManagerSkillViewPresenter("visual-skill")).toMatchObject({
+      skill_root: fs.realpathSync(path.join(tmpHome, "skills", "visual-skill")),
+      command: "node",
+      args: ["presenter.js"],
+      timeout_ms: 5000,
+    });
 
     writeA2uiTemplateManifest(tmpHome, "visual-skill", { id: "../escape" });
     expect(readManagerSkillViewTemplates("visual-skill")).toEqual([]);
@@ -156,5 +168,6 @@ describe("Manager Agent skill discovery", () => {
     fs.symlinkSync(outside, file);
 
     expect(readManagerSkillViewTemplates("linked-view")).toEqual([]);
+    expect(readManagerSkillViewPresenter("linked-view")).toBeUndefined();
   });
 });

--- a/homerail_manager/tests/settings-bootstrap.test.ts
+++ b/homerail_manager/tests/settings-bootstrap.test.ts
@@ -114,6 +114,154 @@ describe("settings bootstrap routes", () => {
     expect(traversal.status).toBe(404);
   });
 
+  it("materializes only validated local Skill view templates from semantic data", async () => {
+    const skillDir = path.join(tmpHome, "skills", "route-skill");
+    const viewDir = path.join(skillDir, "assets", "homerail");
+    fs.mkdirSync(viewDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, "SKILL.md"), [
+      "---",
+      "name: route-skill",
+      "description: Render verified routes",
+      "---",
+      "",
+      "# Route skill",
+    ].join("\n"));
+    fs.writeFileSync(path.join(viewDir, "view-templates.json"), JSON.stringify({
+      manifest_version: 1,
+      presenter: {
+        command: "node",
+        args: ["presenter.js"],
+        timeout_ms: 5000,
+      },
+      templates: [{
+        id: "route",
+        description: "Show one verified route.",
+        data_schema: {
+          type: "object",
+          properties: {
+            title: { type: "string", minLength: 1, maxLength: 200 },
+            steps: { type: "array", maxItems: 12, items: { type: "string", maxLength: 200 } },
+          },
+          required: ["title", "steps"],
+          additionalProperties: false,
+        },
+        a2ui: {
+          version: "v1.0",
+          catalogId: "https://homerail.dev/a2ui/catalogs/core/v1",
+          components: [
+            { id: "root", component: "Column", children: ["title"] },
+            { id: "title", component: "Text", text: { path: "/data/title" } },
+          ],
+        },
+        defaults: {
+          surface: "result",
+          importance: "primary",
+          density: "summary",
+          canvas_size: "1x2",
+          persistence: "session",
+        },
+        allowed_canvas_sizes: ["1x2", "2x2"],
+      }],
+    }));
+    fs.writeFileSync(path.join(skillDir, "presenter.js"), [
+      "const [start, finish] = process.argv.slice(2);",
+      "process.stdout.write(JSON.stringify({",
+      "  template: 'route',",
+      "  id: `route-${start}-${finish}`,",
+      "  canvas_size: '1x2',",
+      "  data: { title: `${start} to ${finish}`, steps: [start, finish] },",
+      "  response_text: `${start} reaches ${finish}.`,",
+      "}));",
+    ].join("\n"));
+
+    const port = await listen(server);
+    const response = await fetch(
+      `http://127.0.0.1:${port}/api/skills/route-skill/views/route/materialize`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id: "route-result",
+          canvas_size: "2x2",
+          data: { title: "Verified route", steps: ["start", "finish"] },
+        }),
+      },
+    );
+    const body = await response.json() as {
+      success: boolean;
+      data: { input: Record<string, unknown> };
+    };
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data.input).toMatchObject({
+      id: "route-result",
+      title: "Verified route",
+      canvas_size: "2x2",
+      content: { data: { title: "Verified route", steps: ["start", "finish"] } },
+    });
+    expect((body.data.input.a2ui as Record<string, unknown>).components).toEqual([
+      { id: "root", component: "Column", children: ["title"] },
+      { id: "title", component: "Text", text: { path: "/data/title" } },
+    ]);
+
+    const presentedResponse = await fetch(
+      `http://127.0.0.1:${port}/api/skills/route-skill/views/present`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ argv: ["start", "finish"] }),
+      },
+    );
+    const presented = await presentedResponse.json() as {
+      success: boolean;
+      data: { input: Record<string, unknown>; template_id: string; response_text: string };
+    };
+    expect(presentedResponse.status).toBe(200);
+    expect(presented.success).toBe(true);
+    expect(presented.data).toMatchObject({
+      template_id: "route",
+      response_text: "start reaches finish.",
+      input: {
+        id: "route-start-finish",
+        title: "start to finish",
+        canvas_size: "1x2",
+        content: { data: { title: "start to finish", steps: ["start", "finish"] } },
+      },
+    });
+
+    const invalidArgv = await fetch(
+      `http://127.0.0.1:${port}/api/skills/route-skill/views/present`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ argv: ["start\nunsafe", "finish"] }),
+      },
+    );
+    expect(invalidArgv.status).toBe(400);
+
+    const invalid = await fetch(
+      `http://127.0.0.1:${port}/api/skills/route-skill/views/route/materialize`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id: "route-result", data: { title: "Missing steps" } }),
+      },
+    );
+    expect(invalid.status).toBe(400);
+
+    const missing = await fetch(
+      `http://127.0.0.1:${port}/api/skills/route-skill/views/missing/materialize`,
+      { method: "POST", body: "{}" },
+    );
+    expect(missing.status).toBe(404);
+
+    const traversal = await fetch(
+      `http://127.0.0.1:${port}/api/skills/%2E%2E%2Fsecrets/views/route/materialize`,
+      { method: "POST", body: "{}" },
+    );
+    expect(traversal.status).toBe(404);
+  });
+
   it("returns asset diagnostics with concrete checks", async () => {
     const port = await listen(server);
     const response = await fetch(`http://127.0.0.1:${port}/api/assets/diagnostics`);

--- a/homerail_protocol/src/manager-agent-prompt.ts
+++ b/homerail_protocol/src/manager-agent-prompt.ts
@@ -137,7 +137,7 @@ export function buildManagerAgentSystemPrompt(input: ManagerAgentPromptInput = {
       if (skill.view_templates?.length) {
         lines.push(
           "",
-          "Validated Skill visual templates are available as skill_view_* Tools. When one matches the requested result, you must call that template Tool and must not recreate its layout with the raw generated-view Tool:",
+          "Validated Skill visual templates are available through skill_view_present, skill_view_render, and selected skill_view_* Tools. When one matches the requested result, call the trusted Skill Tool and do not recreate its layout with the raw generated-view Tool:",
           ...skill.view_templates.map((template) => `- ${template.id}: ${template.description}`),
         );
       }
@@ -165,8 +165,9 @@ export function buildManagerAgentSystemPrompt(input: ManagerAgentPromptInput = {
       "Do not use Markdown headings, bullet lists, tables, or long capability inventories in the final spoken text.",
       "When saying a path, model name, command, or identifier in voice mode, use plain text without backticks or Markdown formatting.",
       "For capability questions, answer with two or three broad examples, then ask what the user wants to do next.",
-      "Use tools only when the user asks to inspect, start, supervise, or change real state; do not create status widgets or runs for simple chat.",
+      "Do not create runs or status widgets for casual small talk or capability questions. When a task needs external facts, a domain Skill, or a visual result, use the relevant tools instead of answering from memory.",
       "When the answer needs lists, evidence, task details, long status, artifacts, or execution state, use the appropriate currently available Core or plugin Tool and keep finish text as a short pointer.",
+      "When a loaded Skill provides a present command, prefer one skill_view_present call over native shell so HomeRail can execute, validate, and publish the result atomically. If presenter data was already obtained elsewhere, its template, id, and unchanged data remain an unfinished visual contract: call skill_view_render before finishing; do not replace either path with Markdown or copied A2UI.",
       "Use tool-created widgets for generated UI. Do not create a Manager Agent status card for ordinary small talk or capability questions.",
       "Do not put raw reasoning, command output, JSON, paths, or logs in commentary or final spoken text.",
     );

--- a/homerail_protocol/src/manager-agent-skill-views.ts
+++ b/homerail_protocol/src/manager-agent-skill-views.ts
@@ -8,6 +8,7 @@ import {
   type HomerailA2uiSurfaceV1,
 } from "./generative-ui/index.js";
 import { validateHomerailPluginToolInput } from "./plugins/projection.js";
+import type { AgentToolDefinition } from "./types.js";
 
 export type ManagerAgentSkillViewSurfaceV1 = "task" | "execution" | "result" | "ambient";
 export type ManagerAgentSkillViewImportanceV1 = "critical" | "primary" | "secondary" | "ambient";
@@ -45,6 +46,95 @@ export interface ManagerAgentSkillWithViewsV1 {
   id: string;
   content?: string;
   view_templates?: ManagerAgentSkillViewTemplateV1[];
+}
+
+export const MANAGER_AGENT_SKILL_VIEW_RENDER_TOOL_NAME = "skill_view_render";
+export const MANAGER_AGENT_SKILL_VIEW_PRESENT_TOOL_NAME = "skill_view_present";
+
+export function managerAgentSkillViewPresentToolDefinition(): AgentToolDefinition {
+  return {
+    name: MANAGER_AGENT_SKILL_VIEW_PRESENT_TOOL_NAME,
+    description: [
+      "Run the trusted visual presenter shipped by an enabled local HomeRail Skill and publish its validated template in one call.",
+      "Use this instead of a native shell when the Skill gives a present command; pass only the argv tokens after the Skill's trusted base command.",
+      "Example: a Skill instruction 'present route A B --limit 4' becomes {skill_id:'catalog', argv:['present','route','A','B','--limit','4']}.",
+      "HomeRail executes without a shell, validates the returned template, id, canvas_size, and data, then commits the visual result.",
+      "After success, use the returned response_text as the short final answer; do not call skill_view_render again.",
+    ].join(" "),
+    input_schema: {
+      type: "object",
+      properties: {
+        skill_id: {
+          type: "string",
+          minLength: 1,
+          maxLength: 200,
+          description: "Enabled local Skill id that owns the trusted presenter and view templates.",
+        },
+        argv: {
+          type: "array",
+          minItems: 1,
+          maxItems: 32,
+          items: {
+            type: "string",
+            minLength: 1,
+            maxLength: 512,
+          },
+          description: "Presenter arguments exactly as specified by the loaded Skill, excluding its trusted base command.",
+        },
+      },
+      required: ["skill_id", "argv"],
+      additionalProperties: false,
+    },
+  };
+}
+
+export function managerAgentSkillViewRenderToolDefinition(): AgentToolDefinition {
+  return {
+    name: MANAGER_AGENT_SKILL_VIEW_RENDER_TOOL_NAME,
+    description: [
+      "Render or update a validated visual template owned by an enabled local HomeRail Skill.",
+      "Use the skill_id and template_id returned by the natively loaded Skill or its presenter,",
+      "and pass the presenter's semantic data unchanged. HomeRail owns and validates the A2UI layout.",
+      "A presenter result with template, id, and data is incomplete until this Tool succeeds.",
+      "Example: presenter {template:'route', id:'route-1', canvas_size:'1x2', data:X} from Skill 'catalog' becomes {skill_id:'catalog', template_id:'route', id:'route-1', canvas_size:'1x2', data:X}.",
+      "Do not answer it as Markdown or copy A2UI into the raw generated-view Tool.",
+    ].join(" "),
+    input_schema: {
+      type: "object",
+      properties: {
+        skill_id: {
+          type: "string",
+          minLength: 1,
+          maxLength: 200,
+          description: "Enabled local Skill id, for example the id shown in the HomeRail Skill catalog.",
+        },
+        template_id: {
+          type: "string",
+          pattern: "^[a-z0-9][a-z0-9_-]{0,63}$",
+          description: "Stable template id returned by the Skill presenter.",
+        },
+        id: {
+          type: "string",
+          minLength: 1,
+          maxLength: 200,
+          description: "Stable Block id. Reuse it for follow-up updates.",
+        },
+        data: {
+          type: "object",
+          maxProperties: 128,
+          additionalProperties: true,
+          description: "Semantic presenter data. Do not add, remove, recompute, or rearrange its fields.",
+        },
+        canvas_size: {
+          type: "string",
+          enum: ["1x1", "1x2", "2x2", "3x3"],
+          description: "Optional footprint override allowed by the selected template.",
+        },
+      },
+      required: ["skill_id", "template_id", "id", "data"],
+      additionalProperties: false,
+    },
+  };
 }
 
 function toolSlug(value: string, maxLength: number): string {
@@ -106,6 +196,25 @@ function templateToolInputSchema(template: ManagerAgentSkillViewTemplateV1): Rec
   };
 }
 
+function skillViewToolDefinition(
+  skillId: string,
+  template: ManagerAgentSkillViewTemplateV1,
+): ManagerAgentSkillViewToolDefinitionV1 {
+  return {
+    name: managerAgentSkillViewToolName(skillId, template.id),
+    description: [
+      `Render or update the selected ${skillId} result with its validated '${template.id}' visual template.`,
+      template.description,
+      "Provide semantic data only; HomeRail owns the layout. data.title is used as the Block title.",
+      "HomeRail A2UI formatString accepts only ${/absolute/pointer} and template-relative ${pointer} interpolation; escape a literal opener as \\${. Nested functions and other expressions are rejected.",
+      "Reuse the current selected Block id for follow-up updates. When this schema matches, use this Tool; the raw generated-view Tool rejects matching data so HomeRail can preserve this layout.",
+    ].join(" "),
+    input_schema: templateToolInputSchema(template),
+    skill_id: skillId,
+    template,
+  };
+}
+
 export function managerAgentSkillViewToolDefinitions(
   skills: readonly ManagerAgentSkillWithViewsV1[],
 ): ManagerAgentSkillViewToolDefinitionV1[] {
@@ -114,22 +223,11 @@ export function managerAgentSkillViewToolDefinitions(
   for (const skill of skills) {
     if (!skill.content?.trim()) continue;
     for (const template of skill.view_templates ?? []) {
-      const name = managerAgentSkillViewToolName(skill.id, template.id);
+      const definition = skillViewToolDefinition(skill.id, template);
+      const name = definition.name;
       if (names.has(name)) throw new Error(`Skill view Tool name collision: ${name}`);
       names.add(name);
-      definitions.push({
-        name,
-        description: [
-          `Render or update the selected ${skill.id} result with its validated '${template.id}' visual template.`,
-          template.description,
-          "Provide semantic data only; HomeRail owns the layout. data.title is used as the Block title.",
-          "HomeRail A2UI formatString accepts only ${/absolute/pointer} and template-relative ${pointer} interpolation; escape a literal opener as \\${. Nested functions and other expressions are rejected.",
-          "Reuse the current selected Block id for follow-up updates. When this schema matches, use this Tool; the raw generated-view Tool rejects matching data so HomeRail can preserve this layout.",
-        ].join(" "),
-        input_schema: templateToolInputSchema(template),
-        skill_id: skill.id,
-        template,
-      });
+      definitions.push(definition);
     }
   }
   return definitions;
@@ -139,6 +237,51 @@ function record(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === "object" && !Array.isArray(value)
     ? value as Record<string, unknown>
     : undefined;
+}
+
+export function compactManagerAgentSkillViewPresentResult(
+  pluginResult: Record<string, unknown>,
+  responseText = "",
+): Record<string, unknown> {
+  const normalizedResponse = responseText.trim();
+  const projected = record(pluginResult.projection);
+  const projectedNode = record(projected?.node);
+  if (
+    pluginResult.execution_version === 1
+    && pluginResult.status === "projected"
+    && pluginResult.committed === false
+    && typeof projectedNode?.id === "string"
+  ) {
+    return {
+      execution_version: 1,
+      status: "projected",
+      committed: false,
+      node_id: projectedNode.id,
+      ...(normalizedResponse ? { response_text: normalizedResponse } : {}),
+    };
+  }
+  const data = record(pluginResult.data) ?? pluginResult;
+  const result = record(data.result);
+  const revision = Number(result?.document_revision);
+  if (
+    data.status !== "committed"
+    || result?.output_type !== "ui_transaction"
+    || typeof result.document_id !== "string"
+    || !Number.isSafeInteger(revision)
+    || revision < 1
+  ) throw new Error("Generated view Tool returned an invalid committed result");
+  return {
+    success: pluginResult.success !== false,
+    data: {
+      status: "committed",
+      result: {
+        output_type: "ui_transaction",
+        document_id: result.document_id,
+        document_revision: revision,
+      },
+      ...(normalizedResponse ? { response_text: normalizedResponse } : {}),
+    },
+  };
 }
 
 /**
@@ -199,4 +342,15 @@ export function materializeManagerAgentSkillViewInput(
     content,
     a2ui: structuredClone(a2uiValidation.value),
   };
+}
+
+export function materializeManagerAgentSkillViewTemplateInput(
+  skillId: string,
+  template: ManagerAgentSkillViewTemplateV1,
+  input: Record<string, unknown>,
+): Record<string, unknown> {
+  return materializeManagerAgentSkillViewInput(
+    skillViewToolDefinition(skillId, template),
+    input,
+  );
 }

--- a/homerail_protocol/src/manager-agent-tools.ts
+++ b/homerail_protocol/src/manager-agent-tools.ts
@@ -5,6 +5,10 @@
 
 import type { AgentToolDefinition } from "./types.js";
 import type { HomerailPluginToolDescriptorV1 } from "./plugins/types.js";
+import {
+  MANAGER_AGENT_SKILL_VIEW_PRESENT_TOOL_NAME,
+  MANAGER_AGENT_SKILL_VIEW_RENDER_TOOL_NAME,
+} from "./manager-agent-skill-views.js";
 
 export const MANAGER_AGENT_WIDGET_FILE_TYPES = [
   "memo",
@@ -320,6 +324,8 @@ export function managerAgentOutcomeObjectivePrompt(value: unknown): string {
 const MANAGER_AGENT_RESERVED_TOOL_NAMES = new Set<string>([
   ...MANAGER_AGENT_COMMON_TOOL_NAMES,
   ...MANAGER_AGENT_COMMON_VOICE_TOOL_NAMES,
+  MANAGER_AGENT_SKILL_VIEW_PRESENT_TOOL_NAME,
+  MANAGER_AGENT_SKILL_VIEW_RENDER_TOOL_NAME,
   "remove_generated_view",
   "update_selected_generated_view",
 ]);

--- a/homerail_protocol/tests/manager-agent-skill-views.test.ts
+++ b/homerail_protocol/tests/manager-agent-skill-views.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  MANAGER_AGENT_SKILL_VIEW_PRESENT_TOOL_NAME,
+  MANAGER_AGENT_SKILL_VIEW_RENDER_TOOL_NAME,
+  compactManagerAgentSkillViewPresentResult,
+  managerAgentSkillViewPresentToolDefinition,
+  managerAgentSkillViewRenderToolDefinition,
   matchingManagerAgentSkillViewToolDefinition,
   managerAgentSkillViewToolDefinitions,
   managerAgentSkillViewToolName,
   materializeManagerAgentSkillViewInput,
+  materializeManagerAgentSkillViewTemplateInput,
   type ManagerAgentSkillViewTemplateV1,
 } from "../src/manager-agent-skill-views.js";
 
@@ -41,6 +47,83 @@ const template: ManagerAgentSkillViewTemplateV1 = {
 };
 
 describe("Manager Agent Skill view templates", () => {
+  it("exposes one compact trusted presenter Tool", () => {
+    const definition = managerAgentSkillViewPresentToolDefinition();
+    expect(definition.name).toBe(MANAGER_AGENT_SKILL_VIEW_PRESENT_TOOL_NAME);
+    expect(definition.input_schema).toMatchObject({
+      type: "object",
+      required: ["skill_id", "argv"],
+      additionalProperties: false,
+      properties: {
+        skill_id: { type: "string" },
+        argv: { type: "array", minItems: 1, maxItems: 32 },
+      },
+    });
+    expect(definition.description).toContain("without a shell");
+    expect(definition.description).toContain("do not call skill_view_render again");
+  });
+
+  it("keeps presenter Tool results compact while preserving committed evidence", () => {
+    expect(compactManagerAgentSkillViewPresentResult({
+      success: true,
+      data: {
+        status: "committed",
+        result: {
+          output_type: "ui_transaction",
+          document_id: "voice-document",
+          document_revision: 3,
+          projection: { large: "omitted" },
+        },
+      },
+    }, "Route ready.")).toEqual({
+      success: true,
+      data: {
+        status: "committed",
+        result: {
+          output_type: "ui_transaction",
+          document_id: "voice-document",
+          document_revision: 3,
+        },
+        response_text: "Route ready.",
+      },
+    });
+    expect(() => compactManagerAgentSkillViewPresentResult({
+      success: true,
+      data: { status: "projected", result: {} },
+    })).toThrow(/invalid committed result/);
+    expect(compactManagerAgentSkillViewPresentResult({
+      execution_version: 1,
+      status: "projected",
+      committed: false,
+      projection: { node: { id: "com.example:route" } },
+    }, "Route ready.")).toEqual({
+      execution_version: 1,
+      status: "projected",
+      committed: false,
+      node_id: "com.example:route",
+      response_text: "Route ready.",
+    });
+  });
+
+  it("exposes one compact generic renderer independent of installed Skill schemas", () => {
+    const definition = managerAgentSkillViewRenderToolDefinition();
+    expect(definition.name).toBe(MANAGER_AGENT_SKILL_VIEW_RENDER_TOOL_NAME);
+    expect(definition.input_schema).toMatchObject({
+      type: "object",
+      required: ["skill_id", "template_id", "id", "data"],
+      additionalProperties: false,
+      properties: {
+        skill_id: { type: "string" },
+        template_id: { type: "string" },
+        id: { type: "string" },
+        data: { type: "object" },
+      },
+    });
+    expect(JSON.stringify(definition)).not.toContain("components");
+    expect(definition.description).toContain("presenter {template:'route'");
+    expect(definition.description).toContain("skill_id:'catalog'");
+  });
+
   it("builds stable bounded Tool names and only exposes loaded Skill templates", () => {
     const name = managerAgentSkillViewToolName("palquery", "profile");
     expect(name).toMatch(/^skill_view_[a-z0-9_-]+$/);
@@ -77,6 +160,23 @@ describe("Manager Agent Skill view templates", () => {
       content: { data: { title: "Anubis", summary: "Strong worker", value: 4 } },
       a2ui: template.a2ui,
     });
+
+    expect(materializeManagerAgentSkillViewTemplateInput("palquery", template, {
+      id: "pal-profile-anubis",
+      canvas_size: "1x2",
+      data: { title: "Anubis", summary: "Strong worker", value: 4 },
+    })).toEqual({
+      id: "pal-profile-anubis",
+      title: "Anubis",
+      summary: "Strong worker",
+      surface: "result",
+      importance: "primary",
+      density: "summary",
+      canvas_size: "1x2",
+      persistence: "session",
+      content: { data: { title: "Anubis", summary: "Strong worker", value: 4 } },
+      a2ui: template.a2ui,
+    });
   });
 
   it("rejects missing required data and unsupported canvas sizes", () => {
@@ -91,6 +191,10 @@ describe("Manager Agent Skill view templates", () => {
       id: "pal-profile-anubis",
       canvas_size: "3x3",
       data: { title: "Anubis", value: 4 },
+    })).toThrow(/invalid/i);
+    expect(() => materializeManagerAgentSkillViewTemplateInput("palquery", template, {
+      id: "pal-profile-anubis",
+      data: { title: "Anubis", value: 4, invented: true },
     })).toThrow(/invalid/i);
   });
 

--- a/homerail_protocol/tests/manager-agent.test.ts
+++ b/homerail_protocol/tests/manager-agent.test.ts
@@ -863,8 +863,14 @@ describe("Manager Agent harness contract", () => {
       }],
     });
 
-    expect(prompt).toContain("Validated Skill visual templates are available as skill_view_* Tools");
+    expect(prompt).toContain("Validated Skill visual templates are available through skill_view_present");
     expect(prompt).toContain("pal-profile: Compact profile with a real icon.");
+    expect(prompt).toContain("an unfinished visual contract");
+    expect(prompt).toContain("call skill_view_render");
+    expect(prompt).toContain("prefer one skill_view_present call over native shell");
+    expect(prompt).toContain("unchanged data");
+    expect(prompt).toContain("external facts, a domain Skill, or a visual result");
+    expect(prompt).not.toContain("Use tools only when the user asks to inspect");
   });
 
   it("describes non-Codex manager agents as host processes", () => {

--- a/homerail_worker/src/manager-agent/server.ts
+++ b/homerail_worker/src/manager-agent/server.ts
@@ -19,6 +19,7 @@ import type {
 import {
   buildManagerAgentSystemPrompt,
   canonicalManagerAgentToolCallName,
+  compactManagerAgentSkillViewPresentResult,
   createManagerAgentWidgetFileTools,
   DEFAULT_PR_REVIEW_EXPECTED_USAGE,
   DEFAULT_MANAGER_AGENT_RUNTIME_AGENT_TYPE,
@@ -32,6 +33,8 @@ import {
   managerAgentPluginToolCallName,
   managerAgentOutcomeObjectivePrompt,
   managerAgentRequiredToolObjectivePrompt,
+  managerAgentSkillViewPresentToolDefinition,
+  managerAgentSkillViewRenderToolDefinition,
   managerAgentSkillViewToolDefinitions,
   matchingManagerAgentSkillViewToolDefinition,
   materializeManagerAgentSkillViewInput,
@@ -1547,6 +1550,64 @@ export function createManagerTools(state: {
     );
   };
   if (generatedViewDescriptor) {
+    tools.push({
+      ...managerAgentSkillViewPresentToolDefinition(),
+      async handler(args, context) {
+        const skillId = String(args.skill_id || "").trim();
+        if (!skillId) throw new Error("skill_view_present requires skill_id");
+        const body = await requestManager(
+          `/skills/${encodeURIComponent(skillId)}/views/present`,
+          {
+            method: "POST",
+            body: JSON.stringify({ argv: args.argv }),
+          },
+        );
+        const data = managerData(body);
+        const input = data.input;
+        if (!input || typeof input !== "object" || Array.isArray(input)) {
+          throw new Error("Manager returned an invalid presented Skill view");
+        }
+        const result = await invokePluginTool(generatedViewDescriptor, input as Record<string, unknown>, context);
+        const responseText = typeof data.response_text === "string" ? data.response_text.trim() : "";
+        const rawResult = result.content.map((item) => item.text).join("");
+        let resultBody: Record<string, unknown>;
+        try {
+          const parsed = JSON.parse(rawResult) as unknown;
+          if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error("invalid");
+          resultBody = parsed as Record<string, unknown>;
+        } catch {
+          throw new Error("Generated view Tool returned an invalid result");
+        }
+        return { content: [{
+          type: "text" as const,
+          text: JSON.stringify(compactManagerAgentSkillViewPresentResult(resultBody, responseText)),
+        }] };
+      },
+    });
+    tools.push({
+      ...managerAgentSkillViewRenderToolDefinition(),
+      async handler(args, context) {
+        const skillId = String(args.skill_id || "").trim();
+        const templateId = String(args.template_id || "").trim();
+        if (!skillId || !templateId) throw new Error("skill_view_render requires skill_id and template_id");
+        const body = await requestManager(
+          `/skills/${encodeURIComponent(skillId)}/views/${encodeURIComponent(templateId)}/materialize`,
+          {
+            method: "POST",
+            body: JSON.stringify({
+              id: args.id,
+              data: args.data,
+              ...(args.canvas_size === undefined ? {} : { canvas_size: args.canvas_size }),
+            }),
+          },
+        );
+        const input = managerData(body).input;
+        if (!input || typeof input !== "object" || Array.isArray(input)) {
+          throw new Error("Manager returned an invalid materialized Skill view");
+        }
+        return invokePluginTool(generatedViewDescriptor, input as Record<string, unknown>, context);
+      },
+    });
     for (const definition of skillViewDefinitions) {
       if (tools.some((tool) => tool.name === definition.name)) {
         throw new Error(`Skill view Tool collides with an existing Tool: ${definition.name}`);


### PR DESCRIPTION
## Summary

- add generic skill_view_present and skill_view_render Manager tools
- execute only the enabled local Skill's manifest-pinned presenter with shell disabled and bounded input, output, environment, and timeout
- validate semantic presenter output against the Skill-owned template before invoking the generated-view Tool
- keep host and Worker Manager tool behavior and turn-envelope scopes in parity
- preserve concise presenter response text as the final voice answer
- focus a generated card without scrolling its internal content away from the title

## Behavior boundary

This adds a generic Skill and Tool capability, not domain routing or reply hard-coding. Kimi Code receives no compatibility workaround; its officially unsupported full Manager tool path remains documented as partial support. The verified main path is claude_agent_sdk.

## Real-machine validation

Fresh Voice session voice-bd0ff57cf0f76aedd823 used claude_agent_sdk and called read_skill, one skill_view_present, then finish. The presenter committed canonical A2UI revision 1, returned the exact grounded response, and reported no Agent errors.

At 1920x1080 the resulting 1x2 route starts at scrollTop 0, shows title, summary, and the first generation, and remains internally scrollable. Screenshot: /Volumes/P7000Z/Temp/homerail-claude-sdk-skill-presenter-final-1920x1080.png

## Tests

- Protocol focused: 35 passed
- Manager full: 968 passed, 2 existing skips
- Agent UI focus regression: 3 passed
- Agent UI typecheck and production build: passed
- Palquery resource tests: 23 passed
- git diff --check: passed

The full repository matrix is left to GitHub CI after the faster focused and real-machine gate.

Companion Skill PR: https://github.com/xiaotianfotos/homerail_resources/pull/1