### PR TITLE
fix production LAN deployment defaults

### DIFF
--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -14,8 +14,12 @@ runner environment file defines:
 - `HOMERAIL_PRODUCTION_ROOT` for immutable releases;
 - `HOMERAIL_PRODUCTION_HOME` for persistent runtime data;
 - `HOMERAIL_PRODUCTION_RESOURCES` for optional external Skills;
-- `HOMERAIL_PRODUCTION_UI_URL` and `HOMERAIL_PRODUCTION_PUBLIC_HOST` for the
-  LAN-facing UI;
+- `HOMERAIL_PRODUCTION_PUBLIC_HOST` for the required LAN-facing host or IP;
+- optional `HOMERAIL_PRODUCTION_UI_URL` when the default
+  `https://<public-host>:19192` address needs overriding;
+- optional `HOMERAIL_PRODUCTION_UI_PORT` and
+  `HOMERAIL_PRODUCTION_UI_HTTP_PORT` overrides (defaults: `19192` and
+  `19193`);
 - optional Manager URL/host/port overrides when the default loopback endpoint
   would conflict with another local runtime.
 
@@ -32,8 +36,9 @@ revision-tagged Worker image, copies the runnable tree plus its Node.js binary
 into a new release directory, and atomically switches `current`. The systemd
 user service owns Manager, Node, and the static Agent UI as one cgroup and
 restarts after a process or health failure. Deployment waits for both Manager
-and HTTPS UI health, and requires a connected Docker Node. A failed health
-check switches `current` back to the prior release and restarts it. The
+and HTTPS UI health through its LAN address, and requires a connected Docker
+Node. Deployment rejects loopback-only UI binds and loopback public addresses.
+A failed health check switches `current` back to the prior release and restarts it. The
 dedicated Manager port prevents desktop/E2E runtimes from being mistaken for
 the production Manager. The newest three releases and their Worker images are
 retained; database, model settings, sessions, certificates, and external Skills

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -11,11 +11,49 @@ UNIT_PATH="$HOME/.config/systemd/user/$SERVICE_NAME"
 MANAGER_HOST="${HOMERAIL_PRODUCTION_MANAGER_HOST:-127.0.0.1}"
 MANAGER_PORT="${HOMERAIL_PRODUCTION_MANAGER_PORT:-39191}"
 MANAGER_URL="${HOMERAIL_PRODUCTION_MANAGER_URL:-http://$MANAGER_HOST:$MANAGER_PORT}"
