### PR TITLE
Add generic execution credential store

### DIFF
--- a/docs/credential-store.md
+++ b/docs/credential-store.md
@@ -1,0 +1,113 @@
+# Credential Store
+
+HomeRail stores execution credentials in the Manager database as AES-256-GCM
+ciphertext. A WorkflowSpec contains only a `credential_ref` and an explicit
+projection policy. List, show, audit, and mutation responses expose metadata and
+secret field names, never secret values.
+
+Supported credential types are `api_key`, `oauth_token`, `bot`, `ssh_key`,
+`certificate`, and `opaque`. Every create, rotate, revoke, delete, materialize,
+and denied use is recorded in an append-only audit ledger.
+
+## CLI
+
+Secret values are accepted from stdin so they do not appear in process
+arguments or shell history.
+
+```bash
+printf '%s' "$API_KEY" | homerail credential set build-api \
+  --type api_key --name "Build API"
+
+jq -n --arg app_id "$LARK_APP_ID" --arg app_secret "$LARK_APP_SECRET" \
+  '{app_id:$app_id,app_secret:$app_secret}' \
+  | homerail credential set lark-bot --type bot --name "Lark Bot" --json-stdin
+
+jq -n --rawfile private_key ~/.ssh/id_ed25519 \
+  --rawfile known_hosts ~/.ssh/known_hosts \
+  '{private_key:$private_key,known_hosts:$known_hosts}' \
+  | homerail credential set deploy-ssh --type ssh_key --name "Deploy SSH" --json-stdin
+
+homerail credential list
+homerail credential audit deploy-ssh
+homerail credential revoke deploy-ssh
+```
+
+`rotate` reads replacement values using the same stdin forms. Revoked and
+expired credentials fail closed at dispatch time.
+
+## WorkflowSpec
+
+Environment projection maps named encrypted fields to non-reserved variables:
+
+```yaml
+allowed_dag_tools: [handoff]
+credentials:
+  - credential_ref: lark-bot
+    purpose: publish a report
+    inject:
+      mode: env
+      mappings:
+        app_id: LARK_APP_ID
+        app_secret: LARK_APP_SECRET
+```
+
+File and stdin projections create a private per-turn directory. Linux Workers
+use `/dev/shm`; other platforms use the OS temporary directory. Files are mode
+`0600`, their path is exposed through the declared environment variable, and
+the entire directory is removed in the Worker turn's `finally` block. `stdin`
+means the consumer should redirect the temporary file to its process stdin.
+
+```yaml
+credentials:
+  - credential_ref: deploy-ssh
+    purpose: connect to the build host
+    inject:
+      mode: file
+      field: private_key
+      filename: id_ed25519
+      env: SSH_KEY_PATH
+  - credential_ref: deploy-ssh
+    purpose: pin the build host key
+    inject:
+      mode: stdin
+      field: known_hosts
+      filename: known_hosts
+      env: SSH_KNOWN_HOSTS_PATH
+```
+
+Manager broker projection keeps the credential entirely on the host. The
+Worker receives only an opaque reference and may call only actions declared in
+the WorkflowSpec. Broker calls use the authenticated Worker WebSocket and are
+fenced to the current run, node, session, generation, and lease.
+
+```yaml
+allowed_dag_tools: [credential_broker_call, handoff]
+credentials:
+  - credential_ref: lark-bot
+    purpose: inspect the configured application bot
+    inject:
+      mode: manager_broker
+      broker: lark_bot
+      allowed_actions: [bot_info]
+```
+
+The initial built-in broker is `lark_bot/bot_info`. Broker implementations are
+registered in the Manager and receive decrypted fields only for the duration of
+one action. Results are size-bounded and rejected if they reflect a secret
+value. A Worker never receives the Lark tenant token or app secret.
+
+## Security Boundary
+
+- Workflow source, dispatch audit, session transcript, and API responses never
+  contain stored plaintext.
+- Worker text, debug events, tool telemetry, local audit files, and WebSocket
+  output redact the actual turn-scoped values. A handoff that reflects one of
+  those values is rejected before it can enter persistent DAG state.
+- Remote Worker control planes must use the existing secure WebSocket policy;
+  env/file projections necessarily traverse that authenticated channel.
+- Environment variables are intended for command-line tools that require them.
+  Prefer file projection for private keys and certificates, and Manager brokers
+  when the external operation can remain host-side.
+- JavaScript strings cannot be reliably zeroed. HomeRail minimizes plaintext
+  lifetime and removes temporary files, but process memory remains inside the
+  trusted Manager and Worker boundary.

--- a/homerail_cli/src/commands/credential.ts
+++ b/homerail_cli/src/commands/credential.ts
@@ -1,0 +1,132 @@
+import type { Command } from "commander";
+import { getClient, type BaseResponse } from "../index.js";
+
+interface GlobalOpts {
+  baseUrl?: string;
+  json?: boolean;
+  requestTimeout?: number;
+}
+
+interface CredentialRecord {
+  id: string;
+  credential_type: string;
+  name: string;
+  status: string;
+  version: number;
+  secret_fields: string[];
+  expires_at?: string;
+}
+
+interface CredentialResponse extends BaseResponse {
+  data?: { credential?: CredentialRecord; credentials?: CredentialRecord[]; events?: unknown[] };
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  const value = Buffer.concat(chunks).toString("utf8");
+  if (!value) throw new Error("Credential stdin is empty");
+  return value;
+}
+
+async function readSecret(opts: { field?: string; jsonStdin?: boolean }): Promise<Record<string, string>> {
+  const value = await readStdin();
+  if (!opts.jsonStdin) return { [opts.field ?? "value"]: value.replace(/\r?\n$/, "") };
+  const parsed = JSON.parse(value) as unknown;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("--json-stdin requires one JSON object");
+  }
+  const entries = Object.entries(parsed);
+  if (!entries.every(([, secret]) => typeof secret === "string")) {
+    throw new Error("Every --json-stdin credential field must be a string");
+  }
+  return Object.fromEntries(entries) as Record<string, string>;
+}
+
+function output(globalOpts: GlobalOpts, value: unknown): void {
+  console.log(JSON.stringify(value, null, globalOpts.json ? 2 : 0));
+}
+
+function printCredential(record: CredentialRecord): void {
+  console.log(`${record.id}\t${record.credential_type}\t${record.status}\tv${record.version}\t${record.secret_fields.join(",")}`);
+}
+
+export function registerCredentialCommand(program: Command): void {
+  const credential = program.command("credential").description("Manage encrypted execution credentials");
+
+  credential.command("list").action(async () => {
+    const globalOpts = program.opts<GlobalOpts>();
+    const response = await getClient(globalOpts).get<CredentialResponse>("/api/credentials");
+    if (globalOpts.json) output(globalOpts, response);
+    else for (const record of response.data?.credentials ?? []) printCredential(record);
+  });
+
+  credential.command("show <id>").action(async (id: string) => {
+    const globalOpts = program.opts<GlobalOpts>();
+    const response = await getClient(globalOpts).get<CredentialResponse>(`/api/credentials/${encodeURIComponent(id)}`);
+    if (globalOpts.json) output(globalOpts, response);
+    else if (response.data?.credential) printCredential(response.data.credential);
+  });
+
+  credential.command("set <id>")
+    .requiredOption("--type <type>", "api_key, oauth_token, bot, ssh_key, certificate, or opaque")
+    .requiredOption("--name <name>", "Display name")
+    .option("--field <name>", "Secret field for raw stdin", "value")
+    .option("--json-stdin", "Read a JSON object of secret fields from stdin")
+    .option("--expires-at <timestamp>", "RFC3339 expiration time")
+    .action(async (id: string, opts: {
+      type: string;
+      name: string;
+      field?: string;
+      jsonStdin?: boolean;
+      expiresAt?: string;
+    }) => {
+      const globalOpts = program.opts<GlobalOpts>();
+      const response = await getClient(globalOpts).post<CredentialResponse>("/api/credentials", {
+        id,
+        credential_type: opts.type,
+        name: opts.name,
+        secret: await readSecret(opts),
+        expires_at: opts.expiresAt,
+      });
+      if (globalOpts.json) output(globalOpts, response);
+      else if (response.data?.credential) printCredential(response.data.credential);
+    });
+
+  credential.command("rotate <id>")
+    .option("--field <name>", "Secret field for raw stdin", "value")
+    .option("--json-stdin", "Read a JSON object of secret fields from stdin")
+    .option("--expires-at <timestamp>", "RFC3339 expiration time")
+    .action(async (id: string, opts: { field?: string; jsonStdin?: boolean; expiresAt?: string }) => {
+      const globalOpts = program.opts<GlobalOpts>();
+      const response = await getClient(globalOpts).post<CredentialResponse>(
+        `/api/credentials/${encodeURIComponent(id)}/rotate`,
+        { secret: await readSecret(opts), expires_at: opts.expiresAt },
+      );
+      if (globalOpts.json) output(globalOpts, response);
+      else if (response.data?.credential) printCredential(response.data.credential);
+    });
+
+  credential.command("revoke <id>").action(async (id: string) => {
+    const globalOpts = program.opts<GlobalOpts>();
+    const response = await getClient(globalOpts).post<CredentialResponse>(
+      `/api/credentials/${encodeURIComponent(id)}/revoke`,
+    );
+    if (globalOpts.json) output(globalOpts, response);
+    else if (response.data?.credential) printCredential(response.data.credential);
+  });
+
+  credential.command("delete <id>").action(async (id: string) => {
+    const globalOpts = program.opts<GlobalOpts>();
+    const response = await getClient(globalOpts).delete<CredentialResponse>(`/api/credentials/${encodeURIComponent(id)}`);
+    output(globalOpts, response);
+  });
+
+  credential.command("audit <id>").action(async (id: string) => {
+    const globalOpts = program.opts<GlobalOpts>();
+    const response = await getClient(globalOpts).get<CredentialResponse>(
+      `/api/credentials/${encodeURIComponent(id)}/audit`,
+    );
+    output(globalOpts, response);
+  });
+}

--- a/homerail_cli/src/index.ts
+++ b/homerail_cli/src/index.ts
@@ -19,6 +19,7 @@ import { registerRuntimeCommands } from "./commands/runtime.js";
 import { registerPatternsCommand } from "./commands/patterns.js";
 import { registerPluginCommand } from "./commands/plugin.js";
 import { DEFAULT_MANAGER_URL } from "./local-config.js";
+import { registerCredentialCommand } from "./commands/credential.js";
 
 export { HomeRailClient } from "./client.js";
 export type { BaseResponse, HomeRailClientOptions } from "./client.js";
