### PR TITLE
Add stable interactive Artifact revisions

### DIFF
--- a/agent-ui/src/components/generative-ui/A2uiRenderer.test.ts
+++ b/agent-ui/src/components/generative-ui/A2uiRenderer.test.ts
@@ -185,7 +185,7 @@ describe('A2uiRenderer', () => {
       },
       {
         id: 'html', component: 'HrArtifact', kind: 'html',
-        uri: '/api/voice-agent/sessions/session-one/artifacts/story.html',
+        uri: '/api/voice-agent/sessions/session-one/artifacts/by-id/story/preview?revision=2',
         title: 'Story page', description: 'Interactive draft',
       },
     ]), {
@@ -217,6 +217,7 @@ describe('A2uiRenderer', () => {
     expect(frame.getAttribute('sandbox')).toBe('allow-scripts')
     expect(frame.getAttribute('referrerpolicy')).toBe('no-referrer')
     expect(frame.getAttribute('allow')).toBe('')
+    expect(frame.getAttribute('src')).toContain('/artifacts/by-id/story/preview?revision=2')
 
     mounted.querySelector<HTMLButtonElement>('button.hr-a2ui__artifact')?.click()
     mounted.querySelector<HTMLButtonElement>('div.hr-a2ui__artifact > button')?.click()
@@ -315,6 +316,36 @@ describe('A2uiRenderer', () => {
     expect(detailsTab.getAttribute('aria-selected')).toBe('true')
     expect(document.activeElement).toBe(detailsTab)
     expect(root.querySelector('.hr-a2ui__tab-panel')?.textContent).toContain('Updated details')
+  })
+
+  it('refreshes an interactive Artifact in place when its revision URL changes', async () => {
+    const artifact = (revision: number) => surface([
+      { id: 'root', component: 'Column', children: ['preview'] },
+      {
+        id: 'preview', component: 'HrArtifact', kind: 'html', title: 'Live preview',
+        uri: `/api/voice-agent/sessions/session-one/artifacts/by-id/live-preview/preview?revision=${revision}`,
+      },
+    ])
+    const currentNode = ref(node(artifact(1)))
+    root = document.createElement('div')
+    document.body.appendChild(root)
+    app = createApp({
+      setup: () => () => h(A2uiRenderer, { node: currentNode.value, placement, context }),
+    })
+    app.use(i18n)
+    app.mount(root)
+
+    const frame = root.querySelector<HTMLIFrameElement>('[data-a2ui-id="preview"] iframe')!
+    currentNode.value = {
+      ...node(artifact(2)),
+      revision: 2,
+      updated_at: '2026-07-12T10:00:01.000Z',
+    }
+    await nextTick()
+    await nextTick()
+
+    expect(root.querySelector('[data-a2ui-id="preview"] iframe')).toBe(frame)
+    expect(frame.getAttribute('src')).toContain('preview?revision=2')
   })
 
   it('keeps invalid inputs editable, binds writable values, and disables failed actions', async () => {

--- a/docs/generative-ui-a2ui.md
+++ b/docs/generative-ui-a2ui.md
@@ -53,6 +53,8 @@ An A2UI event name is only a trigger. It must match an action already declared b
 
 Artifact components carry passive references only. `HrArtifact` previews resolve through the existing broker and HTML sandbox. Basic image, video, and audio components may use validated HTTP(S) media references. `HrLink` is the only Core Catalog component that creates external navigation, and it accepts only credential-free HTTP(S) URLs opened with `noopener`, `noreferrer`, and a no-referrer policy. Executable schemes, credentials, data URLs, network shares, and unsafe local schemes are rejected. A function cannot create a new network or execution capability.
 
+Session Artifacts have a stable logical `artifact_id` and immutable numbered revisions. The first `publish_artifact` call returns revision 1. A later update must reuse the ID and pass the last revision as `expected_revision`; stale updates fail with HTTP 409. Each result includes an immutable `revision_url`, a stable `stable_url`, and a revision-addressed `preview_url`. A2UI should retain its Block and component IDs while replacing the `HrArtifact.uri` with the latest `preview_url`, so an interactive HTML preview refreshes without moving or recreating the surrounding surface.
+
 ## Runtime Invariants
 
 HomeRail applies stricter snapshot rules in addition to the official A2UI JSON Schema:

--- a/homerail_manager/src/persistence/db.ts
+++ b/homerail_manager/src/persistence/db.ts
@@ -71,6 +71,8 @@ const CLEARABLE_TABLES = new Set([
   "manager_agent_config",
   "voice_agent_config",
   "voice_agent_sessions",
+  "voice_artifact_revisions",
+  "voice_artifacts",
   "generative_ui_user_overrides",
   "generative_ui_transactions",
   "generative_ui_documents",
@@ -1878,6 +1880,42 @@ function validateCredentialStoreSchemaV31(db: SqliteDatabase): void {
     if (!hasColumn(db, "execution_credentials", column)) {
       throw new Error(`Schema migration 31 is incomplete: execution_credentials is missing column ${column}`);
     }
+  }
+}
+
+function validateVoiceArtifactSchemaV32(db: SqliteDatabase): void {
+  if (!hasTable(db, "voice_artifacts") || !hasTable(db, "voice_artifact_revisions")) {
+    throw new Error("Schema migration 32 is incomplete: voice artifact tables are missing");
+  }
+  for (const column of [
+    "session_id",
+    "artifact_id",
+    "current_revision",
+    "current_digest",
+    "current_filename",
+  ]) {
+    if (!hasColumn(db, "voice_artifacts", column)) {
+      throw new Error(`Schema migration 32 is incomplete: voice_artifacts is missing column ${column}`);
+    }
+  }
+  for (const column of ["revision", "digest", "filename", "size_bytes", "created_at"]) {
+    if (!hasColumn(db, "voice_artifact_revisions", column)) {
+      throw new Error(`Schema migration 32 is incomplete: voice_artifact_revisions is missing column ${column}`);
+    }
+  }
+  const immutableTrigger = db.prepare(`
+    SELECT name FROM sqlite_master
+    WHERE type = 'trigger' AND name = 'trg_voice_artifact_revisions_no_update'
+  `).get();
+  if (!immutableTrigger) {
+    throw new Error("Schema migration 32 is incomplete: voice artifact revisions are mutable");
+  }
+  const revisionForeignKeys = new Set(
+    (db.prepare("PRAGMA foreign_key_list(voice_artifact_revisions)").all() as Array<{ table: string }>)
+      .map((entry) => entry.table),
+  );
+  if (!revisionForeignKeys.has("voice_artifacts")) {
+    throw new Error("Schema migration 32 is incomplete: voice artifact revision ownership is invalid");
   }
 }
 
@@ -3994,6 +4032,55 @@ const SCHEMA_MIGRATIONS: readonly SchemaMigration[] = [
       `);
     },
     validate: validateCredentialStoreSchemaV31,
+  },
+  {
+    version: 32,
+    up: (db) => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS voice_artifacts (
+          session_id TEXT NOT NULL,
+          artifact_id TEXT NOT NULL,
+          title TEXT NOT NULL,
+          kind TEXT NOT NULL CHECK(kind IN ('image', 'html')),
+          media_type TEXT NOT NULL,
+          current_revision INTEGER NOT NULL CHECK(current_revision >= 1),
+          current_digest TEXT NOT NULL CHECK(
+            length(current_digest) = 64 AND current_digest NOT GLOB '*[^0-9a-f]*'
+          ),
+          current_filename TEXT NOT NULL,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          PRIMARY KEY(session_id, artifact_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_voice_artifacts_session_updated
+          ON voice_artifacts(session_id, updated_at DESC, artifact_id);
+
+        CREATE TABLE IF NOT EXISTS voice_artifact_revisions (
+          session_id TEXT NOT NULL,
+          artifact_id TEXT NOT NULL,
+          revision INTEGER NOT NULL CHECK(revision >= 1),
+          title TEXT NOT NULL,
+          kind TEXT NOT NULL CHECK(kind IN ('image', 'html')),
+          media_type TEXT NOT NULL,
+          digest TEXT NOT NULL CHECK(length(digest) = 64 AND digest NOT GLOB '*[^0-9a-f]*'),
+          filename TEXT NOT NULL,
+          size_bytes INTEGER NOT NULL CHECK(size_bytes >= 1),
+          created_at TEXT NOT NULL,
+          PRIMARY KEY(session_id, artifact_id, revision),
+          FOREIGN KEY(session_id, artifact_id)
+            REFERENCES voice_artifacts(session_id, artifact_id)
+            ON UPDATE RESTRICT ON DELETE RESTRICT
+        );
+        CREATE INDEX IF NOT EXISTS idx_voice_artifact_revisions_digest
+          ON voice_artifact_revisions(session_id, artifact_id, digest);
+        CREATE TRIGGER IF NOT EXISTS trg_voice_artifact_revisions_no_update
+        BEFORE UPDATE ON voice_artifact_revisions
+        BEGIN
+          SELECT RAISE(ABORT, 'Voice artifact revisions are append-only');
+        END;
+      `);
+    },
+    validate: validateVoiceArtifactSchemaV32,
   },
 ];
 

--- a/homerail_manager/src/server/host-codex-manager-agent.ts
+++ b/homerail_manager/src/server/host-codex-manager-agent.ts
@@ -1570,7 +1570,12 @@ export function createManagerTools(state: {
           `/voice-agent/sessions/${encodeURIComponent(state.sessionId)}/artifacts/publish`,
           {
             method: "POST",
-            body: JSON.stringify({ source_path: sourcePath, title: args.title }),
+            body: JSON.stringify({
+              source_path: sourcePath,
+              title: args.title,
+              artifact_id: args.artifact_id,
+              expected_revision: args.expected_revision,
+            }),
           },
         );
         return { content: [{ type: "text", text: short(body, 4000) }] };

--- a/homerail_manager/src/server/voice-agent-bootstrap.ts
+++ b/homerail_manager/src/server/voice-agent-bootstrap.ts
@@ -78,6 +78,8 @@ import { acceptPluginToolExecution } from "../plugins/execution-broker.js";
 import {
   publishVoiceArtifact,
   resolveVoiceArtifact,
+  resolveVoiceArtifactRevision,
+  VoiceArtifactRevisionConflictError,
 } from "./voice-artifacts.js";
 import {
   assembleLegacyWidgetReservations,
@@ -278,6 +280,10 @@ function created(res: http.ServerResponse, message: string, data?: unknown) {
 
 function badRequest(res: http.ServerResponse, message: string) {
   json(res, 400, { success: false, message, error: message });
+}
+
+function conflict(res: http.ServerResponse, message: string) {
+  json(res, 409, { success: false, message, error: message });
 }
 
 function notFound(res: http.ServerResponse, message: string) {
@@ -1884,6 +1890,9 @@ export function voiceAgentBootstrapHandler(
 
   const artifactPreview = pathname.match(/^\/api\/voice-agent\/sessions\/([^/]+)\/artifacts\/preview$/);
   const artifactPublish = pathname.match(/^\/api\/voice-agent\/sessions\/([^/]+)\/artifacts\/publish$/);
+  const artifactById = pathname.match(
+    /^\/api\/voice-agent\/sessions\/([^/]+)\/artifacts\/by-id\/([^/]+)\/preview$/,
+  );
   const artifactFile = pathname.match(/^\/api\/voice-agent\/sessions\/([^/]+)\/artifacts\/(.+)$/);
   if (method === "POST" && artifactPublish) {
     readJsonBody(req).then((body) => {
@@ -1892,24 +1901,36 @@ export function voiceAgentBootstrapHandler(
       if (!workspace) throw new HttpNotFoundError("Voice workspace not found");
       const sourcePath = typeof body.source_path === "string" ? body.source_path : "";
       if (!sourcePath) throw new HttpBadRequestError("Missing required field: source_path");
+      if (body.expected_revision !== undefined && typeof body.expected_revision !== "number") {
+        throw new HttpBadRequestError("expected_revision must be a number");
+      }
       const artifact = publishVoiceArtifact({
         session_id: sessionId,
         project_id: workspace.project_id,
         source_path: sourcePath,
         title: typeof body.title === "string" ? body.title : undefined,
+        artifact_id: typeof body.artifact_id === "string" ? body.artifact_id : undefined,
+        expected_revision: typeof body.expected_revision === "number" ? body.expected_revision : undefined,
       });
       ok(res, "Voice artifact published", { artifact });
     }).catch((cause) => {
       if (cause instanceof HttpNotFoundError) notFound(res, cause.message);
+      else if (cause instanceof VoiceArtifactRevisionConflictError) conflict(res, cause.message);
       else badRequest(res, cause instanceof Error ? cause.message : "Artifact publishing failed");
     });
     return true;
   }
-  if (method === "GET" && (artifactPreview || artifactFile)) {
+  if (method === "GET" && (artifactById || artifactPreview || artifactFile)) {
     try {
-      const sessionId = decodeURIComponent((artifactPreview ?? artifactFile)![1]);
-      const filePath = artifactPreview ? "index.html" : decodeURIComponent(artifactFile![2]);
-      const resolved = resolveVoiceArtifact(sessionId, filePath);
+      const sessionId = decodeURIComponent((artifactById ?? artifactPreview ?? artifactFile)![1]);
+      const revisionValue = url.searchParams.get("revision");
+      const revision = revisionValue === null ? undefined : Number(revisionValue);
+      const resolved = artifactById
+        ? resolveVoiceArtifactRevision(sessionId, decodeURIComponent(artifactById[2]), revision).path
+        : resolveVoiceArtifact(
+          sessionId,
+          artifactPreview ? "index.html" : decodeURIComponent(artifactFile![2]),
+        );
       const ext = path.extname(resolved).toLowerCase();
       const type = ext === ".html" ? "text/html; charset=utf-8"
         : ext === ".png" ? "image/png"
@@ -1919,6 +1940,7 @@ export function voiceAgentBootstrapHandler(
       res.writeHead(200, {
         "Content-Type": type,
         "X-Content-Type-Options": "nosniff",
+        "Cache-Control": artifactById ? "no-store" : "private, max-age=31536000, immutable",
         ...(ext === ".html" ? { "Content-Security-Policy": "sandbox allow-scripts allow-forms allow-pointer-lock allow-popups" } : {}),
       });
       fs.createReadStream(resolved).pipe(res);

--- a/homerail_manager/src/server/voice-artifacts.ts
+++ b/homerail_manager/src/server/voice-artifacts.ts
@@ -1,8 +1,10 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { ensureDefaultWorkspacePath, getDataRoot } from "../config/env.js";
+import { dbTransaction, getDb } from "../persistence/db.js";
 import { getProject } from "../persistence/projects-changes.js";
+import { nowIso } from "../persistence/time.js";
 
 const MAX_ARTIFACT_BYTES = 16 * 1024 * 1024;
 const MAX_HTML_BYTES = 2 * 1024 * 1024;
@@ -17,17 +19,61 @@ const ARTIFACT_FORMATS = new Map([
 ]);
 
 export interface PublishedVoiceArtifact {
+  artifact_id: string;
+  revision: number;
+  title: string;
   filename: string;
   url: string;
+  preview_url: string;
+  stable_url: string;
+  revision_url: string;
   media_type: string;
   kind: "image" | "html";
   size_bytes: number;
   digest: string;
 }
 
+interface VoiceArtifactRow {
+  session_id: string;
+  artifact_id: string;
+  title: string;
+  kind: "image" | "html";
+  media_type: string;
+  current_revision: number;
+  current_digest: string;
+  current_filename: string;
+}
+
+interface VoiceArtifactRevisionRow {
+  revision: number;
+  title: string;
+  kind: "image" | "html";
+  media_type: string;
+  digest: string;
+  filename: string;
+  size_bytes: number;
+}
+
+export interface ResolvedVoiceArtifactRevision extends PublishedVoiceArtifact {
+  path: string;
+}
+
+export class VoiceArtifactRevisionConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "VoiceArtifactRevisionConflictError";
+  }
+}
+
 function safeSessionId(value: string): string {
   if (!/^[A-Za-z0-9_.-]+$/.test(value)) throw new Error("invalid voice session id");
   return value;
+}
+
+function safeArtifactId(value: string): string {
+  const clean = value.trim();
+  if (!/^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$/.test(clean)) throw new Error("invalid voice artifact id");
+  return clean;
 }
 
 export function voiceArtifactRoot(sessionId: string): string {
@@ -80,6 +126,58 @@ function slug(value: string): string {
   return normalized.slice(0, 48) || "artifact";
 }
 
+function artifactUrls(sessionId: string, artifactId: string, revision: number, filename: string) {
+  const session = encodeURIComponent(sessionId);
+  const id = encodeURIComponent(artifactId);
+  const revisionUrl = `/api/voice-agent/sessions/${session}/artifacts/${encodeURIComponent(filename)}`;
+  const stableUrl = `/api/voice-agent/sessions/${session}/artifacts/by-id/${id}/preview`;
+  return {
+    url: revisionUrl,
+    revision_url: revisionUrl,
+    stable_url: stableUrl,
+    preview_url: `${stableUrl}?revision=${revision}`,
+  };
+}
+
+function publishedFromRows(
+  sessionId: string,
+  artifactId: string,
+  artifact: VoiceArtifactRow,
+  revision: VoiceArtifactRevisionRow,
+): PublishedVoiceArtifact {
+  return {
+    artifact_id: artifactId,
+    revision: revision.revision,
+    title: revision.title,
+    filename: revision.filename,
+    ...artifactUrls(sessionId, artifactId, revision.revision, revision.filename),
+    media_type: revision.media_type,
+    kind: revision.kind,
+    size_bytes: revision.size_bytes,
+    digest: revision.digest,
+  };
+}
+
+function getArtifactRow(sessionId: string, artifactId: string): VoiceArtifactRow | undefined {
+  return getDb().prepare(`
+    SELECT session_id, artifact_id, title, kind, media_type, current_revision, current_digest, current_filename
+    FROM voice_artifacts
+    WHERE session_id = ? AND artifact_id = ?
+  `).get(sessionId, artifactId) as VoiceArtifactRow | undefined;
+}
+
+function getRevisionRow(
+  sessionId: string,
+  artifactId: string,
+  revision: number,
+): VoiceArtifactRevisionRow | undefined {
+  return getDb().prepare(`
+    SELECT revision, title, kind, media_type, digest, filename, size_bytes
+    FROM voice_artifact_revisions
+    WHERE session_id = ? AND artifact_id = ? AND revision = ?
+  `).get(sessionId, artifactId, revision) as VoiceArtifactRevisionRow | undefined;
+}
+
 function verifyMagic(content: Buffer, extension: string): void {
   if (extension === ".png" && !content.subarray(0, 8).equals(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]))) {
     throw new Error("PNG artifact signature is invalid");
@@ -97,7 +195,15 @@ export function publishVoiceArtifact(input: {
   project_id?: string | null;
   source_path: string;
   title?: string;
+  artifact_id?: string;
+  expected_revision?: number;
 }): PublishedVoiceArtifact {
+  const sessionId = safeSessionId(input.session_id);
+  const artifactId = input.artifact_id ? safeArtifactId(input.artifact_id) : `artifact-${randomUUID()}`;
+  if (input.expected_revision !== undefined
+    && (!Number.isInteger(input.expected_revision) || input.expected_revision < 0)) {
+    throw new Error("expected_revision must be a non-negative integer");
+  }
   const root = projectRoot(input.project_id);
   const source = sourceFile(root, input.source_path);
   const extension = path.extname(source).toLowerCase();
@@ -110,17 +216,116 @@ export function publishVoiceArtifact(input: {
   verifyMagic(content, extension);
   const digest = createHash("sha256").update(content).digest("hex");
   const outputExtension = extension === ".htm" ? ".html" : extension;
-  const filename = `${slug(input.title || path.basename(source, extension))}-${digest.slice(0, 16)}${outputExtension}`;
-  const destinationRoot = voiceArtifactRoot(input.session_id);
+  const title = String(input.title || path.basename(source, extension)).trim().slice(0, 200) || "Artifact";
+  const filename = `${slug(title)}-${digest.slice(0, 16)}${outputExtension}`;
+  const destinationRoot = voiceArtifactRoot(sessionId);
   const destination = path.join(destinationRoot, filename);
   fs.mkdirSync(destinationRoot, { recursive: true });
   if (!fs.existsSync(destination)) fs.writeFileSync(destination, content, { mode: 0o600 });
+
+  return dbTransaction(() => {
+    const existing = getArtifactRow(sessionId, artifactId);
+    if (!existing) {
+      if (input.expected_revision !== undefined && input.expected_revision !== 0) {
+        throw new VoiceArtifactRevisionConflictError(
+          `voice artifact does not exist; expected_revision must be 0, received ${input.expected_revision}`,
+        );
+      }
+      const createdAt = nowIso();
+      getDb().prepare(`
+        INSERT INTO voice_artifacts (
+          session_id, artifact_id, title, kind, media_type, current_revision,
+          current_digest, current_filename, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, 1, ?, ?, ?, ?)
+      `).run(sessionId, artifactId, title, format.kind, format.mediaType, digest, filename, createdAt, createdAt);
+      getDb().prepare(`
+        INSERT INTO voice_artifact_revisions (
+          session_id, artifact_id, revision, title, kind, media_type,
+          digest, filename, size_bytes, created_at
+        ) VALUES (?, ?, 1, ?, ?, ?, ?, ?, ?, ?)
+      `).run(sessionId, artifactId, title, format.kind, format.mediaType, digest, filename, stat.size, createdAt);
+      const artifact = getArtifactRow(sessionId, artifactId)!;
+      const revision = getRevisionRow(sessionId, artifactId, 1)!;
+      return publishedFromRows(sessionId, artifactId, artifact, revision);
+    }
+
+    if (input.expected_revision === undefined) {
+      throw new VoiceArtifactRevisionConflictError(
+        `expected_revision is required to update voice artifact ${artifactId}`,
+      );
+    }
+    if (input.expected_revision !== existing.current_revision) {
+      throw new VoiceArtifactRevisionConflictError(
+        `voice artifact revision conflict: expected ${input.expected_revision}, current ${existing.current_revision}`,
+      );
+    }
+    if (existing.current_digest === digest
+      && existing.kind === format.kind
+      && existing.media_type === format.mediaType) {
+      const revision = getRevisionRow(sessionId, artifactId, existing.current_revision)!;
+      return publishedFromRows(sessionId, artifactId, existing, revision);
+    }
+
+    const nextRevision = existing.current_revision + 1;
+    const updatedAt = nowIso();
+    getDb().prepare(`
+      INSERT INTO voice_artifact_revisions (
+        session_id, artifact_id, revision, title, kind, media_type,
+        digest, filename, size_bytes, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      sessionId,
+      artifactId,
+      nextRevision,
+      title,
+      format.kind,
+      format.mediaType,
+      digest,
+      filename,
+      stat.size,
+      updatedAt,
+    );
+    const update = getDb().prepare(`
+      UPDATE voice_artifacts
+      SET title = ?, kind = ?, media_type = ?, current_revision = ?,
+          current_digest = ?, current_filename = ?, updated_at = ?
+      WHERE session_id = ? AND artifact_id = ? AND current_revision = ?
+    `).run(
+      title,
+      format.kind,
+      format.mediaType,
+      nextRevision,
+      digest,
+      filename,
+      updatedAt,
+      sessionId,
+      artifactId,
+      existing.current_revision,
+    );
+    if (update.changes !== 1) {
+      throw new VoiceArtifactRevisionConflictError("voice artifact changed during publication");
+    }
+    const artifact = getArtifactRow(sessionId, artifactId)!;
+    const revision = getRevisionRow(sessionId, artifactId, nextRevision)!;
+    return publishedFromRows(sessionId, artifactId, artifact, revision);
+  });
+}
+
+export function resolveVoiceArtifactRevision(
+  sessionIdInput: string,
+  artifactIdInput: string,
+  revisionInput?: number,
+): ResolvedVoiceArtifactRevision {
+  const sessionId = safeSessionId(sessionIdInput);
+  const artifactId = safeArtifactId(artifactIdInput);
+  const artifact = getArtifactRow(sessionId, artifactId);
+  if (!artifact) throw new Error("voice artifact not found");
+  const revisionNumber = revisionInput ?? artifact.current_revision;
+  if (!Number.isInteger(revisionNumber) || revisionNumber < 1) throw new Error("invalid voice artifact revision");
+  const revision = getRevisionRow(sessionId, artifactId, revisionNumber);
+  if (!revision) throw new Error("voice artifact revision not found");
   return {
-    filename,
-    url: `/api/voice-agent/sessions/${encodeURIComponent(input.session_id)}/artifacts/${encodeURIComponent(filename)}`,
-    media_type: format.mediaType,
-    kind: format.kind,
-    size_bytes: stat.size,
-    digest,
+    ...publishedFromRows(sessionId, artifactId, artifact, revision),
+    path: resolveVoiceArtifact(sessionId, revision.filename),
   };
 }

--- a/homerail_manager/tests/voice-artifacts.test.ts
+++ b/homerail_manager/tests/voice-artifacts.test.ts
@@ -3,9 +3,12 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getDefaultWorkspacePath } from "../src/config/env.js";
+import { closeDb, getDb } from "../src/persistence/db.js";
 import {
   publishVoiceArtifact,
   resolveVoiceArtifact,
+  resolveVoiceArtifactRevision,
+  VoiceArtifactRevisionConflictError,
 } from "../src/server/voice-artifacts.js";
 
 const ONE_PIXEL_PNG = Buffer.from(
@@ -18,12 +21,14 @@ describe("voice artifact publishing", () => {
   let oldHome: string | undefined;
 
   beforeEach(() => {
+    closeDb();
     oldHome = process.env.HOMERAIL_HOME;
     home = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-artifact-"));
     process.env.HOMERAIL_HOME = home;
   });
 
   afterEach(() => {
+    closeDb();
     if (oldHome === undefined) delete process.env.HOMERAIL_HOME;
     else process.env.HOMERAIL_HOME = oldHome;
     fs.rmSync(home, { recursive: true, force: true });
@@ -41,15 +46,18 @@ describe("voice artifact publishing", () => {
     });
 
     expect(published).toMatchObject({
+      revision: 1,
       kind: "image",
       media_type: "image/png",
       size_bytes: ONE_PIXEL_PNG.byteLength,
     });
     expect(published.url).toBe(`/api/voice-agent/sessions/session-one/artifacts/${published.filename}`);
+    expect(published.preview_url).toBe(`${published.stable_url}?revision=1`);
+    expect(published.stable_url).toContain(`/artifacts/by-id/${published.artifact_id}/preview`);
     expect(fs.readFileSync(resolveVoiceArtifact("session-one", published.filename))).toEqual(ONE_PIXEL_PNG);
   });
 
-  it("publishes standalone HTML and reuses the same digest path", () => {
+  it("publishes standalone HTML and reuses the same immutable digest path", () => {
     const workspace = getDefaultWorkspacePath();
     fs.mkdirSync(workspace, { recursive: true });
     fs.writeFileSync(path.join(workspace, "story.html"), "<!doctype html><title>AI story</title>");
@@ -57,9 +65,80 @@ describe("voice artifact publishing", () => {
     const first = publishVoiceArtifact({ session_id: "session-two", source_path: "story.html" });
     const second = publishVoiceArtifact({ session_id: "session-two", source_path: "story.html" });
 
-    expect(first).toEqual(second);
+    expect(first.artifact_id).not.toBe(second.artifact_id);
+    expect(first.filename).toBe(second.filename);
+    expect(first.digest).toBe(second.digest);
     expect(first.kind).toBe("html");
     expect(first.url).toContain("/artifacts/story-");
+  });
+
+  it("updates one stable Artifact with immutable revisions and refreshable preview URLs", () => {
+    const workspace = getDefaultWorkspacePath();
+    fs.mkdirSync(workspace, { recursive: true });
+    const source = path.join(workspace, "dashboard.html");
+    fs.writeFileSync(source, "<!doctype html><button id=counter>First</button>");
+
+    const first = publishVoiceArtifact({
+      session_id: "session-stable",
+      source_path: "dashboard.html",
+      artifact_id: "live-dashboard",
+      expected_revision: 0,
+    });
+    fs.writeFileSync(source, "<!doctype html><button id=counter>Second</button>");
+    const second = publishVoiceArtifact({
+      session_id: "session-stable",
+      source_path: "dashboard.html",
+      artifact_id: first.artifact_id,
+      expected_revision: first.revision,
+    });
+
+    expect(second.artifact_id).toBe(first.artifact_id);
+    expect(second.revision).toBe(2);
+    expect(second.stable_url).toBe(first.stable_url);
+    expect(second.preview_url).not.toBe(first.preview_url);
+    expect(fs.readFileSync(resolveVoiceArtifactRevision("session-stable", "live-dashboard", 1).path, "utf8"))
+      .toContain("First");
+    expect(fs.readFileSync(resolveVoiceArtifactRevision("session-stable", "live-dashboard").path, "utf8"))
+      .toContain("Second");
+  });
+
+  it("rejects stale or unguarded updates without changing the current revision", () => {
+    const workspace = getDefaultWorkspacePath();
+    fs.mkdirSync(workspace, { recursive: true });
+    fs.writeFileSync(path.join(workspace, "status.html"), "<!doctype html><p>one</p>");
+    const first = publishVoiceArtifact({
+      session_id: "session-cas",
+      source_path: "status.html",
+      artifact_id: "status",
+    });
+    fs.writeFileSync(path.join(workspace, "status.html"), "<!doctype html><p>two</p>");
+
+    expect(() => publishVoiceArtifact({
+      session_id: "session-cas",
+      source_path: "status.html",
+      artifact_id: "status",
+    })).toThrow(VoiceArtifactRevisionConflictError);
+    expect(() => publishVoiceArtifact({
+      session_id: "session-cas",
+      source_path: "status.html",
+      artifact_id: "status",
+      expected_revision: 0,
+    })).toThrow("revision conflict");
+    expect(resolveVoiceArtifactRevision("session-cas", "status").revision).toBe(first.revision);
+  });
+
+  it("installs the versioned Artifact schema with immutable revision rows", () => {
+    const workspace = getDefaultWorkspacePath();
+    fs.mkdirSync(workspace, { recursive: true });
+    fs.writeFileSync(path.join(workspace, "schema.html"), "<!doctype html><p>schema</p>");
+    const artifact = publishVoiceArtifact({ session_id: "session-schema", source_path: "schema.html" });
+
+    const db = getDb();
+    expect(db.prepare("SELECT MAX(version) AS version FROM schema_migrations").get()).toEqual({ version: 32 });
+    expect(() => db.prepare(`
+      UPDATE voice_artifact_revisions SET title = 'changed'
+      WHERE session_id = ? AND artifact_id = ? AND revision = 1
+    `).run("session-schema", artifact.artifact_id)).toThrow("append-only");
   });
 
   it("rejects workspace escapes and disguised images", () => {

--- a/homerail_manager/tests/voice-bootstrap.test.ts
+++ b/homerail_manager/tests/voice-bootstrap.test.ts
@@ -1304,20 +1304,63 @@ describe("voice bootstrap routes", () => {
         body: JSON.stringify({ project_id: project.project_id }),
       });
       const createdBody = await created.json() as { data: { session_id: string } };
-      const published = await fetch(`${baseUrl}/api/voice-agent/sessions/${createdBody.data.session_id}/artifacts/publish`, {
+      const publishUrl = `${baseUrl}/api/voice-agent/sessions/${createdBody.data.session_id}/artifacts/publish`;
+      const published = await fetch(publishUrl, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ source_path: "story.html", title: "AI story" }),
+        body: JSON.stringify({
+          source_path: "story.html",
+          title: "AI story",
+          artifact_id: "interactive-story",
+          expected_revision: 0,
+        }),
       });
-      const publishedBody = await published.json() as { data: { artifact: { url: string; kind: string } } };
+      const publishedBody = await published.json() as {
+        data: { artifact: { artifact_id: string; revision: number; url: string; preview_url: string; kind: string } };
+      };
       expect(published.status).toBe(200);
       expect(publishedBody.data.artifact.kind).toBe("html");
+      expect(publishedBody.data.artifact.revision).toBe(1);
 
       const preview = await fetch(`${baseUrl}${publishedBody.data.artifact.url}`);
       expect(preview.status).toBe(200);
       expect(preview.headers.get("content-security-policy"))
         .toBe("sandbox allow-scripts allow-forms allow-pointer-lock allow-popups");
       expect(await preview.text()).toContain("<h1>AI story</h1>");
+
+      fs.writeFileSync(
+        path.join(projectRoot, "story.html"),
+        "<!doctype html><title>Updated story</title><button id=next>Continue</button>",
+      );
+      const updated = await fetch(publishUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          source_path: "story.html",
+          title: "AI story",
+          artifact_id: publishedBody.data.artifact.artifact_id,
+          expected_revision: 1,
+        }),
+      });
+      const updatedBody = await updated.json() as typeof publishedBody;
+      expect(updatedBody.data.artifact).toMatchObject({ artifact_id: "interactive-story", revision: 2 });
+      expect(updatedBody.data.artifact.preview_url).not.toBe(publishedBody.data.artifact.preview_url);
+
+      const stablePreview = await fetch(`${baseUrl}${updatedBody.data.artifact.preview_url}`);
+      expect(stablePreview.status).toBe(200);
+      expect(stablePreview.headers.get("cache-control")).toBe("no-store");
+      expect(await stablePreview.text()).toContain("id=next");
+
+      const stale = await fetch(publishUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          source_path: "story.html",
+          artifact_id: "interactive-story",
+          expected_revision: 1,
+        }),
+      });
+      expect(stale.status).toBe(409);
     } finally {
       fs.rmSync(projectRoot, { recursive: true, force: true });
     }

--- a/homerail_protocol/src/generative-ui/artifact-uri.ts
+++ b/homerail_protocol/src/generative-ui/artifact-uri.ts
@@ -45,8 +45,19 @@ export function isSafeGenerativeUiArtifactUri(value: unknown): value is string {
 /** Browser-renderable Artifact URLs are narrower than passive file refs. */
 export function isSafeGenerativeUiPreviewUri(value: unknown): value is string {
   if (!isSafeGenerativeUiArtifactUri(value)) return false;
+  if (value.startsWith("/")) {
+    const pathOnly = value.split(/[?#]/, 1)[0];
+    try {
+      if (pathOnly.split("/").some((segment) => {
+        const decoded = decodeURIComponent(segment);
+        return decoded === "." || decoded === ".." || decoded.includes("/") || decoded.includes("\\");
+      })) return false;
+    } catch {
+      return false;
+    }
+  }
   return /^https?:\/\//i.test(value)
-    || /^\/api\/voice-agent\/sessions\/[^/]+\/artifacts\/(?:preview|[^?#]+)$/i.test(value)
+    || /^\/api\/voice-agent\/sessions\/[^/?#]+\/artifacts\/(?:preview|[^/?#]+|by-id\/[^/?#]+\/preview)(?:[?#].*)?$/i.test(value)
     || /^\/artifacts\/[^/]+\/[^/]+\/preview(?:[?#].*)?$/i.test(value)
     || /^\/api\/plugins\/artifacts\/[^/]+\/[^/]+\/[a-f0-9]{64}$/i.test(value)
     || DAG_ACTOR_MEDIA_PREVIEW_URI.test(value);

--- a/homerail_protocol/src/manager-agent-tools.ts
+++ b/homerail_protocol/src/manager-agent-tools.ts
@@ -1265,7 +1265,8 @@ export const MANAGER_AGENT_TOOL_SPECS: Record<ManagerAgentToolName, AgentToolDef
     name: "publish_artifact",
     description: [
       "Publish a generated PNG, JPEG, WebP, or standalone HTML file from the current project workspace to the current voice session.",
-      "Pass a project-relative source_path. The result returns a persistent browser-safe URL; bind that URL from a HomeRail A2UI HrArtifact component.",
+      "Pass a project-relative source_path. The result includes a stable artifact_id, revision, and preview_url; bind preview_url from a HomeRail A2UI HrArtifact component.",
+      "To update an existing Artifact in place, preserve artifact_id and pass the last returned revision as expected_revision. Keep the same A2UI Block/component identity and replace only its preview_url with the newly returned value.",
       "This tool publishes an existing file only. It does not generate content and never accepts paths outside the current project workspace.",
     ].join(" "),
     input_schema: {
@@ -1273,6 +1274,8 @@ export const MANAGER_AGENT_TOOL_SPECS: Record<ManagerAgentToolName, AgentToolDef
       properties: {
         source_path: { type: "string", minLength: 1, maxLength: 2048 },
         title: { type: "string", maxLength: 200 },
+        artifact_id: { type: "string", pattern: "^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$" },
+        expected_revision: { type: "integer", minimum: 0 },
       },
       required: ["source_path"],
       additionalProperties: false,

--- a/homerail_protocol/tests/artifact-uri.test.ts
+++ b/homerail_protocol/tests/artifact-uri.test.ts
@@ -10,6 +10,20 @@ describe("generative UI preview artifact URIs", () => {
     )).toBe(true);
   });
 
+  it("accepts stable, revision-addressed voice Artifact previews", () => {
+    expect(isSafeGenerativeUiPreviewUri(
+      "/api/voice-agent/sessions/session-one/artifacts/by-id/live-dashboard/preview?revision=2",
+    )).toBe(true);
+  });
+
+  it.each([
+    "/api/voice-agent/sessions/session-one/artifacts/by-id/live-dashboard/preview/extra",
+    "/api/voice-agent/sessions/session-one/artifacts/by-id/../preview?revision=2",
+    "/api/voice-agent/sessions/session-one/artifacts/by-id/live-dashboard/preview?revision=2\nscript",
+  ])("rejects an unsafe stable voice Artifact path: %s", (uri) => {
+    expect(isSafeGenerativeUiPreviewUri(uri)).toBe(false);
+  });
+
   it.each([
     `/api/runs/run-01/artifacts/actor-media-${sha256}.webp`,
     `/api/runs/run-01/artifacts/actor-media-${sha256}.svg/content`,

--- a/homerail_protocol/tests/manager-agent.test.ts
+++ b/homerail_protocol/tests/manager-agent.test.ts
@@ -274,6 +274,10 @@ describe("Manager Agent harness contract", () => {
     expect(managerAgentToolSpec("write_widget_file").input_schema.properties).toMatchObject({
       widget_type: { type: "string", enum: MANAGER_AGENT_WIDGET_FILE_TYPES },
     });
+    expect(managerAgentToolSpec("publish_artifact").input_schema.properties).toMatchObject({
+      artifact_id: { type: "string", pattern: "^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$" },
+      expected_revision: { type: "integer", minimum: 0 },
+    });
   });
 
   it("declares strict Manager Supervisor tool contracts", () => {

--- a/homerail_worker/src/manager-agent/server.ts
+++ b/homerail_worker/src/manager-agent/server.ts
@@ -1417,7 +1417,12 @@ export function createManagerTools(state: {
           `/voice-agent/sessions/${encodeURIComponent(state.voiceSessionId)}/artifacts/publish`,
           {
             method: "POST",
-            body: JSON.stringify({ source_path: sourcePath, title: args.title }),
+            body: JSON.stringify({
+              source_path: sourcePath,
+              title: args.title,
+              artifact_id: args.artifact_id,
+              expected_revision: args.expected_revision,
+            }),
           },
         );
         return { content: [{ type: "text", text: short(body, 4000) }] };


### PR DESCRIPTION
## Summary

- add stable session Artifact IDs with immutable numbered revisions and schema migration 32
- require revision CAS for updates while preserving legacy content-addressed URLs
- expose stable and revision-addressed preview URLs for sandboxed image/HTML rendering
- teach Manager Agent and Worker tool surfaces to update an Artifact without replacing its A2UI Block
- preserve A2UI DOM identity while refreshing an interactive iframe revision

Milestone: M3 Stable updatable Artifact. Base retargeted to `main` after #71 merged. Current head: `967624ffa4d68b33be2fdd44a668423fed752c0d`.

## Verification

Local focused verification from the rebased PR head:

- Protocol tests: 301 passed
- Manager focused voice/artifact/persistent-document/tool suites: 83 passed
- Agent UI A2UI renderer: 10 passed
- Protocol build: passed
- Manager typecheck: passed
- Worker typecheck: passed
- real local browser: HTML script interaction succeeded; revision 1 remained readable after revision 2; stable preview returned no-store plus sandbox CSP in earlier M3 validation

GitHub Actions from current head:

- Core Linux Node 20: passed
- Core Linux Node 24: passed
- Core Windows Node 24: passed
- Agent UI coverage: passed
- Docker smoke: passed
- Live DAG patterns: skipped by workflow gating

Evidence from earlier M3 validation is local under `/Volumes/P7000Z/Temp/homerail-artifact-e2e/evidence` on the original machine.

## Stack

#68, #70, and #71 have merged into `main`; this PR is now directly based on `main`. After this PR is merged, retarget #74 to `main` and re-run/confirm CI before merging #74.