### PR TITLE
fix: improve Windows Docker guidance and proxy realtime ASR

### DIFF
--- a/agent-ui/src/components/agent/onboarding/docker-workspace-status.test.ts
+++ b/agent-ui/src/components/agent/onboarding/docker-workspace-status.test.ts
@@ -26,6 +26,17 @@ describe('Docker workspace guidance', () => {
     expect(dockerWorkspaceGuidance({
       available: false,
       host_path: '/workspace',
+      error: 'failed to connect to the docker API at npipe:////./pipe/dockerDesktopLinuxEngine; check if the daemon is running: The system cannot find the file specified.',
+    })).toBe('start')
+    expect(dockerWorkspaceGuidance({
+      available: false,
+      host_path: '/workspace',
+      code: 'docker_daemon_unavailable',
+      error: 'Docker Desktop engine is unavailable',
+    })).toBe('start')
+    expect(dockerWorkspaceGuidance({
+      available: false,
+      host_path: '/workspace',
       error: 'permission denied while trying to connect to the Docker daemon; add the user to the docker group',
     })).toBe('permission')
   })

--- a/agent-ui/src/components/agent/onboarding/docker-workspace-status.ts
+++ b/agent-ui/src/components/agent/onboarding/docker-workspace-status.ts
@@ -17,8 +17,11 @@ export function dockerWorkspaceGuidance(
     return 'install'
   }
   if (
+    result.code === 'docker_daemon_unavailable' ||
     message.includes('cannot connect to the docker daemon') ||
-    message.includes('is the docker daemon running')
+    message.includes('failed to connect to the docker api') ||
+    message.includes('is the docker daemon running') ||
+    message.includes('dockerdesktoplinuxengine')
   ) {
     return 'start'
   }

--- a/homerail_cli/src/static-ui-server.ts
+++ b/homerail_cli/src/static-ui-server.ts
@@ -223,9 +223,11 @@ function proxyHttp(req: http.IncomingMessage, res: http.ServerResponse): void {
 }
 
 function handleWebSocket(req: http.IncomingMessage, socket: net.Socket, head: Buffer): void {
-  // Proxy a WebSocket upgrade to the Manager (/ws).
+  // Proxy WebSocket upgrades to the Manager. This includes the general event
+  // stream and Voice ASR's same-origin realtime endpoint.
   const target = new URL(MANAGER_WS);
-  const proxyReq = http.request(
+  const request = target.protocol === "wss:" ? https.request : http.request;
+  const proxyReq = request(
     {
       method: "GET",
       protocol: target.protocol === "ws:" ? "http:" : "https:",
@@ -274,7 +276,8 @@ function onRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
 }
 
 server.on("upgrade", (req, socket, head) => {
-  if ((req.url || "").startsWith("/ws")) {
+  const pathname = new URL(req.url || "/", "http://localhost").pathname;
+  if (pathname === "/ws" || pathname === "/api/voice/asr/realtime") {
     handleWebSocket(req, socket as unknown as net.Socket, head);
     return;
   }

--- a/homerail_cli/tests/static-ui-admin-proxy.integration.test.ts
+++ b/homerail_cli/tests/static-ui-admin-proxy.integration.test.ts
@@ -1,6 +1,7 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import * as fs from "node:fs";
 import * as http from "node:http";
+import * as net from "node:net";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -21,6 +22,35 @@ afterEach(async () => {
 });
 
 describe("static Agent UI mutation proxy", () => {
+  it("proxies the same-origin ASR realtime WebSocket to the Manager", async () => {
+    let upgradedPath = "";
+    const manager = http.createServer();
+    manager.on("upgrade", (req, socket) => {
+      upgradedPath = req.url || "";
+      socket.write(
+        "HTTP/1.1 101 Switching Protocols\r\n" +
+        "Connection: Upgrade\r\n" +
+        "Upgrade: websocket\r\n" +
+        "\r\n",
+      );
+      socket.end();
+    });
+    servers.push(manager);
+    const managerUrl = await listen(manager, "127.0.0.1");
+    const uiPort = await reservePort();
+    const uiOrigin = `http://127.0.0.1:${uiPort}`;
+    await startStaticUi({
+      port: uiPort,
+      host: "127.0.0.1",
+      origin: uiOrigin,
+      managerUrl,
+    });
+
+    const response = await websocketUpgrade(uiPort, "/api/voice/asr/realtime");
+    expect(response).toContain("HTTP/1.1 101 Switching Protocols");
+    expect(upgradedPath).toBe("/api/voice/asr/realtime");
+  }, 15_000);
+
   it("rejects no-Origin/cross-origin requests and injects only for exact local self-Origin", async () => {
     const received: Array<{ authorization?: string; origin?: string; method?: string }> = [];
     const manager = http.createServer((req, res) => {
@@ -189,6 +219,38 @@ async function reservePort(host = "127.0.0.1"): Promise<number> {
   const port = address.port;
   await new Promise<void>((resolve) => server.close(() => resolve()));
   return port;
+}
+
+async function websocketUpgrade(port: number, requestPath: string): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const socket = net.createConnection({ host: "127.0.0.1", port });
+    let response = "";
+    const timer = setTimeout(() => {
+      socket.destroy();
+      reject(new Error("WebSocket upgrade timed out"));
+    }, 5_000);
+    socket.setEncoding("utf8");
+    socket.on("connect", () => {
+      socket.write(
+        `GET ${requestPath} HTTP/1.1\r\n` +
+        `Host: 127.0.0.1:${port}\r\n` +
+        "Connection: Upgrade\r\n" +
+        "Upgrade: websocket\r\n" +
+        "Sec-WebSocket-Version: 13\r\n" +
+        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+        "\r\n",
+      );
+    });
+    socket.on("data", (chunk) => { response += chunk; });
+    socket.on("end", () => {
+      clearTimeout(timer);
+      resolve(response);
+    });
+    socket.on("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+  });
 }
 
 async function waitUntil(check: () => Promise<boolean>): Promise<void> {


### PR DESCRIPTION
## What changed

- classify Windows Docker Desktop named-pipe and structured daemon errors as “start Docker” guidance
- proxy the same-origin `/api/voice/asr/realtime` WebSocket through the static UI server
- support both HTTP and HTTPS Manager WebSocket targets
- add focused UI and CLI integration coverage

## Why

When Docker Desktop was installed but its Linux engine was stopped, Windows returned a named-pipe API error that onboarding treated as an unknown workspace failure. Separately, the packaged static UI only forwarded `/ws`, so realtime ASR upgrades never reached the Manager.

## Impact

Windows users now receive actionable Docker startup guidance, and realtime ASR works through the packaged same-origin UI endpoint.

## Validation

- `agent-ui`: Docker workspace status test — 3 passed
- `homerail_cli`: static UI proxy integration test — 5 passed
- `homerail_cli`: TypeScript typecheck
- `agent-ui`: Vue/TypeScript typecheck