@@ -36,6 +37,7 @@ export function createProgram(): Command {
   registerTemplatesCommand(program);
   registerPatternsCommand(program);
   registerPluginCommand(program);
+  registerCredentialCommand(program);
   registerRunCommand(program);
   registerRunsCommand(program);
   registerStatusCommand(program);

--- a/homerail_cli/tests/commands.test.ts
+++ b/homerail_cli/tests/commands.test.ts
@@ -68,6 +68,31 @@ beforeEach(() => {
   delete process.env.HOMERAIL_UI_SERVE_STATIC;
 });
 
+describe("credential command", () => {
+  it("lists only credential metadata", async () => {
+    mockFetch({
+      success: true,
+      data: {
+        credentials: [{
+          id: "deploy-ssh",
+          credential_type: "ssh_key",
+          name: "Deploy SSH",
+          status: "active",
+          version: 2,
+          secret_fields: ["private_key", "known_hosts"],
+        }],
+      },
+    });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const program = createProgram();
+    await program.parseAsync(["node", "homerail", "credential", "list"]);
+
+    const output = logSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+    expect(output).toContain("deploy-ssh\tssh_key\tactive\tv2\tprivate_key,known_hosts");
+    expect(output).not.toContain("BEGIN PRIVATE KEY");
+  });
+});
+
 afterEach(() => {
   restoreEnv("HOMERAIL_HOME", previousHome);
   restoreEnv("HOMERAIL_CONFIG_PATH", previousConfigPath);

--- a/homerail_manager/src/orchestration/dag-dispatcher.ts
+++ b/homerail_manager/src/orchestration/dag-dispatcher.ts
@@ -6,6 +6,7 @@ import type {
   DagAgentToolName,
   DagWorkspaceAccess,
   DagWorkerSkillContextV1,
+  DagCredentialProjection,
 } from "homerail-protocol";
 
 export interface DispatchEnvelope {
@@ -36,6 +37,8 @@ export interface DispatchEnvelope {
   workspaceAccess?: DagWorkspaceAccess;
   allowedBuiltinTools?: AgentBuiltinToolName[];
   allowedDagTools?: DagAgentToolName[];
+  /** Turn-scoped secrets or opaque Manager-broker references. Never persist this field. */
+  credentialProjections?: DagCredentialProjection[];
   activity?: {
     roundId: string;
     actorId: string;

--- a/homerail_manager/src/orchestration/workflow-spec-v1-schema.ts
+++ b/homerail_manager/src/orchestration/workflow-spec-v1-schema.ts
@@ -127,6 +127,36 @@ const DagAgentToolName = Type.Union(
   DAG_AGENT_TOOL_NAMES.map((name) => Type.Literal(name)),
 );
 
+const CredentialBinding = Type.Object({
+  credential_ref: Type.String({ minLength: 1, maxLength: 128, pattern: "^[A-Za-z0-9][A-Za-z0-9._:-]*$" }),
+  purpose: Type.String({ minLength: 1, maxLength: 256 }),
+  inject: Type.Union([
+    Type.Object({
+      mode: Type.Literal("env"),
+      mappings: Type.Record(
+        Type.String({ minLength: 1, maxLength: 128, pattern: "^[A-Za-z_][A-Za-z0-9_]*$" }),
+        Type.String({ minLength: 1, maxLength: 128, pattern: "^[A-Z_][A-Z0-9_]*$" }),
+        { minProperties: 1, maxProperties: 16 },
+      ),
+    }, { additionalProperties: false }),
+    Type.Object({
+      mode: Type.Union([Type.Literal("file"), Type.Literal("stdin")]),
+      field: Type.String({ minLength: 1, maxLength: 128, pattern: "^[A-Za-z_][A-Za-z0-9_]*$" }),
+      filename: Type.String({ minLength: 1, maxLength: 128, pattern: "^[A-Za-z0-9][A-Za-z0-9._-]*$" }),
+      env: Type.String({ minLength: 1, maxLength: 128, pattern: "^[A-Z_][A-Z0-9_]*$" }),
+    }, { additionalProperties: false }),
+    Type.Object({
+      mode: Type.Literal("manager_broker"),
+      broker: Type.String({ minLength: 1, maxLength: 128, pattern: "^[A-Za-z0-9][A-Za-z0-9._:-]*$" }),
+      allowed_actions: Type.Array(Type.String({ minLength: 1, maxLength: 128 }), {
+        minItems: 1,
+        maxItems: 64,
+        uniqueItems: true,
+      }),
+    }, { additionalProperties: false }),
+  ]),
+}, { additionalProperties: false });
+
 const AgentNode = Type.Object({
   kind: Type.Literal("agent"),
   agent: Identifier,
@@ -141,6 +171,10 @@ const AgentNode = Type.Object({
     uniqueItems: true,
     maxItems: DAG_AGENT_TOOL_NAMES.length,
     description: "Exact allowlist for HomeRail DAG tools.",
+  })),
+  credentials: Type.Optional(Type.Array(CredentialBinding, {
+    maxItems: 16,
+    description: "Credential references and turn-scoped injection policy; secret values are never valid WorkflowSpec fields.",
   })),
   ...NodeBase,
 }, { additionalProperties: false });

--- a/homerail_manager/src/orchestration/workflow-spec-v1.ts
+++ b/homerail_manager/src/orchestration/workflow-spec-v1.ts
@@ -396,6 +396,16 @@ function semanticDiagnostics(context: SourceContext, workflow: WorkflowSpecV1): 
           "agent nodes with outputs must allow the handoff DAG tool",
         );
       }
+      if (
+        (node.credentials ?? []).some((binding) => binding.inject.mode === "manager_broker")
+        && !node.allowed_dag_tools?.includes("credential_broker_call")
+      ) {
+        add(
+          `${nodePath}/allowed_dag_tools`,
+          "DAG_SEMANTIC_CREDENTIAL_BROKER_TOOL_REQUIRED",
+          "agent nodes with manager_broker credentials must allow credential_broker_call",
+        );
+      }
     }
     for (const dependency of node.depends_on ?? []) {
       if (!nodes[dependency]) {
@@ -744,6 +754,7 @@ function canonicalNode(id: string, node: WorkflowSpecV1Node): CanonicalNode {
       ...(node.allowed_dag_tools !== undefined
         ? { allowed_dag_tools: [...node.allowed_dag_tools].sort() }
         : {}),
+      ...(node.credentials !== undefined ? { credentials: node.credentials } : {}),
     };
     return {
       ...base,

--- a/homerail_manager/src/orchestration/ws-dispatch-adapter.ts
+++ b/homerail_manager/src/orchestration/ws-dispatch-adapter.ts
@@ -33,6 +33,7 @@ import {
   recordNodeDispatchRetry,
 } from "../runtime/active-runs.js";
 import { getPort } from "../config/env.js";
+import { summarizeDagCredentialProjection } from "homerail-protocol";
 import {
   deprovisionProvisionedWorker,
   registerProvisionedWorker,
@@ -70,11 +71,14 @@ export interface WsDispatchAdapterOptions {
 }
 
 export function dispatchEnvelopeAuditView(envelope: DispatchEnvelope): unknown {
-  const { skillContext, ...withoutSkillContent } = envelope;
+  const { skillContext, credentialProjections, ...withoutSkillContent } = envelope;
   return redactTelemetry({
     ...withoutSkillContent,
     ...(skillContext
       ? { skillContext: summarizeDagWorkerSkillContextV1(skillContext) }
+      : {}),
+    ...(credentialProjections
+      ? { credentialProjections: credentialProjections.map(summarizeDagCredentialProjection) }
       : {}),
   });
 }

--- a/homerail_manager/src/persistence/credentials.ts
+++ b/homerail_manager/src/persistence/credentials.ts
@@ -1,0 +1,499 @@
+import { randomUUID } from "node:crypto";
+import { getDb } from "./db.js";
+import {
+  decryptSecret,
+  encryptSecret,
+  isEncryptedSecret,
+  type EncryptedSecret,
+} from "./secret-store.js";
+import { nowIso } from "./time.js";
+
+export const CREDENTIAL_TYPES = [
+  "api_key",
+  "oauth_token",
+  "bot",
+  "ssh_key",
+  "certificate",
+  "opaque",
+] as const;
+
+export type CredentialType = typeof CREDENTIAL_TYPES[number];
+export type CredentialStatus = "active" | "revoked";
+
+export interface CredentialMetadata {
+  description?: string;
+  scopes?: string[];
+  labels?: Record<string, string>;
+}
+
+export interface CredentialRecord {
+  id: string;
+  credential_type: CredentialType;
+  name: string;
+  status: CredentialStatus;
+  version: number;
+  secret_fields: string[];
+  metadata: CredentialMetadata;
+  expires_at?: string;
+  last_used_at?: string;
+  rotated_at?: string;
+  revoked_at?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CredentialAuditEvent {
+  sequence: number;
+  event_id: string;
+  credential_id: string;
+  event_type: "created" | "rotated" | "revoked" | "deleted" | "materialized" | "denied";
+  actor: string;
+  run_id?: string;
+  node_id?: string;
+  purpose?: string;
+  result: "success" | "denied" | "failed";
+  detail: Record<string, unknown>;
+  created_at: string;
+}
+
+interface StoredCredentialRow {
+  id: string;
+  credential_type: string;
+  name: string;
+  encrypted_payload: string;
+  metadata: string | null;
+  status: string;
+  version: number;
+  expires_at: string | null;
+  last_used_at: string | null;
+  rotated_at: string | null;
+  revoked_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface EncryptedCredentialPayloadV1 {
+  schema_version: 1;
+  secret_fields: string[];
+  secret: EncryptedSecret;
+}
+
+export interface CredentialMutationContext {
+  actor: string;
+}
+
+export interface CredentialUseContext {
+  actor: string;
+  run_id?: string;
+  node_id?: string;
+  purpose?: string;
+  broker?: string;
+  action?: string;
+}
+
+const ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const FIELD_PATTERN = /^[A-Za-z_][A-Za-z0-9_]{0,127}$/;
+const MAX_SECRET_BYTES = 2 * 1024 * 1024;
+
+function assertCredentialType(value: string): asserts value is CredentialType {
+  if (!(CREDENTIAL_TYPES as readonly string[]).includes(value)) {
+    throw new Error(`Unsupported credential type: ${value}`);
+  }
+}
+
+function normalizedId(value: string): string {
+  const id = value.trim();
+  if (!ID_PATTERN.test(id)) throw new Error("Credential id must be 1-128 safe identifier characters");
+  return id;
+}
+
+function normalizedName(value: string): string {
+  const name = value.trim();
+  if (!name || name.length > 256) throw new Error("Credential name must be 1-256 characters");
+  return name;
+}
+
+function normalizedActor(value: string): string {
+  const actor = value.trim();
+  if (!actor || actor.length > 256) throw new Error("Credential actor must be 1-256 characters");
+  return actor;
+}
+
+function normalizedOptionalText(value: string | undefined, maxLength: number): string | undefined {
+  if (value === undefined) return undefined;
+  const normalized = value.trim();
+  if (!normalized) return undefined;
+  if (normalized.length > maxLength) throw new Error(`Value exceeds ${maxLength} characters`);
+  return normalized;
+}
+
+function normalizedExpiresAt(value: string | undefined): string | undefined {
+  const expiresAt = normalizedOptionalText(value, 64);
+  if (!expiresAt) return undefined;
+  const time = Date.parse(expiresAt);
+  if (!Number.isFinite(time)) throw new Error("expires_at must be an RFC3339 timestamp");
+  return new Date(time).toISOString();
+}
+
+function normalizedMetadata(value: CredentialMetadata | undefined): CredentialMetadata {
+  const description = normalizedOptionalText(value?.description, 2048);
+  const scopes = [...new Set((value?.scopes ?? []).map((entry) => normalizedOptionalText(entry, 256)).filter(
+    (entry): entry is string => Boolean(entry),
+  ))].sort();
+  if (scopes.length > 128) throw new Error("Credential metadata has too many scopes");
+  const labels: Record<string, string> = {};
+  for (const [key, raw] of Object.entries(value?.labels ?? {})) {
+    if (!FIELD_PATTERN.test(key)) throw new Error(`Invalid credential metadata label: ${key}`);
+    const label = normalizedOptionalText(raw, 512);
+    if (label) labels[key] = label;
+  }
+  if (Object.keys(labels).length > 64) throw new Error("Credential metadata has too many labels");
+  return {
+    ...(description ? { description } : {}),
+    ...(scopes.length > 0 ? { scopes } : {}),
+    ...(Object.keys(labels).length > 0 ? { labels } : {}),
+  };
+}
+
+function normalizedSecrets(value: Record<string, string>): Record<string, string> {
+  const entries = Object.entries(value);
+  if (entries.length === 0 || entries.length > 16) {
+    throw new Error("Credential secret must contain 1-16 fields");
+  }
+  let totalBytes = 0;
+  const normalized: Record<string, string> = {};
+  for (const [key, secret] of entries) {
+    if (!FIELD_PATTERN.test(key)) throw new Error(`Invalid credential secret field: ${key}`);
+    if (typeof secret !== "string" || secret.length === 0) {
+      throw new Error(`Credential secret field '${key}' must be a non-empty string`);
+    }
+    totalBytes += Buffer.byteLength(secret, "utf8");
+    normalized[key] = secret;
+  }
+  if (totalBytes > MAX_SECRET_BYTES) throw new Error("Credential secret exceeds 2 MiB");
+  return normalized;
+}
+
+function assertRequiredSecretFields(type: CredentialType, secret: Record<string, string>): void {
+  const required: Partial<Record<CredentialType, string[]>> = {
+    api_key: ["value"],
+    bot: ["app_id", "app_secret"],
+    ssh_key: ["private_key"],
+    certificate: ["certificate", "private_key"],
+  };
+  for (const field of required[type] ?? []) {
+    if (!secret[field]) throw new Error(`Credential type '${type}' requires secret field '${field}'`);
+  }
+  if (type === "oauth_token" && !secret.access_token && !secret.refresh_token) {
+    throw new Error("Credential type 'oauth_token' requires access_token or refresh_token");
+  }
+}
+
+function encodePayload(secret: Record<string, string>): string {
+  const secretFields = Object.keys(secret).sort();
+  const payload: EncryptedCredentialPayloadV1 = {
+    schema_version: 1,
+    secret_fields: secretFields,
+    secret: encryptSecret(JSON.stringify(secret)),
+  };
+  return JSON.stringify(payload);
+}
+
+function parsePayload(value: string): EncryptedCredentialPayloadV1 {
+  let payload: unknown;
+  try {
+    payload = JSON.parse(value);
+  } catch {
+    throw new Error("Credential payload uses an unsupported legacy format");
+  }
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("Credential payload is invalid");
+  }
+  const raw = payload as Record<string, unknown>;
+  if (raw.schema_version !== 1 || !Array.isArray(raw.secret_fields) || !isEncryptedSecret(raw.secret)) {
+    throw new Error("Credential payload uses an unsupported schema version");
+  }
+  if (!raw.secret_fields.every((field) => typeof field === "string" && FIELD_PATTERN.test(field))) {
+    throw new Error("Credential secret field manifest is invalid");
+  }
+  return raw as unknown as EncryptedCredentialPayloadV1;
+}
+
+function decodePayload(value: string): { secret_fields: string[]; secret: Record<string, string> } {
+  const payload = parsePayload(value);
+  const plaintext = decryptSecret(payload.secret);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(plaintext);
+  } finally {
+    // JavaScript strings cannot be zeroed; keep the plaintext lifetime inside this function.
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Credential plaintext is invalid");
+  }
+  const secret = normalizedSecrets(parsed as Record<string, string>);
+  const secretFields = Object.keys(secret).sort();
+  if (JSON.stringify(secretFields) !== JSON.stringify([...payload.secret_fields].sort())) {
+    throw new Error("Credential secret field manifest does not match the encrypted payload");
+  }
+  return { secret_fields: secretFields, secret };
+}
+
+function rowMetadata(row: StoredCredentialRow): CredentialMetadata {
+  if (!row.metadata) return {};
+  try {
+    return normalizedMetadata(JSON.parse(row.metadata) as CredentialMetadata);
+  } catch {
+    return {};
+  }
+}
+
+function publicRecord(row: StoredCredentialRow): CredentialRecord {
+  assertCredentialType(row.credential_type);
+  const payload = parsePayload(row.encrypted_payload);
+  return {
+    id: row.id,
+    credential_type: row.credential_type,
+    name: row.name,
+    status: row.status === "revoked" ? "revoked" : "active",
+    version: row.version,
+    secret_fields: [...payload.secret_fields].sort(),
+    metadata: rowMetadata(row),
+    ...(row.expires_at ? { expires_at: row.expires_at } : {}),
+    ...(row.last_used_at ? { last_used_at: row.last_used_at } : {}),
+    ...(row.rotated_at ? { rotated_at: row.rotated_at } : {}),
+    ...(row.revoked_at ? { revoked_at: row.revoked_at } : {}),
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+function selectRow(id: string): StoredCredentialRow | undefined {
+  return getDb().prepare(`
+    SELECT id, credential_type, name, encrypted_payload, metadata, status, version,
+           expires_at, last_used_at, rotated_at, revoked_at, created_at, updated_at
+    FROM execution_credentials WHERE id = ?
+  `).get(id) as StoredCredentialRow | undefined;
+}
+
+function appendAudit(input: Omit<CredentialAuditEvent, "sequence" | "event_id" | "created_at">): void {
+  getDb().prepare(`
+    INSERT INTO credential_audit_events(
+      event_id, credential_id, event_type, actor, run_id, node_id, purpose, result, detail, created_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    randomUUID(),
+    input.credential_id,
+    input.event_type,
+    normalizedActor(input.actor),
+    input.run_id ?? null,
+    input.node_id ?? null,
+    input.purpose ?? null,
+    input.result,
+    JSON.stringify(input.detail),
+    nowIso(),
+  );
+}
+
+export function createCredential(input: {
+  id: string;
+  credential_type: string;
+  name: string;
+  secret: Record<string, string>;
+  metadata?: CredentialMetadata;
+  expires_at?: string;
+}, context: CredentialMutationContext): CredentialRecord {
+  const id = normalizedId(input.id);
+  assertCredentialType(input.credential_type);
+  const name = normalizedName(input.name);
+  const secret = normalizedSecrets(input.secret);
+  assertRequiredSecretFields(input.credential_type, secret);
+  const metadata = normalizedMetadata(input.metadata);
+  const expiresAt = normalizedExpiresAt(input.expires_at);
+  const now = nowIso();
+  const db = getDb();
+  db.transaction(() => {
+    db.prepare(`
+      INSERT INTO execution_credentials(
+        id, credential_type, name, encrypted_payload, metadata, status, version,
+        expires_at, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, 'active', 1, ?, ?, ?)
+    `).run(id, input.credential_type, name, encodePayload(secret), JSON.stringify(metadata), expiresAt ?? null, now, now);
+    appendAudit({
+      credential_id: id,
+      event_type: "created",
+      actor: context.actor,
+      result: "success",
+      detail: { credential_type: input.credential_type, secret_fields: Object.keys(secret).sort() },
+    });
+  }).immediate();
+  return getCredential(id)!;
+}
+
+export function listCredentials(): CredentialRecord[] {
+  const rows = getDb().prepare(`
+    SELECT id, credential_type, name, encrypted_payload, metadata, status, version,
+           expires_at, last_used_at, rotated_at, revoked_at, created_at, updated_at
+    FROM execution_credentials ORDER BY name, id
+  `).all() as StoredCredentialRow[];
+  return rows.map(publicRecord);
+}
+
+export function getCredential(idValue: string): CredentialRecord | undefined {
+  const row = selectRow(normalizedId(idValue));
+  return row ? publicRecord(row) : undefined;
+}
+
+export function rotateCredential(idValue: string, input: {
+  secret: Record<string, string>;
+  expires_at?: string;
+}, context: CredentialMutationContext): CredentialRecord {
+  const id = normalizedId(idValue);
+  const row = selectRow(id);
+  if (!row) throw new Error(`Credential not found: ${id}`);
+  assertCredentialType(row.credential_type);
+  const secret = normalizedSecrets(input.secret);
+  assertRequiredSecretFields(row.credential_type, secret);
+  const expiresAt = normalizedExpiresAt(input.expires_at);
+  const now = nowIso();
+  getDb().transaction(() => {
+    const updated = getDb().prepare(`
+      UPDATE execution_credentials
+      SET encrypted_payload = ?, status = 'active', version = version + 1,
+          expires_at = ?, rotated_at = ?, revoked_at = NULL, updated_at = ?
+      WHERE id = ? AND version = ?
+    `).run(encodePayload(secret), expiresAt ?? null, now, now, id, row.version);
+    if (updated.changes !== 1) throw new Error(`Credential changed concurrently: ${id}`);
+    appendAudit({
+      credential_id: id,
+      event_type: "rotated",
+      actor: context.actor,
+      result: "success",
+      detail: { from_version: row.version, to_version: row.version + 1, secret_fields: Object.keys(secret).sort() },
+    });
+  }).immediate();
+  return getCredential(id)!;
+}
+
+export function revokeCredential(idValue: string, context: CredentialMutationContext): CredentialRecord {
+  const id = normalizedId(idValue);
+  const row = selectRow(id);
+  if (!row) throw new Error(`Credential not found: ${id}`);
+  if (row.status === "revoked") return publicRecord(row);
+  const now = nowIso();
+  getDb().transaction(() => {
+    const updated = getDb().prepare(`
+      UPDATE execution_credentials
+      SET status = 'revoked', revoked_at = ?, updated_at = ?
+      WHERE id = ? AND version = ? AND status = 'active'
+    `).run(now, now, id, row.version);
+    if (updated.changes !== 1) throw new Error(`Credential changed concurrently: ${id}`);
+    appendAudit({
+      credential_id: id,
+      event_type: "revoked",
+      actor: context.actor,
+      result: "success",
+      detail: { version: row.version },
+    });
+  }).immediate();
+  return getCredential(id)!;
+}
+
+export function deleteCredential(idValue: string, context: CredentialMutationContext): void {
+  const id = normalizedId(idValue);
+  const row = selectRow(id);
+  if (!row) throw new Error(`Credential not found: ${id}`);
+  getDb().transaction(() => {
+    appendAudit({
+      credential_id: id,
+      event_type: "deleted",
+      actor: context.actor,
+      result: "success",
+      detail: { version: row.version, status: row.status },
+    });
+    getDb().prepare("DELETE FROM execution_credentials WHERE id = ?").run(id);
+  }).immediate();
+}
+
+export function materializeCredential(idValue: string, context: CredentialUseContext): {
+  record: CredentialRecord;
+  secret: Record<string, string>;
+} {
+  const id = normalizedId(idValue);
+  const row = selectRow(id);
+  const denied = (reason: string): never => {
+    appendAudit({
+      credential_id: id,
+      event_type: "denied",
+      actor: context.actor,
+      run_id: context.run_id,
+      node_id: context.node_id,
+      purpose: context.purpose,
+      result: "denied",
+      detail: { reason },
+    });
+    throw new Error(reason);
+  };
+  if (!row) return denied(`Credential not found: ${id}`);
+  if (row.status !== "active") denied(`Credential is revoked: ${id}`);
+  if (row.expires_at && Date.parse(row.expires_at) <= Date.now()) denied(`Credential is expired: ${id}`);
+  const decoded = decodePayload(row.encrypted_payload);
+  const usedAt = nowIso();
+  getDb().transaction(() => {
+    getDb().prepare("UPDATE execution_credentials SET last_used_at = ? WHERE id = ?").run(usedAt, id);
+    appendAudit({
+      credential_id: id,
+      event_type: "materialized",
+      actor: context.actor,
+      run_id: context.run_id,
+      node_id: context.node_id,
+      purpose: context.purpose,
+      result: "success",
+      detail: {
+        version: row.version,
+        secret_fields: decoded.secret_fields,
+        ...(context.broker ? { broker: context.broker } : {}),
+        ...(context.action ? { action: context.action } : {}),
+      },
+    });
+  }).immediate();
+  return { record: getCredential(id)!, secret: decoded.secret };
+}
+
+export function recordCredentialUseFailure(
+  idValue: string,
+  context: CredentialUseContext,
+  reason: string,
+): void {
+  const id = normalizedId(idValue);
+  appendAudit({
+    credential_id: id,
+    event_type: "denied",
+    actor: context.actor,
+    run_id: context.run_id,
+    node_id: context.node_id,
+    purpose: context.purpose,
+    result: "failed",
+    detail: {
+      reason: normalizedOptionalText(reason, 512) ?? "credential broker call failed",
+      ...(context.broker ? { broker: context.broker } : {}),
+      ...(context.action ? { action: context.action } : {}),
+    },
+  });
+}
+
+export function listCredentialAuditEvents(idValue: string): CredentialAuditEvent[] {
+  const id = normalizedId(idValue);
+  const rows = getDb().prepare(`
+    SELECT sequence, event_id, credential_id, event_type, actor, run_id, node_id,
+           purpose, result, detail, created_at
+    FROM credential_audit_events WHERE credential_id = ? ORDER BY sequence
+  `).all(id) as Array<Omit<CredentialAuditEvent, "detail"> & { detail: string }>;
+  return rows.map((row) => ({
+    ...row,
+    ...(row.run_id ? {} : { run_id: undefined }),
+    ...(row.node_id ? {} : { node_id: undefined }),
+    ...(row.purpose ? {} : { purpose: undefined }),
+    detail: JSON.parse(row.detail) as Record<string, unknown>,
+  }));
+}

--- a/homerail_manager/src/persistence/db.ts
+++ b/homerail_manager/src/persistence/db.ts
@@ -103,6 +103,7 @@ const CLEARABLE_TABLES = new Set([
   "container_volumes",
   "storage_usage_trackers",
   "encrypted_credentials",
+  "execution_credentials",
   "temporary_keys",
   "security_policies",
   "security_audit_logs",
@@ -1859,6 +1860,24 @@ function validateDagActorSurfacePatchSchemaV30(db: SqliteDatabase): void {
     || !viewForeignKeys.has("dag_actors")
     || !viewForeignKeys.has("generative_ui_documents")) {
     throw new Error("Schema migration 30 is incomplete: Actor surface ownership constraints are invalid");
+  }
+}
+
+function validateCredentialStoreSchemaV31(db: SqliteDatabase): void {
+  if (!hasTable(db, "execution_credentials") || !hasTable(db, "credential_audit_events")) {
+    throw new Error("Schema migration 31 is incomplete: credential store tables are missing");
+  }
+  for (const column of [
+    "status",
+    "version",
+    "expires_at",
+    "last_used_at",
+    "rotated_at",
+    "revoked_at",
+  ]) {
+    if (!hasColumn(db, "execution_credentials", column)) {
+      throw new Error(`Schema migration 31 is incomplete: execution_credentials is missing column ${column}`);
+    }
   }
 }
 
@@ -3923,6 +3942,58 @@ const SCHEMA_MIGRATIONS: readonly SchemaMigration[] = [
       END;
     `),
     validate: validateDagActorSurfacePatchSchemaV30,
+  },
+  {
+    version: 31,
+    up: (db) => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS execution_credentials (
+          id TEXT PRIMARY KEY,
+          credential_type TEXT NOT NULL,
+          name TEXT NOT NULL,
+          encrypted_payload TEXT NOT NULL,
+          metadata TEXT,
+          status TEXT NOT NULL DEFAULT 'active' CHECK(status IN ('active', 'revoked')),
+          version INTEGER NOT NULL DEFAULT 1 CHECK(version >= 1),
+          expires_at TEXT,
+          last_used_at TEXT,
+          rotated_at TEXT,
+          revoked_at TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_execution_credentials_status
+          ON execution_credentials(status, name, id);
+        CREATE TABLE IF NOT EXISTS credential_audit_events (
+          sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+          event_id TEXT NOT NULL UNIQUE,
+          credential_id TEXT NOT NULL,
+          event_type TEXT NOT NULL CHECK(event_type IN (
+            'created', 'rotated', 'revoked', 'deleted', 'materialized', 'denied'
+          )),
+          actor TEXT NOT NULL,
+          run_id TEXT,
+          node_id TEXT,
+          purpose TEXT,
+          result TEXT NOT NULL CHECK(result IN ('success', 'denied', 'failed')),
+          detail TEXT NOT NULL,
+          created_at TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_credential_audit_events_credential
+          ON credential_audit_events(credential_id, sequence);
+        CREATE TRIGGER IF NOT EXISTS trg_credential_audit_events_no_update
+        BEFORE UPDATE ON credential_audit_events
+        BEGIN
+          SELECT RAISE(ABORT, 'Credential audit events are append-only');
+        END;
+        CREATE TRIGGER IF NOT EXISTS trg_credential_audit_events_no_delete
+        BEFORE DELETE ON credential_audit_events
+        BEGIN
+          SELECT RAISE(ABORT, 'Credential audit events are append-only');
+        END;
+      `);
+    },
+    validate: validateCredentialStoreSchemaV31,
   },
 ];
 

--- a/homerail_manager/src/runtime/active-runs.ts
+++ b/homerail_manager/src/runtime/active-runs.ts
@@ -45,6 +45,7 @@ import {
   type DagAdvisorConfig,
   type DagAgentToolName,
   type DagWorkspaceAccess,
+  type DagCredentialProjection,
 } from "homerail-protocol";
 import { resolveAgentRuntimeConfig } from "./agent-runtime-resolver.js";
 import {
@@ -85,6 +86,7 @@ import type { RunWorkspaceRetention } from "../persistence/types.js";
 import { getDagActivitySequenceCursor } from "../persistence/dag-activity-journal.js";
 import { getDagActorSurfaceView } from "../persistence/dag-actor-surface-patches.js";
 import { getDb } from "../persistence/db.js";
+import { getCredential, materializeCredential } from "../persistence/credentials.js";
 import {
   createInitialDagRunRound,
   getCurrentDagRunRound,
@@ -4325,6 +4327,96 @@ function _allowedDagTools(node: DAGGraphNode): DagAgentToolName[] | undefined {
   ));
 }
 
+function _credentialProjections(run: ActiveRun, node: DAGGraphNode): DagCredentialProjection[] {
+  const raw = _agentRuntimeConfig(node).credentials;
+  if (!Array.isArray(raw) || raw.length === 0) return [];
+  const projections: DagCredentialProjection[] = [];
+  const claimedEnv = new Set<string>();
+  const forbiddenEnv = /^(?:HOMERAIL_|MANAGER_|AGENT_BACKEND$|PATH$|HOME$|NODE_OPTIONS$|LD_|DYLD_|ANTHROPIC_|OPENAI_|KIMI_|LLM_)/;
+
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error(`Invalid credential binding on node ${node.node_id}`);
+    }
+    const binding = entry as Record<string, unknown>;
+    const credentialRef = String(binding.credential_ref ?? "");
+    const purpose = String(binding.purpose ?? "");
+    const inject = binding.inject;
+    if (!inject || typeof inject !== "object" || Array.isArray(inject)) {
+      throw new Error(`Credential binding '${credentialRef}' has no injection policy`);
+    }
+    const policy = inject as Record<string, unknown>;
+    const mode = String(policy.mode ?? "");
+    if (mode === "manager_broker") {
+      const record = getCredential(credentialRef);
+      if (!record || record.status !== "active") {
+        throw new Error(`Manager-broker credential is unavailable: ${credentialRef}`);
+      }
+      if (record.expires_at && Date.parse(record.expires_at) <= Date.now()) {
+        throw new Error(`Manager-broker credential is expired: ${credentialRef}`);
+      }
+      projections.push({
+        credential_ref: credentialRef,
+        purpose,
+        mode,
+        broker: String(policy.broker ?? ""),
+        allowed_actions: Array.isArray(policy.allowed_actions)
+          ? policy.allowed_actions.map(String)
+          : [],
+      });
+      continue;
+    }
+
+    const materialized = materializeCredential(credentialRef, {
+      actor: `dag:${run.runId}:${node.node_id}`,
+      run_id: run.runId,
+      node_id: node.node_id,
+      purpose,
+    });
+    if (mode === "env") {
+      const mappings = policy.mappings;
+      if (!mappings || typeof mappings !== "object" || Array.isArray(mappings)) {
+        throw new Error(`Credential binding '${credentialRef}' has invalid env mappings`);
+      }
+      const values: Record<string, string> = {};
+      for (const [secretField, rawEnv] of Object.entries(mappings)) {
+        const env = String(rawEnv);
+        if (forbiddenEnv.test(env)) throw new Error(`Credential binding cannot override reserved env '${env}'`);
+        if (claimedEnv.has(env)) throw new Error(`Credential env '${env}' is bound more than once on node ${node.node_id}`);
+        const secret = materialized.secret[secretField];
+        if (secret === undefined) {
+          throw new Error(`Credential '${credentialRef}' has no secret field '${secretField}'`);
+        }
+        claimedEnv.add(env);
+        values[env] = secret;
+      }
+      projections.push({ credential_ref: credentialRef, purpose, mode, values });
+      continue;
+    }
+    if (mode === "file" || mode === "stdin") {
+      const field = String(policy.field ?? "");
+      const env = String(policy.env ?? "");
+      if (forbiddenEnv.test(env)) throw new Error(`Credential binding cannot override reserved env '${env}'`);
+      if (claimedEnv.has(env)) throw new Error(`Credential env '${env}' is bound more than once on node ${node.node_id}`);
+      const content = materialized.secret[field];
+      if (content === undefined) throw new Error(`Credential '${credentialRef}' has no secret field '${field}'`);
+      claimedEnv.add(env);
+      projections.push({
+        credential_ref: credentialRef,
+        purpose,
+        mode,
+        field,
+        content,
+        filename: String(policy.filename ?? "credential"),
+        env,
+      });
+      continue;
+    }
+    throw new Error(`Credential binding '${credentialRef}' has unsupported mode '${mode}'`);
+  }
+  return projections;
+}
+
 function _requiredDispatchCapabilities(
   run: ActiveRun,
   node: DAGGraphNode,
@@ -4394,6 +4486,12 @@ function _buildDispatchEnvelope(run: ActiveRun, nodeId: string): DispatchEnvelop
   if (!credentials.ok) return credentials;
   const advisorResolution = _advisorConfigs(run, node);
   if (!advisorResolution.ok) return advisorResolution;
+  let credentialProjections: DagCredentialProjection[];
+  try {
+    credentialProjections = _credentialProjections(run, node);
+  } catch (cause) {
+    return { ok: false, reason: cause instanceof Error ? cause.message : String(cause) };
+  }
 
   const inputs = _nodeInputs(run.dagRun, nodeId);
   const nodeSession = _ensureNodeSession(run, nodeId);
@@ -4461,6 +4559,7 @@ function _buildDispatchEnvelope(run: ActiveRun, nodeId: string): DispatchEnvelop
       workspaceAccess: _workspaceAccess(node),
       allowedBuiltinTools: _allowedBuiltinTools(node),
       allowedDagTools: _allowedDagTools(node),
+      ...(credentialProjections.length > 0 ? { credentialProjections } : {}),
       activity: {
         roundId: run.currentRound.round_id,
         actorId,

--- a/homerail_manager/src/runtime/credential-broker.ts
+++ b/homerail_manager/src/runtime/credential-broker.ts
@@ -1,0 +1,221 @@
+import type {
+  DagCredentialBrokerCallRequest,
+  DagCredentialBrokerCallResult,
+} from "homerail-protocol";
+import {
+  materializeCredential,
+  recordCredentialUseFailure,
+  type CredentialRecord,
+} from "../persistence/credentials.js";
+import { getActiveRun } from "./active-runs.js";
+
+export interface CredentialBrokerContext {
+  credential: CredentialRecord;
+  secret: Readonly<Record<string, string>>;
+  input: Readonly<Record<string, unknown>>;
+}
+
+export type CredentialBrokerHandler = (
+  context: CredentialBrokerContext,
+) => Promise<unknown>;
+
+const BROKER_NAME = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const ACTION_NAME = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const MAX_INPUT_BYTES = 64 * 1024;
+const MAX_RESULT_BYTES = 256 * 1024;
+const handlers = new Map<string, Map<string, CredentialBrokerHandler>>();
+
+function safeJsonSize(value: unknown): number {
+  const encoded = JSON.stringify(value);
+  if (encoded === undefined) throw new Error("Credential broker value is not JSON serializable");
+  return Buffer.byteLength(encoded, "utf8");
+}
+
+function assertResultDoesNotRevealSecrets(
+  result: unknown,
+  secret: Readonly<Record<string, string>>,
+): void {
+  const secretValues = Object.values(secret);
+  const seen = new WeakSet<object>();
+  const containsSecret = (value: unknown): boolean => {
+    if (typeof value === "string") return secretValues.some((candidate) => value.includes(candidate));
+    if (typeof value === "number" || typeof value === "boolean") {
+      return secretValues.includes(String(value));
+    }
+    if (!value || typeof value !== "object") return false;
+    if (seen.has(value)) return false;
+    seen.add(value);
+    if (Array.isArray(value)) return value.some(containsSecret);
+    return Object.entries(value).some(([key, entry]) => containsSecret(key) || containsSecret(entry));
+  };
+  if (containsSecret(result)) {
+    throw new Error("Credential broker result reflected a secret value");
+  }
+}
+
+export function registerCredentialBroker(
+  broker: string,
+  action: string,
+  handler: CredentialBrokerHandler,
+): void {
+  if (!BROKER_NAME.test(broker)) throw new Error("Invalid credential broker name");
+  if (!ACTION_NAME.test(action)) throw new Error("Invalid credential broker action");
+  const actions = handlers.get(broker) ?? new Map<string, CredentialBrokerHandler>();
+  actions.set(action, handler);
+  handlers.set(broker, actions);
+}
+
+export async function invokeCredentialBroker(
+  broker: string,
+  action: string,
+  context: CredentialBrokerContext,
+): Promise<unknown> {
+  const handler = handlers.get(broker)?.get(action);
+  if (!handler) throw new Error(`Unsupported credential broker action: ${broker}/${action}`);
+  if (safeJsonSize(context.input) > MAX_INPUT_BYTES) {
+    throw new Error("Credential broker input exceeds 64 KiB");
+  }
+  const result = await handler(context);
+  assertResultDoesNotRevealSecrets(result, context.secret);
+  if (safeJsonSize(result) > MAX_RESULT_BYTES) {
+    throw new Error("Credential broker result exceeds 256 KiB");
+  }
+  return result;
+}
+
+function managerBrokerBinding(
+  runId: string,
+  nodeId: string,
+  credentialRef: string,
+): {
+  purpose: string;
+  broker: string;
+  allowed_actions: string[];
+} {
+  const run = getActiveRun(runId);
+  if (!run || run.status !== "active") throw new Error("Credential broker run is not active");
+  const node = run.dagRun.graph.nodes.find((candidate) => candidate.node_id === nodeId);
+  if (!node) throw new Error("Credential broker node was not found");
+  const runtime = node.extra?.agent_runtime;
+  const credentials = runtime && typeof runtime === "object" && !Array.isArray(runtime)
+    ? (runtime as Record<string, unknown>).credentials
+    : undefined;
+  if (!Array.isArray(credentials)) throw new Error("Credential broker is not declared on this node");
+  for (const raw of credentials) {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) continue;
+    const binding = raw as Record<string, unknown>;
+    if (binding.credential_ref !== credentialRef) continue;
+    const inject = binding.inject;
+    if (!inject || typeof inject !== "object" || Array.isArray(inject)) continue;
+    const policy = inject as Record<string, unknown>;
+    if (policy.mode !== "manager_broker") continue;
+    return {
+      purpose: String(binding.purpose ?? ""),
+      broker: String(policy.broker ?? ""),
+      allowed_actions: Array.isArray(policy.allowed_actions)
+        ? policy.allowed_actions.filter((entry): entry is string => typeof entry === "string")
+        : [],
+    };
+  }
+  throw new Error("Credential broker reference is not declared on this node");
+}
+
+export async function executeCredentialBrokerCall(
+  workerId: string,
+  request: DagCredentialBrokerCallRequest,
+): Promise<DagCredentialBrokerCallResult> {
+  const fail = (error: string): DagCredentialBrokerCallResult => ({
+    request_id: request.request_id,
+    ok: false,
+    error,
+  });
+  if (!request.request_id || !request.run_id || !request.node_id || !request.session_id) {
+    return fail("Credential broker transport identity is incomplete");
+  }
+  if (!BROKER_NAME.test(request.broker) || !ACTION_NAME.test(request.action)) {
+    return fail("Credential broker or action is invalid");
+  }
+  let binding;
+  let materializedSecret: Readonly<Record<string, string>> | undefined;
+  try {
+    binding = managerBrokerBinding(request.run_id, request.node_id, request.credential_ref);
+    if (binding.broker !== request.broker || !binding.allowed_actions.includes(request.action)) {
+      throw new Error("Credential broker action is not permitted by the WorkflowSpec");
+    }
+    const useContext = {
+      actor: `credential-broker:worker:${workerId}`,
+      run_id: request.run_id,
+      node_id: request.node_id,
+      purpose: binding.purpose,
+      broker: request.broker,
+      action: request.action,
+    };
+    const materialized = materializeCredential(request.credential_ref, useContext);
+    materializedSecret = materialized.secret;
+    const result = await invokeCredentialBroker(request.broker, request.action, {
+      credential: materialized.record,
+      secret: materialized.secret,
+      input: request.input,
+    });
+    return { request_id: request.request_id, ok: true, result };
+  } catch (error) {
+    const rawMessage = error instanceof Error ? error.message : String(error);
+    const message = materializedSecret && Object.values(materializedSecret).some((value) => rawMessage.includes(value))
+      ? "Credential broker call failed without exposing provider details"
+      : rawMessage;
+    if (request.credential_ref) {
+      try {
+        recordCredentialUseFailure(request.credential_ref, {
+          actor: `credential-broker:worker:${workerId}`,
+          run_id: request.run_id,
+          node_id: request.node_id,
+          purpose: binding?.purpose,
+          broker: request.broker,
+          action: request.action,
+        }, message);
+      } catch {
+        // Failure auditing must not replace the original bounded error.
+      }
+    }
+    return fail(message);
+  }
+}
+
+registerCredentialBroker("lark_bot", "bot_info", async ({ credential, secret }) => {
+  if (credential.credential_type !== "bot" || !secret.app_id || !secret.app_secret) {
+    throw new Error("lark_bot requires a bot credential");
+  }
+  const tokenResponse = await fetch(
+    "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ app_id: secret.app_id, app_secret: secret.app_secret }),
+      signal: AbortSignal.timeout(10_000),
+    },
+  );
+  const tokenBody = await tokenResponse.json() as {
+    code?: number;
+    tenant_access_token?: string;
+  };
+  if (!tokenResponse.ok || tokenBody.code !== 0 || !tokenBody.tenant_access_token) {
+    throw new Error("Lark Bot authentication failed");
+  }
+  const infoResponse = await fetch("https://open.feishu.cn/open-apis/bot/v3/info", {
+    headers: { Authorization: `Bearer ${tokenBody.tenant_access_token}` },
+    signal: AbortSignal.timeout(10_000),
+  });
+  const infoBody = await infoResponse.json() as {
+    code?: number;
+    bot?: { app_name?: string; avatar_url?: string; open_id?: string; activate_status?: number };
+  };
+  if (!infoResponse.ok || infoBody.code !== 0 || !infoBody.bot) {
+    throw new Error("Lark Bot info request failed");
+  }
+  return {
+    bot_name: infoBody.bot.app_name ?? "",
+    avatar_url: infoBody.bot.avatar_url ?? "",
+    open_id: infoBody.bot.open_id ?? "",
+    activate_status: infoBody.bot.activate_status ?? 0,
+  };
+});

--- a/homerail_manager/src/server/credentials.ts
+++ b/homerail_manager/src/server/credentials.ts
@@ -1,0 +1,161 @@
+import type * as http from "node:http";
+import {
+  createCredential,
+  deleteCredential,
+  getCredential,
+  listCredentialAuditEvents,
+  listCredentials,
+  revokeCredential,
+  rotateCredential,
+  type CredentialMetadata,
+} from "../persistence/credentials.js";
+
+const BASE_PATH = "/api/credentials";
+const MAX_BODY_BYTES = 3 * 1024 * 1024;
+
+function json(res: http.ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(body));
+}
+
+function actorFor(req: http.IncomingMessage): string {
+  const remote = req.socket.remoteAddress ?? "unknown";
+  return `credential-api:${remote}`.slice(0, 256);
+}
+
+async function readJsonBody(req: http.IncomingMessage): Promise<Record<string, unknown>> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of req) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    total += buffer.length;
+    if (total > MAX_BODY_BYTES) throw new Error("Credential request body exceeds 3 MiB");
+    chunks.push(buffer);
+  }
+  if (chunks.length === 0) return {};
+  const parsed = JSON.parse(Buffer.concat(chunks).toString("utf8")) as unknown;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Credential request body must be a JSON object");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function requiredString(body: Record<string, unknown>, key: string): string {
+  const value = body[key];
+  if (typeof value !== "string" || !value.trim()) throw new Error(`Missing required field: ${key}`);
+  return value;
+}
+
+function secretObject(body: Record<string, unknown>): Record<string, string> {
+  const value = body.secret;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Missing required object: secret");
+  }
+  const entries = Object.entries(value);
+  if (!entries.every(([, entry]) => typeof entry === "string")) {
+    throw new Error("Every credential secret field must be a string");
+  }
+  return Object.fromEntries(entries) as Record<string, string>;
+}
+
+function metadataObject(body: Record<string, unknown>): CredentialMetadata | undefined {
+  const value = body.metadata;
+  if (value === undefined) return undefined;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("metadata must be an object");
+  }
+  return value as CredentialMetadata;
+}
+
+function idFromPath(pathname: string): { id: string; action?: "rotate" | "revoke" | "audit" } | undefined {
+  if (!pathname.startsWith(`${BASE_PATH}/`)) return undefined;
+  const parts = pathname.slice(BASE_PATH.length + 1).split("/").map(decodeURIComponent);
+  if (parts.length === 1 && parts[0]) return { id: parts[0] };
+  if (parts.length === 2 && parts[0] && ["rotate", "revoke", "audit"].includes(parts[1])) {
+    return { id: parts[0], action: parts[1] as "rotate" | "revoke" | "audit" };
+  }
+  return undefined;
+}
+
+export function credentialRoutesHandler(req: http.IncomingMessage, res: http.ServerResponse): boolean {
+  const pathname = new URL(req.url || "/", "http://localhost").pathname;
+  const match = idFromPath(pathname);
+
+  if (pathname === BASE_PATH && req.method === "GET") {
+    json(res, 200, { success: true, message: "Credentials retrieved", data: { credentials: listCredentials() } });
+    return true;
+  }
+
+  if (pathname === BASE_PATH && req.method === "POST") {
+    void readJsonBody(req).then((body) => {
+      const credential = createCredential({
+        id: requiredString(body, "id"),
+        credential_type: requiredString(body, "credential_type"),
+        name: requiredString(body, "name"),
+        secret: secretObject(body),
+        metadata: metadataObject(body),
+        expires_at: typeof body.expires_at === "string" ? body.expires_at : undefined,
+      }, { actor: actorFor(req) });
+      json(res, 201, { success: true, message: "Credential created", data: { credential } });
+    }).catch((error) => json(res, 400, {
+      success: false,
+      message: error instanceof Error ? error.message : String(error),
+    }));
+    return true;
+  }
+
+  if (match?.action === "audit" && req.method === "GET") {
+    json(res, 200, {
+      success: true,
+      message: "Credential audit retrieved",
+      data: { events: listCredentialAuditEvents(match.id) },
+    });
+    return true;
+  }
+
+  if (match?.action === "rotate" && req.method === "POST") {
+    void readJsonBody(req).then((body) => {
+      const credential = rotateCredential(match.id, {
+        secret: secretObject(body),
+        expires_at: typeof body.expires_at === "string" ? body.expires_at : undefined,
+      }, { actor: actorFor(req) });
+      json(res, 200, { success: true, message: "Credential rotated", data: { credential } });
+    }).catch((error) => json(res, 400, {
+      success: false,
+      message: error instanceof Error ? error.message : String(error),
+    }));
+    return true;
+  }
+
+  if (match?.action === "revoke" && req.method === "POST") {
+    try {
+      const credential = revokeCredential(match.id, { actor: actorFor(req) });
+      json(res, 200, { success: true, message: "Credential revoked", data: { credential } });
+    } catch (error) {
+      json(res, 400, { success: false, message: error instanceof Error ? error.message : String(error) });
+    }
+    return true;
+  }
+
+  if (match && !match.action && req.method === "GET") {
+    const credential = getCredential(match.id);
+    if (!credential) {
+      json(res, 404, { success: false, message: `Credential not found: ${match.id}` });
+    } else {
+      json(res, 200, { success: true, message: "Credential retrieved", data: { credential } });
+    }
+    return true;
+  }
+
+  if (match && !match.action && req.method === "DELETE") {
+    try {
+      deleteCredential(match.id, { actor: actorFor(req) });
+      json(res, 200, { success: true, message: "Credential deleted", data: { id: match.id } });
+    } catch (error) {
+      json(res, 400, { success: false, message: error instanceof Error ? error.message : String(error) });
+    }
+    return true;
+  }
+
+  return false;
+}

--- a/homerail_manager/src/server/http.ts
+++ b/homerail_manager/src/server/http.ts
@@ -52,6 +52,8 @@ import { startWorkspaceCleanupScheduler } from "../runtime/workspace-retention.j
 import { runArtifactRoutesHandler } from "./run-artifacts.js";
 import { startRunArtifactService } from "../runtime/run-artifact-service.js";
 import { startDagActorLeaseReaper } from "../runtime/dag-actor-lease-reaper.js";
+import { credentialRoutesHandler } from "./credentials.js";
+import { executeCredentialBrokerCall } from "../runtime/credential-broker.js";
 
 function json(res: http.ServerResponse, status: number, body: unknown) {
   res.writeHead(status, { "Content-Type": "application/json" });
@@ -344,6 +346,10 @@ export function createServer(
       return;
     }
 
+    if (credentialRoutesHandler(req, res)) {
+      return;
+    }
+
     if (memoryRoutesHandler(req, res)) {
       return;
     }
@@ -468,6 +474,7 @@ export function createServer(
         };
       }
     },
+    onCredentialBrokerCall: executeCredentialBrokerCall,
     onFirstWorkerRegistered: () => {
       // Consume waiting fallbacks first, dispatch their READY round nodes, then
       // retry only live commands that still have an active Worker target.

--- a/homerail_manager/src/worker/types.ts
+++ b/homerail_manager/src/worker/types.ts
@@ -50,6 +50,11 @@ export interface ManagerCommandMessage {
   data: Record<string, unknown>;
 }
 
+export interface CredentialBrokerCallMessage {
+  type: "credential_broker_call";
+  data: DagCredentialBrokerCallRequest;
+}
+
 export interface DagActorLiveCommandStatusMessage {
   type: "dag_actor_command_status";
   data: DagActorLiveCommandStatusData;
@@ -97,6 +102,7 @@ export type IncomingWorkerMessage =
   | StreamMessage
   | ContentMessage
   | ManagerCommandMessage
+  | CredentialBrokerCallMessage
   | DagActorLiveCommandStatusMessage
   | NodeErrorMessage
   | SessionEndMessage
@@ -202,6 +208,26 @@ export function parseIncomingMessage(raw: unknown): IncomingWorkerMessage | null
         type: "manager_command",
         data: obj.data as Record<string, unknown>,
       };
+    case "credential_broker_call": {
+      if (typeof obj.data !== "object" || obj.data === null || Array.isArray(obj.data)) return null;
+      const data = obj.data as Record<string, unknown>;
+      if (
+        typeof data.request_id !== "string"
+        || typeof data.run_id !== "string"
+        || typeof data.node_id !== "string"
+        || typeof data.session_id !== "string"
+        || typeof data.credential_ref !== "string"
+        || typeof data.broker !== "string"
+        || typeof data.action !== "string"
+        || typeof data.input !== "object"
+        || data.input === null
+        || Array.isArray(data.input)
+      ) return null;
+      return {
+        type: "credential_broker_call",
+        data: data as unknown as DagCredentialBrokerCallRequest,
+      };
+    }
     case "dag_actor_command_status":
       if (typeof obj.data !== "object" || obj.data === null || Array.isArray(obj.data)) return null;
       return {
@@ -255,4 +281,7 @@ export function parseIncomingMessage(raw: unknown): IncomingWorkerMessage | null
       return null;
   }
 }
-import type { DagActorLiveCommandStatusData } from "homerail-protocol";
+import type {
+  DagActorLiveCommandStatusData,
+  DagCredentialBrokerCallRequest,
+} from "homerail-protocol";

--- a/homerail_manager/src/worker/websocket.ts
+++ b/homerail_manager/src/worker/websocket.ts
@@ -36,6 +36,10 @@ import { ingestDagActivityStream } from "../runtime/dag-activity-stream.js";
 import { handleDagActorLiveCommandStatus } from "../runtime/dag-actor-live-command-runtime.js";
 import { ingestDagActorSurfacePatchStream } from "../runtime/dag-actor-surface-patch-stream.js";
 import { ingestDagActorSurfaceMediaStream } from "../runtime/dag-actor-surface-media-stream.js";
+import type {
+  DagCredentialBrokerCallRequest,
+  DagCredentialBrokerCallResult,
+} from "homerail-protocol";
 
 const WS_URL_PATTERN = /^\/ws\/projects\/([^\/]+)\/workers\/([^\/]+)$/;
 const DEFAULT_REGISTRATION_TIMEOUT_MS = 10_000;
@@ -210,6 +214,10 @@ export interface WorkerWebSocketOptions {
     workerId: string,
     data: Record<string, unknown>,
   ) => { ok: boolean; result?: unknown; error?: string };
+  onCredentialBrokerCall?: (
+    workerId: string,
+    request: DagCredentialBrokerCallRequest,
+  ) => Promise<DagCredentialBrokerCallResult>;
   /** Fired once, after the first worker successfully registers. Used by the
    * cold-recovery boot path to re-dispatch READY nodes of recovered runs now
    * that a dispatch target exists. */
@@ -300,7 +308,7 @@ export function setupWorkerWebSocket(
       ws.on("close", cleanup);
       ws.on("error", cleanup);
 
-      ws.on("message", (raw: Buffer) => {
+      ws.on("message", async (raw: Buffer) => {
         let msg: IncomingWorkerMessage | null;
         let rawMessage: unknown;
         try {
@@ -688,6 +696,42 @@ export function setupWorkerWebSocket(
               type: "manager_command_result",
               data: result,
             }));
+          }
+          return;
+        }
+
+        if (msg.type === "credential_broker_call") {
+          let result: DagCredentialBrokerCallResult;
+          if (!isCurrentDagTransport(
+            worker_id,
+            "credential_broker_call",
+            { ...msg.data },
+            msg.data.session_id,
+          )) {
+            result = {
+              request_id: msg.data.request_id,
+              ok: false,
+              error: "Credential broker call has stale or invalid transport identity",
+            };
+          } else if (!options.onCredentialBrokerCall) {
+            result = {
+              request_id: msg.data.request_id,
+              ok: false,
+              error: "Credential broker handler unavailable",
+            };
+          } else {
+            try {
+              result = await options.onCredentialBrokerCall(worker_id, msg.data);
+            } catch {
+              result = {
+                request_id: msg.data.request_id,
+                ok: false,
+                error: "Credential broker call failed without exposing provider details",
+              };
+            }
+          }
+          if (ws.readyState === WebSocket.OPEN) {
+            ws.send(JSON.stringify({ type: "credential_broker_result", data: result }));
           }
           return;
         }

--- a/homerail_manager/tests/credentials.test.ts
+++ b/homerail_manager/tests/credentials.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { dispatchEnvelopeAuditView } from "../src/orchestration/ws-dispatch-adapter.js";
 import { parseWorkflowSource } from "../src/orchestration/workflow-spec-v1.js";
 import { closeDb, getDb } from "../src/persistence/db.js";
+import { expectCurrentSchemaMigrationVersion } from "./schema-migration-helpers.js";
 import {
   createCredential,
   deleteCredential,
@@ -114,7 +115,7 @@ describe("generic credential store", () => {
       "deleted",
     ]);
     expect(JSON.stringify(listCredentialAuditEvents("demo-api"))).not.toContain(secret);
-    expect(getDb().prepare("SELECT MAX(version) AS version FROM schema_migrations").get()).toEqual({ version: 31 });
+    expectCurrentSchemaMigrationVersion(undefined, 31);
   });
 
   it("does not reinterpret legacy encrypted_credentials rows as execution credentials", () => {

--- a/homerail_manager/tests/credentials.test.ts
+++ b/homerail_manager/tests/credentials.test.ts
@@ -1,0 +1,343 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { dispatchEnvelopeAuditView } from "../src/orchestration/ws-dispatch-adapter.js";
+import { parseWorkflowSource } from "../src/orchestration/workflow-spec-v1.js";
+import { closeDb, getDb } from "../src/persistence/db.js";
+import {
+  createCredential,
+  deleteCredential,
+  getCredential,
+  listCredentialAuditEvents,
+  listCredentials,
+  materializeCredential,
+  revokeCredential,
+  rotateCredential,
+} from "../src/persistence/credentials.js";
+import {
+  _clearActiveRuns,
+  buildCurrentDispatchEnvelope,
+  createActiveRun,
+} from "../src/runtime/active-runs.js";
+import {
+  executeCredentialBrokerCall,
+  invokeCredentialBroker,
+  registerCredentialBroker,
+} from "../src/runtime/credential-broker.js";
+import { parseIncomingMessage } from "../src/worker/types.js";
+
+function workflow(credentials: string): string {
+  return `
+api_version: homerail.ai/v1
+kind: Workflow
+metadata: { id: credential-test, name: Credential test }
+spec:
+  contracts:
+    Task: { type: object }
+  agents:
+    worker: { system: "Use the credential" }
+  nodes:
+    work:
+      kind: agent
+      agent: worker
+      allowed_dag_tools: [handoff, credential_broker_call]
+      credentials:
+${credentials.replace(/^/gm, "        ")}
+      inputs: { task: { contract: Task } }
+      outputs: { done: {} }
+    done: { kind: terminal, outcome: success, inputs: { result: {} } }
+  edges:
+    - { from: $run.input, to: work.task }
+    - { from: work.done, to: done.result }
+`;
+}
+
+describe("generic credential store", () => {
+  let home: string;
+  let previousHome: string | undefined;
+
+  beforeEach(() => {
+    previousHome = process.env.HOMERAIL_HOME;
+    home = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-credentials-"));
+    process.env.HOMERAIL_HOME = home;
+    closeDb();
+    _clearActiveRuns();
+  });
+
+  afterEach(() => {
+    _clearActiveRuns();
+    closeDb();
+    if (previousHome === undefined) delete process.env.HOMERAIL_HOME;
+    else process.env.HOMERAIL_HOME = previousHome;
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it("encrypts values, never returns plaintext, rotates, revokes, and preserves audit after delete", () => {
+    const secret = "sk-credential-plain-value";
+    const created = createCredential({
+      id: "demo-api",
+      credential_type: "api_key",
+      name: "Demo API",
+      secret: { value: secret },
+      metadata: { scopes: ["read"] },
+    }, { actor: "test" });
+    expect(created).toMatchObject({ status: "active", version: 1, secret_fields: ["value"] });
+    expect(JSON.stringify(created)).not.toContain(secret);
+    const stored = getDb().prepare(
+      "SELECT encrypted_payload FROM execution_credentials WHERE id = ?",
+    ).get("demo-api") as { encrypted_payload: string };
+    expect(stored.encrypted_payload).not.toContain(secret);
+
+    expect(materializeCredential("demo-api", {
+      actor: "dag:test:node",
+      run_id: "run-1",
+      node_id: "node-1",
+      purpose: "test call",
+    }).secret.value).toBe(secret);
+    const rotated = rotateCredential("demo-api", { secret: { value: "replacement" } }, { actor: "test" });
+    expect(rotated.version).toBe(2);
+    expect(materializeCredential("demo-api", { actor: "test" }).secret.value).toBe("replacement");
+    expect(revokeCredential("demo-api", { actor: "test" }).status).toBe("revoked");
+    expect(() => materializeCredential("demo-api", { actor: "test" })).toThrow("revoked");
+
+    deleteCredential("demo-api", { actor: "test" });
+    expect(getCredential("demo-api")).toBeUndefined();
+    expect(listCredentialAuditEvents("demo-api").map((event) => event.event_type)).toEqual([
+      "created",
+      "materialized",
+      "rotated",
+      "materialized",
+      "revoked",
+      "denied",
+      "deleted",
+    ]);
+    expect(JSON.stringify(listCredentialAuditEvents("demo-api"))).not.toContain(secret);
+    expect(getDb().prepare("SELECT MAX(version) AS version FROM schema_migrations").get()).toEqual({ version: 31 });
+  });
+
+  it("does not reinterpret legacy encrypted_credentials rows as execution credentials", () => {
+    getDb().prepare(`
+      INSERT INTO encrypted_credentials(
+        id, credential_type, name, encrypted_payload, metadata, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      "legacy-row",
+      "legacy",
+      "Legacy compatibility row",
+      "legacy-payload-format",
+      "{}",
+      "2026-01-01T00:00:00.000Z",
+      "2026-01-01T00:00:00.000Z",
+    );
+    expect(listCredentials()).toEqual([]);
+    expect(getDb().prepare("SELECT id FROM encrypted_credentials WHERE id = ?").get("legacy-row"))
+      .toEqual({ id: "legacy-row" });
+  });
+
+  it("compiles only credential references and redacts materialized dispatch payloads from audit", () => {
+    createCredential({
+      id: "lark-bot",
+      credential_type: "bot",
+      name: "Lark bot",
+      secret: { app_id: "cli_demo", app_secret: "bot-secret-not-for-logs" },
+    }, { actor: "test" });
+    const parsed = parseWorkflowSource(workflow(`- credential_ref: lark-bot
+  purpose: publish a document
+  inject:
+    mode: env
+    mappings:
+      app_id: LARK_APP_ID
+      app_secret: LARK_APP_SECRET`));
+    parsed.meta.agents!.worker.agent_type = "deterministic";
+    createActiveRun("credential-dispatch", parsed);
+    const built = buildCurrentDispatchEnvelope("credential-dispatch", "work");
+    expect(built.ok).toBe(true);
+    if (!built.ok) return;
+    expect(built.envelope.credentialProjections).toEqual([expect.objectContaining({
+      credential_ref: "lark-bot",
+      mode: "env",
+      values: { LARK_APP_ID: "cli_demo", LARK_APP_SECRET: "bot-secret-not-for-logs" },
+    })]);
+    const audit = JSON.stringify(dispatchEnvelopeAuditView(built.envelope));
+    expect(audit).not.toContain("cli_demo");
+    expect(audit).not.toContain("bot-secret-not-for-logs");
+    expect(audit).toContain("LARK_APP_SECRET");
+  });
+
+  it("rejects inline secret fields in WorkflowSpec", () => {
+    expect(() => parseWorkflowSource(workflow(`- credential_ref: lark-bot
+  purpose: publish
+  secret: should-never-compile
+  inject:
+    mode: env
+  mappings: { app_secret: LARK_APP_SECRET }`))).toThrow(/DAG_SCHEMA_INVALID_FIELD/);
+  });
+
+  it("requires the credential broker tool for manager_broker bindings", () => {
+    const source = workflow([
+      "- credential_ref: lark-bot",
+      "  purpose: inspect the bot",
+      "  inject:",
+      "    mode: manager_broker",
+      "    broker: lark_bot",
+      "    allowed_actions: [bot_info]",
+    ].join("\n")).replace(
+      "allowed_dag_tools: [handoff, credential_broker_call]",
+      "allowed_dag_tools: [handoff]",
+    );
+    expect(() => parseWorkflowSource(source)).toThrow(/DAG_SEMANTIC_CREDENTIAL_BROKER_TOOL_REQUIRED/);
+  });
+
+  it("keeps Manager broker secrets host-side and enforces declared actions", async () => {
+    createCredential({
+      id: "broker-api",
+      credential_type: "api_key",
+      name: "Broker API",
+      secret: { value: "broker-secret-value-123" },
+    }, { actor: "test" });
+    registerCredentialBroker("test_broker", "inspect", async ({ credential, secret, input }) => {
+      if (input.throw_secret === true) throw new Error(secret.value);
+      return {
+        credential_id: credential.id,
+        authorized: secret.value === "broker-secret-value-123",
+        input,
+      };
+    });
+    const parsed = parseWorkflowSource(workflow([
+      "- credential_ref: broker-api",
+      "  purpose: inspect through Manager",
+      "  inject:",
+      "    mode: manager_broker",
+      "    broker: test_broker",
+      "    allowed_actions: [inspect]",
+    ].join("\n")));
+    parsed.meta.agents!.worker.agent_type = "deterministic";
+    createActiveRun("credential-broker-run", parsed);
+
+    const result = await executeCredentialBrokerCall("worker-1", {
+      request_id: "request-1",
+      run_id: "credential-broker-run",
+      node_id: "work",
+      session_id: "credential-broker-run",
+      credential_ref: "broker-api",
+      broker: "test_broker",
+      action: "inspect",
+      input: { question: "status" },
+    });
+    expect(result).toEqual({
+      request_id: "request-1",
+      ok: true,
+      result: {
+        credential_id: "broker-api",
+        authorized: true,
+        input: { question: "status" },
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain("broker-secret-value-123");
+
+    const denied = await executeCredentialBrokerCall("worker-1", {
+      request_id: "request-2",
+      run_id: "credential-broker-run",
+      node_id: "work",
+      session_id: "credential-broker-run",
+      credential_ref: "broker-api",
+      broker: "test_broker",
+      action: "delete",
+      input: {},
+    });
+    expect(denied).toMatchObject({ ok: false, error: expect.stringContaining("not permitted") });
+    const providerError = await executeCredentialBrokerCall("worker-1", {
+      request_id: "request-3",
+      run_id: "credential-broker-run",
+      node_id: "work",
+      session_id: "credential-broker-run",
+      credential_ref: "broker-api",
+      broker: "test_broker",
+      action: "inspect",
+      input: { throw_secret: true },
+    });
+    expect(providerError).toMatchObject({
+      ok: false,
+      error: "Credential broker call failed without exposing provider details",
+    });
+    expect(JSON.stringify(providerError)).not.toContain("broker-secret-value-123");
+    expect(listCredentialAuditEvents("broker-api")).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        event_type: "materialized",
+        detail: expect.objectContaining({ broker: "test_broker", action: "inspect" }),
+      }),
+      expect.objectContaining({ event_type: "denied", result: "failed" }),
+    ]));
+  });
+
+  it("rejects broker results that reflect a secret", async () => {
+    registerCredentialBroker("reflection_test", "echo", async ({ secret }) => ({
+      echoed: `reflected:${secret.value}`,
+    }));
+    await expect(invokeCredentialBroker("reflection_test", "echo", {
+      credential: {
+        id: "reflection",
+        credential_type: "api_key",
+        name: "Reflection",
+        status: "active",
+        version: 1,
+        secret_fields: ["value"],
+        metadata: {},
+        created_at: "2026-01-01T00:00:00.000Z",
+        updated_at: "2026-01-01T00:00:00.000Z",
+      },
+      secret: { value: "must-not-leak-secret" },
+      input: {},
+    })).rejects.toThrow("reflected a secret");
+
+    await expect(invokeCredentialBroker("reflection_test", "echo", {
+      credential: {
+        id: "short-reflection",
+        credential_type: "api_key",
+        name: "Short reflection",
+        status: "active",
+        version: 1,
+        secret_fields: ["value"],
+        metadata: {},
+        created_at: "2026-01-01T00:00:00.000Z",
+        updated_at: "2026-01-01T00:00:00.000Z",
+      },
+      secret: { value: "x" },
+      input: {},
+    })).rejects.toThrow("reflected a secret");
+  });
+
+  it("accepts complete broker transport messages and rejects malformed input", () => {
+    expect(parseIncomingMessage({
+      type: "credential_broker_call",
+      data: {
+        request_id: "request-transport",
+        run_id: "run-transport",
+        node_id: "node-transport",
+        session_id: "session-transport",
+        credential_ref: "credential-transport",
+        broker: "test_broker",
+        action: "inspect",
+        input: { question: "status" },
+      },
+    })).toMatchObject({
+      type: "credential_broker_call",
+      data: { request_id: "request-transport", action: "inspect" },
+    });
+    expect(parseIncomingMessage({
+      type: "credential_broker_call",
+      data: {
+        request_id: "request-transport",
+        run_id: "run-transport",
+        node_id: "node-transport",
+        session_id: "session-transport",
+        credential_ref: "credential-transport",
+        broker: "test_broker",
+        action: "inspect",
+        input: "not-an-object",
+      },
+    })).toBeNull();
+  });
+});

--- a/homerail_manager/tests/dag-actor-interventions.test.ts
+++ b/homerail_manager/tests/dag-actor-interventions.test.ts
@@ -15,6 +15,7 @@ import {
 } from "../src/persistence/dag-actor-interventions.js";
 import { registerDagActor } from "../src/persistence/dag-actors.js";
 import { closeDb, getDb } from "../src/persistence/db.js";
+import { expectCurrentSchemaMigrationVersion, expectSchemaMigrationRange } from "./schema-migration-helpers.js";
 import { ensureRunDir } from "../src/persistence/store.js";
 
 describe("DAG actor intervention persistence", () => {
@@ -44,7 +45,7 @@ describe("DAG actor intervention persistence", () => {
   });
 
   it("creates and validates the strict intervention and dispatch-fence schemas on fresh and upgraded databases", () => {
-    expect(getDb().prepare("SELECT MAX(version) AS version FROM schema_migrations").get()).toEqual({ version: 30 });
+    expectCurrentSchemaMigrationVersion();
     expect(getDb().prepare("PRAGMA foreign_key_check").all()).toEqual([]);
     getDb().exec(`
       DROP TABLE dag_actor_dispatch_exclusions;
@@ -98,14 +99,7 @@ describe("DAG actor intervention persistence", () => {
     closeDb();
 
     const migrated = getDb();
-    expect(migrated.prepare(
-      "SELECT version FROM schema_migrations WHERE version >= 27 ORDER BY version",
-    ).all()).toEqual([
-      { version: 27 },
-      { version: 28 },
-      { version: 29 },
-      { version: 30 },
-    ]);
+    expectSchemaMigrationRange(27, migrated);
     expect(migrated.prepare(`
       SELECT agent_id, context_json FROM dag_run_skill_contexts
       WHERE run_id = ? AND agent_id = ?

--- a/homerail_manager/tests/dag-actor-leases.test.ts
+++ b/homerail_manager/tests/dag-actor-leases.test.ts
@@ -26,6 +26,7 @@ import {
 import { getDagActor, registerDagActor } from "../src/persistence/dag-actors.js";
 import { clearTables, closeDb, getDb } from "../src/persistence/db.js";
 import { ensureRunDir } from "../src/persistence/store.js";
+import { expectCurrentSchemaMigrationVersion } from "./schema-migration-helpers.js";
 
 function checkpoint(overrides: Partial<DagActorCheckpointV1> = {}): DagActorCheckpointV1 {
   return {
@@ -99,8 +100,7 @@ describe("DAG actor lease persistence", () => {
 
   it("creates and revalidates the strict actor lease schema on a fresh database", () => {
     const db = getDb();
-    expect(db.prepare("SELECT MAX(version) AS version FROM schema_migrations").get())
-      .toEqual({ version: 30 });
+    expectCurrentSchemaMigrationVersion(db);
     expect(db.prepare(`
       SELECT name FROM sqlite_master
       WHERE type = 'table' AND name IN (

--- a/homerail_manager/tests/dag-actor-live-commands.test.ts
+++ b/homerail_manager/tests/dag-actor-live-commands.test.ts
@@ -15,6 +15,7 @@ import {
 } from "../src/persistence/dag-actor-live-commands.js";
 import { registerDagActor } from "../src/persistence/dag-actors.js";
 import { closeDb, getDb } from "../src/persistence/db.js";
+import { expectCurrentSchemaMigrationVersion } from "./schema-migration-helpers.js";
 import { ensureRunDir } from "../src/persistence/store.js";
 
 const token = "a".repeat(64);
@@ -71,7 +72,7 @@ describe("durable DAG Actor live commands", () => {
   }
 
   it("creates, validates, and reapplies migration 28 on repeated startup", () => {
-    expect(getDb().prepare("SELECT MAX(version) AS version FROM schema_migrations").get()).toEqual({ version: 30 });
+    expectCurrentSchemaMigrationVersion();
     expect(getDb().prepare("PRAGMA foreign_key_check").all()).toEqual([]);
     getDb().exec(`
       DROP TABLE dag_actor_live_commands;

--- a/homerail_manager/tests/dag-actor-surface-patches.test.ts
+++ b/homerail_manager/tests/dag-actor-surface-patches.test.ts
@@ -26,6 +26,7 @@ import {
 } from "../src/persistence/dag-actors.js";
 import { acquireDagActorLease, ensureDagActorLease } from "../src/persistence/dag-actor-leases.js";
 import { closeDb, getDb } from "../src/persistence/db.js";
+import { expectCurrentSchemaMigrationVersion } from "./schema-migration-helpers.js";
 import { createInitialDagRunRound } from "../src/persistence/dag-run-rounds.js";
 import { ensureRunDir } from "../src/persistence/store.js";
 
@@ -166,8 +167,7 @@ describe("DAG Actor surface patch persistence", () => {
     closeDb();
 
     const migrated = getDb();
-    expect(migrated.prepare("SELECT MAX(version) AS version FROM schema_migrations").get())
-      .toEqual({ version: 30 });
+    expectCurrentSchemaMigrationVersion(migrated);
     expect(migrated.prepare(`
       SELECT name FROM sqlite_master
       WHERE type = 'table' AND name LIKE 'dag_actor_surface_%'

--- a/homerail_manager/tests/dag-run-rounds.test.ts
+++ b/homerail_manager/tests/dag-run-rounds.test.ts
@@ -12,6 +12,7 @@ import {
   registerDagActor,
 } from "../src/persistence/dag-actors.js";
 import { closeDb, getDb } from "../src/persistence/db.js";
+import { expectSchemaMigrationRange } from "./schema-migration-helpers.js";
 import {
   createInitialDagRunRound,
   DagRunRoundConflictError,
@@ -134,19 +135,7 @@ describe("DAG run round persistence", () => {
     closeDb();
 
     const migrated = getDb();
-    expect(migrated.prepare("SELECT version FROM schema_migrations WHERE version >= 21 ORDER BY version").all())
-      .toEqual([
-        { version: 21 },
-        { version: 22 },
-        { version: 23 },
-        { version: 24 },
-        { version: 25 },
-        { version: 26 },
-        { version: 27 },
-        { version: 28 },
-        { version: 29 },
-        { version: 30 },
-      ]);
+    expectSchemaMigrationRange(21, migrated);
     expect(migrated.prepare("SELECT * FROM dag_actor_commands ORDER BY command_id").all())
       .toEqual(expectedRows);
     expect(migrated.prepare("PRAGMA foreign_key_check").all()).toEqual([]);

--- a/homerail_manager/tests/generative-ui-persistent-document-service.test.ts
+++ b/homerail_manager/tests/generative-ui-persistent-document-service.test.ts
@@ -31,6 +31,13 @@ function transaction(documentId = "persistent-document", title = "Persistent not
   return compiled;
 }
 
+function expectContinuousSchemaMigrations(minLatestVersion = 30) {
+  const rows = getDb().prepare("SELECT version FROM schema_migrations ORDER BY version").all() as Array<{ version: number }>;
+  const latestVersion = rows.at(-1)?.version ?? 0;
+  expect(latestVersion).toBeGreaterThanOrEqual(minLatestVersion);
+  expect(rows).toEqual(Array.from({ length: latestVersion }, (_, index) => ({ version: index + 1 })));
+}
+
 describe("PersistentGenerativeUiDocumentService", () => {
   let previousHome: string | undefined;
   let tmpHome: string;
@@ -186,8 +193,7 @@ describe("PersistentGenerativeUiDocumentService", () => {
     `).run("legacy-v2", time0, legacyPayload);
     legacy.close();
 
-    expect(getDb().prepare("SELECT version FROM schema_migrations ORDER BY version").all())
-      .toEqual(Array.from({ length: 30 }, (_, index) => ({ version: index + 1 })));
+    expectContinuousSchemaMigrations();
     expect(getDb().prepare("SELECT data FROM voice_agent_sessions WHERE session_id = ?").get("legacy-v2"))
       .toEqual({ data: legacyPayload });
     expect(getDb().prepare(`
@@ -268,8 +274,7 @@ describe("PersistentGenerativeUiDocumentService", () => {
     `);
     mainDb.close();
 
-    expect(getDb().prepare("SELECT version FROM schema_migrations ORDER BY version").all())
-      .toEqual(Array.from({ length: 30 }, (_, index) => ({ version: index + 1 })));
+    expectContinuousSchemaMigrations();
     expect(getDb().prepare(`
       SELECT name FROM sqlite_master
       WHERE type = 'table' AND name IN ('generative_ui_documents', 'generative_ui_user_overrides')

--- a/homerail_manager/tests/plugin-distribution.test.ts
+++ b/homerail_manager/tests/plugin-distribution.test.ts
@@ -9,6 +9,7 @@ import {
   verifyHrpArchive,
 } from "homerail-plugin-sdk";
 import { closeDb, getDb } from "../src/persistence/db.js";
+import { expectCurrentSchemaMigrationVersion } from "./schema-migration-helpers.js";
 import {
   getPluginDistributionRevision,
   listPluginPublisherTrust,
@@ -147,8 +148,6 @@ describe("plugin publisher trust persistence", () => {
       expect.objectContaining({ state: "trusted", revision: 1 }),
     ]);
     expect(listPluginPublisherTrustEvents()).toHaveLength(1);
-    expect(getDb().prepare(
-      "SELECT MAX(version) AS version FROM schema_migrations",
-    ).get()).toEqual({ version: 30 });
+    expectCurrentSchemaMigrationVersion();
   });
 });

--- a/homerail_manager/tests/plugin-package-lifecycle.test.ts
+++ b/homerail_manager/tests/plugin-package-lifecycle.test.ts
@@ -12,6 +12,7 @@ import {
 } from "homerail-plugin-sdk";
 import { GenerativeUiKindRegistry } from "../src/generative-ui/kind-registry.js";
 import { closeDb, getDb } from "../src/persistence/db.js";
+import { expectCurrentSchemaMigrationVersion } from "./schema-migration-helpers.js";
 import {
   getPluginPermissionRevision,
   getActivePlugin,
@@ -260,7 +261,7 @@ describe("external plugin package lifecycle", () => {
       expect.objectContaining({ plugin_version: "1.1.0", active: false, enabled: false }),
       expect.objectContaining({ plugin_version: "1.2.0", active: false, enabled: false }),
     ]));
-    expect(getDb().prepare("SELECT MAX(version) AS version FROM schema_migrations").get()).toEqual({ version: 30 });
+    expectCurrentSchemaMigrationVersion();
     expect(inspectInstalledPlugin("com.example.release-notes")).toMatchObject({ healthy: true, issues: [] });
   });
 
@@ -454,8 +455,7 @@ describe("external plugin package lifecycle", () => {
     closeDb();
 
     expect(getPluginRegistryState().revision).toBe(101);
-    expect(getDb().prepare("SELECT MAX(version) AS version FROM schema_migrations").get())
-      .toEqual({ version: 30 });
+    expectCurrentSchemaMigrationVersion();
   });
 
   it("rejects a stale uninstall when an inactive version was installed concurrently", () => {

--- a/homerail_manager/tests/plugin-remote-registry.test.ts
+++ b/homerail_manager/tests/plugin-remote-registry.test.ts
@@ -13,6 +13,7 @@ import {
   sourceFilesForPack,
 } from "homerail-plugin-sdk";
 import { closeDb, getDb } from "../src/persistence/db.js";
+import { expectCurrentSchemaMigrationVersion } from "./schema-migration-helpers.js";
 import {
   getPluginRegistrySource,
   listPluginRegistryReleases,
@@ -235,8 +236,7 @@ describe("signed remote plugin registry", () => {
     ]);
     expect(listPluginRegistryUpdateAttempts("stable.example").filter((attempt) => attempt.status === "failed"))
       .toHaveLength(3);
-    expect(getDb().prepare("SELECT MAX(version) AS version FROM schema_migrations").get())
-      .toEqual({ version: 30 });
+    expectCurrentSchemaMigrationVersion();
   });
 
   it("rejects signed catalog releases whose payload or publisher digest disagrees with the HRP", () => {

--- a/homerail_manager/tests/schema-migration-helpers.ts
+++ b/homerail_manager/tests/schema-migration-helpers.ts
@@ -1,0 +1,32 @@
+import { expect } from "vitest";
+
+import { getDb } from "../src/persistence/db.js";
+
+type MigrationDb = {
+  prepare(sql: string): {
+    get(): unknown;
+    all(): unknown[];
+  };
+};
+
+export function expectCurrentSchemaMigrationVersion(
+  db: MigrationDb = getDb(),
+  minLatestVersion = 30,
+): number {
+  const row = db.prepare("SELECT MAX(version) AS version FROM schema_migrations").get() as { version: number };
+  expect(row.version).toBeGreaterThanOrEqual(minLatestVersion);
+  return row.version;
+}
+
+export function expectSchemaMigrationRange(
+  startVersion: number,
+  db: MigrationDb = getDb(),
+  minLatestVersion = 30,
+): void {
+  const latestVersion = expectCurrentSchemaMigrationVersion(db, minLatestVersion);
+  expect(db.prepare(
+    `SELECT version FROM schema_migrations WHERE version >= ${startVersion} ORDER BY version`,
+  ).all()).toEqual(
+    Array.from({ length: latestVersion - startVersion + 1 }, (_, index) => ({ version: startVersion + index })),
+  );
+}

--- a/homerail_protocol/src/dag-credentials.ts
+++ b/homerail_protocol/src/dag-credentials.ts
@@ -1,3 +1,8 @@
+/**
+ * DAG credential projection contracts.
+ * @version 0.1.0
+ */
+
 export type DagCredentialProjection =
   | {
       credential_ref: string;

--- a/homerail_protocol/src/dag-credentials.ts
+++ b/homerail_protocol/src/dag-credentials.ts
@@ -1,0 +1,85 @@
+export type DagCredentialProjection =
+  | {
+      credential_ref: string;
+      purpose: string;
+      mode: "env";
+      values: Record<string, string>;
+    }
+  | {
+      credential_ref: string;
+      purpose: string;
+      mode: "file" | "stdin";
+      field: string;
+      content: string;
+      filename: string;
+      env: string;
+    }
+  | {
+      credential_ref: string;
+      purpose: string;
+      mode: "manager_broker";
+      broker: string;
+      allowed_actions: string[];
+    };
+
+export interface DagCredentialProjectionSummary {
+  credential_ref: string;
+  purpose: string;
+  mode: DagCredentialProjection["mode"];
+  fields?: string[];
+  env?: string;
+  broker?: string;
+  allowed_actions?: string[];
+}
+
+export interface DagCredentialBrokerCallRequest {
+  request_id: string;
+  run_id: string;
+  node_id: string;
+  session_id: string;
+  round_id?: string;
+  actor_id?: string;
+  generation?: number;
+  lease_generation?: number;
+  command_id?: string;
+  credential_ref: string;
+  broker: string;
+  action: string;
+  input: Record<string, unknown>;
+}
+
+export interface DagCredentialBrokerCallResult {
+  request_id: string;
+  ok: boolean;
+  result?: unknown;
+  error?: string;
+}
+
+export function summarizeDagCredentialProjection(
+  projection: DagCredentialProjection,
+): DagCredentialProjectionSummary {
+  if (projection.mode === "env") {
+    return {
+      credential_ref: projection.credential_ref,
+      purpose: projection.purpose,
+      mode: projection.mode,
+      fields: Object.keys(projection.values).sort(),
+    };
+  }
+  if (projection.mode === "manager_broker") {
+    return {
+      credential_ref: projection.credential_ref,
+      purpose: projection.purpose,
+      mode: projection.mode,
+      broker: projection.broker,
+      allowed_actions: [...projection.allowed_actions].sort(),
+    };
+  }
+  return {
+    credential_ref: projection.credential_ref,
+    purpose: projection.purpose,
+    mode: projection.mode,
+    fields: [projection.field],
+    env: projection.env,
+  };
+}

--- a/homerail_protocol/src/index.ts
+++ b/homerail_protocol/src/index.ts
@@ -11,6 +11,7 @@ export const PROTOCOL_VERSION = "0.1.0";
 export * from "./types.js";
 export * from "./dag-activity.js";
 export * from "./dag-worker-skill-context.js";
+export * from "./dag-credentials.js";
 export * from "./dag-actor-surface-patch.js";
 export * from "./dag-actor-surface-media.js";
 export * from "./codec.js";

--- a/homerail_protocol/src/types.ts
+++ b/homerail_protocol/src/types.ts
@@ -451,6 +451,7 @@ export const DAG_AGENT_TOOL_NAMES = [
   "get_graph_context",
   "manager_command",
   "consult_advisor",
+  "credential_broker_call",
   "report_activity",
   "report_surface_state",
 ] as const;

--- a/homerail_worker/Dockerfile
+++ b/homerail_worker/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 ENV PATH="/app/node_modules/.bin:${PATH}"
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends bash ca-certificates curl git \
+  && apt-get install -y --no-install-recommends bash ca-certificates curl git openssh-client \
   && rm -rf /var/lib/apt/lists/*
 RUN npm install -g npm@11.6.2
 

--- a/homerail_worker/src/__tests__/claude-sdk.test.ts
+++ b/homerail_worker/src/__tests__/claude-sdk.test.ts
@@ -504,11 +504,16 @@ describe("ClaudeSdkAdapter", () => {
     const { ClaudeSdkAdapter } = await import("../agent/claude-sdk.js");
     const adapter = new ClaudeSdkAdapter();
     const events: AgentEvent[] = [];
-    for await (const e of adapter.run("test", [], { ...ctx, apiKey: "anthropic-secret-value" })) {
+    for await (const e of adapter.run("test", [], {
+      ...ctx,
+      apiKey: "anthropic-secret-value",
+      environmentVariables: { SERVICE_TEST_TOKEN: "turn-scoped-value" },
+    })) {
       events.push(e);
     }
 
     expect((captured[0].env as Record<string, string>).ANTHROPIC_API_KEY).toBe("anthropic-secret-value");
+    expect((captured[0].env as Record<string, string>).SERVICE_TEST_TOKEN).toBe("turn-scoped-value");
     expect((captured[0].env as Record<string, string>).ANTHROPIC_BASE_URL).toBe("https://api.anthropic.com");
     expect((captured[0].env as Record<string, string>).LLM_BASE_URL).toBe("https://api.anthropic.com");
     // Claude Code internal/background model + telemetry are pinned so gateway

--- a/homerail_worker/src/__tests__/credential-projection.test.ts
+++ b/homerail_worker/src/__tests__/credential-projection.test.ts
@@ -1,0 +1,119 @@
+import * as fs from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  containsCredentialValue,
+  materializeCredentialProjections,
+  redactCredentialValues,
+} from "../credential-projection.js";
+import { createDagToolsState } from "../dag-tools/index.js";
+import { createCredentialBrokerCallTool } from "../dag-tools/credential-broker.js";
+
+describe("turn-scoped credential projection", () => {
+  it("projects env and tmpfs files, then removes every value", () => {
+    const materialized = materializeCredentialProjections([
+      {
+        credential_ref: "bot",
+        purpose: "publish",
+        mode: "env",
+        values: { LARK_APP_ID: "app-id", LARK_APP_SECRET: "app-secret" },
+      },
+      {
+        credential_ref: "ssh",
+        purpose: "remote smoke",
+        mode: "file",
+        field: "private_key",
+        content: "PRIVATE KEY CONTENT",
+        filename: "id_ed25519",
+        env: "SSH_KEY_PATH",
+      },
+      {
+        credential_ref: "ssh",
+        purpose: "known hosts stdin",
+        mode: "stdin",
+        field: "known_hosts",
+        content: "example ssh-ed25519 AAAA",
+        filename: "known_hosts",
+        env: "SSH_KNOWN_HOSTS_STDIN_PATH",
+      },
+    ]);
+    const keyPath = materialized.env.SSH_KEY_PATH;
+    const stdinPath = materialized.env.SSH_KNOWN_HOSTS_STDIN_PATH;
+    expect(materialized.env).toMatchObject({ LARK_APP_ID: "app-id", LARK_APP_SECRET: "app-secret" });
+    expect(fs.readFileSync(keyPath, "utf8")).toBe("PRIVATE KEY CONTENT");
+    expect(fs.readFileSync(stdinPath, "utf8")).toBe("example ssh-ed25519 AAAA");
+    expect(materialized.redaction_values).toEqual(expect.arrayContaining([
+      "app-secret",
+      "PRIVATE KEY CONTENT",
+      "example ssh-ed25519 AAAA",
+    ]));
+    if (process.platform !== "win32") expect(fs.statSync(keyPath).mode & 0o077).toBe(0);
+    expect(keyPath.startsWith("/dev/shm/") || keyPath.includes("homerail-credentials")).toBe(true);
+
+    materialized.cleanup();
+    expect(fs.existsSync(keyPath)).toBe(false);
+    expect(fs.existsSync(stdinPath)).toBe(false);
+    expect(materialized.env).toEqual({});
+    expect(materialized.redaction_values).toEqual([]);
+  });
+
+  it("redacts turn secrets and detects reflected handoff values", () => {
+    expect(redactCredentialValues({ text: "prefix-secret-value-suffix" }, ["secret-value"]))
+      .toEqual({ text: "prefix-***-suffix" });
+    expect(containsCredentialValue({ result: "prefix-secret-value-suffix" }, ["secret-value"]))
+      .toBe(true);
+    expect(containsCredentialValue({ result: "safe" }, ["secret-value"]))
+      .toBe(false);
+  });
+
+  it("keeps Manager broker bindings opaque", () => {
+    const materialized = materializeCredentialProjections([{
+      credential_ref: "lark-user",
+      purpose: "write user document",
+      mode: "manager_broker",
+      broker: "lark-user",
+      allowed_actions: ["document.create"],
+    }]);
+    expect(materialized.env).toEqual({});
+    expect(materialized.broker_refs).toEqual([expect.objectContaining({ credential_ref: "lark-user" })]);
+    materialized.cleanup();
+  });
+
+  it("only calls a Manager broker action declared for the node", async () => {
+    const state = createDagToolsState({
+      node_id: "worker",
+      agent_type: "deterministic",
+      model: "test",
+      outgoing_edges: [],
+      incoming_edges: [],
+      graph_nodes: ["worker"],
+      session_id: "session-1",
+    }, "run-1", () => {});
+    const calls: unknown[] = [];
+    const tool = createCredentialBrokerCallTool(state, [{
+      credential_ref: "lark-bot",
+      purpose: "read bot info",
+      mode: "manager_broker",
+      broker: "lark_bot",
+      allowed_actions: ["bot_info"],
+    }], async (request) => {
+      calls.push(request);
+      return { request_id: request.request_id, ok: true, result: { bot_name: "Codex" } };
+    });
+
+    const accepted = await tool.handler({ credential_ref: "lark-bot", action: "bot_info", input: {} });
+    expect(accepted.is_error).not.toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      run_id: "run-1",
+      node_id: "worker",
+      session_id: "session-1",
+      credential_ref: "lark-bot",
+      broker: "lark_bot",
+      action: "bot_info",
+    });
+
+    const denied = await tool.handler({ credential_ref: "lark-bot", action: "send_message", input: {} });
+    expect(denied.is_error).toBe(true);
+    expect(calls).toHaveLength(1);
+  });
+});

--- a/homerail_worker/src/__tests__/kimi-code.test.ts
+++ b/homerail_worker/src/__tests__/kimi-code.test.ts
@@ -243,6 +243,7 @@ describe("KimiCodeAdapter", () => {
           apiKey: "my-api-key",
           baseUrl: "https://api.moonshot.cn/v1",
           model: "kimi-latest",
+          environmentVariables: { SERVICE_TEST_TOKEN: "turn-scoped-value" },
         },
         "/tmp/kimi-home-123",
       );
@@ -253,6 +254,7 @@ describe("KimiCodeAdapter", () => {
       expect(env.KIMI_MODEL_API_KEY).toBe("my-api-key");
       expect(env.KIMI_MODEL_NAME).toBe("kimi-latest");
       expect(env.KIMI_MODEL_BASE_URL).toBe("https://api.moonshot.cn/v1");
+      expect(env.SERVICE_TEST_TOKEN).toBe("turn-scoped-value");
     });
 
     it("does not leak secrets in the returned env object debug output", () => {

--- a/homerail_worker/src/__tests__/prompt-runner.test.ts
+++ b/homerail_worker/src/__tests__/prompt-runner.test.ts
@@ -700,7 +700,7 @@ describe("prompt runner", () => {
       const mockAgent: AgentClient = {
         run() {
           return (async function* () {
-            yield { type: "text" as const, text: "assistant sk-outputsecret12345" };
+            yield { type: "text" as const, text: "assistant sk-outputsecret12345 arbitrary-turn-value" };
             yield { type: "error" as const, message: "failure token=error-secret-value" };
             yield { type: "done" as const };
           })();
@@ -713,6 +713,7 @@ describe("prompt runner", () => {
         sender: "test",
         runId: "run-all-path-redaction",
         dagConfig: makeConfigWith({ session_id: "redacted-session" }),
+        credentialRedactionValues: ["arbitrary-turn-value"],
       }, {
         wsSend: (data) => sent.push(data),
         agentBackend: "test-all-path-redaction",
@@ -727,6 +728,7 @@ describe("prompt runner", () => {
       expect(evidence).not.toContain("task-secret-value");
       expect(evidence).not.toContain("sk-outputsecret12345");
       expect(evidence).not.toContain("error-secret-value");
+      expect(evidence).not.toContain("arbitrary-turn-value");
       expect(evidence).toContain("***REDACTED***");
       const resumableSession = readFileSync(
         join(tmpHome, "manager", "session-store", "redacted-session", "session.json"),
@@ -1097,5 +1099,37 @@ describe("prompt runner", () => {
       lease_generation: 9,
     });
     expect(parsed.map((msg) => msg.type)).toContain("SESSION_END");
+  });
+
+  it("rejects a handoff that reflects a turn-scoped credential", async () => {
+    delete process.env.LLM_BASE_URL;
+    const terminalMessages: string[] = [];
+    const result = await runPrompt({
+      task: "Initial user task wrapper",
+      sender: "test",
+      runId: "run-secret-handoff",
+      dagConfig: {
+        ...makeConfig(),
+        node_id: "secret_node",
+        agent_type: "deterministic",
+        graph_nodes: ["secret_node"],
+        outgoing_edges: [{ from_port: "done", to_node: "", to_port: "" }],
+      },
+      systemPrompt: "HANDOFF port=done content=prefix-arbitrary-turn-value-suffix",
+      credentialRedactionValues: ["arbitrary-turn-value"],
+    }, {
+      wsSend: () => {},
+      onTerminalMessage: (data) => terminalMessages.push(data),
+      agentBackend: "deterministic",
+    });
+
+    expect(result).toMatchObject({ status: "failed", reason: expect.stringContaining("DAG_CREDENTIAL_OUTPUT_REJECTED") });
+    const parsed = terminalMessages.map((message) => JSON.parse(message));
+    expect(parsed.some((message) => message.type === "response")).toBe(false);
+    expect(parsed).toContainEqual(expect.objectContaining({
+      type: "node_error",
+      data: expect.objectContaining({ message: expect.stringContaining("DAG_CREDENTIAL_OUTPUT_REJECTED") }),
+    }));
+    expect(terminalMessages.join("\n")).not.toContain("arbitrary-turn-value");
   });
 });

--- a/homerail_worker/src/agent/claude-sdk.ts
+++ b/homerail_worker/src/agent/claude-sdk.ts
@@ -644,6 +644,7 @@ export class ClaudeSdkAdapter implements AgentClient {
     const fromLlmBaseUrl = process.env.LLM_BASE_URL ?? "";
     const baseUrl = fromContextBaseUrl || fromAnthropicBaseUrl || fromLlmBaseUrl;
     const env = sanitizedAgentChildEnv();
+    Object.assign(env, context.environmentVariables ?? {});
     if (apiKey) env.ANTHROPIC_API_KEY = apiKey;
     if (baseUrl) {
       env.ANTHROPIC_BASE_URL = baseUrl;

--- a/homerail_worker/src/agent/codex-appserver.ts
+++ b/homerail_worker/src/agent/codex-appserver.ts
@@ -573,6 +573,7 @@ export class CodexAppServerAdapter implements AgentClient {
 
   private buildEnv(context: AgentRunContext): Record<string, string | undefined> {
     const env = sanitizedAgentChildEnv();
+    Object.assign(env, context.environmentVariables ?? {});
 
     const apiKey = context.apiKey || process.env.OPENAI_API_KEY || process.env.LLM_API_KEY || "";
     if (apiKey) {

--- a/homerail_worker/src/agent/kimi-code.ts
+++ b/homerail_worker/src/agent/kimi-code.ts
@@ -928,6 +928,7 @@ export class KimiCodeAdapter implements AgentClient {
    */
   buildKimiEnv(context: AgentRunContext, kimiHome: string): Record<string, string | undefined> {
     const env = sanitizedAgentChildEnv();
+    Object.assign(env, context.environmentVariables ?? {});
 
     // Isolated KIMI_CODE_HOME
     env.KIMI_CODE_HOME = kimiHome;

--- a/homerail_worker/src/agent/types.ts
+++ b/homerail_worker/src/agent/types.ts
@@ -98,4 +98,6 @@ export interface AgentRunContext {
   allowedBuiltinTools?: AgentBuiltinToolName[];
   /** Trusted Skills visible to this turn. */
   skillProjection?: AgentSkillProjection;
+  /** Turn-scoped environment assembled from encrypted credential references. */
+  environmentVariables?: Readonly<Record<string, string>>;
 }

--- a/homerail_worker/src/credential-projection.ts
+++ b/homerail_worker/src/credential-projection.ts
@@ -1,0 +1,125 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { randomUUID } from "node:crypto";
+import type { DagCredentialProjection } from "homerail-protocol";
+
+export interface MaterializedCredentialProjection {
+  env: Record<string, string>;
+  broker_refs: Array<Extract<DagCredentialProjection, { mode: "manager_broker" }>>;
+  redaction_values: string[];
+  cleanup: () => void;
+}
+
+export function containsCredentialValue(value: unknown, secrets: readonly string[]): boolean {
+  const candidates = secrets.filter(Boolean);
+  const seen = new WeakSet<object>();
+  const visit = (entry: unknown): boolean => {
+    if (typeof entry === "string") return candidates.some((secret) => entry.includes(secret));
+    if (typeof entry === "number" || typeof entry === "boolean") return candidates.includes(String(entry));
+    if (!entry || typeof entry !== "object") return false;
+    if (seen.has(entry)) return false;
+    seen.add(entry);
+    if (Array.isArray(entry)) return entry.some(visit);
+    return Object.entries(entry).some(([key, child]) => visit(key) || visit(child));
+  };
+  return visit(value);
+}
+
+export function redactCredentialValues(value: unknown, secrets: readonly string[]): unknown {
+  const candidates = [...new Set(secrets.filter(Boolean))].sort((a, b) => b.length - a.length);
+  const redactText = (text: string): string => {
+    let redacted = text;
+    for (const secret of candidates) redacted = redacted.split(secret).join("***");
+    return redacted;
+  };
+  const seen = new WeakMap<object, unknown>();
+  const visit = (entry: unknown): unknown => {
+    if (typeof entry === "string") return redactText(entry);
+    if (!entry || typeof entry !== "object") return entry;
+    const cached = seen.get(entry);
+    if (cached !== undefined) return cached;
+    if (Array.isArray(entry)) {
+      const output: unknown[] = [];
+      seen.set(entry, output);
+      for (const child of entry) output.push(visit(child));
+      return output;
+    }
+    const output: Record<string, unknown> = {};
+    seen.set(entry, output);
+    for (const [key, child] of Object.entries(entry)) output[redactText(key)] = visit(child);
+    return output;
+  };
+  return visit(value);
+}
+
+function credentialTempRoot(): string {
+  const sharedMemory = "/dev/shm";
+  return process.platform !== "win32" && fs.existsSync(sharedMemory)
+    ? sharedMemory
+    : os.tmpdir();
+}
+
+export function materializeCredentialProjections(
+  projections: readonly DagCredentialProjection[],
+): MaterializedCredentialProjection {
+  const env: Record<string, string> = {};
+  const brokerRefs: Array<Extract<DagCredentialProjection, { mode: "manager_broker" }>> = [];
+  const redactionValues: string[] = [];
+  let directory: string | undefined;
+  const ensureDirectory = (): string => {
+    if (directory) return directory;
+    const parent = path.join(credentialTempRoot(), "homerail-credentials");
+    fs.mkdirSync(parent, { recursive: true, mode: 0o700 });
+    directory = path.join(parent, randomUUID());
+    fs.mkdirSync(directory, { mode: 0o700 });
+    return directory;
+  };
+
+  try {
+    for (const projection of projections) {
+      if (projection.mode === "manager_broker") {
+        brokerRefs.push(structuredClone(projection));
+        continue;
+      }
+      if (projection.mode === "env") {
+        for (const [name, value] of Object.entries(projection.values)) {
+          if (Object.prototype.hasOwnProperty.call(env, name)) {
+            throw new Error(`Credential env '${name}' is projected more than once`);
+          }
+          env[name] = value;
+          redactionValues.push(value);
+        }
+        continue;
+      }
+      const filePath = path.join(ensureDirectory(), projection.filename);
+      if (path.dirname(filePath) !== directory || fs.existsSync(filePath)) {
+        throw new Error(`Credential file '${projection.filename}' is unsafe or duplicated`);
+      }
+      fs.writeFileSync(filePath, projection.content, { mode: 0o600, flag: "wx" });
+      try {
+        fs.chmodSync(filePath, 0o600);
+      } catch {
+        // Best effort on platforms without POSIX modes.
+      }
+      env[projection.env] = filePath;
+      redactionValues.push(projection.content);
+    }
+  } catch (cause) {
+    if (directory) fs.rmSync(directory, { recursive: true, force: true });
+    throw cause;
+  }
+
+  const exposedRedactionValues = [...new Set(redactionValues)];
+  return {
+    env,
+    broker_refs: brokerRefs,
+    redaction_values: exposedRedactionValues,
+    cleanup: () => {
+      if (directory) fs.rmSync(directory, { recursive: true, force: true });
+      for (const key of Object.keys(env)) delete env[key];
+      redactionValues.splice(0);
+      exposedRedactionValues.splice(0);
+    },
+  };
+}

--- a/homerail_worker/src/dag-tools/credential-broker.ts
+++ b/homerail_worker/src/dag-tools/credential-broker.ts
@@ -1,0 +1,84 @@
+import { randomUUID } from "node:crypto";
+import type {
+  DagCredentialBrokerCallRequest,
+  DagCredentialBrokerCallResult,
+  DagCredentialProjection,
+} from "homerail-protocol";
+import type { DagToolDefinition } from "../agent/types.js";
+import type { DagToolsState } from "./index.js";
+
+export type CredentialBrokerBinding = Extract<DagCredentialProjection, { mode: "manager_broker" }>;
+export type CredentialBrokerCaller = (
+  request: DagCredentialBrokerCallRequest,
+) => Promise<DagCredentialBrokerCallResult>;
+
+export function createCredentialBrokerCallTool(
+  state: DagToolsState,
+  bindings: readonly CredentialBrokerBinding[],
+  call: CredentialBrokerCaller,
+): DagToolDefinition {
+  return {
+    name: "credential_broker_call",
+    description:
+      "Ask the Manager to perform one declared credential-backed action. "
+      + "The credential stays in the Manager; only the action result is returned.",
+    input_schema: {
+      type: "object",
+      properties: {
+        credential_ref: { type: "string", minLength: 1, maxLength: 128 },
+        action: { type: "string", minLength: 1, maxLength: 128 },
+        input: { type: "object", additionalProperties: true },
+      },
+      required: ["credential_ref", "action"],
+      additionalProperties: false,
+    },
+    async handler(args) {
+      const credentialRef = String(args.credential_ref ?? "").trim();
+      const action = String(args.action ?? "").trim();
+      const binding = bindings.find((candidate) => candidate.credential_ref === credentialRef);
+      if (!binding) {
+        return {
+          content: [{ type: "text", text: `Credential broker reference '${credentialRef}' is not available to this node.` }],
+          is_error: true,
+        };
+      }
+      if (!binding.allowed_actions.includes(action)) {
+        return {
+          content: [{ type: "text", text: `Action '${action}' is not allowed for credential '${credentialRef}'.` }],
+          is_error: true,
+        };
+      }
+      const input = args.input;
+      if (input !== undefined && (typeof input !== "object" || input === null || Array.isArray(input))) {
+        return {
+          content: [{ type: "text", text: "input must be an object" }],
+          is_error: true,
+        };
+      }
+      const result = await call({
+        request_id: randomUUID(),
+        run_id: state.runId,
+        node_id: state.nodeId,
+        session_id: state.sessionId,
+        ...(state.roundId ? { round_id: state.roundId } : {}),
+        ...(state.actorId ? { actor_id: state.actorId } : {}),
+        ...(state.generation !== undefined ? { generation: state.generation } : {}),
+        ...(state.leaseGeneration !== undefined ? { lease_generation: state.leaseGeneration } : {}),
+        ...(state.commandId ? { command_id: state.commandId } : {}),
+        credential_ref: credentialRef,
+        broker: binding.broker,
+        action,
+        input: input as Record<string, unknown> | undefined ?? {},
+      });
+      if (!result.ok) {
+        return {
+          content: [{ type: "text", text: result.error ?? "Credential broker call failed" }],
+          is_error: true,
+        };
+      }
+      return {
+        content: [{ type: "text", text: JSON.stringify(result.result ?? null) }],
+      };
+    },
+  };
+}

--- a/homerail_worker/src/dag-tools/index.ts
+++ b/homerail_worker/src/dag-tools/index.ts
@@ -8,6 +8,7 @@ import type {
   DagActorSurfacePatchPhaseV1,
   DagAdvisorConfig,
   DagActivityType,
+  DagCredentialProjection,
   DagNodeConfig,
   DagWorkerSkillVisualDataContractV1,
   DagWorkspaceAccess,
@@ -27,6 +28,10 @@ import {
   type SurfacePatchEmitter,
 } from "./report-surface-state.js";
 import type { SurfaceMediaPublisher } from "./surface-media.js";
+import {
+  createCredentialBrokerCallTool,
+  type CredentialBrokerCaller,
+} from "./credential-broker.js";
 
 export interface AdvisorCallResult {
   text: string;
@@ -44,6 +49,10 @@ export interface DagToolsOptions {
   pinnedSurfaceViews?: PinnedSurfaceViewRegistry;
   pinnedSurfaceDataContracts?: ReadonlyMap<string, DagWorkerSkillVisualDataContractV1>;
   trustedInputs?: Readonly<Record<string, unknown[]>>;
+  credentialBrokerBindings?: ReadonlyArray<
+    Extract<DagCredentialProjection, { mode: "manager_broker" }>
+  >;
+  credentialBrokerCaller?: CredentialBrokerCaller;
 }
 
 /** Mutable state shared across all DAG tools for a single prompt run. */
@@ -161,6 +170,13 @@ export function createDagTools(state: DagToolsState, options: DagToolsOptions = 
   }
   if (options.activityEmitter) {
     tools.push(createReportActivityTool(options.activityEmitter));
+  }
+  if (options.credentialBrokerBindings?.length && options.credentialBrokerCaller) {
+    tools.push(createCredentialBrokerCallTool(
+      state,
+      options.credentialBrokerBindings,
+      options.credentialBrokerCaller,
+    ));
   }
   if (options.surfacePatchEmitter) {
     tools.push(createReportSurfaceStateTool(

--- a/homerail_worker/src/index.ts
+++ b/homerail_worker/src/index.ts
@@ -8,6 +8,10 @@ import { WsClient } from "./ws-client.js";
 import { runPrompt } from "./prompt-runner.js";
 import type { PromptJob, PromptRunResult } from "./prompt-runner.js";
 import {
+  materializeCredentialProjections,
+  type MaterializedCredentialProjection,
+} from "./credential-projection.js";
+import {
   DAG_ACTOR_LIVE_COMMAND_CAPABILITY,
   DAG_TRANSPORT_FENCE_CAPABILITY,
   DAG_TRANSPORT_FENCE_V1_CAPABILITY,
@@ -17,6 +21,9 @@ import {
   type DagAgentToolName,
   type DagNodeConfig,
   type DagWorkspaceAccess,
+  type DagCredentialProjection,
+  type DagCredentialBrokerCallRequest,
+  type DagCredentialBrokerCallResult,
 } from "homerail-protocol";
 import { startManagerAgentServer } from "./manager-agent/server.js";
 import { resolveWorkerAgentBackend } from "./agent/backend-selection.js";
@@ -87,6 +94,28 @@ let activePrompt:
       deliverInbox?: (content: unknown) => void;
     })
   | null = null;
+
+const pendingCredentialBrokerCalls = new Map<string, {
+  resolve: (result: DagCredentialBrokerCallResult) => void;
+  timer: ReturnType<typeof setTimeout>;
+}>();
+
+function callCredentialBroker(
+  request: DagCredentialBrokerCallRequest,
+): Promise<DagCredentialBrokerCallResult> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      pendingCredentialBrokerCalls.delete(request.request_id);
+      resolve({
+        request_id: request.request_id,
+        ok: false,
+        error: "Credential broker call timed out",
+      });
+    }, 30_000);
+    pendingCredentialBrokerCalls.set(request.request_id, { resolve, timer });
+    client.send(JSON.stringify({ type: "credential_broker_call", data: request }));
+  });
+}
 
 function stringField(data: Record<string, unknown>, ...keys: string[]): string {
   for (const key of keys) {
@@ -234,6 +263,28 @@ client.on("task", async (msg) => {
   );
 
   const trustedInputs = structuredClone(envelope?.inputs ?? {}) as Record<string, unknown[]>;
+  let credentialProjection: MaterializedCredentialProjection;
+  try {
+    const projections = Array.isArray(envelope?.credentialProjections)
+      ? envelope.credentialProjections as DagCredentialProjection[]
+      : [];
+    credentialProjection = materializeCredentialProjections(projections);
+    if (credentialProjection.broker_refs.length > 0) {
+      trustedInputs.credential_brokers = credentialProjection.broker_refs.map((binding) => ({
+        credential_ref: binding.credential_ref,
+        purpose: binding.purpose,
+        broker: binding.broker,
+        allowed_actions: binding.allowed_actions,
+      }));
+    }
+  } catch (cause) {
+    const message = `Worker credential projection rejected: ${cause instanceof Error ? cause.message : String(cause)}`;
+    client.send(JSON.stringify({
+      type: "node_error",
+      data: { runId, nodeId, message, ...(sessionId ? { session_id: sessionId } : {}) },
+    }));
+    return;
+  }
   const job: PromptJob = {
     task,
     sender,
@@ -257,6 +308,9 @@ client.on("task", async (msg) => {
       preparedSkillContext.allowedSurfaceViewIds,
     ),
     trustedInputs,
+    credentialEnv: credentialProjection.env,
+    credentialRedactionValues: credentialProjection.redaction_values,
+    credentialBrokerBindings: credentialProjection.broker_refs,
   };
 
   const abortController = new AbortController();
@@ -303,6 +357,7 @@ client.on("task", async (msg) => {
       agentBackend: backend,
       abortSignal: abortController.signal,
       turnController,
+      credentialBrokerCall: callCredentialBroker,
       registerInboxHandler: (handler) => {
         if (activePrompt?.controller === turnController) {
           activePrompt.deliverInbox = handler;
@@ -321,6 +376,7 @@ client.on("task", async (msg) => {
     };
     console.error("[homerail_worker] prompt runner error:", err);
   } finally {
+    credentialProjection.cleanup();
     const closeResult = await turnController.close({
       outcome: promptResult.status === "completed" ? "completed" : "failed",
       ...(promptResult.status === "failed" ? { reason: promptResult.reason } : {}),
@@ -356,6 +412,21 @@ client.on("dag_actor_command", (msg) => {
     .finally(() => {
       prompt?.commandRoutes.delete(routing);
     });
+});
+
+client.on("credential_broker_result", (msg) => {
+  const data = (msg.data ?? msg) as Partial<DagCredentialBrokerCallResult>;
+  if (typeof data.request_id !== "string" || typeof data.ok !== "boolean") return;
+  const pending = pendingCredentialBrokerCalls.get(data.request_id);
+  if (!pending) return;
+  clearTimeout(pending.timer);
+  pendingCredentialBrokerCalls.delete(data.request_id);
+  pending.resolve({
+    request_id: data.request_id,
+    ok: data.ok,
+    ...(data.result !== undefined ? { result: data.result } : {}),
+    ...(typeof data.error === "string" ? { error: data.error } : {}),
+  });
 });
 
 client.on("inject", (msg) => {
@@ -416,6 +487,11 @@ async function shutdown() {
     await Promise.allSettled([...prompt.commandRoutes]);
   }
   client.close();
+  for (const [requestId, pending] of pendingCredentialBrokerCalls) {
+    clearTimeout(pending.timer);
+    pending.resolve({ request_id: requestId, ok: false, error: "Worker shutting down" });
+  }
+  pendingCredentialBrokerCalls.clear();
   process.exit(0);
 }
 

--- a/homerail_worker/src/prompt-runner.ts
+++ b/homerail_worker/src/prompt-runner.ts
@@ -9,6 +9,9 @@ import {
   validateDagActorSurfaceMediaV1,
   type DagActorCheckpointV1,
   type DagAdvisorConfig,
+  type DagCredentialBrokerCallRequest,
+  type DagCredentialBrokerCallResult,
+  type DagCredentialProjection,
   type DagNodeConfig,
   type DagWorkerSkillContextSummaryV1,
   type DagWorkerSkillVisualDataContractV1,
@@ -38,6 +41,10 @@ import {
   createSurfaceMediaPublisher,
   type SurfaceMediaDownloader,
 } from "./dag-tools/surface-media.js";
+import {
+  containsCredentialValue,
+  redactCredentialValues,
+} from "./credential-projection.js";
 
 export interface PromptJob {
   task: string;
@@ -62,6 +69,11 @@ export interface PromptJob {
   pinnedSurfaceDataContracts?: ReadonlyMap<string, DagWorkerSkillVisualDataContractV1>;
   /** Manager-dispatched structured inputs retained outside the model prompt. */
   trustedInputs?: Readonly<Record<string, unknown[]>>;
+  credentialEnv?: Readonly<Record<string, string>>;
+  credentialRedactionValues?: readonly string[];
+  credentialBrokerBindings?: ReadonlyArray<
+    Extract<DagCredentialProjection, { mode: "manager_broker" }>
+  >;
 }
 
 export interface PromptRunnerDeps {
@@ -73,6 +85,9 @@ export interface PromptRunnerDeps {
   turnController?: AgentTurnController;
   registerInboxHandler?: (handler: (content: unknown) => void) => () => void;
   surfaceMediaDownloader?: SurfaceMediaDownloader;
+  credentialBrokerCall?: (
+    request: DagCredentialBrokerCallRequest,
+  ) => Promise<DagCredentialBrokerCallResult>;
 }
 
 export type PromptRunResult =
@@ -169,7 +184,15 @@ export async function runPrompt(
   job: PromptJob,
   deps: PromptRunnerDeps,
 ): Promise<PromptRunResult> {
-  const { wsSend, agentBackend, auditDir } = deps;
+  const { wsSend: rawWsSend, agentBackend, auditDir } = deps;
+  const credentialRedactionValues = job.credentialRedactionValues ?? [];
+  const redactForTurn = (value: unknown): unknown => redactCredentialValues(
+    redactTelemetry(value),
+    credentialRedactionValues,
+  );
+  const wsSend = (data: string): void => {
+    rawWsSend(String(redactCredentialValues(data, credentialRedactionValues)));
+  };
   const sessionId = job.dagConfig.session_id ?? job.runId;
   const effectiveTask = job.actorCheckpoint
     ? [
@@ -190,8 +213,8 @@ export async function runPrompt(
         nodeId: job.dagConfig.node_id,
         sessionId,
         timestamp: Date.now(),
-        content: redactTelemetry(content),
-        metadata: redactTelemetry(metadata) as Record<string, unknown> | undefined,
+        content: redactForTurn(content),
+        metadata: redactForTurn(metadata) as Record<string, unknown> | undefined,
       });
     } catch {
       // Session transcript persistence is best-effort. The manager DB run
@@ -259,6 +282,9 @@ export async function runPrompt(
   const allDagTools = createDagTools(dagState, {
     advisorRunner: (advisor, question) => runAdvisorCall(advisor, question, workspace, deps.abortSignal),
     activityEmitter: (type, payload) => activityEmitter.emit(type, payload),
+    trustedInputs: job.trustedInputs,
+    credentialBrokerBindings: job.credentialBrokerBindings,
+    credentialBrokerCaller: deps.credentialBrokerCall,
     ...(surfacePatchAllowed
       ? {
           surfacePatchEmitter: ({ surface_id, patch }) => sendStream({
@@ -269,7 +295,6 @@ export async function runPrompt(
           surfaceMediaPublisher,
           pinnedSurfaceViews: job.pinnedSurfaceViews,
           pinnedSurfaceDataContracts: job.pinnedSurfaceDataContracts,
-          trustedInputs: job.trustedInputs,
         }
       : {}),
   });
@@ -323,7 +348,7 @@ export async function runPrompt(
 
   // Stream content via WS
   function sendContent(text: string) {
-    const redactedText = String(redactTelemetry(text));
+    const redactedText = String(redactForTurn(text));
     wsSend(
       JSON.stringify({
         type: "content",
@@ -351,7 +376,7 @@ export async function runPrompt(
       }
       redactedData = { event: "dag_actor_surface_media", media: data.media };
     } else {
-      redactedData = redactTelemetry(data) as Record<string, unknown>;
+      redactedData = redactForTurn(data) as Record<string, unknown>;
     }
     wsSend(
       JSON.stringify({
@@ -418,6 +443,7 @@ export async function runPrompt(
       handoffOnly: correctionOnly,
       allowedBuiltinTools: job.dagConfig.allowed_builtin_tools,
       skillProjection: job.skillProjection,
+      environmentVariables: job.credentialEnv,
     };
     try {
       saveSession({
@@ -437,12 +463,12 @@ export async function runPrompt(
       switch (event.type) {
         case "text":
           sendContent(event.text);
-          audit?.transcript.write({ event: "text", text: event.text });
-          appendSessionTranscript("text", event.text);
+          audit?.transcript.write({ event: "text", text: redactForTurn(event.text) });
+          appendSessionTranscript("text", redactForTurn(event.text));
           break;
         case "debug": {
-          const debugMessage = String(redactTelemetry(event.message));
-          const debugData = redactTelemetry(event.data ?? {}) as Record<string, unknown>;
+          const debugMessage = String(redactForTurn(event.message));
+          const debugData = redactForTurn(event.data ?? {}) as Record<string, unknown>;
           sendStream({
             event: "agent_debug",
             source: event.source,
@@ -476,13 +502,13 @@ export async function runPrompt(
           appendSessionTranscript("tool_use", undefined, {
             tool_name: event.name,
             tool_id: event.id,
-            tool_input: redactTelemetry(event.input),
+            tool_input: redactForTurn(event.input),
           });
           sendStream({
             event: "tool_use",
             tool_name: event.name,
             tool_id: event.id,
-            tool_input: redactTelemetry(event.input),
+            tool_input: redactForTurn(event.input),
           });
           if (event.name !== "report_activity" && event.name !== REPORT_SURFACE_STATE_TOOL_NAME) {
             activityEmitter.emit("tool_used", {
@@ -496,7 +522,7 @@ export async function runPrompt(
             event: "tool_use",
             tool_name: event.name,
             tool_id: event.id,
-            input: redactTelemetry(event.input),
+            input: redactForTurn(event.input),
             node_id: job.dagConfig.node_id,
             run_id: job.runId,
           });
@@ -505,13 +531,13 @@ export async function runPrompt(
           appendSessionTranscript("tool_result", undefined, {
             tool_use_id: event.tool_use_id,
             is_error: event.is_error,
-            result_preview: redactTelemetry(event.content),
+            result_preview: redactForTurn(event.content),
           });
           sendStream({
             event: "tool_result",
             tool_use_id: event.tool_use_id,
             is_error: event.is_error,
-            result_preview: redactTelemetry(event.content),
+            result_preview: redactForTurn(event.content),
           });
           if (toolNamesById.get(event.tool_use_id) !== "report_activity"
             && toolNamesById.get(event.tool_use_id) !== REPORT_SURFACE_STATE_TOOL_NAME) {
@@ -520,7 +546,7 @@ export async function runPrompt(
               tool_name: toolNamesById.get(event.tool_use_id) ?? "unknown",
               tool_id: event.tool_use_id,
               is_error: event.is_error === true,
-              result_preview: String(redactTelemetry(event.content)).slice(0, 4000),
+              result_preview: String(redactForTurn(event.content)).slice(0, 4000),
             });
           }
           audit?.toolEvents.write({
@@ -532,7 +558,7 @@ export async function runPrompt(
           });
           break;
         case "error":
-          errorMessage = String(redactTelemetry(event.message));
+          errorMessage = String(redactForTurn(event.message));
           sendContent(`[ERROR] ${errorMessage}`);
           audit?.transcript.write({ event: "error", message: errorMessage });
           appendSessionTranscript("error", errorMessage);
@@ -576,6 +602,12 @@ export async function runPrompt(
           sendNodeError(`DAG_WORKSPACE_POLICY_VIOLATION ${JSON.stringify(policyResult)}`);
         }
       }
+      if (workspaceValid && dagState.handoffData
+        && containsCredentialValue(dagState.handoffData, credentialRedactionValues)) {
+        dagState.yielded = false;
+        sendNodeError("DAG_CREDENTIAL_OUTPUT_REJECTED handoff reflected a turn-scoped credential");
+        workspaceValid = false;
+      }
       if (workspaceValid && dagState.handoffData) {
         const handoff = dagState.handoffData as Record<string, unknown>;
         activityEmitter.emit("completed", completedActivityPayloadForHandoff(handoff));
@@ -591,7 +623,7 @@ export async function runPrompt(
       }
     }
   } catch (err) {
-    const msg = String(redactTelemetry(err instanceof Error ? err.message : String(err)));
+    const msg = String(redactForTurn(err instanceof Error ? err.message : String(err)));
     sendContent(`[FATAL] ${msg}`);
     audit?.transcript.write({ event: "fatal", message: msg });
     appendSessionTranscript("fatal", msg);
@@ -643,7 +675,7 @@ export async function runPrompt(
   }
 
   function sendNodeError(message: string) {
-    const redactedMessage = String(redactTelemetry(message));
+    const redactedMessage = String(redactForTurn(message));
     promptResult = { status: "failed", reason: redactedMessage };
     if (!terminalActivityEmitted) {
       activityEmitter.emit("failed", { message: redactedMessage });

--- a/homerail_worker/src/ws-client.ts
+++ b/homerail_worker/src/ws-client.ts
@@ -159,6 +159,9 @@ export class WsClient extends EventEmitter {
       case "dag_actor_command":
         this.emit("dag_actor_command", msg);
         break;
+      case "credential_broker_result":
+        this.emit("credential_broker_result", msg);
+        break;
       case "inject":
         this.emit("inject", msg);
         break;


### PR DESCRIPTION
## Summary

- add encrypted API key, OAuth, Bot, SSH key, certificate, and opaque credential CRUD/rotate/revoke/audit APIs plus CLI commands
- compile credential references into WorkflowSpec with env, private file/stdin, or Manager-broker projection policies
- keep broker credentials host-side, fence calls to the current Worker transport, and reject secret-reflecting results or handoffs
- materialize Worker files in tmpfs when available, propagate turn-scoped env to supported agent backends, and clean all projections after each turn
- preserve compatibility with the existing `encrypted_credentials` table by using a separately versioned `execution_credentials` store
- include the credential protocol `@version` marker and migration high-water assertions that track the current schema chain instead of hard-coding an old max version

Milestone: M2 Credential Store. Base retargeted to `main` after #70 merged. Current head: `9887607527ea64e92a70837c0255d93a5290898b`.

## Verification

Local focused verification from the rebased PR head:

- Protocol tests: 297 passed
- Manager focused migration/credential/plugin/DAG suites: 76 passed
- Worker credential/projection/backend suites: 100 passed, 1 skipped
- CLI commands suite: 80 passed
- Protocol build: passed
- Manager typecheck: passed
- Worker typecheck: passed
- CLI typecheck: passed
- real Lark Bot call through the Manager-only broker: passed in earlier M2 validation
- real SSH from the rebuilt Worker container: passed in earlier M2 validation
- Worker tmpfs placement, mode 0600, and post-turn cleanup: passed in earlier M2 validation
- staged secret scan and CLI lockfile check: clean in earlier M2 validation

GitHub Actions from current head:

- Core Linux Node 20: passed
- Core Linux Node 24: passed
- Core Windows Node 24: passed
- Agent UI coverage: passed
- Docker smoke: passed
- Live DAG patterns: skipped by workflow gating

## Security boundary

Secret values are never returned by CRUD APIs or audit views. Env/file projection values cross only the authenticated Worker channel. Worker output and evidence redact the actual turn values, and persistent DAG handoffs fail closed if they reflect one. The built-in Lark broker never sends the app secret or tenant token to the Worker.

## Stack

#68 and #70 have merged into `main`; this PR is now directly based on `main`. After this PR is merged, retarget #72 to `main` and re-run/confirm CI before merging #72.