-UI_URL="${HOMERAIL_PRODUCTION_UI_URL:-https://127.0.0.1:29192}"
+UI_HOST="${HOMERAIL_PRODUCTION_UI_HOST:-0.0.0.0}"
+UI_PORT="${HOMERAIL_PRODUCTION_UI_PORT:-19192}"
+UI_HTTP_PORT="${HOMERAIL_PRODUCTION_UI_HTTP_PORT:-19193}"
+PUBLIC_HOST="${HOMERAIL_PRODUCTION_PUBLIC_HOST:-}"
+UI_URL="${HOMERAIL_PRODUCTION_UI_URL:-}"
 
 case "$PRODUCTION_ROOT" in /*) ;; *) echo "HOMERAIL_PRODUCTION_ROOT must be absolute." >&2; exit 1 ;; esac
 case "$HOMERAIL_HOME" in /*) ;; *) echo "HOMERAIL_PRODUCTION_HOME must be absolute." >&2; exit 1 ;; esac
 case "$RESOURCE_ROOT" in /*) ;; *) echo "HOMERAIL_PRODUCTION_RESOURCES must be absolute." >&2; exit 1 ;; esac
+if [ "$UI_HOST" != "0.0.0.0" ] && [ "$UI_HOST" != "::" ]; then
+  echo "HOMERAIL_PRODUCTION_UI_HOST must bind all interfaces (0.0.0.0 or ::)." >&2
+  exit 1
+fi
+case "$PUBLIC_HOST" in
+  ""|localhost|127.*|::1|\[::1\])
+    echo "HOMERAIL_PRODUCTION_PUBLIC_HOST must be a LAN-accessible host or address." >&2
+    exit 1
+    ;;
+esac
+for port in "$UI_PORT" "$UI_HTTP_PORT"; do
+  if [[ ! "$port" =~ ^[0-9]+$ ]] || [ "$port" -lt 1 ] || [ "$port" -gt 65535 ]; then
+    echo "Production UI ports must be integers from 1 through 65535." >&2
+    exit 1
+  fi
+done
+if [ -z "$UI_URL" ]; then
+  if [[ "$PUBLIC_HOST" == *:* ]]; then
+    UI_URL="https://[$PUBLIC_HOST]:$UI_PORT"
+  else
+    UI_URL="https://$PUBLIC_HOST:$UI_PORT"
+  fi
+fi
+case "$UI_URL" in
+  https://localhost:*|https://localhost/*|https://127.*|https://\[::1\]*)
+    echo "HOMERAIL_PRODUCTION_UI_URL must use the LAN-facing HTTPS endpoint." >&2
+    exit 1
+    ;;
+  https://*) ;;
+  *)
+    echo "HOMERAIL_PRODUCTION_UI_URL must use HTTPS." >&2
+    exit 1
+    ;;
+esac
 if [[ ! "$REVISION" =~ ^[0-9a-f]{40}$ ]]; then
   echo "HOMERAIL_DEPLOY_REVISION must be an exact 40-character commit SHA." >&2
   exit 1
@@ -98,7 +136,10 @@ Environment=HOMERAIL_PRODUCTION_MANAGER_HOST=$MANAGER_HOST
 Environment=HOMERAIL_PRODUCTION_MANAGER_PORT=$MANAGER_PORT
 Environment=HOMERAIL_PRODUCTION_MANAGER_PUBLIC_URL=${HOMERAIL_PRODUCTION_MANAGER_PUBLIC_URL:-$MANAGER_URL}
 Environment=HOMERAIL_PRODUCTION_UI_URL=$UI_URL
-Environment=HOMERAIL_PRODUCTION_PUBLIC_HOST=${HOMERAIL_PRODUCTION_PUBLIC_HOST:-127.0.0.1}
+Environment=HOMERAIL_PRODUCTION_UI_HOST=$UI_HOST
+Environment=HOMERAIL_PRODUCTION_UI_PORT=$UI_PORT
+Environment=HOMERAIL_PRODUCTION_UI_HTTP_PORT=$UI_HTTP_PORT
+Environment=HOMERAIL_PRODUCTION_PUBLIC_HOST=$PUBLIC_HOST
 Environment=PATH=/usr/local/bin:/usr/bin:/bin
 ExecStart=$PRODUCTION_ROOT/current/scripts/run-production-service.sh
 Restart=always
@@ -130,7 +171,7 @@ healthy=0
 for _ in $(seq 1 60); do
   if systemctl --user is-active --quiet "$SERVICE_NAME" \
     && curl -fsS --connect-timeout 3 --max-time 5 "$MANAGER_URL/health" >/dev/null \
-    && curl -fkSs --connect-timeout 3 --max-time 5 "$UI_URL/" >/dev/null \
+    && curl -fkSs --connect-timeout 3 --max-time 5 "${UI_URL%/}/" >/dev/null \
     && curl -fsS --connect-timeout 3 --max-time 5 "$MANAGER_URL/runtime/status" \
       | "$PRODUCTION_ROOT/current/runtime/node" -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const v=JSON.parse(s);process.exit(Number(v.connected_nodes)>0?0:1)})"; then
     healthy=1

--- a/scripts/production-deploy-contracts.test.mjs
+++ b/scripts/production-deploy-contracts.test.mjs
@@ -35,6 +35,13 @@ test("production deployment is atomic, health checked, and rollback capable", ()
   assert.match(deploy, /grep -Fxl -- "\$old_revision"/);
   assert.match(deploy, /HOMERAIL_PRODUCTION_MANAGER_HOST=\$MANAGER_HOST/);
   assert.match(deploy, /HOMERAIL_PRODUCTION_MANAGER_PORT=\$MANAGER_PORT/);
+  assert.match(deploy, /HOMERAIL_PRODUCTION_UI_HOST=\$UI_HOST/);
+  assert.match(deploy, /HOMERAIL_PRODUCTION_UI_PORT=\$UI_PORT/);
+  assert.match(deploy, /HOMERAIL_PRODUCTION_UI_HTTP_PORT=\$UI_HTTP_PORT/);
+  assert.match(deploy, /must be a LAN-accessible host or address/);
+  assert.match(deploy, /HOMERAIL_PRODUCTION_UI_PORT:-19192/);
+  assert.match(service, /HOMERAIL_PRODUCTION_UI_PORT:-19192/);
+  assert.match(service, /Production UI must bind all interfaces/);
   assert.match(service, /HOMERAIL_UI_SERVE_STATIC=1/);
   assert.match(service, /RELEASE_ROOT="\$\(readlink -f "\$CURRENT"\)"/);
   assert.match(service, /HOMERAIL_REPO_ROOT="\$RELEASE_ROOT"/);

--- a/scripts/run-production-service.sh
+++ b/scripts/run-production-service.sh
@@ -7,7 +7,11 @@ RELEASE_ROOT="$(readlink -f "$CURRENT")"
 HOMERAIL_HOME="${HOMERAIL_HOME:-$HOME/.local/share/homerail-production-data}"
 RESOURCE_ROOT="${HOMERAIL_PRODUCTION_RESOURCES:-$HOME/.local/share/homerail-resources}"
 MANAGER_URL="${HOMERAIL_PRODUCTION_MANAGER_URL:-http://127.0.0.1:39191}"
-UI_URL="${HOMERAIL_PRODUCTION_UI_URL:-https://127.0.0.1:29192}"
+UI_HOST="${HOMERAIL_PRODUCTION_UI_HOST:-0.0.0.0}"
+UI_PORT="${HOMERAIL_PRODUCTION_UI_PORT:-19192}"
+UI_HTTP_PORT="${HOMERAIL_PRODUCTION_UI_HTTP_PORT:-19193}"
+PUBLIC_HOST="${HOMERAIL_PRODUCTION_PUBLIC_HOST:-}"
+UI_URL="${HOMERAIL_PRODUCTION_UI_URL:-}"
 NODE="$RELEASE_ROOT/runtime/node"
 CLI="$RELEASE_ROOT/homerail_cli/dist/cli.js"
 REVISION="$(tr -d '[:space:]' < "$RELEASE_ROOT/REVISION")"
@@ -19,6 +23,23 @@ if [[ "$RELEASE_ROOT" != "$PRODUCTION_ROOT"/releases/* ]] \
   echo "Production release is incomplete." >&2
   exit 1
 fi
+if [ "$UI_HOST" != "0.0.0.0" ] && [ "$UI_HOST" != "::" ]; then
+  echo "Production UI must bind all interfaces." >&2
+  exit 1
+fi
+case "$PUBLIC_HOST" in
+  ""|localhost|127.*|::1|\[::1\])
+    echo "Production UI requires a LAN-accessible public host." >&2
+    exit 1
+    ;;
+esac
+if [ -z "$UI_URL" ]; then
+  if [[ "$PUBLIC_HOST" == *:* ]]; then
+    UI_URL="https://[$PUBLIC_HOST]:$UI_PORT"
+  else
+    UI_URL="https://$PUBLIC_HOST:$UI_PORT"
+  fi
+fi
 
 export HOMERAIL_HOME
 export HOMERAIL_REPO_ROOT="$RELEASE_ROOT"
@@ -26,11 +47,11 @@ export HOMERAIL_MANAGER_URL="$MANAGER_URL"
 export HOMERAIL_MANAGER_PORT="${HOMERAIL_PRODUCTION_MANAGER_PORT:-39191}"
 export HOMERAIL_MANAGER_HOST="${HOMERAIL_PRODUCTION_MANAGER_HOST:-127.0.0.1}"
 export HOMERAIL_MANAGER_PUBLIC_URL="${HOMERAIL_PRODUCTION_MANAGER_PUBLIC_URL:-http://127.0.0.1:39191}"
-export HOMERAIL_UI_HOST="${HOMERAIL_PRODUCTION_UI_HOST:-0.0.0.0}"
-export HOMERAIL_UI_PORT="${HOMERAIL_PRODUCTION_UI_PORT:-29192}"
-export HOMERAIL_UI_HTTP_PORT="${HOMERAIL_PRODUCTION_UI_HTTP_PORT:-29193}"
+export HOMERAIL_UI_HOST="$UI_HOST"
+export HOMERAIL_UI_PORT="$UI_PORT"
+export HOMERAIL_UI_HTTP_PORT="$UI_HTTP_PORT"
 export HOMERAIL_UI_PUBLIC_URL="$UI_URL"
-export HOMERAIL_PUBLIC_HOST="${HOMERAIL_PRODUCTION_PUBLIC_HOST:-127.0.0.1}"
+export HOMERAIL_PUBLIC_HOST="$PUBLIC_HOST"
 export HOMERAIL_UI_SERVE_STATIC=1
 export HOMERAIL_WORKER_IMAGE="homerail-worker:production-${REVISION:0:12}"
 
@@ -81,7 +102,7 @@ runtime_has_node() {
 failures=0
 while sleep 10; do
   if curl -fsS --connect-timeout 3 --max-time 10 "$MANAGER_URL/health" >/dev/null \
-    && curl -fkSs --connect-timeout 3 --max-time 10 "$UI_URL/" >/dev/null \
+    && curl -fkSs --connect-timeout 3 --max-time 10 "${UI_URL%/}/" >/dev/null \
     && runtime_has_node; then
     failures=0
     continue


### PR DESCRIPTION
## What changed

- restore the production HTTPS UI default to port `19192` (`19193` for the HTTP companion)
- require production UI services to bind all interfaces
- require a non-loopback LAN/public host and an HTTPS public URL
- propagate the UI host and ports into the generated systemd service
- health-check the advertised LAN HTTPS endpoint during deploy and supervision
- document and test the deployment contract

## Root cause

The first persistent deployment used private production defaults `29192/29193`. The service was healthy and bound to `0.0.0.0`, but it was not available at HomeRail's normal `19192` HTTPS address. The generated systemd unit also did not propagate the configured UI port variables, so machine configuration alone could not reliably correct the port on subsequent deploys.

## Impact

Production deployment now fails closed when configured as loopback-only and defaults to the normal HomeRail HTTPS port. Machine-specific addresses and persistent Home paths remain in the runner's private environment file and are not committed.

## Validation

- `bash -n scripts/deploy-production.sh scripts/run-production-service.sh`
- `npm run test:live-validator` (36 passed)
- live service on the deployment host listens on `0.0.0.0:19192`
- cross-machine HTTPS probe to the deployment host returned HTTP 200
- existing persistent database remained available through the configured Home path
