### PR TITLE
Launch durable multi-Actor results from Skills

### DIFF
--- a/homerail_manager/src/generative-ui/dag-live-surface-projector.ts
+++ b/homerail_manager/src/generative-ui/dag-live-surface-projector.ts
@@ -561,6 +561,89 @@ function ensureProjection(actor: DagActorRecord, timestamp: number): DagLiveSurf
   return requireProjection(actor.run_id, actor.actor_id);
 }
 
+/**
+ * Materialize concurrent entry Actors in workflow order before any Worker can
+ * race to publish its first activity. Later updates patch these stable nodes.
+ */
+export function initializeDagLiveSurfaceRoster(
+  actors: readonly DagActorRecord[],
+  timestamp = Date.now(),
+): GenerativeUiDocumentV1 | undefined {
+  if (actors.length === 0) return undefined;
+  const runId = actors[0].run_id;
+  if (actors.some((actor) => actor.run_id !== runId)) {
+    throw new DagLiveSurfaceProjectionError("identity_mismatch", "DAG live surface roster spans multiple runs");
+  }
+  const actorIds = new Set<string>();
+  const surfaceIds = new Set<string>();
+  for (const actor of actors) {
+    if (actorIds.has(actor.actor_id) || surfaceIds.has(actor.surface_id)) {
+      throw new DagLiveSurfaceProjectionError("identity_mismatch", "DAG live surface roster contains duplicate identities");
+    }
+    actorIds.add(actor.actor_id);
+    surfaceIds.add(actor.surface_id);
+  }
+
+  return getDb().transaction(() => {
+    const projections = actors.map((actor) => {
+      const projection = ensureProjection(actor, timestamp);
+      ensureDagActorSurfaceView({ actor, document_id: projection.document_id, now: timestamp });
+      return projection;
+    });
+    const document = persistentGenerativeUiDocumentService.get(
+      projections[0].document_id,
+      scopeFor(runId),
+    );
+    if (!document) throw new Error(`A2UI document not found: ${projections[0].document_id}`);
+    const existingIds = new Set(document.nodes.map((node) => node.id));
+    const operations = actors.flatMap((actor, index) => {
+      const projection = projections[index];
+      if (existingIds.has(projection.surface_id)) return [];
+      const event: DagActivityEventV1 = {
+        schema_version: 1,
+        event_id: `roster:${actor.actor_id}:g${actor.generation}`,
+        run_id: runId,
+        round_id: "roster",
+        node_id: actor.node_id,
+        actor_id: actor.actor_id,
+        generation: actor.generation,
+        surface_id: actor.surface_id,
+        sequence: 0,
+        timestamp,
+        type: "started",
+        payload: { message: "Waiting to start" },
+      };
+      const projected = buildProjectedNode({
+        actor,
+        projection: { ...projection, surface_revision: -1 },
+        event,
+        received_at: timestamp,
+      });
+      return [{ op: "put" as const, node: projected.node }];
+    });
+    if (operations.length === 0) return document;
+    const rosterDigest = createHash("sha256")
+      .update(JSON.stringify(actors.map((actor) => [actor.actor_id, actor.surface_id])))
+      .digest("hex");
+    const result = persistentGenerativeUiDocumentService.apply({
+      ir_version: GENERATIVE_UI_IR_VERSION,
+      transaction_id: `dag-live-surface-roster-${rosterDigest}`,
+      document_id: document.document_id,
+      base_revision: document.revision,
+      actor: { type: GenerativeUiActorType.SYSTEM, id: PROJECTOR_ID },
+      operations,
+      created_at: new Date(timestamp).toISOString(),
+    }, scopeFor(runId));
+    if (result.status !== "applied" && result.status !== "duplicate") {
+      throw new DagLiveSurfaceProjectionError(
+        result.status === "conflict" ? "a2ui_revision_conflict" : "a2ui_rejected",
+        "DAG live surface roster could not be materialized",
+      );
+    }
+    return result.document;
+  })();
+}
+
 function assertJournalIdentity(entry: DagActivityJournalEntry, actor: DagActorRecord): void {
   const { event } = entry;
   if (

--- a/homerail_manager/src/orchestration/change-orchestrator.ts
+++ b/homerail_manager/src/orchestration/change-orchestrator.ts
@@ -56,6 +56,9 @@ export interface CreateRunRequest {
   prompt?: string;
   llmSettingId?: string;
   admissionSource?: string;
+  expectedWorkflowRevision?: number;
+  expectedCanonicalHash?: string;
+  expectedProfileUpdatedAt?: string;
 }
 
 export interface CreateRunResponse {
@@ -264,6 +267,12 @@ function _loadDagForRequest(request: CreateRunRequest): ParsedDAG {
     if (!workflow) {
       throw new Error(`DAG workflow not found in database: ${workflowId}. Run hr dag sync first.`);
     }
+    if (request.expectedWorkflowRevision !== undefined && workflow.head_revision !== request.expectedWorkflowRevision) {
+      throw new Error(`DAG workflow revision conflict: expected ${request.expectedWorkflowRevision}, got ${workflow.head_revision}`);
+    }
+    if (request.expectedCanonicalHash && workflow.canonical_hash !== request.expectedCanonicalHash) {
+      throw new Error("DAG workflow canonical hash conflict");
+    }
     return parseStoredDagWorkflow(workflow);
   }
   if (!request.yamlPath) {
@@ -275,16 +284,27 @@ function _loadDagForRequest(request: CreateRunRequest): ParsedDAG {
 
 function _applyRuntimeProfile(parsed: ParsedDAG, request: CreateRunRequest): ParsedDAG {
   const profileName = request.profile?.trim();
-  if (!profileName) return parsed;
+  if (!profileName) {
+    if (request.expectedProfileUpdatedAt) {
+      throw new Error("DAG runtime profile version requires a database-backed profile");
+    }
+    return parsed;
+  }
   const workflowId = request.workflowId?.trim() || parsed.meta.workflow_id;
   if (workflowId) {
     const dbProfile = getDagRuntimeProfile(workflowId, profileName);
     if (dbProfile) {
+      if (request.expectedProfileUpdatedAt && dbProfile.updated_at !== request.expectedProfileUpdatedAt) {
+        throw new Error("DAG runtime profile version conflict");
+      }
       return applyDagRuntimeProfile(parsed, resolveDagRuntimeProfile(dbProfile));
     }
     if (!parsed.meta.runtime_profiles?.[profileName]) {
       throw new Error(`DAG runtime profile not found in database for workflow '${workflowId}': ${profileName}. Run hr profile sync first.`);
     }
+  }
+  if (request.expectedProfileUpdatedAt) {
+    throw new Error("DAG runtime profile version requires a database-backed profile");
   }
   return _applyProfile(parsed, profileName);
 }

--- a/homerail_manager/src/persistence/dag-workflows.ts
+++ b/homerail_manager/src/persistence/dag-workflows.ts
@@ -452,6 +452,12 @@ function _parseProfileYaml(yamlText: string, workflowIdOverride?: string): Omit<
   };
 }
 
+export function inspectDagRuntimeProfileYaml(
+  yamlText: string,
+): Omit<DagRuntimeProfile, "profile_key" | "created_at" | "updated_at"> {
+  return _parseProfileYaml(yamlText);
+}
+
 function _assertProfileHasNoProviderModel(root: Record<string, unknown>): void {
   const failures: string[] = [];
   const checkEntry = (prefix: string, value: unknown) => {
@@ -494,8 +500,25 @@ export function upsertDagRuntimeProfileFromYaml(input: {
   yaml_text: string;
   workflow_id?: string;
   source_path?: string;
+  expected_workflow_id?: string;
+  expected_profile_id?: string;
 }): { profile: DagRuntimeProfile; created: boolean } {
+  const declared = input.expected_workflow_id || input.expected_profile_id
+    ? _parseProfileYaml(input.yaml_text)
+    : undefined;
+  if (input.expected_workflow_id && declared?.workflow_id !== input.expected_workflow_id) {
+    throw new Error(`Runtime profile workflow identity mismatch: expected ${input.expected_workflow_id}, got ${declared?.workflow_id}`);
+  }
+  if (input.expected_profile_id && declared?.profile_id !== input.expected_profile_id) {
+    throw new Error(`Runtime profile identity mismatch: expected ${input.expected_profile_id}, got ${declared?.profile_id}`);
+  }
   const parsed = _parseProfileYaml(input.yaml_text, input.workflow_id);
+  if (input.expected_workflow_id && parsed.workflow_id !== input.expected_workflow_id) {
+    throw new Error(`Runtime profile workflow identity mismatch: expected ${input.expected_workflow_id}, got ${parsed.workflow_id}`);
+  }
+  if (input.expected_profile_id && parsed.profile_id !== input.expected_profile_id) {
+    throw new Error(`Runtime profile identity mismatch: expected ${input.expected_profile_id}, got ${parsed.profile_id}`);
+  }
   const workflow = getDagWorkflow(parsed.workflow_id);
   if (!workflow) {
     throw new Error(`DAG workflow not found in database: ${parsed.workflow_id}. Run hr dag sync first.`);

--- a/homerail_manager/src/runtime/active-runs.ts
+++ b/homerail_manager/src/runtime/active-runs.ts
@@ -146,6 +146,7 @@ import {
   type DagActorInterventionRecord,
 } from "../persistence/dag-actor-interventions.js";
 import {
+  initializeDagLiveSurfaceRoster,
   resetDagLiveSurfaceActorBody,
   supersedeDagLiveSurfaceForIntervention,
 } from "../generative-ui/dag-live-surface-projector.js";
@@ -534,9 +535,19 @@ function _ensureLogicalActor(run: ActiveRun, node: DAGGraphNode): DagActorRecord
 
 function _registerLogicalActors(run: ActiveRun): void {
   _assertLogicalActorIdentities(run.dagRun.graph.nodes);
+  const actorsByNode = new Map<string, DagActorRecord>();
   for (const node of run.dagRun.graph.nodes) {
-    if (!_isGatewayNode(node)) _ensureLogicalActor(run, node);
+    if (!_isGatewayNode(node)) actorsByNode.set(node.node_id, _ensureLogicalActor(run, node));
   }
+  const roster: DagActorRecord[] = [];
+  const rosterIds = new Set<string>();
+  for (const target of run.runInputTargets ?? []) {
+    const actor = actorsByNode.get(target.node);
+    if (!actor || rosterIds.has(actor.actor_id)) continue;
+    rosterIds.add(actor.actor_id);
+    roster.push(actor);
+  }
+  if (roster.length > 1) initializeDagLiveSurfaceRoster(roster, run.createdAt);
 }
 
 function _bindLogicalActorSession(

--- a/homerail_manager/src/runtime/dag-actor-lease-reaper.ts
+++ b/homerail_manager/src/runtime/dag-actor-lease-reaper.ts
@@ -6,10 +6,12 @@ import {
   listDagProvisionedWorkers,
   listExpiredDagActorLeases,
   releaseDagActorLease,
+  transitionDagProvisionedWorker,
 } from "../persistence/dag-actor-leases.js";
 import { listDagActors } from "../persistence/dag-actors.js";
 import { listPersistedRunIds, loadRunMetadata } from "../persistence/store.js";
 import type { DagRunStatus } from "../persistence/status.js";
+import { getWorker } from "../worker/registry.js";
 import { loadDagActorLeaseSettings } from "../config/dag-actor-lease-settings.js";
 import {
   deprovisionProvisionedWorker,
@@ -95,6 +97,48 @@ export async function reapDagActorLeases(
         && lease.lease_generation === worker.lease_generation
         && (lease.target_type === "worker" || lease.target_type === "provisioned_worker")
         && lease.target_id === worker.worker_id;
+      if (
+        stillOwned
+        && runStatus(worker.run_id) === "waiting"
+        && lease.idle_deadline! > now
+        && !getWorker(worker.worker_id)
+      ) {
+        try {
+          transitionDagProvisionedWorker({
+            run_id: worker.run_id,
+            actor_id: worker.actor_id,
+            lease_generation: worker.lease_generation,
+            worker_id: worker.worker_id,
+            expected_status: "active",
+            status: "failed",
+            expected_version: worker.version,
+            now,
+            failure: {
+              reason: "provisioned_worker_disconnected",
+              message: "Provisioned Worker is no longer connected while its actor is waiting",
+            },
+          });
+          releaseDagActorLease({
+            run_id: lease.run_id,
+            actor_id: lease.actor_id,
+            lease_generation: lease.lease_generation,
+            target_type: lease.target_type!,
+            target_id: lease.target_id!,
+            expected_version: lease.version,
+            now,
+          });
+          report.released++;
+          emit("dag:actor_lease_released", {
+            runId: lease.run_id,
+            actorId: lease.actor_id,
+            leaseGeneration: lease.lease_generation,
+            reason: "provisioned_worker_disconnected",
+          });
+        } catch {
+          // A concurrent command, reconnect, or cleanup changed the durable row.
+          continue;
+        }
+      }
       if (stillOwned) continue;
     }
     report.worker_cleanup_attempted++;

--- a/homerail_manager/src/server/host-codex-manager-agent.ts
+++ b/homerail_manager/src/server/host-codex-manager-agent.ts
@@ -1755,6 +1755,7 @@ export function createManagerTools(state: {
             typeof data.response_text === "string" ? data.response_text : "",
           );
           state.createdRunIds.push(String(compact.run_id));
+          state.objectiveToolCalls.push({ name: "skill_view_present", success: true });
           state.objectiveToolCalls.push({ name: "start_supervised_dag", success: true });
           return { content: [{ type: "text", text: JSON.stringify(compact) }] };
         }
@@ -1773,6 +1774,7 @@ export function createManagerTools(state: {
         } catch {
           throw new Error("Generated view Tool returned an invalid result");
         }
+        state.objectiveToolCalls.push({ name: "skill_view_present", success: true });
         return { content: [{
           type: "text",
           text: JSON.stringify(compactManagerAgentSkillViewPresentResult(resultBody, responseText)),
@@ -2182,10 +2184,23 @@ function buildHostCodexManagerAgentResult(
   );
   const missingRequiredToolCalls = requiredToolCalls.filter((name) => !successfulRequiredToolCalls.has(name));
   if (missingRequiredToolCalls.length > 0) {
+    const callsById = new Map(toolCalls.map((call) => [call.id, call]));
     throw new HostCodexManagerAgentObjectiveUnsatisfiedError({
       required_tool_calls: requiredToolCalls,
       missing_tool_calls: missingRequiredToolCalls,
       observed_tool_calls: toolCalls.map((item) => item.name),
+      observed_tool_call_details: toolCalls.map((item) => ({
+        id: item.id,
+        name: item.name,
+        input: short(item.input, 1000),
+      })),
+      failed_tool_results: toolResults
+        .filter((item) => item.is_error === true)
+        .map((item) => ({
+          tool_use_id: item.tool_use_id,
+          name: callsById.get(item.tool_use_id)?.name ?? null,
+          content: short(item.content, 1000),
+        })),
       objective_tool_calls: state.objectiveToolCalls,
       run_ids: state.createdRunIds,
     });

--- a/homerail_manager/src/server/host-codex-manager-agent.ts
+++ b/homerail_manager/src/server/host-codex-manager-agent.ts
@@ -20,6 +20,7 @@ import type { ManagerAgentRuntimeConfig } from "./manager-agent-runtime-config.j
 import {
   buildManagerAgentSystemPrompt,
   canonicalManagerAgentToolCallName,
+  compactManagerAgentSkillSupervisedDagResult,
   compactManagerAgentSkillViewPresentResult,
   createManagerAgentWidgetFileTools,
   DEFAULT_PR_REVIEW_EXPECTED_USAGE,
@@ -41,6 +42,7 @@ import {
   mergeManagerAgentPluginSkillCatalog,
   normalizeManagerAgentDagActorCommandInput,
   normalizeManagerAgentDagActorInterventionInput,
+  normalizeManagerAgentSkillSupervisedDagLaunch,
   normalizeManagerAgentRequiredToolCalls,
   executeHomerailPluginTool,
   homerailPluginTurnContextDigestInput,
@@ -96,6 +98,14 @@ function stablePluginModelCallIdentifiers(input: {
     request_id: `tool_${digest}`,
     call_id: `call_${createHash("sha256").update(rawCallId ?? digest).digest("hex")}`,
   };
+}
+
+function stableSkillPresenterRunId(sessionId: string | undefined, skillId: string, argv: unknown): string {
+  const digest = createHash("sha256")
+    .update(JSON.stringify([sessionId ?? "default", skillId, argv]))
+    .digest("hex")
+    .slice(0, 32);
+  return `skill_${digest}`;
 }
 
 interface VoiceSurfaceState {
@@ -1451,7 +1461,7 @@ export function createManagerTools(state: {
     },
     {
       name: "invoke_run",
-      description: "Invoke or tick an existing DAG run.",
+      description: "Invoke or tick a non-terminal DAG run when runtime status indicates it needs dispatch. Do not use this to recover a completed or cancelled run, and do not use it after a command validation error.",
       input_schema: {
         type: "object",
         properties: { runId: { type: "string" } },
@@ -1722,6 +1732,32 @@ export function createManagerTools(state: {
           },
         );
         const data = managerData(body);
+        const launch = normalizeManagerAgentSkillSupervisedDagLaunch(data);
+        if (launch) {
+          const runId = stableSkillPresenterRunId(state.sessionId, skillId, args.argv);
+          let started: Record<string, unknown>;
+          try {
+            started = await requestManager(state.restUrl, "/runs/create-and-run", {
+              method: "POST",
+              body: JSON.stringify({ ...launch, runId }),
+            }) as Record<string, unknown>;
+          } catch (error) {
+            try {
+              await requestManager(state.restUrl, `/runs/${encodeURIComponent(runId)}/status`);
+              started = { data: { run_id: runId } };
+            } catch {
+              throw error;
+            }
+          }
+          const compact = compactManagerAgentSkillSupervisedDagResult(
+            started,
+            launch,
+            typeof data.response_text === "string" ? data.response_text : "",
+          );
+          state.createdRunIds.push(String(compact.run_id));
+          state.objectiveToolCalls.push({ name: "start_supervised_dag", success: true });
+          return { content: [{ type: "text", text: JSON.stringify(compact) }] };
+        }
         const input = data.input;
         if (!input || typeof input !== "object" || Array.isArray(input)) {
           throw new Error("Manager returned an invalid presented Skill view");

--- a/homerail_manager/src/server/http.ts
+++ b/homerail_manager/src/server/http.ts
@@ -214,6 +214,17 @@ export function createServer(
     turnAuthorizer: (credential, method, pathname) => (
       getManagerAgentTurnEnvelopeAuthority().authorizeApiRequest({ credential, method, pathname })
     ),
+    scopedMutationAuthorizer: ({ method, pathname, headers, remoteAddress }) => {
+      const skillViewPresent = method === "POST" && /^\/api\/skills\/[^/]+\/views\/present$/.test(pathname);
+      if (!requiresDagMutationAuthorization(pathname, method) && !skillViewPresent) return false;
+      const rawHeader = headers["x-homerail-dag-token"];
+      const headerToken = Array.isArray(rawHeader) ? rawHeader[0] : rawHeader;
+      return isDagMutationRequestAuthorized({
+        remoteAddress,
+        headerToken,
+        configuredToken: process.env.HOMERAIL_DAG_MUTATION_TOKEN,
+      });
+    },
   });
   const workerControlPlaneAuth = resolveWorkerControlPlaneAuth();
   const effectiveWorkerToken = wsOptions?.authToken?.trim()

--- a/homerail_manager/src/server/manager-agent-runtime.ts
+++ b/homerail_manager/src/server/manager-agent-runtime.ts
@@ -111,6 +111,7 @@ export interface ResolvedManagerAgentTurnAssets {
 
 export interface ResolvedManagerSkill extends ManagerSkillSummary {
   content?: string;
+  asset_root?: string;
   view_templates?: ManagerAgentSkillViewTemplateV1[];
 }
 
@@ -292,7 +293,7 @@ function inlineMatchingLocalSkills(
     .filter((candidate) => candidate.score >= MIN_LOCAL_SKILL_MATCH_SCORE)
     .sort((left, right) => right.score - left.score || left.skill.id.localeCompare(right.skill.id));
 
-  const selected = new Map<string, string>();
+  const selected = new Map<string, { content: string; asset_root?: string }>();
   let totalChars = 0;
   for (const candidate of candidates) {
     if (selected.size >= MAX_INLINE_LOCAL_SKILLS) break;
@@ -300,15 +301,20 @@ function inlineMatchingLocalSkills(
     const content = detail?.content?.trim();
     if (!content || content.length > MAX_INLINE_LOCAL_SKILL_CHARS) continue;
     if (totalChars + content.length > MAX_INLINE_LOCAL_SKILL_TOTAL_CHARS) continue;
-    selected.set(candidate.skill.id, content);
+    selected.set(candidate.skill.id, { content, asset_root: detail?.asset_root });
     totalChars += content.length;
   }
 
   if (selected.size === 0) return skills;
   return skills.map((skill) => {
-    const content = selected.get(skill.id);
-    return content
-      ? { ...skill, content, view_templates: readManagerSkillViewTemplates(skill.id) }
+    const selectedSkill = selected.get(skill.id);
+    return selectedSkill
+      ? {
+        ...skill,
+        content: selectedSkill.content,
+        asset_root: selectedSkill.asset_root,
+        view_templates: readManagerSkillViewTemplates(skill.id),
+      }
       : skill;
   });
 }

--- a/homerail_manager/src/server/manager-skills.ts
+++ b/homerail_manager/src/server/manager-skills.ts
@@ -32,6 +32,8 @@ export interface ManagerSkillSummary {
 
 export interface ManagerSkillDetail extends ManagerSkillSummary {
   content: string;
+  /** Canonical root for local Skill-owned references and scripts. */
+  asset_root?: string;
 }
 
 export interface ManagerSkillInstallResult {
@@ -55,6 +57,7 @@ const MAX_SKILL_VIEW_PRESENTER_ARGUMENTS = 32;
 const MAX_SKILL_VIEW_PRESENTER_ARGUMENT_BYTES = 512;
 const MAX_SKILL_VIEW_PRESENTER_ARGUMENT_TOTAL_BYTES = 8 * 1024;
 const MAX_SKILL_VIEW_PRESENTER_OUTPUT_BYTES = 1024 * 1024;
+const MAX_SKILL_DAG_ASSET_BYTES = 2 * 1024 * 1024;
 const MAX_SKILL_VIEW_PRESENTER_TIMEOUT_MS = 5 * 60 * 1000;
 const SKILL_VIEW_MANIFEST = path.join("assets", "homerail", "view-templates.json");
 const VIEW_SURFACES = new Set(["task", "execution", "result", "ambient"]);
@@ -297,6 +300,38 @@ export async function executeManagerSkillViewPresenter(
   return output;
 }
 
+export function readManagerSkillDagAsset(
+  id: string,
+  assetPathValue: unknown,
+): { text: string; source_path: string } {
+  const presenter = readManagerSkillViewPresenter(id);
+  if (!presenter) throw new Error("Skill view presenter not found");
+  const assetPath = typeof assetPathValue === "string" ? assetPathValue.trim() : "";
+  if (!assetPath || assetPath.length > 4096 || /[\u0000-\u001f\u007f]/.test(assetPath)) {
+    throw new Error("Skill DAG asset path is invalid");
+  }
+  const root = fs.realpathSync(presenter.skill_root);
+  const candidate = path.isAbsolute(assetPath) ? path.resolve(assetPath) : path.resolve(root, assetPath);
+  let resolved: string;
+  try {
+    resolved = fs.realpathSync(candidate);
+  } catch {
+    throw new Error("Skill DAG asset was not found");
+  }
+  const relative = path.relative(root, resolved);
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error("Skill DAG asset must stay inside the enabled Skill");
+  }
+  const stat = fs.statSync(resolved);
+  if (!stat.isFile() || stat.size > MAX_SKILL_DAG_ASSET_BYTES) {
+    throw new Error("Skill DAG asset is invalid or too large");
+  }
+  return {
+    text: fs.readFileSync(resolved, "utf8"),
+    source_path: `skill:${id}/${relative.split(path.sep).join("/")}`,
+  };
+}
+
 function scanSkills(root: string, source: ManagerSkillSummary["source"]): ManagerSkillDetail[] {
   if (!fs.existsSync(root)) return [];
   let entries: fs.Dirent[];
@@ -320,6 +355,7 @@ function scanSkills(root: string, source: ManagerSkillSummary["source"]): Manage
         source,
         enabled: true as const,
         content,
+        asset_root: fs.realpathSync(path.join(root, entry.name)),
       }];
     })
     .sort((a, b) => a.id.localeCompare(b.id));
@@ -380,7 +416,7 @@ export function listManagerSkills(
   }
   const local = Array.from(byId.values())
     .sort((a, b) => a.id.localeCompare(b.id))
-    .map(({ content: _content, ...summary }) => summary);
+    .map(({ content: _content, asset_root: _assetRoot, ...summary }) => summary);
   const plugin = (pluginContext?.skills ?? []).map((skill): ManagerSkillSummary => ({
     id: skill.qualified_id,
     name: skill.local_id,

--- a/homerail_manager/src/server/mutations.ts
+++ b/homerail_manager/src/server/mutations.ts
@@ -412,8 +412,29 @@ export function mutationRoutesHandler(
         const runId = typeof b.runId === "string" ? b.runId : undefined;
         const prompt = typeof b.prompt === "string" ? b.prompt : undefined;
         const llmSettingId = typeof b.llm_setting_id === "string" && b.llm_setting_id.trim() ? b.llm_setting_id.trim() : undefined;
+        const expectedWorkflowRevision = b.workflow_revision === undefined ? undefined : Number(b.workflow_revision);
+        const expectedCanonicalHash = typeof b.canonical_hash === "string" ? b.canonical_hash.trim() : undefined;
+        const expectedProfileUpdatedAt = typeof b.profile_updated_at === "string" ? b.profile_updated_at.trim() : undefined;
+        if (expectedWorkflowRevision !== undefined && (!Number.isSafeInteger(expectedWorkflowRevision) || expectedWorkflowRevision < 1)) {
+          _badRequest(res, "workflow_revision must be a positive integer");
+          return;
+        }
+        if (expectedCanonicalHash !== undefined && !/^[a-f0-9]{64}$/.test(expectedCanonicalHash)) {
+          _badRequest(res, "canonical_hash must be a SHA-256 digest");
+          return;
+        }
         try {
-          const result = changeOrchestrator.createAndRun({ yamlPath, workflowId, profile, runId, prompt, llmSettingId });
+          const result = changeOrchestrator.createAndRun({
+            yamlPath,
+            workflowId,
+            profile,
+            runId,
+            prompt,
+            llmSettingId,
+            expectedWorkflowRevision,
+            expectedCanonicalHash,
+            expectedProfileUpdatedAt,
+          });
           _created(res, "Run created and invoked", result);
         } catch (err) {
           _runCreationError(res, err);

--- a/homerail_manager/src/server/plugin-http-trust.ts
+++ b/homerail_manager/src/server/plugin-http-trust.ts
@@ -10,7 +10,8 @@ export const MIN_ADMIN_TOKEN_BYTES = 32;
 const MAX_ADMIN_TOKEN_BYTES = 4 * 1024;
 const API_PREFIX = "/api";
 const MUTATION_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
-const PREFLIGHT_HEADERS = new Set(["authorization", "content-type", "if-none-match", HOMERAIL_MANAGER_TURN_HEADER]);
+const DAG_MUTATION_TOKEN_HEADER = "x-homerail-dag-token";
+const PREFLIGHT_HEADERS = new Set(["authorization", "content-type", "if-none-match", DAG_MUTATION_TOKEN_HEADER, HOMERAIL_MANAGER_TURN_HEADER]);
 
 export interface PluginHttpTrustPolicyOptions {
   bindHost?: string;
@@ -19,6 +20,12 @@ export interface PluginHttpTrustPolicyOptions {
   allowedOrigins?: string;
   unsafeAllowUnauthenticatedPublic?: boolean;
   turnAuthorizer?: (credential: string, method: string, pathname: string) => boolean;
+  scopedMutationAuthorizer?: (input: {
+    method: string;
+    pathname: string;
+    headers: http.IncomingHttpHeaders;
+    remoteAddress?: string;
+  }) => boolean;
 }
 
 export interface PluginHttpTrustPolicy {
@@ -28,6 +35,12 @@ export interface PluginHttpTrustPolicy {
   readonly allowedOrigins: readonly string[];
   readonly unsafeAllowUnauthenticatedPublic: boolean;
   readonly turnAuthorizer?: (credential: string, method: string, pathname: string) => boolean;
+  readonly scopedMutationAuthorizer?: (input: {
+    method: string;
+    pathname: string;
+    headers: http.IncomingHttpHeaders;
+    remoteAddress?: string;
+  }) => boolean;
 }
 
 /**
@@ -57,6 +70,7 @@ export function createPluginHttpTrustPolicy(
     allowedOrigins: Object.freeze(parseAllowedOrigins(options.allowedOrigins)),
     unsafeAllowUnauthenticatedPublic,
     turnAuthorizer: options.turnAuthorizer,
+    scopedMutationAuthorizer: options.scopedMutationAuthorizer,
   });
 }
 
@@ -131,6 +145,12 @@ export function pluginHttpTrustHandler(
   if (policy.adminToken) {
     const turnCredential = singleHeader(req.headers[HOMERAIL_MANAGER_TURN_HEADER]);
     if (turnCredential && policy.turnAuthorizer?.(turnCredential, method, pathname)) return false;
+    if (policy.scopedMutationAuthorizer?.({
+      method,
+      pathname,
+      headers: req.headers,
+      remoteAddress: req.socket.remoteAddress,
+    })) return false;
     const supplied = parseBearerToken(req.headers.authorization);
     if (!supplied) {
       req.resume();

--- a/homerail_manager/src/server/settings-bootstrap.ts
+++ b/homerail_manager/src/server/settings-bootstrap.ts
@@ -9,9 +9,19 @@ import {
   ensureManagerSkillsInstalled,
   executeManagerSkillViewPresenter,
   listManagerSkills,
+  readManagerSkillDagAsset,
   readManagerSkill,
   readManagerSkillViewTemplates,
 } from "./manager-skills.js";
+import {
+  getDagRuntimeProfile,
+  getDagWorkflow,
+  inspectDagRuntimeProfileYaml,
+  upsertDagRuntimeProfileFromYaml,
+  upsertDagWorkflowFromYaml,
+} from "../persistence/dag-workflows.js";
+import { compileWorkflowSource } from "../orchestration/workflow-spec-v1.js";
+import { isDagMutationRequestAuthorized } from "./mutations.js";
 import {
   isCanonicalHomerailPluginSemver,
   materializeManagerAgentSkillViewTemplateInput,
@@ -603,6 +613,89 @@ export function settingsBootstrapHandler(
     readJsonBody(req)
       .then(async (body) => {
         const presented = await executeManagerSkillViewPresenter(skillId, body.argv);
+        if (presented.mode === "supervised_dag") {
+          const rawMutationHeader = req.headers["x-homerail-dag-token"];
+          const mutationHeader = Array.isArray(rawMutationHeader) ? rawMutationHeader[0] : rawMutationHeader;
+          if (!isDagMutationRequestAuthorized({
+            remoteAddress: req.socket.remoteAddress,
+            headerToken: mutationHeader,
+            configuredToken: process.env.HOMERAIL_DAG_MUTATION_TOKEN,
+          })) {
+            json(res, 403, {
+              success: false,
+              message: "Skill supervised DAG preparation requires DAG mutation authorization",
+              error: "Skill supervised DAG preparation requires DAG mutation authorization",
+            });
+            return;
+          }
+          const workflowId = typeof presented.workflow_id === "string" ? presented.workflow_id.trim() : "";
+          const prompt = typeof presented.workflow_prompt === "string" ? presented.workflow_prompt : "";
+          const profileId = typeof presented.profile_id === "string" ? presented.profile_id.trim() : "";
+          const hasProfilePath = presented.profile_path !== undefined;
+          const responseText = presented.response_text === undefined
+            ? ""
+            : typeof presented.response_text === "string"
+              ? presented.response_text.trim()
+              : "";
+          if (
+            !workflowId
+            || workflowId.length > 200
+            || !prompt.trim()
+            || prompt.length > 24_000
+            || responseText.length > 2_000
+            || Boolean(profileId) !== hasProfilePath
+          ) throw new Error("Skill view presenter returned an invalid supervised DAG contract");
+          const workflowAsset = readManagerSkillDagAsset(skillId, presented.workflow_path);
+          const compilation = compileWorkflowSource(workflowAsset.text);
+          if (!compilation.valid || !compilation.canonical || compilation.canonical.workflow_id !== workflowId) {
+            throw new Error("Skill DAG workflow identity does not match its trusted asset");
+          }
+          const existingWorkflow = getDagWorkflow(workflowId);
+          if (existingWorkflow && existingWorkflow.source_path !== workflowAsset.source_path) {
+            throw new Error("Skill DAG workflow identity is already owned by another source");
+          }
+          let profileAsset: ReturnType<typeof readManagerSkillDagAsset> | undefined;
+          if (profileId) {
+            profileAsset = readManagerSkillDagAsset(skillId, presented.profile_path);
+            const inspectedProfile = inspectDagRuntimeProfileYaml(profileAsset.text);
+            if (inspectedProfile.workflow_id !== workflowId || inspectedProfile.profile_id !== profileId) {
+              throw new Error("Skill DAG profile identity does not match its trusted asset");
+            }
+            const existingProfile = getDagRuntimeProfile(workflowId, profileId);
+            if (existingProfile && existingProfile.source_path !== profileAsset.source_path) {
+              throw new Error("Skill DAG profile identity is already owned by another source");
+            }
+          }
+          const workflowResult = upsertDagWorkflowFromYaml({
+            yaml_text: workflowAsset.text,
+            source_path: workflowAsset.source_path,
+          });
+          let profileUpdatedAt = "";
+          if (profileId) {
+            const profileResult = upsertDagRuntimeProfileFromYaml({
+              yaml_text: profileAsset!.text,
+              source_path: profileAsset!.source_path,
+              expected_workflow_id: workflowId,
+              expected_profile_id: profileId,
+            });
+            profileUpdatedAt = profileResult.profile.updated_at;
+          }
+          _ok(res, "Skill supervised DAG prepared", {
+            mode: "supervised_dag",
+            launch: {
+              workflow_id: workflowId,
+              prompt,
+              workflow_revision: workflowResult.workflow.head_revision,
+              canonical_hash: workflowResult.workflow.canonical_hash,
+              ...(profileId ? { profile: profileId } : {}),
+              ...(profileUpdatedAt ? { profile_updated_at: profileUpdatedAt } : {}),
+            },
+            workflow_revision: workflowResult.workflow.head_revision,
+            canonical_hash: workflowResult.workflow.canonical_hash,
+            ...(responseText ? { response_text: responseText } : {}),
+          });
+          return;
+        }
         const templateId = typeof presented.template === "string" ? presented.template.trim() : "";
         const id = typeof presented.id === "string" ? presented.id.trim() : "";
         const data = presented.data && typeof presented.data === "object" && !Array.isArray(presented.data)

--- a/homerail_manager/src/server/voice-agent-bootstrap.ts
+++ b/homerail_manager/src/server/voice-agent-bootstrap.ts
@@ -37,6 +37,7 @@ import { resolveCodexBinary, runCodexCommandSync } from "./codex-binary.js";
 import {
   managerAgentRuntimePlacementForHarness,
   managerAgentPluginOwnedLegacyWidgetType,
+  normalizeManagerAgentRequiredToolCalls,
   normalizeManagerAgentHarness,
   type GenerativeUiNodeV1,
   type HomerailPluginTurnContextV1,
@@ -1501,6 +1502,7 @@ async function submitVoiceWorkspaceToManagerAgent(
   options?: HostShellManagerAgentOptions,
   realtimeHooks?: ManagerAgentRealtimeHooks,
   selectedNodeId?: string,
+  requiredToolCalls: string[] = [],
 ): Promise<ManagerAgentHandoffResult> {
   if (workspace.task_draft) workspace.task_draft.status = "submitted";
   workspace.pending_confirmations = [];
@@ -1560,6 +1562,7 @@ async function submitVoiceWorkspaceToManagerAgent(
       canvas_context: canvasContext,
       dag_context: workspaceDagContext(workspace),
       history: managerAgentHistory(workspace),
+      required_tool_calls: requiredToolCalls,
       agent_config: agentConfig,
       voice_ui_rules: voiceUiRules,
       plugin_routing: {
@@ -1698,6 +1701,7 @@ async function processTurn(
   realtimeHooks?: ManagerAgentRealtimeHooks,
   managerAgentConfigOptions: ManagerAgentConfigRoutesOptions = {},
   selectedNodeId?: string,
+  requiredToolCalls: string[] = [],
 ): Promise<VoiceTurnResult> {
   appendConversation(workspace, "user", text);
   ensureVoiceSessionTitle(workspace, text);
@@ -1712,6 +1716,7 @@ async function processTurn(
     options,
     realtimeHooks,
     selectedNodeId,
+    requiredToolCalls,
   );
 }
 
@@ -2006,6 +2011,7 @@ export function voiceAgentBootstrapHandler(
         }
         const projectIdPatch = typeof body.project_id === "string" ? body.project_id : null;
         const selectedNodeId = selectedGenerativeUiNodeId(body);
+        const requiredToolCalls = normalizeManagerAgentRequiredToolCalls(body.required_tool_calls);
         // workspace 必须在锁内重新读取：否则并发 turn 的第二个请求会拿着旧快照覆盖第一个的结果。
         const result = await withSessionLock(sessionId, async () => {
           const workspace = loadWorkspace(sessionId);
@@ -2021,6 +2027,7 @@ export function voiceAgentBootstrapHandler(
               undefined,
               managerAgentConfigOptions,
               selectedNodeId,
+              requiredToolCalls,
             );
             const saved = saveWorkspace(workspace);
             completeTurn(sessionId, saved.progress_brief?.status || "done");
@@ -2055,6 +2062,7 @@ export function voiceAgentBootstrapHandler(
         const text = typeof body.text === "string" ? body.text.trim() : "";
         const projectIdPatch = typeof body.project_id === "string" ? body.project_id : null;
         const selectedNodeId = selectedGenerativeUiNodeId(body);
+        const requiredToolCalls = normalizeManagerAgentRequiredToolCalls(body.required_tool_calls);
         res.writeHead(200, { "Content-Type": "application/x-ndjson" });
         if (!text) {
           streamLine(res, { type: "error", message: "Missing required field: text" });
@@ -2096,7 +2104,7 @@ export function voiceAgentBootstrapHandler(
                 }
                 streamLine(res, { type: "speech", event, workspace: saved });
               },
-            }, managerAgentConfigOptions, selectedNodeId);
+            }, managerAgentConfigOptions, selectedNodeId, requiredToolCalls);
             const saved = saveWorkspace(workspace);
             if (streamGenerativeUi) {
               generativeUiCursor = streamCommittedGenerativeUiTransactions(

--- a/homerail_manager/tests/dag-actor-lease-reaper.test.ts
+++ b/homerail_manager/tests/dag-actor-lease-reaper.test.ts
@@ -18,6 +18,7 @@ import { getDagActor, registerDagActor } from "../src/persistence/dag-actors.js"
 import { closeDb } from "../src/persistence/db.js";
 import { ensureRunDir, loadRunMetadata, writeRunMetadata } from "../src/persistence/store.js";
 import { reapDagActorLeases } from "../src/runtime/dag-actor-lease-reaper.js";
+import { _clearWorkers, registerWorker } from "../src/worker/registry.js";
 
 describe("DAG actor lease reaper", () => {
   let home: string;
@@ -48,6 +49,7 @@ describe("DAG actor lease reaper", () => {
     else process.env.HOMERAIL_HOME = oldHome;
     if (oldIdleTtl === undefined) delete process.env.HOMERAIL_DAG_WORKER_IDLE_TTL_MS;
     else process.env.HOMERAIL_DAG_WORKER_IDLE_TTL_MS = oldIdleTtl;
+    _clearWorkers();
     fs.rmSync(home, { recursive: true, force: true });
   });
 
@@ -111,6 +113,53 @@ describe("DAG actor lease reaper", () => {
     expect(getDagActorLease({ run_id: "run-reaper", actor_id: "actor-1" })).toMatchObject({
       state: "leased",
       idle_deadline: now + 15,
+    });
+  });
+
+  it("releases a waiting actor when its provisioned Worker disconnects before idle expiry", async () => {
+    setRunStatus("waiting");
+    acquireWorker("worker-disconnected");
+
+    const report = await reapDagActorLeases({
+      now: now + 2,
+      deprovisionFn: async () => ({ stopped: true, removed: true, dockerCleanupVerified: true }),
+    });
+
+    expect(report).toMatchObject({ released: 1, worker_cleanup_attempted: 0 });
+    expect(getDagActorLease({ run_id: "run-reaper", actor_id: "actor-1" })).toMatchObject({
+      state: "dormant",
+      lease_generation: 1,
+    });
+    expect(listDagProvisionedWorkers({ run_id: "run-reaper" })[0]).toMatchObject({
+      worker_id: "worker-disconnected",
+      status: "failed",
+      failure: expect.objectContaining({ reason: "provisioned_worker_disconnected" }),
+    });
+  });
+
+  it("does not release a waiting actor while its provisioned Worker remains connected", async () => {
+    setRunStatus("waiting");
+    acquireWorker("worker-connected");
+    registerWorker({
+      worker_id: "worker-connected",
+      project_id: "",
+      socket: {} as never,
+      status: "connected",
+      capabilities: [],
+      registered_at: now,
+      last_heartbeat: now,
+    });
+
+    const report = await reapDagActorLeases({ now: now + 2 });
+
+    expect(report.released).toBe(0);
+    expect(getDagActorLease({ run_id: "run-reaper", actor_id: "actor-1" })).toMatchObject({
+      state: "leased",
+      target_id: "worker-connected",
+    });
+    expect(listDagProvisionedWorkers({ run_id: "run-reaper" })[0]).toMatchObject({
+      worker_id: "worker-connected",
+      status: "active",
     });
   });
 

--- a/homerail_manager/tests/dag-live-surface-projector.test.ts
+++ b/homerail_manager/tests/dag-live-surface-projector.test.ts
@@ -12,6 +12,7 @@ import {
   DagLiveSurfaceProjectionError,
   getDagLiveSurfaceDocument,
   getDagLiveSurfaceProjection,
+  initializeDagLiveSurfaceRoster,
   isDagLiveSurfaceProjectionNode,
   listDagLiveSurfaceGenerationHistory,
   listDagLiveSurfaceProjections,
@@ -259,6 +260,44 @@ describe("DAG Live Surface Projector", () => {
       actor: { id: "research", node_id: "research" },
       state: { summary: "source found", sequence: 2 },
     });
+  });
+
+  it("pins concurrent Actor surfaces to workflow order before racing updates", () => {
+    const runId = "ordered-roster";
+    ensureRunDir(runId);
+    const actors = ["research", "build", "verify"].map((actorId) => {
+      register(runId, actorId);
+      return getDagActor(runId, actorId)!;
+    });
+
+    const initial = initializeDagLiveSurfaceRoster(actors, BASE_TIME)!;
+    expect(initial.revision).toBe(1);
+    expect(initial.nodes.map((node) => node.id)).toEqual([
+      "surface:research",
+      "surface:build",
+      "surface:verify",
+    ]);
+    expect(initial.nodes.map((node) => node.revision)).toEqual([1, 1, 1]);
+    expect(listDagLiveSurfaceProjections(runId).map((projection) => projection.surface_revision))
+      .toEqual([0, 0, 0]);
+    expect(initializeDagLiveSurfaceRoster(actors, BASE_TIME + 1)).toEqual(initial);
+
+    for (const actorId of ["verify", "research", "build"]) {
+      appendAndProject(activity({
+        run_id: runId,
+        actor_id: actorId,
+        sequence: 1,
+        type: "started",
+        payload: { message: `${actorId} started` },
+      }));
+    }
+    const updated = getDagLiveSurfaceDocument(runId)!;
+    expect(updated.nodes.map((node) => node.id)).toEqual([
+      "surface:research",
+      "surface:build",
+      "surface:verify",
+    ]);
+    expect(updated.nodes.map((node) => node.revision)).toEqual([2, 2, 2]);
   });
 
   it("queues out-of-order activity, deduplicates replay, and rejects late generations", () => {

--- a/homerail_manager/tests/dag-runtime-primitives.test.ts
+++ b/homerail_manager/tests/dag-runtime-primitives.test.ts
@@ -807,6 +807,7 @@ edges:
     ]) {
       expect(requiresDagMutationAuthorization(pathname, "POST"), pathname).toBe(true);
     }
+    expect(requiresDagMutationAuthorization("/api/skills/palquery/views/present", "POST")).toBe(false);
     expect(requiresDagMutationAuthorization("/api/runs/run-1/node/node-1/approval", "POST")).toBe(false);
     expect(requiresDagMutationAuthorization("/api/dag/validate", "POST")).toBe(false);
     expect(requiresDagMutationAuthorization("/api/runs", "GET")).toBe(false);

--- a/homerail_manager/tests/dag-workflows.test.ts
+++ b/homerail_manager/tests/dag-workflows.test.ts
@@ -8,6 +8,7 @@ import { FakeDAGDispatcher } from "../src/orchestration/dag-dispatcher.js";
 import { GraphExecutor } from "../src/orchestration/graph-executor.js";
 import {
   _clearDagWorkflowTablesForTest,
+  getDagRuntimeProfile,
   upsertDagRuntimeProfileFromYaml,
   upsertDagWorkflowFromYaml,
 } from "../src/persistence/dag-workflows.js";
@@ -100,6 +101,9 @@ default:
       workflowId: "db-workflow",
       profile: "qwen-main",
       prompt: "plan",
+      expectedWorkflowRevision: 1,
+      expectedCanonicalHash: synced.workflow.canonical_hash,
+      expectedProfileUpdatedAt: getDagRuntimeProfile("db-workflow", "qwen-main")!.updated_at,
     });
 
     expect(result.workflowId).toBe("db-workflow");
@@ -121,6 +125,20 @@ default:
       yaml_text: WORKFLOW_YAML.replace("Plan and hand off.", "Plan, verify, and hand off."),
     });
     expect(updated.workflow.head_revision).toBe(2);
+    expect(() => orchestrator.createAndRun({
+      workflowId: "db-workflow",
+      profile: "qwen-main",
+      expectedWorkflowRevision: 1,
+      expectedCanonicalHash: synced.workflow.canonical_hash,
+      expectedProfileUpdatedAt: getDagRuntimeProfile("db-workflow", "qwen-main")!.updated_at,
+    })).toThrow(/workflow revision conflict/);
+    expect(() => orchestrator.createAndRun({
+      workflowId: "db-workflow",
+      profile: "qwen-main",
+      expectedWorkflowRevision: updated.workflow.head_revision,
+      expectedCanonicalHash: updated.workflow.canonical_hash,
+      expectedProfileUpdatedAt: "stale-profile-version",
+    })).toThrow(/profile version conflict/);
     expect(loadRunMetadata(result.runId)).toMatchObject({
       workflowRevision: 1,
       canonicalHash: synced.workflow.canonical_hash,
@@ -150,5 +168,17 @@ default:
   model: qwen3.6
 `,
     })).toThrow(/must reference DB model_alias or llm_setting_id/);
+
+    expect(() => upsertDagRuntimeProfileFromYaml({
+      yaml_text: `
+profile_id: mismatched
+workflow_id: another-workflow
+default:
+  agent_type: claude-sdk
+`,
+      workflow_id: "db-workflow",
+      expected_workflow_id: "db-workflow",
+      expected_profile_id: "mismatched",
+    })).toThrow(/workflow identity mismatch/);
   });
 });

--- a/homerail_manager/tests/manager-agent-capability-routing.test.ts
+++ b/homerail_manager/tests/manager-agent-capability-routing.test.ts
@@ -435,6 +435,8 @@ describe("Manager Agent per-turn capability routing", () => {
     });
     expect(routed.manager_skills.find((skill) => skill.id === "palquery")?.content)
       .toContain("LOCAL_SKILL_BODY_LOADED");
+    expect(routed.manager_skills.find((skill) => skill.id === "palquery")?.asset_root)
+      .toBe(fs.realpathSync(path.join(tmpHome, "skills", "palquery")));
     expect(routed.manager_skills.find((skill) => skill.id === "palquery")?.view_templates)
       .toEqual([expect.objectContaining({
         id: "result",

--- a/homerail_manager/tests/manager-agent-tool-parity.test.ts
+++ b/homerail_manager/tests/manager-agent-tool-parity.test.ts
@@ -330,6 +330,108 @@ describe("Manager Agent deterministic result envelope parity", () => {
     ]);
   });
 
+  it("starts a Skill-owned supervised DAG in the same presenter Tool call", async () => {
+    const context = assemblePluginTurnContext(undefined, { modality: "voice" });
+    const { hostState, workerState, hostTools, workerTools } = createHarnessTools("voice", context);
+    hostState.restUrl = "https://manager.test/api";
+    vi.stubEnv("MANAGER_REST_URL", "https://manager.test/api");
+    const observed: Array<{ pathname: string; body: Record<string, unknown> }> = [];
+    vi.stubGlobal("fetch", async (request: string | URL | Request, init?: RequestInit) => {
+      const rawUrl = typeof request === "string"
+        ? request
+        : request instanceof URL
+          ? request.toString()
+          : request.url;
+      const pathname = new URL(rawUrl).pathname;
+      observed.push({
+        pathname,
+        body: typeof init?.body === "string" ? JSON.parse(init.body) as Record<string, unknown> : {},
+      });
+      const data = pathname.endsWith("/views/present")
+        ? {
+            mode: "supervised_dag",
+            launch: {
+              workflow_id: "three-worker",
+              profile: "local-model",
+              prompt: "verified evidence",
+              workflow_revision: 3,
+              canonical_hash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              profile_updated_at: "2026-07-18T00:00:00.000Z",
+            },
+            response_text: "Three panels are updating.",
+          }
+        : { run_id: "run-three", dispatched: 3 };
+      return new Response(JSON.stringify({ success: true, data }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    const input = { skill_id: "route-skill", argv: ["present", "copilot"] };
+    const hostResult = await requireTool(hostTools, "skill_view_present").handler(input);
+    const workerPayload = {
+      project_id: "project-parity",
+      session_id: "session-parity",
+      response_mode: "voice" as const,
+      manager_api_scopes: [
+        "POST:/api/skills/*/views/present",
+        "POST:/api/runs/create-and-run",
+      ],
+    };
+    const workerTurn: ManagerAgentTurnEnvelopeV1 = {
+      claims: {
+        turn_envelope_version: 1,
+        issuer: "homerail-manager",
+        audience: "homerail-manager-agent-worker",
+        key_id: "manager-parity-key",
+        turn_id: "turn-skill-dag",
+        issued_at: "2026-07-15T00:00:00.000Z",
+        expires_at: "2026-07-15T00:05:00.000Z",
+        payload_digest: "b".repeat(64),
+        scope: managerAgentTurnScopeFromPayload(workerPayload, {
+          runtime_placement: "host_shell",
+          worker_id: "worker-parity",
+        }),
+      },
+      signature: "B".repeat(86),
+    };
+    const workerResult = await _withManagerTurnEnvelopeForTest(
+      workerTurn,
+      () => requireTool(workerTools, "skill_view_present").handler(input),
+    );
+    expect(hostResult).toEqual(workerResult);
+    expect(JSON.parse(hostResult.content[0]?.text || "{}") as Record<string, unknown>).toEqual({
+      mode: "supervised_dag",
+      run_id: "run-three",
+      workflow_id: "three-worker",
+      workflow_revision: 3,
+      canonical_hash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      profile: "local-model",
+      response_text: "Three panels are updating.",
+    });
+    expect(observed.map((entry) => entry.pathname)).toEqual([
+      "/api/skills/route-skill/views/present",
+      "/api/runs/create-and-run",
+      "/api/skills/route-skill/views/present",
+      "/api/runs/create-and-run",
+    ]);
+    const launchBodies = observed.filter((entry) => entry.pathname.endsWith("/create-and-run")).map((entry) => entry.body);
+    expect(launchBodies).toHaveLength(2);
+    expect(launchBodies[0]).toEqual(launchBodies[1]);
+    expect(launchBodies[0]).toMatchObject({
+      workflow_id: "three-worker",
+      workflow_revision: 3,
+      canonical_hash: expect.stringMatching(/^[a-f0-9]{64}$/),
+      profile: "local-model",
+      profile_updated_at: "2026-07-18T00:00:00.000Z",
+      prompt: "verified evidence",
+      runId: expect.stringMatching(/^skill_[a-f0-9]{32}$/),
+    });
+    expect(hostState.createdRunIds).toEqual(["run-three"]);
+    expect(workerState.createdRunIds).toEqual(["run-three"]);
+    expect(hostState.objectiveToolCalls).toEqual([{ name: "start_supervised_dag", success: true }]);
+    expect(workerState.objectiveToolCalls).toEqual([{ name: "start_supervised_dag", success: true }]);
+  });
+
   it("rejects raw generated-view submissions already owned by a loaded Skill template", async () => {
     const context = assemblePluginTurnContext(undefined, { modality: "voice" });
     const { hostTools, workerTools } = createHarnessTools(

--- a/homerail_manager/tests/manager-agent-tool-parity.test.ts
+++ b/homerail_manager/tests/manager-agent-tool-parity.test.ts
@@ -428,8 +428,14 @@ describe("Manager Agent deterministic result envelope parity", () => {
     });
     expect(hostState.createdRunIds).toEqual(["run-three"]);
     expect(workerState.createdRunIds).toEqual(["run-three"]);
-    expect(hostState.objectiveToolCalls).toEqual([{ name: "start_supervised_dag", success: true }]);
-    expect(workerState.objectiveToolCalls).toEqual([{ name: "start_supervised_dag", success: true }]);
+    expect(hostState.objectiveToolCalls).toEqual([
+      { name: "skill_view_present", success: true },
+      { name: "start_supervised_dag", success: true },
+    ]);
+    expect(workerState.objectiveToolCalls).toEqual([
+      { name: "skill_view_present", success: true },
+      { name: "start_supervised_dag", success: true },
+    ]);
   });
 
   it("rejects raw generated-view submissions already owned by a loaded Skill template", async () => {

--- a/homerail_manager/tests/plugin-http-trust.test.ts
+++ b/homerail_manager/tests/plugin-http-trust.test.ts
@@ -142,6 +142,40 @@ describe("Manager HTTP mutation trust gate", () => {
     expect((await fetch(`${baseUrl}/api/plugins`)).status).toBe(200);
   });
 
+  it("allows scoped DAG mutation tokens without granting general Manager mutation access", async () => {
+    process.env[HOMERAIL_MANAGER_ADMIN_TOKEN] = VALID_TOKEN;
+    process.env.HOMERAIL_DAG_MUTATION_TOKEN = "dag-mutation-secret";
+    await start();
+
+    const dagMutation = await fetch(`${baseUrl}/api/runs/create-and-run`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Homerail-Dag-Token": "dag-mutation-secret",
+      },
+      body: "{}",
+    });
+    expect(dagMutation.status).not.toBe(401);
+    expect(dagMutation.status).not.toBe(403);
+
+    const skillPresenter = await fetch(`${baseUrl}/api/skills/missing-skill/views/present`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Homerail-Dag-Token": "dag-mutation-secret",
+      },
+      body: JSON.stringify({ argv: ["present"] }),
+    });
+    expect(skillPresenter.status).not.toBe(401);
+    expect(skillPresenter.status).not.toBe(403);
+
+    const generalMutation = await fetch(`${baseUrl}/api/plugins/install`, {
+      method: "POST",
+      headers: { "X-Homerail-Dag-Token": "dag-mutation-secret" },
+    });
+    expect(generalMutation.status).toBe(401);
+  });
+
   it("fails server creation closed for LAN/public configuration without a strong token", () => {
     process.env.HOMERAIL_MANAGER_HOST = "0.0.0.0";
     expect(() => createServer(0, undefined, undefined, false)).toThrow(HOMERAIL_MANAGER_ADMIN_TOKEN);

--- a/homerail_manager/tests/settings-bootstrap.test.ts
+++ b/homerail_manager/tests/settings-bootstrap.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { parseDAGYaml } from "../src/orchestration/yaml-loader.js";
 import { closeDb } from "../src/persistence/db.js";
+import { getDagRuntimeProfile, getDagWorkflow } from "../src/persistence/dag-workflows.js";
 import { _clearAllPersistence } from "../src/persistence/store.js";
 import { _clearActiveRuns, createActiveRun } from "../src/runtime/active-runs.js";
 import { createServer } from "../src/server/http.js";
@@ -165,6 +166,18 @@ describe("settings bootstrap routes", () => {
     }));
     fs.writeFileSync(path.join(skillDir, "presenter.js"), [
       "const [start, finish] = process.argv.slice(2);",
+      "if (['dag', 'escape', 'workflow-mismatch', 'profile-mismatch', 'symlink-escape'].includes(start)) {",
+      "  process.stdout.write(JSON.stringify({",
+      "    mode: 'supervised_dag',",
+      "    workflow_id: 'skill-dag',",
+      "    workflow_path: start === 'escape' ? '../../secret.yaml' : start === 'workflow-mismatch' ? 'assets/homerail/mismatched-workflow.yaml' : start === 'symlink-escape' ? 'assets/homerail/linked-workflow.yaml' : 'assets/homerail/workflow.yaml',",
+      "    profile_id: 'skill-profile',",
+      "    profile_path: start === 'profile-mismatch' ? 'assets/homerail/mismatched-profile.yaml' : 'assets/homerail/profile.yaml',",
+      "    workflow_prompt: 'verified mission',",
+      "    response_text: 'Workers started.',",
+      "  }));",
+      "  return;",
+      "}",
       "process.stdout.write(JSON.stringify({",
       "  template: 'route',",
       "  id: `route-${start}-${finish}`,",
@@ -173,6 +186,43 @@ describe("settings bootstrap routes", () => {
       "  response_text: `${start} reaches ${finish}.`,",
       "}));",
     ].join("\n"));
+    fs.writeFileSync(path.join(viewDir, "workflow.yaml"), [
+      "name: skill-dag",
+      "workflow_id: skill-dag",
+      "agents:",
+      "  worker:",
+      "    agent_type: claude-sdk",
+      "    system: HANDOFF port=done content=ok",
+      "nodes:",
+      "  work:",
+      "    agent: worker",
+      "    after: []",
+      "    outputs:",
+      "      done:",
+      "        to: ''",
+    ].join("\n"));
+    fs.writeFileSync(path.join(viewDir, "profile.yaml"), [
+      "profile_id: skill-profile",
+      "workflow_id: skill-dag",
+      "default:",
+      "  agent_type: claude-sdk",
+    ].join("\n"));
+    fs.writeFileSync(path.join(viewDir, "mismatched-workflow.yaml"), [
+      "name: another-dag",
+      "workflow_id: another-dag",
+      "agents: {}",
+      "nodes: {}",
+    ].join("\n"));
+    fs.writeFileSync(path.join(viewDir, "mismatched-profile.yaml"), [
+      "profile_id: skill-profile",
+      "workflow_id: another-dag",
+      "default:",
+      "  agent_type: claude-sdk",
+    ].join("\n"));
+    fs.writeFileSync(path.join(tmpHome, "secret.yaml"), "workflow_id: escaped\n");
+    if (process.platform !== "win32") {
+      fs.symlinkSync(path.join(tmpHome, "secret.yaml"), path.join(viewDir, "linked-workflow.yaml"));
+    }
 
     const port = await listen(server);
     const response = await fetch(
@@ -228,6 +278,84 @@ describe("settings bootstrap routes", () => {
         content: { data: { title: "start to finish", steps: ["start", "finish"] } },
       },
     });
+
+    const dagResponse = await fetch(
+      `http://127.0.0.1:${port}/api/skills/route-skill/views/present`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ argv: ["dag"] }),
+      },
+    );
+    const dagPresented = await dagResponse.json() as {
+      success: boolean;
+      data: Record<string, unknown>;
+    };
+    expect(dagResponse.status).toBe(200);
+    expect(dagPresented.data).toMatchObject({
+      mode: "supervised_dag",
+      launch: {
+        workflow_id: "skill-dag",
+        profile: "skill-profile",
+        prompt: "verified mission",
+        workflow_revision: 1,
+        canonical_hash: expect.stringMatching(/^[a-f0-9]{64}$/),
+        profile_updated_at: expect.any(String),
+      },
+      workflow_revision: 1,
+      response_text: "Workers started.",
+    });
+    expect(getDagWorkflow("skill-dag")?.source_path).toBe("skill:route-skill/assets/homerail/workflow.yaml");
+    expect(getDagRuntimeProfile("skill-dag", "skill-profile")?.source_path)
+      .toBe("skill:route-skill/assets/homerail/profile.yaml");
+
+    const escapedDag = await fetch(
+      `http://127.0.0.1:${port}/api/skills/route-skill/views/present`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ argv: ["escape"] }),
+      },
+    );
+    expect(escapedDag.status).toBe(400);
+
+    const workflowBeforeMismatch = getDagWorkflow("skill-dag");
+    const mismatchedWorkflow = await fetch(
+      `http://127.0.0.1:${port}/api/skills/route-skill/views/present`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ argv: ["workflow-mismatch"] }),
+      },
+    );
+    expect(mismatchedWorkflow.status).toBe(400);
+    expect(getDagWorkflow("skill-dag")).toEqual(workflowBeforeMismatch);
+    expect(getDagWorkflow("another-dag")).toBeUndefined();
+
+    const profileBeforeMismatch = getDagRuntimeProfile("skill-dag", "skill-profile");
+    const mismatchedProfile = await fetch(
+      `http://127.0.0.1:${port}/api/skills/route-skill/views/present`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ argv: ["profile-mismatch"] }),
+      },
+    );
+    expect(mismatchedProfile.status).toBe(400);
+    expect(getDagWorkflow("skill-dag")).toEqual(workflowBeforeMismatch);
+    expect(getDagRuntimeProfile("skill-dag", "skill-profile")).toEqual(profileBeforeMismatch);
+
+    if (process.platform !== "win32") {
+      const symlinkEscape = await fetch(
+        `http://127.0.0.1:${port}/api/skills/route-skill/views/present`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ argv: ["symlink-escape"] }),
+        },
+      );
+      expect(symlinkEscape.status).toBe(400);
+    }
 
     const invalidArgv = await fetch(
       `http://127.0.0.1:${port}/api/skills/route-skill/views/present`,

--- a/homerail_manager/tests/voice-bootstrap.test.ts
+++ b/homerail_manager/tests/voice-bootstrap.test.ts
@@ -2648,6 +2648,70 @@ describe("voice bootstrap routes", () => {
     expect(body.data.workspace.widgets).not.toContainEqual(expect.objectContaining({ id: "manager-run" }));
   });
 
+  it("passes explicit required tool objectives through voice turns", async () => {
+    const seenRequiredToolCalls: Array<string[] | undefined> = [];
+    _setHostCodexManagerAgentRunnerForTest(async (input) => {
+      seenRequiredToolCalls.push(input.required_tool_calls);
+      return {
+        text: "已调用指定工具。",
+        spoken_text: "已调用指定工具。",
+        session_id: input.session_id || "host-session-required-tools",
+        run_id: null,
+        run_ids: [],
+        objective: {
+          required: true,
+          required_tool_calls: input.required_tool_calls ?? [],
+          satisfied: true,
+          tool_calls: [{ name: "skill_view_present", success: true }],
+        },
+        tool_calls: [{ id: "tool-1", name: "skill_view_present", input: { skill_id: "palquery", argv: ["present", "copilot"] } }],
+        tool_results: [{ tool_use_id: "tool-1", content: "{}" }],
+        worker_id: "host-codex",
+      };
+    });
+    const port = await listen(server);
+    const baseUrl = `http://127.0.0.1:${port}`;
+
+    await fetch(`${baseUrl}/api/voice-agent/config`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ harness: "codex_appserver", model_name: "gpt-5.5", reasoning_effort: "low" }),
+    });
+    const created = await fetch(`${baseUrl}/api/voice-agent/sessions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+    const createdBody = await created.json() as { data: { session_id: string } };
+    const turn = await fetch(`${baseUrl}/api/voice-agent/sessions/${createdBody.data.session_id}/turn`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        text: "用 palquery 启动三面板。",
+        required_tool_calls: ["skill_view_present", "skill_view_present"],
+      }),
+    });
+    const body = await turn.json() as {
+      data: {
+        manager: {
+          objective: {
+            required?: boolean;
+            required_tool_calls?: string[];
+            satisfied?: boolean;
+          } | null;
+        };
+      };
+    };
+
+    expect(turn.status).toBe(200);
+    expect(seenRequiredToolCalls).toEqual([["skill_view_present"]]);
+    expect(body.data.manager.objective).toMatchObject({
+      required: true,
+      required_tool_calls: ["skill_view_present"],
+      satisfied: true,
+    });
+  });
+
   it("does not synthesize generated UI from verbose manager output without voice tools", async () => {
     const verbose = [
       "## Manager Agent",

--- a/homerail_protocol/src/manager-agent-prompt.ts
+++ b/homerail_protocol/src/manager-agent-prompt.ts
@@ -29,6 +29,8 @@ export interface ManagerAgentPromptSkill {
   source?: string;
   /** Exact trusted body selected for this turn; catalog-only skills omit it. */
   content?: string;
+  /** Trusted local root for references and scripts owned by a loaded Skill. */
+  asset_root?: string;
   /** Validated visual grammars loaded from the same selected local Skill. */
   view_templates?: ManagerAgentSkillViewTemplateV1[];
 }
@@ -111,7 +113,7 @@ export function buildManagerAgentSystemPrompt(input: ManagerAgentPromptInput = {
     "HomeRail skills are available through the skill catalog below. Selected Skill bodies marked as already loaded are authoritative for this turn: follow them directly and do not call read_skill again. For catalog-only Skills, call read_skill before acting when the request matches. Skill metadata is always available; load other full bodies only when relevant.",
     "For reusable DAG work, read homerail-dag-patterns, inspect list_dag_patterns, inspect the selected pattern with get_dag_pattern, then call instantiate_dag_pattern and create_and_run. Use list_orchestrations for concrete repo-local templates. For a custom DAG, call get_dag_schema before authoring, validate_dag_workflow, then sync_dag_workflow before execution. Do not force a design pattern when a simple linear DAG is clearer.",
     "For a multi-Actor task that the user wants supervised over time, use start_supervised_dag, then list_dag_actors and get_dag_supervision. Address roles only by the stable actor_id returned by Manager. Never ask for, infer, or expose Worker IDs, container IDs, lease targets, or transport generations.",
-    "Use send_dag_actor_command only after get_dag_supervision. For each target Actor, inspect command_payload_contract: when the user constrains a listed Surface result, set the typed value at its payload_path in addition to a concise instruction; never leave a machine-readable constraint only inside instruction text. Do not invent unadvertised fields. For an active round, copy each target Actor's opaque state_token into that command's expected_state_token and supply a stable per-Actor idempotency_key. For a waiting round, supply the exact expected_round_id so Manager uses the existing safe multiround resume boundary. Submit one atomic commands array; even one Actor is a one-item array. Never infer transport fences or add domain-specific routing. Use focus_dag_actor to draw attention to an Actor's Manager-owned Surface. Cancel or explicitly complete a waiting run only through cancel_dag_run or complete_dag_run.",
+    "Use send_dag_actor_command only after get_dag_supervision. For each target Actor, inspect command_payload_contract: when the user constrains a listed Surface result, set the typed value at its payload_path in addition to a concise instruction; never leave a machine-readable constraint only inside instruction text. Do not invent unadvertised fields. For an active round, copy each target Actor's opaque state_token into that command's expected_state_token and supply a stable per-Actor idempotency_key. For a waiting round, copy current_round.round_id exactly into top-level expected_round_id beside run_id and commands; never place it inside a command or guess a later round. Submit one atomic commands array; even one Actor is a one-item array. Never infer transport fences or add domain-specific routing. Use focus_dag_actor to draw attention to an Actor's Manager-owned Surface. Call cancel_dag_run or complete_dag_run only when the user explicitly asks to stop or end the run; validation and round conflicts are never reasons to end it.",
     "Treat milestone_digest and round_summary as Manager-owned evidence. Do not invent Worker progress, repeat raw tool logs, or narrate high-frequency progress events. A cross-Actor conclusion must cite accepted_results from the current round_summary; if required Actors are absent or targets_truncated/results_truncated is true, say the evidence view is incomplete.",
     "Never claim a DAG started unless create_and_run or invoke_run returned a real run id.",
     "Do not use shell, curl, npm, node, or a locally started manager server to create DAG runs; those do not count as Manager Agent tool execution.",
@@ -132,6 +134,12 @@ export function buildManagerAgentSystemPrompt(input: ManagerAgentPromptInput = {
       lines.push(
         "",
         `## Loaded HomeRail Skill: ${skill.id}`,
+        ...(skill.asset_root?.trim()
+          ? [
+            `Trusted Skill asset root: ${JSON.stringify(skill.asset_root.trim())}`,
+            "Resolve relative Skill references and scripts from this root.",
+          ]
+          : []),
         skill.content!.trim(),
       );
       if (skill.view_templates?.length) {

--- a/homerail_protocol/src/manager-agent-skill-views.ts
+++ b/homerail_protocol/src/manager-agent-skill-views.ts
@@ -55,11 +55,11 @@ export function managerAgentSkillViewPresentToolDefinition(): AgentToolDefinitio
   return {
     name: MANAGER_AGENT_SKILL_VIEW_PRESENT_TOOL_NAME,
     description: [
-      "Run the trusted visual presenter shipped by an enabled local HomeRail Skill and publish its validated template in one call.",
+      "Run the trusted presenter shipped by an enabled local HomeRail Skill and publish its validated visual or start its supervised DAG in one call.",
       "Use this instead of a native shell when the Skill gives a present command; pass only the argv tokens after the Skill's trusted base command.",
       "Example: a Skill instruction 'present route A B --limit 4' becomes {skill_id:'catalog', argv:['present','route','A','B','--limit','4']}.",
-      "HomeRail executes without a shell, validates the returned template, id, canvas_size, and data, then commits the visual result.",
-      "After success, use the returned response_text as the short final answer; do not call skill_view_render again.",
+      "HomeRail executes without a shell. Visual results are validated and committed; supervised DAG results may load only Workflow/Profile assets inside that Skill before the run starts.",
+      "After success, use the returned response_text as the short final answer; do not call skill_view_render or start_supervised_dag again.",
     ].join(" "),
     input_schema: {
       type: "object",
@@ -85,6 +85,73 @@ export function managerAgentSkillViewPresentToolDefinition(): AgentToolDefinitio
       required: ["skill_id", "argv"],
       additionalProperties: false,
     },
+  };
+}
+
+export interface ManagerAgentSkillSupervisedDagLaunchV1 {
+  workflow_id: string;
+  prompt: string;
+  workflow_revision: number;
+  canonical_hash: string;
+  profile?: string;
+  profile_updated_at?: string;
+}
+
+export function normalizeManagerAgentSkillSupervisedDagLaunch(
+  value: Record<string, unknown>,
+): ManagerAgentSkillSupervisedDagLaunchV1 | undefined {
+  if (value.mode !== "supervised_dag") return undefined;
+  const launch = record(value.launch);
+  const workflowId = typeof launch?.workflow_id === "string" ? launch.workflow_id.trim() : "";
+  const prompt = typeof launch?.prompt === "string" ? launch.prompt : "";
+  const profile = typeof launch?.profile === "string" ? launch.profile.trim() : "";
+  const workflowRevision = Number(launch?.workflow_revision);
+  const canonicalHash = typeof launch?.canonical_hash === "string" ? launch.canonical_hash.trim() : "";
+  const profileUpdatedAt = typeof launch?.profile_updated_at === "string" ? launch.profile_updated_at.trim() : "";
+  if (
+    !workflowId
+    || workflowId.length > 200
+    || !prompt.trim()
+    || prompt.length > 24_000
+    || !Number.isSafeInteger(workflowRevision)
+    || workflowRevision < 1
+    || !/^[a-f0-9]{64}$/.test(canonicalHash)
+    || profile.length > 200
+    || Boolean(profile) !== Boolean(profileUpdatedAt)
+  ) {
+    throw new Error("Manager returned an invalid supervised Skill DAG launch");
+  }
+  return {
+    workflow_id: workflowId,
+    prompt,
+    workflow_revision: workflowRevision,
+    canonical_hash: canonicalHash,
+    ...(profile ? { profile } : {}),
+    ...(profileUpdatedAt ? { profile_updated_at: profileUpdatedAt } : {}),
+  };
+}
+
+export function compactManagerAgentSkillSupervisedDagResult(
+  result: Record<string, unknown>,
+  launch: ManagerAgentSkillSupervisedDagLaunchV1,
+  responseText = "",
+): Record<string, unknown> {
+  const data = record(result.data) ?? result;
+  const runId = typeof data.run_id === "string" && data.run_id.trim()
+    ? data.run_id.trim()
+    : typeof data.runId === "string" && data.runId.trim()
+      ? data.runId.trim()
+      : "";
+  if (!runId) throw new Error("Manager did not return a supervised DAG run id");
+  const normalizedResponse = responseText.trim();
+  return {
+    mode: "supervised_dag",
+    run_id: runId,
+    workflow_id: launch.workflow_id,
+    workflow_revision: launch.workflow_revision,
+    canonical_hash: launch.canonical_hash,
+    ...(launch.profile ? { profile: launch.profile } : {}),
+    ...(normalizedResponse ? { response_text: normalizedResponse } : {}),
   };
 }
 

--- a/homerail_protocol/src/manager-agent-tools.ts
+++ b/homerail_protocol/src/manager-agent-tools.ts
@@ -662,7 +662,7 @@ export function normalizeManagerAgentDagActorCommandInput(
       const idempotencyKey = command.idempotency_key === undefined
         ? undefined
         : dagActorCommandIdentifier(command.idempotency_key, `commands[${index}].idempotency_key`);
-      const expectedStateToken = command.expected_state_token === undefined
+      const expectedStateToken = expectedRoundId !== undefined || command.expected_state_token === undefined
         ? undefined
         : dagActorCommandStateToken(command.expected_state_token, `commands[${index}].expected_state_token`);
       return {
@@ -684,7 +684,7 @@ export function normalizeManagerAgentDagActorCommandInput(
 
   const actorId = dagActorCommandIdentifier(args.actor_id, "actor_id");
   const idempotencyKey = dagActorCommandIdentifier(args.idempotency_key, "idempotency_key");
-  const expectedStateToken = args.expected_state_token === undefined
+  const expectedStateToken = expectedRoundId !== undefined || args.expected_state_token === undefined
     ? undefined
     : dagActorCommandStateToken(args.expected_state_token, "expected_state_token");
   if (!hasOwnProperty(args, "payload") || args.payload === undefined) {

--- a/homerail_protocol/src/manager-agent-tools.ts
+++ b/homerail_protocol/src/manager-agent-tools.ts
@@ -1113,7 +1113,7 @@ export const MANAGER_AGENT_TOOL_SPECS: Record<ManagerAgentToolName, AgentToolDef
   },
   send_dag_actor_command: {
     name: "send_dag_actor_command",
-    description: "Atomically send between 1 and 128 commands to stable actor_id values in one request. Call get_dag_supervision first. When an Actor advertises command_payload_contract fields, put every user-requested machine constraint at the advertised payload_path with the declared type; include an instruction for semantics, but never encode those constraints only in prose. For an active round, every item requires the latest expected_state_token and a stable idempotency_key. For a waiting round, supply expected_round_id to use the existing safe multiround resume path. Never accept or expose transient Worker or container IDs, lease, session, or generation identifiers.",
+    description: "Atomically send between 1 and 128 commands to stable actor_id values in one request. Call get_dag_supervision first. When an Actor advertises command_payload_contract fields, put every user-requested machine constraint at the advertised payload_path with the declared type; include an instruction for semantics, but never encode those constraints only in prose. For an active round, every item requires the latest expected_state_token and a stable idempotency_key. For a waiting run, copy current_round.round_id exactly into the top-level expected_round_id beside run_id and commands; never put expected_round_id inside a command. If a round conflict occurs, read supervision again instead of guessing another round. Never accept or expose transient Worker or container IDs, lease, session, or generation identifiers.",
     input_schema: {
       type: "object",
       properties: {
@@ -1192,7 +1192,7 @@ export const MANAGER_AGENT_TOOL_SPECS: Record<ManagerAgentToolName, AgentToolDef
   },
   complete_dag_run: {
     name: "complete_dag_run",
-    description: "Complete the expected round of a supervised DAG run whose actors are addressed by stable actor_id only; never expose transient Worker or container IDs.",
+    description: "End a waiting supervised DAG run only when the user explicitly asks to end, close, or finish that run. This is not an error-recovery action and must not be used after a command validation or round conflict. Copy current_round.round_id from fresh supervision into expected_round_id. The run is supervised through stable actor_id values; never expose transient Worker or container IDs.",
     input_schema: {
       type: "object",
       properties: {
@@ -1205,7 +1205,7 @@ export const MANAGER_AGENT_TOOL_SPECS: Record<ManagerAgentToolName, AgentToolDef
   },
   invoke_run: {
     name: "invoke_run",
-    description: "Invoke or tick an existing DAG run.",
+    description: "Invoke or tick a non-terminal DAG run when runtime status indicates it needs dispatch. Do not use this to recover a completed or cancelled run, and do not use it after a command validation error.",
     input_schema: {
       type: "object",
       properties: { runId: { type: "string" } },

--- a/homerail_protocol/tests/dag-actor-live-command.test.ts
+++ b/homerail_protocol/tests/dag-actor-live-command.test.ts
@@ -84,6 +84,40 @@ describe("DAG Actor live-command protocol", () => {
         payload: { operation: "generic" },
       }],
     });
+    expect(normalizeManagerAgentDagActorCommandInput({
+      run_id: "run-1",
+      expected_round_id: "round-0001",
+      commands: [{
+        actor_id: "actor-1",
+        idempotency_key: "turn-2",
+        expected_state_token: "stale-token-from-previous-active-round",
+        payload: { operation: "generic" },
+      }],
+    })).toEqual({
+      run_id: "run-1",
+      expected_round_id: "round-0001",
+      commands: [{
+        actor_id: "actor-1",
+        idempotency_key: "turn-2",
+        payload: { operation: "generic" },
+      }],
+    });
+    expect(normalizeManagerAgentDagActorCommandInput({
+      run_id: "run-1",
+      expected_round_id: "round-0001",
+      actor_id: "actor-1",
+      idempotency_key: "turn-3",
+      expected_state_token: "stale-token-from-previous-active-round",
+      payload: { operation: "generic" },
+    })).toEqual({
+      run_id: "run-1",
+      expected_round_id: "round-0001",
+      commands: [{
+        actor_id: "actor-1",
+        idempotency_key: "turn-3",
+        payload: { operation: "generic" },
+      }],
+    });
     const spec = managerAgentToolSpec("send_dag_actor_command");
     expect(spec.input_schema.required).toEqual(["run_id", "commands"]);
     expect(JSON.stringify(spec)).not.toMatch(/showcase|researcher|writer|visual/i);

--- a/homerail_protocol/tests/manager-agent-skill-views.test.ts
+++ b/homerail_protocol/tests/manager-agent-skill-views.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   MANAGER_AGENT_SKILL_VIEW_PRESENT_TOOL_NAME,
   MANAGER_AGENT_SKILL_VIEW_RENDER_TOOL_NAME,
+  compactManagerAgentSkillSupervisedDagResult,
   compactManagerAgentSkillViewPresentResult,
   managerAgentSkillViewPresentToolDefinition,
   managerAgentSkillViewRenderToolDefinition,
@@ -11,6 +12,7 @@ import {
   managerAgentSkillViewToolName,
   materializeManagerAgentSkillViewInput,
   materializeManagerAgentSkillViewTemplateInput,
+  normalizeManagerAgentSkillSupervisedDagLaunch,
   type ManagerAgentSkillViewTemplateV1,
 } from "../src/manager-agent-skill-views.js";
 
@@ -60,7 +62,47 @@ describe("Manager Agent Skill view templates", () => {
       },
     });
     expect(definition.description).toContain("without a shell");
-    expect(definition.description).toContain("do not call skill_view_render again");
+    expect(definition.description).toContain("start its supervised DAG in one call");
+    expect(definition.description).toContain("do not call skill_view_render or start_supervised_dag again");
+  });
+
+  it("normalizes and compacts a trusted supervised DAG launch", () => {
+    const launch = normalizeManagerAgentSkillSupervisedDagLaunch({
+      mode: "supervised_dag",
+      launch: {
+        workflow_id: "three-worker",
+        profile: "local-model",
+        prompt: "verified evidence",
+        workflow_revision: 3,
+        canonical_hash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        profile_updated_at: "2026-07-18T00:00:00.000Z",
+      },
+    });
+    expect(launch).toEqual({
+      workflow_id: "three-worker",
+      profile: "local-model",
+      prompt: "verified evidence",
+      workflow_revision: 3,
+      canonical_hash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      profile_updated_at: "2026-07-18T00:00:00.000Z",
+    });
+    expect(compactManagerAgentSkillSupervisedDagResult({
+      success: true,
+      data: { run_id: "run-three", dispatched: 3, internal: "omitted" },
+    }, launch!, "Three panels are updating.")).toEqual({
+      mode: "supervised_dag",
+      run_id: "run-three",
+      workflow_id: "three-worker",
+      workflow_revision: 3,
+      canonical_hash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      profile: "local-model",
+      response_text: "Three panels are updating.",
+    });
+    expect(normalizeManagerAgentSkillSupervisedDagLaunch({ mode: "visual" })).toBeUndefined();
+    expect(() => normalizeManagerAgentSkillSupervisedDagLaunch({
+      mode: "supervised_dag",
+      launch: { workflow_id: "three-worker", prompt: "" },
+    })).toThrow(/invalid supervised Skill DAG launch/);
   });
 
   it("keeps presenter Tool results compact while preserving committed evidence", () => {

--- a/homerail_protocol/tests/manager-agent.test.ts
+++ b/homerail_protocol/tests/manager-agent.test.ts
@@ -465,6 +465,8 @@ describe("Manager Agent harness contract", () => {
     const validate = new Ajv({ strict: true }).compile(spec.input_schema);
     expect(spec.description).toContain("command_payload_contract");
     expect(spec.description).toContain("never encode those constraints only in prose");
+    expect(spec.description).toContain("top-level expected_round_id");
+    expect(spec.description).toContain("read supervision again instead of guessing");
     const commandItems = spec.input_schema.properties?.commands?.items as {
       properties?: { payload?: { description?: string } };
     };
@@ -494,6 +496,10 @@ describe("Manager Agent harness contract", () => {
         payload: index,
       })),
     })).toBe(true);
+
+    expect(managerAgentToolSpec("complete_dag_run").description).toContain("only when the user explicitly asks");
+    expect(managerAgentToolSpec("complete_dag_run").description).toContain("not an error-recovery action");
+    expect(managerAgentToolSpec("invoke_run").description).toContain("Do not use this to recover a completed or cancelled run");
 
     const invalidInputs = [
       { ...legacy, expected_round_id: "" },
@@ -825,11 +831,14 @@ describe("Manager Agent harness contract", () => {
         description: "Build structured voice UI.",
         source: "plugin",
         content: "Use the bound Core Tool once and require a committed result.",
+        asset_root: "/trusted/skills/voice-generative-ui",
       }],
     });
 
     expect(prompt).toContain("com.homerail.core:voice-generative-ui: Build structured voice UI. [plugin] [already loaded]");
     expect(prompt).toContain("## Loaded HomeRail Skill: com.homerail.core:voice-generative-ui");
+    expect(prompt).toContain('Trusted Skill asset root: "/trusted/skills/voice-generative-ui"');
+    expect(prompt).toContain("Resolve relative Skill references and scripts from this root.");
     expect(prompt).toContain("Use the bound Core Tool once and require a committed result.");
     expect(prompt).toContain("do not call read_skill again");
   });

--- a/homerail_worker/src/__tests__/claude-sdk.test.ts
+++ b/homerail_worker/src/__tests__/claude-sdk.test.ts
@@ -3,6 +3,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import type { AgentEvent, AgentRunContext, DagToolDefinition } from "../agent/types.js";
 import {
   jsonSchemaObjectToZodRawShape,
@@ -400,6 +403,78 @@ describe("ClaudeSdkAdapter", () => {
       type: "debug",
       data: expect.objectContaining({ system_prompt_mode: "append" }),
     });
+  });
+
+  it("projects only HomeRail Skills into an isolated native Claude Skill directory", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-claude-skills-test-"));
+    const home = path.join(root, "home");
+    const localSkill = path.join(home, "skills", "local-guide");
+    fs.mkdirSync(path.join(localSkill, "references"), { recursive: true });
+    fs.writeFileSync(path.join(localSkill, "SKILL.md"), [
+      "---",
+      "name: local-guide",
+      "description: Local guide",
+      "---",
+      "",
+      "Read references/details.md when needed.",
+    ].join("\n"));
+    fs.writeFileSync(path.join(localSkill, "references", "details.md"), "trusted details\n");
+    vi.stubEnv("HOMERAIL_HOME", home);
+    const captured: Record<string, unknown>[] = [];
+    let localBody = "";
+    let referenceBody = "";
+    let inlineBody = "";
+    vi.doMock("@anthropic-ai/claude-agent-sdk", () => ({
+      async *query(params: { options?: Record<string, unknown> }) {
+        const options = params.options ?? {};
+        captured.push(options);
+        const configDir = (options.env as Record<string, string>).CLAUDE_CONFIG_DIR;
+        localBody = fs.readFileSync(path.join(configDir, "skills", "local-guide", "SKILL.md"), "utf8");
+        referenceBody = fs.readFileSync(path.join(configDir, "skills", "local-guide", "references", "details.md"), "utf8");
+        inlineBody = fs.readFileSync(path.join(configDir, "skills", "inline-guide", "SKILL.md"), "utf8");
+        yield { type: "result", subtype: "success", is_error: false };
+      },
+      createSdkMcpServer(_opts: { name: string; tools?: Array<Record<string, unknown>> }) {
+        return { type: "sdk", name: _opts.name };
+      },
+      tool(name: string) {
+        return { name };
+      },
+    }));
+
+    try {
+      const { ClaudeSdkAdapter } = await import("../agent/claude-sdk.js");
+      const adapter = new ClaudeSdkAdapter();
+      const events: AgentEvent[] = [];
+      for await (const event of adapter.run("test", [], {
+        ...ctx,
+        skillProjection: {
+          mode: "explicit",
+          directories: [path.join(home, "skills")],
+          definitions: [{
+            id: "plugin:inline-guide",
+            name: "inline-guide",
+            description: "Inline guide",
+            content: "Use the trusted inline procedure.",
+          }],
+        },
+      })) events.push(event);
+
+      expect(captured[0].settingSources).toEqual(["user"]);
+      expect(captured[0].skills).toBe("all");
+      expect(localBody).toContain("Read references/details.md");
+      expect(referenceBody).toBe("trusted details\n");
+      expect(inlineBody).toContain("Use the trusted inline procedure.");
+      const configDir = (captured[0].env as Record<string, string>).CLAUDE_CONFIG_DIR;
+      expect(configDir).toContain(path.join(home, "runtime", "claude-skill-projections"));
+      expect(fs.existsSync(configDir)).toBe(false);
+      expect(events.find((event) => event.type === "debug" && event.message === "query_start")).toMatchObject({
+        type: "debug",
+        data: expect.objectContaining({ projected_skill_count: 2 }),
+      });
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("respects env vars", async () => {

--- a/homerail_worker/src/agent/claude-sdk.ts
+++ b/homerail_worker/src/agent/claude-sdk.ts
@@ -8,6 +8,18 @@
 
 import { AGENT_BUILTIN_TOOL_NAMES } from "homerail-protocol";
 import type { SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import type { AgentClient, AgentEvent, AgentRunContext, AgentUsage, DagToolDefinition } from "./types.js";
 import {
   jsonSchemaObjectToZodRawShape,
@@ -17,6 +29,95 @@ import { sanitizedAgentChildEnv } from "./child-env.js";
 
 const HANDOFF_ONLY_THINKING_BUDGET = 2048;
 const HANDOFF_STOP = Symbol("claude-sdk-handoff-stop");
+
+interface ClaudeSkillProjectionRuntime {
+  configDir: string;
+  skillCount: number;
+  cleanup: () => void;
+}
+
+function projectedSkillName(value: string, fallback: string): string {
+  const normalized = value
+    .normalize("NFKC")
+    .replace(/[^A-Za-z0-9_.-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 120);
+  return normalized || fallback;
+}
+
+function linkOrCopySkill(source: string, destination: string): void {
+  try {
+    symlinkSync(source, destination, process.platform === "win32" ? "junction" : "dir");
+  } catch {
+    cpSync(source, destination, { recursive: true, force: false, errorOnExist: true });
+  }
+}
+
+function prepareClaudeSkillProjection(context: AgentRunContext): ClaudeSkillProjectionRuntime | undefined {
+  const projection = context.skillProjection;
+  if (!projection) return undefined;
+  const configuredRoot = process.env.HOMERAIL_HOME?.trim();
+  const parent = configuredRoot
+    ? join(configuredRoot, "runtime", "claude-skill-projections")
+    : join(tmpdir(), "homerail-claude-skill-projections");
+  mkdirSync(parent, { recursive: true });
+  const configDir = mkdtempSync(join(parent, `${process.pid}-`));
+  const skillsDir = join(configDir, "skills");
+  mkdirSync(skillsDir, { recursive: true });
+  const names = new Set<string>();
+
+  for (const directory of projection.directories ?? []) {
+    const root = resolve(directory);
+    let entries;
+    try {
+      entries = readdirSync(root, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+      const source = join(root, entry.name);
+      let resolvedSource: string;
+      try {
+        resolvedSource = resolve(source);
+        if (!statSync(join(resolvedSource, "SKILL.md")).isFile()) continue;
+      } catch {
+        continue;
+      }
+      const name = projectedSkillName(entry.name, `skill-${names.size + 1}`);
+      if (names.has(name)) continue;
+      linkOrCopySkill(resolvedSource, join(skillsDir, name));
+      names.add(name);
+    }
+  }
+
+  for (const definition of projection.definitions ?? []) {
+    const baseName = projectedSkillName(definition.name || definition.id, `skill-${names.size + 1}`);
+    let name = baseName;
+    let suffix = 2;
+    while (names.has(name)) name = `${baseName}-${suffix++}`;
+    const skillDir = join(skillsDir, name);
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), [
+      "---",
+      `name: ${JSON.stringify(name)}`,
+      `description: ${JSON.stringify(definition.description || `HomeRail Skill ${definition.id}`)}`,
+      "---",
+      "",
+      definition.content.trim(),
+      "",
+    ].join("\n"), { encoding: "utf8", mode: 0o600 });
+    names.add(name);
+  }
+
+  return {
+    configDir,
+    skillCount: names.size,
+    cleanup: () => rmSync(configDir, { recursive: true, force: true }),
+  };
+}
+
+export const _prepareClaudeSkillProjectionForTest = prepareClaudeSkillProjection;
 
 interface SdkModule {
   query(params: {
@@ -301,6 +402,7 @@ export class ClaudeSdkAdapter implements AgentClient {
     let timeout: NodeJS.Timeout | null = null;
     let stderrTail = "";
     let externalAbortHandler: (() => void) | null = null;
+    let skillRuntime: ClaudeSkillProjectionRuntime | undefined;
     let handoffStopRequested = false;
     let resolveHandoffStop: (() => void) | null = null;
     const handoffStop = new Promise<typeof HANDOFF_STOP>((resolve) => {
@@ -326,6 +428,7 @@ export class ClaudeSdkAdapter implements AgentClient {
         ? Math.min(this.thinkingBudget, HANDOFF_ONLY_THINKING_BUDGET)
         : this.thinkingBudget;
       const systemPromptMode = context.systemPromptMode ?? "append";
+      skillRuntime = prepareClaudeSkillProjection(context);
       const options: Record<string, unknown> = {
         model: effectiveModel,
         maxThinkingTokens: effectiveThinkingBudget,
@@ -335,8 +438,11 @@ export class ClaudeSdkAdapter implements AgentClient {
         allowDangerouslySkipPermissions: true,
         cwd: context.workspace ?? process.cwd(),
         stderr: (data: string) => appendStderr(data),
-        env: authEnv.env,
-        settingSources: [],
+        env: skillRuntime
+          ? { ...authEnv.env, CLAUDE_CONFIG_DIR: skillRuntime.configDir }
+          : authEnv.env,
+        settingSources: skillRuntime?.skillCount ? ["user"] : [],
+        skills: skillRuntime?.skillCount ? "all" : [],
         strictMcpConfig: true,
       };
       if (this.maxTurns !== null) {
@@ -428,6 +534,7 @@ export class ClaudeSdkAdapter implements AgentClient {
           timeout_ms: this.queryTimeoutMs > 0 ? this.queryTimeoutMs : null,
           external_abort_signal: Boolean(context.abortSignal),
           builtin_tools: builtinTools,
+          projected_skill_count: skillRuntime?.skillCount ?? 0,
           handoff_only: context.handoffOnly === true,
         },
       };
@@ -580,6 +687,8 @@ export class ClaudeSdkAdapter implements AgentClient {
         context.abortSignal.removeEventListener("abort", externalAbortHandler);
       }
       sdkAbortController = null;
+      skillRuntime?.cleanup();
+      skillRuntime = undefined;
     }
 
     yield {

--- a/homerail_worker/src/manager-agent/server.ts
+++ b/homerail_worker/src/manager-agent/server.ts
@@ -19,6 +19,7 @@ import type {
 import {
   buildManagerAgentSystemPrompt,
   canonicalManagerAgentToolCallName,
+  compactManagerAgentSkillSupervisedDagResult,
   compactManagerAgentSkillViewPresentResult,
   createManagerAgentWidgetFileTools,
   DEFAULT_PR_REVIEW_EXPECTED_USAGE,
@@ -41,6 +42,7 @@ import {
   mergeManagerAgentPluginSkillCatalog,
   normalizeManagerAgentDagActorCommandInput,
   normalizeManagerAgentDagActorInterventionInput,
+  normalizeManagerAgentSkillSupervisedDagLaunch,
   normalizeManagerAgentRequiredToolCalls,
   executeHomerailPluginTool,
   validateHomerailPluginTurnContext,
@@ -149,6 +151,14 @@ function stablePluginModelCallIdentifiers(input: {
     request_id: `tool_${digest}`,
     call_id: `call_${createHash("sha256").update(rawCallId ?? digest).digest("hex")}`,
   };
+}
+
+function stableSkillPresenterRunId(sessionId: string | undefined, skillId: string, argv: unknown): string {
+  const digest = createHash("sha256")
+    .update(JSON.stringify([sessionId ?? "default", skillId, argv]))
+    .digest("hex")
+    .slice(0, 32);
+  return `skill_${digest}`;
 }
 
 interface VoiceSurfaceState {
@@ -1301,7 +1311,7 @@ export function createManagerTools(state: {
     },
     {
       name: "invoke_run",
-      description: "Invoke or tick an existing DAG run.",
+      description: "Invoke or tick a non-terminal DAG run when runtime status indicates it needs dispatch. Do not use this to recover a completed or cancelled run, and do not use it after a command validation error.",
       input_schema: {
         type: "object",
         properties: { runId: { type: "string" } },
@@ -1568,6 +1578,32 @@ export function createManagerTools(state: {
           },
         );
         const data = managerData(body);
+        const launch = normalizeManagerAgentSkillSupervisedDagLaunch(data);
+        if (launch) {
+          const runId = stableSkillPresenterRunId(state.sessionId, skillId, args.argv);
+          let started: Record<string, unknown>;
+          try {
+            started = await requestManager("/runs/create-and-run", {
+              method: "POST",
+              body: JSON.stringify({ ...launch, runId }),
+            }) as Record<string, unknown>;
+          } catch (error) {
+            try {
+              await requestManager(`/runs/${encodeURIComponent(runId)}/status`);
+              started = { data: { run_id: runId } };
+            } catch {
+              throw error;
+            }
+          }
+          const compact = compactManagerAgentSkillSupervisedDagResult(
+            started,
+            launch,
+            typeof data.response_text === "string" ? data.response_text : "",
+          );
+          state.createdRunIds.push(String(compact.run_id));
+          state.objectiveToolCalls.push({ name: "start_supervised_dag", success: true });
+          return { content: [{ type: "text" as const, text: JSON.stringify(compact) }] };
+        }
         const input = data.input;
         if (!input || typeof input !== "object" || Array.isArray(input)) {
           throw new Error("Manager returned an invalid presented Skill view");

--- a/homerail_worker/src/manager-agent/server.ts
+++ b/homerail_worker/src/manager-agent/server.ts
@@ -1601,6 +1601,7 @@ export function createManagerTools(state: {
             typeof data.response_text === "string" ? data.response_text : "",
           );
           state.createdRunIds.push(String(compact.run_id));
+          state.objectiveToolCalls.push({ name: "skill_view_present", success: true });
           state.objectiveToolCalls.push({ name: "start_supervised_dag", success: true });
           return { content: [{ type: "text" as const, text: JSON.stringify(compact) }] };
         }
@@ -1619,6 +1620,7 @@ export function createManagerTools(state: {
         } catch {
           throw new Error("Generated view Tool returned an invalid result");
         }
+        state.objectiveToolCalls.push({ name: "skill_view_present", success: true });
         return { content: [{
           type: "text" as const,
           text: JSON.stringify(compactManagerAgentSkillViewPresentResult(resultBody, responseText)),
@@ -1951,10 +1953,23 @@ async function handleChat(body: ChatRequest): Promise<Record<string, unknown>> {
   );
   const missingRequiredToolCalls = requiredToolCalls.filter((name) => !successfulRequiredToolCalls.has(name));
   if (missingRequiredToolCalls.length > 0) {
+    const callsById = new Map(toolCalls.map((call) => [call.id, call]));
     throw new ManagerAgentObjectiveUnsatisfiedError({
       required_tool_calls: requiredToolCalls,
       missing_tool_calls: missingRequiredToolCalls,
       observed_tool_calls: toolCalls.map((item) => item.name),
+      observed_tool_call_details: toolCalls.map((item) => ({
+        id: item.id,
+        name: item.name,
+        input: short(item.input, 1000),
+      })),
+      failed_tool_results: toolResults
+        .filter((item) => item.is_error === true)
+        .map((item) => ({
+          tool_use_id: item.tool_use_id,
+          name: callsById.get(item.tool_use_id)?.name ?? null,
+          content: short(item.content, 1000),
+        })),
       objective_tool_calls: state.objectiveToolCalls,
       run_ids: state.createdRunIds,
     });


### PR DESCRIPTION
## Summary

- let a trusted Skill presenter validate and launch a version-bound supervised DAG in one Manager tool call
- expose Skill-owned asset roots safely to host Manager Agents and project local Skills into Claude Agent SDK runtimes
- seed stable Actor Surface IDs in workflow order before Worker events so asynchronous completion cannot reorder the canvas
- preserve idempotent run launch and improve waiting-round command guidance for smaller Manager models
- transparently reprovision a disconnected Actor Worker without rebuilding sibling Surfaces or changing their order
- keep M4-only runtime changes in this PR; credential protocol/migration consistency fixes are already in #71

Milestone: M4 Durable multi Actor. Base retargeted to `main` after #72 merged. Current head: `ec59a8cf43455bd2d73f7ca584a6d439c4ab904a`.

## Real-machine validation

- Qwen3.6 launched one three-Actor run from a natural-language request with a single `skill_view_present` call
- the final canvas order stayed `basic_info`, `breeding_formulas`, `breeding_route` despite reverse completion timing
- a same-session follow-up changed only `breeding_formulas` from 3 items to 2 while sibling Surface IDs, revisions, and positions stayed unchanged
- Manager cold restart preserved run status, document identity, Surface order, IDs, and revisions
- after stopping the provisioned `breeding_route` Worker container, a typed follow-up reprovisioned only that Actor Worker and updated the same stable Surface in place; siblings and ordering stayed unchanged; Manager cold restart preserved the recovered waiting run

The current replay only changed ancestry after #68/#70/#71/#72 landed in `main`; M4 runtime semantics are unchanged, so the real-machine evidence remains applicable.

## Tests

Local verification from the rebased PR head:

- Protocol tests: 302 passed
- Manager focused M4 suites: 159 passed
- Worker Claude SDK focused suite: 30 passed
- Protocol build: passed
- Manager typecheck: passed
- Worker typecheck: passed
- CLI typecheck: passed

GitHub Actions from current head:

- Core Linux Node 20: passed
- Core Linux Node 24: passed
- Core Windows Node 24: passed
- Agent UI coverage: passed
- Docker smoke: passed
- Live DAG patterns: skipped by workflow gating

## Stack

#68, #70, #71, and #72 have merged into `main`; this PR is now directly based on `main`. This is the final core PR in the current milestone stack. Do not start M5 from this PR.