### PR TITLE
Allow bounded long-running Skill presenters

### DIFF
--- a/homerail_manager/src/server/manager-skills.ts
+++ b/homerail_manager/src/server/manager-skills.ts
@@ -55,6 +55,7 @@ const MAX_SKILL_VIEW_PRESENTER_ARGUMENTS = 32;
 const MAX_SKILL_VIEW_PRESENTER_ARGUMENT_BYTES = 512;
 const MAX_SKILL_VIEW_PRESENTER_ARGUMENT_TOTAL_BYTES = 8 * 1024;
 const MAX_SKILL_VIEW_PRESENTER_OUTPUT_BYTES = 1024 * 1024;
+const MAX_SKILL_VIEW_PRESENTER_TIMEOUT_MS = 5 * 60 * 1000;
 const SKILL_VIEW_MANIFEST = path.join("assets", "homerail", "view-templates.json");
 const VIEW_SURFACES = new Set(["task", "execution", "result", "ambient"]);
 const VIEW_IMPORTANCE = new Set(["critical", "primary", "secondary", "ambient"]);
@@ -204,7 +205,7 @@ export function readManagerSkillViewPresenter(id: string): ManagerSkillViewPrese
     || args.length > 8
     || !Number.isInteger(timeoutMs)
     || timeoutMs < 1_000
-    || timeoutMs > 60_000
+    || timeoutMs > MAX_SKILL_VIEW_PRESENTER_TIMEOUT_MS
   ) return undefined;
   const normalizedArgs = args.map((item) => typeof item === "string" ? item : "");
   if (normalizedArgs.some((item) => (

--- a/homerail_manager/tests/manager-skills.test.ts
+++ b/homerail_manager/tests/manager-skills.test.ts
@@ -159,6 +159,24 @@ describe("Manager Agent skill discovery", () => {
     expect(readManagerSkillViewTemplates("visual-skill")).toEqual([]);
   });
 
+  it("allows explicitly bounded long-running trusted presenters", () => {
+    writeSkill(tmpHome, "research-skill", "research-skill", "Source-audited research workflow");
+    const file = writeA2uiTemplateManifest(tmpHome, "research-skill");
+    const manifest = JSON.parse(fs.readFileSync(file, "utf8")) as Record<string, unknown>;
+    manifest.presenter = {
+      command: "node",
+      args: ["presenter.js"],
+      timeout_ms: 300_000,
+    };
+    fs.writeFileSync(file, JSON.stringify(manifest), "utf8");
+
+    expect(readManagerSkillViewPresenter("research-skill")?.timeout_ms).toBe(300_000);
+
+    (manifest.presenter as Record<string, unknown>).timeout_ms = 300_001;
+    fs.writeFileSync(file, JSON.stringify(manifest), "utf8");
+    expect(readManagerSkillViewPresenter("research-skill")).toBeUndefined();
+  });
+
   it("does not follow an A2UI template manifest symlink outside the Skill package", () => {
     writeSkill(tmpHome, "linked-view", "linked-view", "Linked visual result workflow");
     const outside = path.join(tmpHome, "outside-template.json");


### PR DESCRIPTION
## Summary

- keep the default trusted Skill presenter timeout at 30 seconds
- allow a Skill manifest to explicitly request up to five minutes for bounded host tasks such as sourced research and editable document publication
- reject values above the five-minute ceiling

Milestone: M1 来源可审计研究. Base retargeted to `main` after #68 merged. Current head: `a6cc583d81884d2e59e97c19765ae3189efb4f26`.

## Safety boundary

This does not add shell execution or arbitrary commands. Presenters remain local enabled Skills, execute through the existing `execFile` path with `shell: false`, bounded argv/environment/output, and validated A2UI results.

## Validation

Local verification from the rebased PR head:

- Protocol focused tests: 35 passed
- Manager focused presenter/skill/outcome/tool parity/settings suites: 50 passed
- Agent UI focus-navigation test: 3 passed
- Protocol build: passed

GitHub Actions from current head:

- Core Linux Node 20: passed
- Core Linux Node 24: passed
- Core Windows Node 24: passed
- Agent UI coverage: passed
- Docker smoke: passed
- Live DAG patterns: skipped by workflow gating

Earlier real validation:

- real Claude Agent SDK presenter run completed in 112 seconds within the explicit bound

## Stack

#68 has merged into `main`; this PR is now directly based on `main`. After this PR is merged, retarget #71 to `main` and re-run/confirm CI before merging #71.