### PR TITLE
Simplify local runtime setup and Docker readiness

### DIFF
--- a/agent-ui/src/admin-proxy-trust.test.ts
+++ b/agent-ui/src/admin-proxy-trust.test.ts
@@ -2,15 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   authorizeAdminProxyRequest,
   isProtectedApiMutation,
-  resolveAdminProxyTrust,
 } from './admin-proxy-trust'
-
-const local = () => resolveAdminProxyTrust({
-  enabled: true,
-  uiOrigin: 'https://localhost:19192',
-  uiBindHost: '127.0.0.1',
-  managerUrl: 'http://localhost:19191',
-})
 
 describe('Vite Manager mutation proxy trust', () => {
   it('recognizes every /api mutation, not just plugin routes', () => {
@@ -21,41 +13,40 @@ describe('Vite Manager mutation proxy trust', () => {
     expect(isProtectedApiMutation('POST', '/artifacts/upload')).toBe(false)
   })
 
-  it('permits only an exact self-Origin when the loopback switch is safe', () => {
-    expect(authorizeAdminProxyRequest(local(), 'https://localhost:19192')).toEqual({ allowed: true })
-    expect(authorizeAdminProxyRequest(local(), undefined)).toMatchObject({ allowed: false })
-    expect(authorizeAdminProxyRequest(local(), 'https://evil.example')).toMatchObject({ allowed: false })
-    expect(authorizeAdminProxyRequest(local(), 'https://localhost:19192', 'cross-site'))
-      .toMatchObject({ allowed: false })
+  it('derives localhost self-Origin without a deployment switch', () => {
+    expect(authorizeAdminProxyRequest({
+      protocol: 'https',
+      host: 'localhost:19194',
+      origin: 'https://localhost:19194',
+      secFetchSite: 'same-origin',
+    })).toEqual({ allowed: true })
   })
 
-  it('fails public UI and non-loopback Manager targets closed even when switched on', () => {
-    expect(resolveAdminProxyTrust({
-      enabled: true,
-      uiOrigin: 'http://192.168.1.9:19193',
-      uiBindHost: '0.0.0.0',
-      managerUrl: 'http://127.0.0.1:19191',
-    }).enabled).toBe(false)
-    expect(resolveAdminProxyTrust({
-      enabled: true,
-      uiOrigin: 'https://localhost:19192',
-      uiBindHost: '127.0.0.1',
-      managerUrl: 'http://192.168.1.9:19191',
-    }).enabled).toBe(false)
+  it('derives LAN self-Origin without configured public URL', () => {
+    expect(authorizeAdminProxyRequest({
+      protocol: 'https',
+      host: 'homerail.lan:19194',
+      origin: 'https://homerail.lan:19194',
+      secFetchSite: 'same-origin',
+    })).toEqual({ allowed: true })
   })
 
-  it('allows an explicitly unsafe public test proxy only for its exact self Origin', () => {
-    const unsafe = resolveAdminProxyTrust({
-      enabled: true,
-      uiOrigin: 'http://192.168.1.9:19193',
-      uiBindHost: '192.168.1.9',
-      managerUrl: 'http://127.0.0.1:19191',
-      unsafeAllowPublicNoAuth: true,
-    })
-    expect(unsafe).toMatchObject({ enabled: true, unsafeAllowPublicNoAuth: true })
-    expect(authorizeAdminProxyRequest(unsafe, 'http://192.168.1.9:19193', 'same-origin'))
-      .toEqual({ allowed: true })
-    expect(authorizeAdminProxyRequest(unsafe, 'https://evil.example', 'cross-site'))
-      .toMatchObject({ allowed: false })
+  it('rejects missing and cross-origin browser mutations', () => {
+    expect(authorizeAdminProxyRequest({
+      protocol: 'http',
+      host: 'localhost:19194',
+      origin: undefined,
+    })).toMatchObject({ allowed: false })
+    expect(authorizeAdminProxyRequest({
+      protocol: 'http',
+      host: 'localhost:19194',
+      origin: 'https://evil.example',
+    })).toMatchObject({ allowed: false })
+    expect(authorizeAdminProxyRequest({
+      protocol: 'http',
+      host: 'localhost:19194',
+      origin: 'http://localhost:19194',
+      secFetchSite: 'cross-site',
+    })).toMatchObject({ allowed: false })
   })
 })

--- a/agent-ui/src/admin-proxy-trust.ts
+++ b/agent-ui/src/admin-proxy-trust.ts
@@ -1,44 +1,10 @@
 const MUTATION_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
 
-export interface AdminProxyTrustOptions {
-  enabled: boolean
-  uiOrigin: string
-  uiBindHost: string
-  managerUrl: string
-  unsafeAllowPublicNoAuth?: boolean
-}
-
-export interface AdminProxyTrust {
-  enabled: boolean
-  uiOrigin?: string
-  unsafeAllowPublicNoAuth?: boolean
-  disabledReason?: string
-}
-
-export function resolveAdminProxyTrust(options: AdminProxyTrustOptions): AdminProxyTrust {
-  if (!options.enabled) return disabled('loopback-safe admin proxy switch is disabled')
-  const uiOrigin = exactOrigin(options.uiOrigin)
-  if (!uiOrigin) return disabled('UI Origin is invalid')
-  const unsafeAllowPublicNoAuth = Boolean(options.unsafeAllowPublicNoAuth)
-  if (
-    (!isLoopbackHost(options.uiBindHost) || !isLoopbackHost(new URL(uiOrigin).hostname))
-    && !unsafeAllowPublicNoAuth
-  ) {
-    return disabled('UI is reachable beyond loopback')
-  }
-  let manager: URL
-  try {
-    manager = new URL(options.managerUrl)
-  } catch {
-    return disabled('Manager URL is invalid')
-  }
-  if (
-    !['http:', 'https:'].includes(manager.protocol)
-    || !isLoopbackHost(manager.hostname)
-    || Boolean(manager.username)
-    || Boolean(manager.password)
-  ) return disabled('Manager is reachable beyond loopback')
-  return { enabled: true, uiOrigin, unsafeAllowPublicNoAuth }
+export interface UiMutationRequestTrust {
+  protocol: 'http' | 'https'
+  host: string | string[] | undefined
+  origin: string | string[] | undefined
+  secFetchSite?: string | string[]
 }
 
 export function isProtectedApiMutation(methodValue?: string, urlValue?: string): boolean {
@@ -51,56 +17,39 @@ export function isProtectedApiMutation(methodValue?: string, urlValue?: string):
   }
 }
 
+/**
+ * Authorize a browser mutation using the origin of the request that reached the
+ * UI server. This deliberately has no deployment switch or configured Origin:
+ * Vite already knows the browser-facing protocol and Host for every request.
+ * Manager remains the canonical trust boundary after the proxy hop.
+ */
 export function authorizeAdminProxyRequest(
-  trust: AdminProxyTrust,
-  origin: string | string[] | undefined,
-  secFetchSite?: string | string[],
+  request: UiMutationRequestTrust,
 ): { allowed: true } | { allowed: false; reason: string } {
-  if (!trust.enabled || !trust.uiOrigin) {
-    return { allowed: false, reason: trust.disabledReason || 'UI mutation proxy is disabled' }
+  const host = singleHeader(request.host)
+  const origin = singleHeader(request.origin)
+  if (!host || !origin) {
+    return { allowed: false, reason: 'UI mutation Origin is required' }
   }
-  if (typeof origin !== 'string' || origin !== trust.uiOrigin) {
-    return { allowed: false, reason: 'UI mutation Origin is missing or not self-origin' }
+
+  let selfOrigin: string
+  try {
+    selfOrigin = new URL(`${request.protocol}://${host}`).origin
+  } catch {
+    return { allowed: false, reason: 'UI request Host is invalid' }
   }
-  if (
-    secFetchSite !== undefined
-    && (typeof secFetchSite !== 'string' || secFetchSite.toLowerCase() !== 'same-origin')
-  ) return { allowed: false, reason: 'Cross-origin UI mutation proxy requests are forbidden' }
+  if (origin !== selfOrigin) {
+    return { allowed: false, reason: 'Cross-origin UI mutation requests are forbidden' }
+  }
+
+  const secFetchSite = singleHeader(request.secFetchSite)?.toLowerCase()
+  if (secFetchSite !== undefined && secFetchSite !== 'same-origin') {
+    return { allowed: false, reason: 'Cross-origin UI mutation requests are forbidden' }
+  }
   return { allowed: true }
 }
 
-function exactOrigin(value: string): string | undefined {
-  let parsed: URL
-  try {
-    parsed = new URL(value)
-  } catch {
-    return undefined
-  }
-  if (
-    !['http:', 'https:'].includes(parsed.protocol)
-    || Boolean(parsed.username)
-    || Boolean(parsed.password)
-    || parsed.pathname !== '/'
-    || Boolean(parsed.search)
-    || Boolean(parsed.hash)
-    || parsed.origin !== value
-  ) return undefined
-  return parsed.origin
-}
-
-function isLoopbackHost(value: string): boolean {
-  let host = value.trim().toLowerCase()
-  if (host.startsWith('[') && host.endsWith(']')) host = host.slice(1, -1)
-  const zone = host.indexOf('%')
-  if (zone >= 0) host = host.slice(0, zone)
-  if (host === 'localhost' || host === '::1' || host === '0:0:0:0:0:0:0:1') return true
-  if (host.startsWith('::ffff:')) host = host.slice('::ffff:'.length)
-  const octets = host.split('.')
-  return octets.length === 4
-    && octets.every(octet => /^\d{1,3}$/.test(octet) && Number(octet) <= 255)
-    && Number(octets[0]) === 127
-}
-
-function disabled(reason: string): AdminProxyTrust {
-  return { enabled: false, disabledReason: reason }
+function singleHeader(value: string | string[] | undefined): string | undefined {
+  if (typeof value !== 'string' || !value || /[\r\n]/.test(value)) return undefined
+  return value
 }

--- a/agent-ui/src/components/agent/onboarding/OnboardingWizard.vue
+++ b/agent-ui/src/components/agent/onboarding/OnboardingWizard.vue
@@ -27,7 +27,7 @@ import {
 import type { Provider } from '@/api/types/orchestration-v2.types'
 import type { LLMSetting } from '@/api/services/llm-settings-api'
 import OnboardingStepForm from './OnboardingStepForm.vue'
-import { dockerWorkspaceGuidance } from './docker-workspace-status'
+import { dockerWorkspaceGuidance, readableDockerWorkspaceError } from './docker-workspace-status'
 
 const props = withDefaults(defineProps<{
   manualDebug?: boolean
@@ -55,7 +55,7 @@ onMounted(async () => {
   const providersPromise = loadProviders()
   const settingsPromise = loadExistingSettings()
   await refresh()
-  const dockerProbePromise = status.value.dockerWorkspace?.required
+  const dockerProbePromise = status.value.dockerWorkspace
     ? checkDockerWorkspace()
     : Promise.resolve()
   await Promise.all([providersPromise, settingsPromise, dockerProbePromise])
@@ -200,8 +200,8 @@ const hostShellMessage = computed(() => {
 })
 const dockerWorkspaceHostPath = computed(() => status.value.dockerWorkspace?.hostPath || '')
 const dockerWorkspaceReady = computed(() => dockerProbeResult.value?.available === true)
-const dockerWorkspaceRequired = computed(() => status.value.dockerWorkspace?.required === true)
-const environmentNeedsAttention = computed(() => !hostShellReady.value || (dockerWorkspaceRequired.value && !dockerWorkspaceReady.value))
+const dockerWorkspaceAvailable = computed(() => Boolean(status.value.dockerWorkspace))
+const environmentNeedsAttention = computed(() => !hostShellReady.value)
 const dockerWorkspaceMessage = computed(() => {
   if (dockerProbeRunning.value) return t('onboarding.environmentCheck.checkingDocker')
   if (dockerProbeResult.value?.available) return t('onboarding.environmentCheck.dockerReady')
@@ -292,7 +292,7 @@ async function checkDockerWorkspace(): Promise<void> {
     dockerProbeResult.value = {
       available: false,
       host_path: dockerWorkspaceHostPath.value,
-      error: err instanceof Error ? err.message : String(err),
+      error: readableDockerWorkspaceError(err, t('onboarding.environmentCheck.dockerCheckUnavailable')),
       code: 'docker_workspace_probe_request_failed',
     }
   } finally {
@@ -301,7 +301,7 @@ async function checkDockerWorkspace(): Promise<void> {
 }
 
 function ensureDockerWorkspaceChecked(): void {
-  if (!dockerWorkspaceRequired.value || dockerProbeRunning.value || dockerProbeResult.value) return
+  if (!dockerWorkspaceAvailable.value || dockerProbeRunning.value || dockerProbeResult.value) return
   void checkDockerWorkspace()
 }
 
@@ -506,7 +506,6 @@ watch(activePane, (pane) => {
               class="onboarding-wizard__blocker"
             >
               <span>{{ blocker.message }}</span>
-              <code>{{ blocker.code }}</code>
             </div>
           </div>
         </section>
@@ -864,7 +863,7 @@ watch(activePane, (pane) => {
 
 .onboarding-wizard__blocker {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr);
   gap: 0.55rem;
   align-items: center;
   padding: 0.55rem 0.65rem;
@@ -878,11 +877,6 @@ watch(activePane, (pane) => {
 .onboarding-wizard__blocker span {
   min-width: 0;
   overflow-wrap: anywhere;
-}
-
-.onboarding-wizard__blocker code {
-  color: var(--hr-text-3);
-  font-size: 0.66rem;
 }
 
 .onboarding-wizard__docker-check {

--- a/agent-ui/src/components/agent/onboarding/OnboardingWizardBehavior.test.ts
+++ b/agent-ui/src/components/agent/onboarding/OnboardingWizardBehavior.test.ts
@@ -3,11 +3,12 @@ import wizardSource from './OnboardingWizard.vue?raw'
 
 describe('OnboardingWizard environment checks', () => {
   it('automatically probes Docker and keeps manual interaction as retry only', () => {
-    expect(wizardSource).toContain('const dockerProbePromise = status.value.dockerWorkspace?.required')
+    expect(wizardSource).toContain('const dockerProbePromise = status.value.dockerWorkspace')
     expect(wizardSource).toContain('? checkDockerWorkspace()')
     expect(wizardSource).toContain("if (pane === 'environment') ensureDockerWorkspaceChecked()")
     expect(wizardSource).toContain("t('onboarding.environmentCheck.recheck')")
     expect(wizardSource).toContain('v-if="dockerWorkspaceReady"')
+    expect(wizardSource).toContain('const environmentNeedsAttention = computed(() => !hostShellReady.value)')
   })
 
   it('renders the Git Bash host-shell check only when the runtime requires it', () => {

--- a/agent-ui/src/components/agent/onboarding/docker-workspace-status.test.ts
+++ b/agent-ui/src/components/agent/onboarding/docker-workspace-status.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { dockerWorkspaceGuidance } from './docker-workspace-status'
+import { dockerWorkspaceGuidance, readableDockerWorkspaceError } from './docker-workspace-status'
 
 describe('Docker workspace guidance', () => {
   it('does not add guidance before probing or after success', () => {
@@ -39,5 +39,16 @@ describe('Docker workspace guidance', () => {
       host_path: '/workspace',
       error: 'permission denied while trying to connect to the Docker daemon; add the user to the docker group',
     })).toBe('permission')
+  })
+
+  it('extracts plain API error objects without rendering object Object', () => {
+    expect(readableDockerWorkspaceError({
+      message: 'Manager mutation Origin is not trusted',
+      code: 403,
+    }, 'Docker check unavailable')).toBe('Manager mutation Origin is not trusted')
+    expect(readableDockerWorkspaceError({
+      error: { message: 'Docker daemon is unavailable' },
+    }, 'Docker check unavailable')).toBe('Docker daemon is unavailable')
+    expect(readableDockerWorkspaceError({}, 'Docker check unavailable')).toBe('Docker check unavailable')
   })
 })

--- a/agent-ui/src/components/agent/onboarding/docker-workspace-status.ts
+++ b/agent-ui/src/components/agent/onboarding/docker-workspace-status.ts
@@ -6,7 +6,7 @@ export function dockerWorkspaceGuidance(
   result: DockerWorkspaceProbeResult | null,
 ): DockerWorkspaceGuidance {
   if (!result || result.available) return null
-  const message = (result.error || '').toLowerCase()
+  const message = typeof result.error === 'string' ? result.error.toLowerCase() : ''
 
   if (
     result.code === 'docker_node_unavailable' ||
@@ -29,4 +29,20 @@ export function dockerWorkspaceGuidance(
     return 'permission'
   }
   return null
+}
+
+export function readableDockerWorkspaceError(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message.trim()) return error.message
+  if (typeof error === 'string' && error.trim()) return error
+  if (error && typeof error === 'object') {
+    const message = (error as { message?: unknown }).message
+    if (typeof message === 'string' && message.trim()) return message
+    const nested = (error as { error?: unknown }).error
+    if (nested && typeof nested === 'object') {
+      const nestedMessage = (nested as { message?: unknown }).message
+      if (typeof nestedMessage === 'string' && nestedMessage.trim()) return nestedMessage
+    }
+    if (typeof nested === 'string' && nested.trim()) return nested
+  }
+  return fallback
 }

--- a/agent-ui/src/locales/en-US/onboarding.json
+++ b/agent-ui/src/locales/en-US/onboarding.json
@@ -17,7 +17,7 @@
   "runtime": {
     "ready": "Manager Agent runtime is ready",
     "currentHarness": "Current harness: {harness}",
-    "notReady": "Manager Agent runtime is not ready. Configure model credentials here, then resolve local dependencies and Docker access under Environment check.",
+    "notReady": "Manager Agent runtime is not ready. Configure model credentials here, then resolve its local dependencies under Environment check.",
     "existing": "Existing Manager Agent settings",
     "switching": "Switching...",
     "use": "Use",
@@ -25,7 +25,7 @@
     "nextAvailable": "You can continue to the next step"
   },
   "environmentCheck": {
-    "description": "Verify local runtime dependencies and Docker workspace access",
+    "description": "Verify Manager Agent dependencies; Docker is only needed for container DAGs",
     "hostNotRequired": "This Manager Agent does not require a Git Bash host-shell environment",
     "gitBashReadyPath": "Git Bash is ready: {path}",
     "gitBashReady": "Git Bash host-shell environment is ready",
@@ -38,6 +38,7 @@
     "dockerStartRequired": "Docker is installed but not running. Start Docker, then check again.",
     "dockerPermissionRequired": "The current user cannot access Docker. Grant Docker access, then check again.",
     "dockerCheckFailed": "Docker workspace check failed: {error}",
+    "dockerCheckUnavailable": "Docker cannot be checked right now. Try again shortly.",
     "passed": "Passed",
     "needsAttention": "Action needed",
     "dockerTitle": "Docker workspace access",

--- a/agent-ui/src/locales/zh-Hans/onboarding.json
+++ b/agent-ui/src/locales/zh-Hans/onboarding.json
@@ -17,7 +17,7 @@
   "runtime": {
     "ready": "主 Agent 运行时已就绪",
     "currentHarness": "当前 Harness：{harness}",
-    "notReady": "主 Agent 运行时未就绪。模型凭证在这里配置，本机依赖和 Docker 访问请到环境检查页处理。",
+    "notReady": "主 Agent 运行时未就绪。模型凭证在这里配置，本机主 Agent 依赖请到环境检查页处理。",
     "existing": "已有主 Agent 配置",
     "switching": "切换中...",
     "use": "使用",
@@ -25,7 +25,7 @@
     "nextAvailable": "可以进入下一步"
   },
   "environmentCheck": {
-    "description": "确认本机运行依赖和 Docker 工作区访问",
+    "description": "确认主 Agent 依赖；Docker 仅在运行容器 DAG 时需要",
     "hostNotRequired": "当前 Manager Agent 不需要 Git Bash host-shell 环境",
     "gitBashReadyPath": "Git Bash 已就绪：{path}",
     "gitBashReady": "Git Bash host-shell 环境已就绪",
@@ -38,6 +38,7 @@
     "dockerStartRequired": "Docker 已安装但未运行。请启动 Docker 后重新检查。",
     "dockerPermissionRequired": "当前用户无法访问 Docker。请授予 Docker 访问权限后重新检查。",
     "dockerCheckFailed": "Docker 工作区检查失败：{error}",
+    "dockerCheckUnavailable": "暂时无法检查 Docker，请稍后重试",
     "passed": "已通过",
     "needsAttention": "需处理",
     "dockerTitle": "Docker 工作区访问",

--- a/agent-ui/src/locales/zh-Hant/onboarding.json
+++ b/agent-ui/src/locales/zh-Hant/onboarding.json
@@ -17,7 +17,7 @@
   "runtime": {
     "ready": "主 Agent 運行時已就緒",
     "currentHarness": "當前 Harness：{harness}",
-    "notReady": "主 Agent 運行時未就緒。模型憑證在這裏配置，本機依賴和 Docker 存取請到環境檢查頁處理。",
+    "notReady": "主 Agent 運行時未就緒。模型憑證在這裏配置，本機主 Agent 依賴請到環境檢查頁處理。",
     "existing": "已有主 Agent 配置",
     "switching": "切換中...",
     "use": "使用",
@@ -25,7 +25,7 @@
     "nextAvailable": "可以進入下一步"
   },
   "environmentCheck": {
-    "description": "確認本機運行依賴和 Docker 工作區存取",
+    "description": "確認主 Agent 依賴；Docker 僅在執行容器 DAG 時需要",
     "hostNotRequired": "當前 Manager Agent 不需要 Git Bash host-shell 環境",
     "gitBashReadyPath": "Git Bash 已就緒：{path}",
     "gitBashReady": "Git Bash host-shell 環境已就緒",
@@ -38,6 +38,7 @@
     "dockerStartRequired": "Docker 已安裝但未執行。請啟動 Docker 後重新檢查。",
     "dockerPermissionRequired": "目前使用者無法存取 Docker。請授予 Docker 存取權限後重新檢查。",
     "dockerCheckFailed": "Docker 工作區檢查失敗：{error}",
+    "dockerCheckUnavailable": "暫時無法檢查 Docker，請稍後重試",
     "passed": "已通過",
     "needsAttention": "需處理",
     "dockerTitle": "Docker 工作區存取",

--- a/agent-ui/vite.config.ts
+++ b/agent-ui/vite.config.ts
@@ -8,7 +8,6 @@ import viteCompression from 'vite-plugin-compression2'
 import {
   authorizeAdminProxyRequest,
   isProtectedApiMutation,
-  resolveAdminProxyTrust,
 } from './src/admin-proxy-trust'
 
 // Dev server gzip compression plugin
@@ -40,14 +39,6 @@ const managerWsTarget = (
   process.env.VITE_WS_URL
   || managerHttpTarget.replace(/^http:/, 'ws:').replace(/^https:/, 'wss:')
 )
-const managerAdminToken = process.env.HOMERAIL_MANAGER_ADMIN_TOKEN || ''
-const adminProxyTrust = resolveAdminProxyTrust({
-  enabled: process.env.HOMERAIL_UI_ADMIN_PROXY_ENABLED === '1',
-  uiOrigin: process.env.HOMERAIL_UI_ORIGIN || '',
-  uiBindHost: process.env.HOMERAIL_UI_HOST || '',
-  managerUrl: managerHttpTarget,
-  unsafeAllowPublicNoAuth: process.env.HOMERAIL_UNSAFE_ALLOW_PUBLIC_MANAGER_WITHOUT_AUTH === '1',
-})
 
 function adminProxyGuardPlugin(): Plugin {
   return {
@@ -56,11 +47,12 @@ function adminProxyGuardPlugin(): Plugin {
     configureServer(server) {
       server.middlewares.use((req, res, next) => {
         if (!isProtectedApiMutation(req.method, req.url)) return next()
-        const authorization = authorizeAdminProxyRequest(
-          adminProxyTrust,
-          req.headers.origin,
-          req.headers['sec-fetch-site'],
-        )
+        const authorization = authorizeAdminProxyRequest({
+          protocol: 'encrypted' in req.socket && req.socket.encrypted ? 'https' : 'http',
+          host: req.headers.host,
+          origin: req.headers.origin,
+          secFetchSite: req.headers['sec-fetch-site'],
+        })
         if (authorization.allowed) return next()
         req.resume()
         res.writeHead(403, {
@@ -71,21 +63,6 @@ function adminProxyGuardPlugin(): Plugin {
       })
     },
   }
-}
-
-function configureManagerProxy(proxy: { on: (event: string, listener: (...args: any[]) => void) => void }): void {
-  proxy.on('proxyReq', (proxyReq: { removeHeader: (name: string) => void; setHeader: (name: string, value: string) => void }, req: { method?: string; url?: string; headers: Record<string, string | string[] | undefined> }) => {
-    if (!isProtectedApiMutation(req.method, req.url)) return
-    proxyReq.removeHeader('authorization')
-    const authorization = authorizeAdminProxyRequest(
-      adminProxyTrust,
-      req.headers.origin,
-      req.headers['sec-fetch-site'],
-    )
-    if (authorization.allowed && managerAdminToken) {
-      proxyReq.setHeader('authorization', `Bearer ${managerAdminToken}`)
-    }
-  })
 }
 
 // NOTE: For production nginx, uncomment `gzip on;` in /usr/trim/nginx/conf/nginx.conf
@@ -136,7 +113,6 @@ export default defineConfig({
         changeOrigin: true,
         secure: false,
         rewrite: (path) => path,
-        configure: configureManagerProxy,
       },
       '/artifacts': {
         target: managerHttpTarget,

--- a/homerail_cli/src/commands/runtime.ts
+++ b/homerail_cli/src/commands/runtime.ts
@@ -28,12 +28,6 @@ import {
   loadLocalSecrets,
   managerWsUrl,
 } from "../local-config.js";
-import {
-  HOMERAIL_UI_ADMIN_PROXY_ENABLED,
-  HOMERAIL_UI_ORIGIN,
-  HOMERAIL_UNSAFE_ALLOW_PUBLIC_MANAGER_WITHOUT_AUTH,
-  createUiAdminProxyPolicy,
-} from "../ui-admin-proxy.js";
 import { applyStoredModelConfig } from "./config.js";
 import { dockerNotFoundDetail, resolveDockerBinary } from "../docker-bin.js";
 import {
@@ -65,7 +59,6 @@ interface StartOpts {
   uiPort?: string;
   uiPublicUrl?: string;
   enableTextMode?: boolean;
-  unsafeNoAdminToken?: boolean;
 }
 
 interface UiStartOpts {
@@ -75,7 +68,6 @@ interface UiStartOpts {
   publicUrl?: string;
   managerUrl?: string;
   enableTextMode?: boolean;
-  unsafeNoAdminToken?: boolean;
 }
 
 interface RuntimeStatus {
@@ -215,37 +207,6 @@ export function mergeManagerAdminOrigins(
     origins.add(parsed.origin);
   }
   return [...origins].sort().join(",");
-}
-
-export interface UiAdminProxyProcessEnvOptions {
-  uiBindHost: string;
-  uiPublicUrl: string;
-  managerUrl: string;
-  adminToken?: string;
-  unsafeNoAdminToken?: boolean;
-}
-
-/** Compute, rather than inherit, the only mode in which a UI may proxy writes. */
-export function resolveUiAdminProxyProcessEnv(
-  options: UiAdminProxyProcessEnvOptions,
-): Record<string, string> {
-  const uiOrigin = new URL(options.uiPublicUrl).origin;
-  const policy = createUiAdminProxyPolicy({
-    enabled: true,
-    uiOrigin,
-    uiBindHost: options.uiBindHost,
-    managerUrl: options.managerUrl,
-    adminToken: undefined,
-    unsafeAllowPublicNoAuth: true,
-  });
-  return {
-    [HOMERAIL_UI_ORIGIN]: uiOrigin,
-    [HOMERAIL_UI_ADMIN_PROXY_ENABLED]: policy.enabled ? "1" : "0",
-    // Admin-token authentication is disabled for this release. Explicitly
-    // erase inherited/local secrets for both the static and Vite UI proxies.
-    HOMERAIL_MANAGER_ADMIN_TOKEN: "",
-    [HOMERAIL_UNSAFE_ALLOW_PUBLIC_MANAGER_WITHOUT_AUTH]: "1",
-  };
 }
 
 export interface ModelConfigApplyStatus {
@@ -552,7 +513,6 @@ async function startRuntime(
       HOMERAIL_MANAGER_HOST: managerHost,
       HOMERAIL_MANAGER_ADMIN_ORIGINS: managerAdminOrigins,
       HOMERAIL_MANAGER_ADMIN_TOKEN: "",
-      [HOMERAIL_UNSAFE_ALLOW_PUBLIC_MANAGER_WITHOUT_AUTH]: "1",
       ...(hasExplicitManagerPublicUrl ? { HOMERAIL_MANAGER_PUBLIC_URL: managerPublicUrl } : {}),
       HOMERAIL_PROJECT_ID: cfg.node?.projectId || "p1",
       ...assetEnv,
@@ -608,7 +568,6 @@ async function startRuntime(
       publicUrl: opts.uiPublicUrl,
       managerUrl: opts.public && !hasExplicitManagerPublicUrl ? undefined : managerPublicUrl,
       enableTextMode: opts.enableTextMode,
-      unsafeNoAdminToken: opts.unsafeNoAdminToken,
     });
     printMessage(`Agent UI: ${uiStatus.uiPidRunning ? "PASS" : "FAIL"} ${uiStatus.uiUrl}`);
   }
@@ -825,7 +784,6 @@ async function startUiServer(globalOpts: GlobalOpts, opts: UiStartOpts = {}): Pr
         managerPort,
         publicUrl: httpsPublicUrl,
         textModeEnabled,
-        unsafeNoAdminToken: opts.unsafeNoAdminToken,
         certificate,
       });
       await waitForHttp(uiProbeUrl(host, httpsPort, "https"));
@@ -847,7 +805,6 @@ async function startUiServer(globalOpts: GlobalOpts, opts: UiStartOpts = {}): Pr
         managerPort,
         publicUrl: httpPublicUrl,
         textModeEnabled,
-        unsafeNoAdminToken: opts.unsafeNoAdminToken,
       });
       await waitForHttp(uiProbeUrl(host, httpPort, "http"));
     } catch (err) {
@@ -876,7 +833,6 @@ interface StartUiProcessOpts {
   managerPort: string;
   publicUrl: string;
   textModeEnabled: boolean;
-  unsafeNoAdminToken?: boolean;
   certificate?: UiCertificate;
 }
 
@@ -903,14 +859,6 @@ function startUiProcess(opts: StartUiProcessOpts): number {
   // also the most reliable source-deploy path when dist exists.
   const serveStatic = shouldServeStaticAgentUi(agentUiDir);
   const managerHttp = opts.managerUrl || `http://localhost:${opts.managerPort}`;
-  const adminProxyEnv = resolveUiAdminProxyProcessEnv({
-    uiBindHost: opts.host,
-    uiPublicUrl: opts.publicUrl,
-    managerUrl: managerHttp,
-    adminToken: undefined,
-    unsafeNoAdminToken: true,
-  });
-
   let child: import("child_process").ChildProcess;
   if (serveStatic) {
     const serverScript = path.join(resolveRepoRoot(), "homerail_cli", "dist", "static-ui-server.js");
@@ -926,7 +874,6 @@ function startUiProcess(opts: StartUiProcessOpts): number {
         HOMERAIL_UI_PORT: String(opts.port),
         HOMERAIL_MANAGER_HTTP: managerHttp,
         HOMERAIL_MANAGER_WS: managerWs,
-        ...adminProxyEnv,
         ...(opts.protocol === "https"
           ? {
             HOMERAIL_UI_HTTPS: "1",
@@ -963,7 +910,6 @@ function startUiProcess(opts: StartUiProcessOpts): number {
         VITE_HOMERAIL_ENABLE_TEXT_MODE: opts.textModeEnabled ? "1" : "0",
         HOMERAIL_MANAGER_HTTP: managerHttp,
         VITE_API_BASE_URL: uiApiOrigin,
-        ...adminProxyEnv,
         ...(opts.protocol === "https"
           ? {
             HOMERAIL_UI_HTTPS: "1",

--- a/homerail_cli/src/static-ui-server.ts
+++ b/homerail_cli/src/static-ui-server.ts
@@ -14,8 +14,6 @@
 //   HOMERAIL_UI_HTTPS_CERT      PEM cert path (HTTPS only)
 //   HOMERAIL_MANAGER_HTTP       manager HTTP origin, e.g. http://localhost:19191
 //   HOMERAIL_MANAGER_WS         manager WS origin, e.g. ws://localhost:19191
-//   HOMERAIL_UI_ORIGIN          exact browser-facing origin for this process
-//   HOMERAIL_UI_ADMIN_PROXY_ENABLED "1" only for runtime-verified loopback mode
 import http from "node:http";
 import https from "node:https";
 import fs from "node:fs";
@@ -23,9 +21,7 @@ import path from "node:path";
 import net from "node:net";
 import { URL } from "node:url";
 import {
-  HOMERAIL_UNSAFE_ALLOW_PUBLIC_MANAGER_WITHOUT_AUTH,
   authorizeUiAdminProxyMutation,
-  createUiAdminProxyPolicy,
   isProtectedApiMutation,
 } from "./ui-admin-proxy.js";
 
@@ -34,18 +30,8 @@ const PORT = Number(process.env.HOMERAIL_UI_PORT || 19192);
 const HOST = process.env.HOMERAIL_UI_HOST || "127.0.0.1";
 const MANAGER_HTTP = process.env.HOMERAIL_MANAGER_HTTP || "http://localhost:19191";
 const MANAGER_WS = process.env.HOMERAIL_MANAGER_WS || "ws://localhost:19191";
-const MANAGER_ADMIN_TOKEN = process.env.HOMERAIL_MANAGER_ADMIN_TOKEN || "";
 const USE_HTTPS = process.env.HOMERAIL_UI_HTTPS === "1";
 const BUILD_MANIFEST = "homerail-build.json";
-const UI_ADMIN_PROXY = createUiAdminProxyPolicy({
-  enabled: process.env.HOMERAIL_UI_ADMIN_PROXY_ENABLED === "1",
-  uiOrigin: process.env.HOMERAIL_UI_ORIGIN || "",
-  uiBindHost: HOST,
-  managerUrl: MANAGER_HTTP,
-  adminToken: MANAGER_ADMIN_TOKEN,
-  unsafeAllowPublicNoAuth:
-    process.env[HOMERAIL_UNSAFE_ALLOW_PUBLIC_MANAGER_WITHOUT_AUTH] === "1",
-});
 
 const MIME: Record<string, string> = {
   ".html": "text/html; charset=utf-8",
@@ -179,11 +165,12 @@ function proxyHttp(req: http.IncomingMessage, res: http.ServerResponse): void {
   const target = new URL(MANAGER_HTTP);
   const headers = { ...req.headers, host: target.host };
   if (isProtectedApiMutation(req.method, req.url)) {
-    const authorization = authorizeUiAdminProxyMutation(
-      UI_ADMIN_PROXY,
-      req.headers.origin,
-      req.headers["sec-fetch-site"],
-    );
+    const authorization = authorizeUiAdminProxyMutation({
+      protocol: USE_HTTPS ? "https" : "http",
+      host: req.headers.host,
+      origin: req.headers.origin,
+      secFetchSite: req.headers["sec-fetch-site"],
+    });
     if (!authorization.allowed) {
       req.resume();
       res.writeHead(403, {
@@ -193,12 +180,8 @@ function proxyHttp(req: http.IncomingMessage, res: http.ServerResponse): void {
       res.end(JSON.stringify({ success: false, error: authorization.reason }));
       return;
     }
-    // The browser never receives or asserts the Manager credential. The
-    // same-origin UI proxy is the only component allowed to inject it.
+    // Browser credentials never override Manager's own trust decision.
     delete headers.authorization;
-    if (UI_ADMIN_PROXY.adminToken) {
-      headers.authorization = `Bearer ${UI_ADMIN_PROXY.adminToken}`;
-    }
   }
   const request = target.protocol === "https:" ? https.request : http.request;
   const proxyReq = request(

--- a/homerail_cli/src/ui-admin-proxy.ts
+++ b/homerail_cli/src/ui-admin-proxy.ts
@@ -1,65 +1,10 @@
-export const HOMERAIL_UI_ADMIN_PROXY_ENABLED = "HOMERAIL_UI_ADMIN_PROXY_ENABLED";
-export const HOMERAIL_UI_ORIGIN = "HOMERAIL_UI_ORIGIN";
-export const HOMERAIL_UNSAFE_ALLOW_PUBLIC_MANAGER_WITHOUT_AUTH = "HOMERAIL_UNSAFE_ALLOW_PUBLIC_MANAGER_WITHOUT_AUTH";
-
 const MUTATION_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
-export interface UiAdminProxyPolicyOptions {
-  enabled: boolean;
-  uiOrigin: string;
-  uiBindHost: string;
-  managerUrl: string;
-  adminToken?: string;
-  unsafeAllowPublicNoAuth?: boolean;
-}
-
-export interface UiAdminProxyPolicy {
-  readonly enabled: boolean;
-  readonly uiOrigin?: string;
-  readonly adminToken?: string;
-  readonly unsafeAllowPublicNoAuth?: boolean;
-  readonly disabledReason?: string;
-}
-
-/**
- * A UI process may hold the Manager credential only when both hops and the
- * advertised browser origin are loopback-only. Public/LAN UI stays useful for
- * reads, but its mutation proxy is deliberately disabled.
- */
-export function createUiAdminProxyPolicy(options: UiAdminProxyPolicyOptions): UiAdminProxyPolicy {
-  if (!options.enabled) return disabled("loopback-safe admin proxy switch is disabled");
-
-  const uiOrigin = parseExactOrigin(options.uiOrigin);
-  if (!uiOrigin) return disabled("UI Origin is not an exact http(s) Origin");
-  const unsafeAllowPublicNoAuth = Boolean(options.unsafeAllowPublicNoAuth && !options.adminToken);
-  if (
-    (!isLoopbackHost(options.uiBindHost) || !isLoopbackHost(new URL(uiOrigin).hostname))
-    && !unsafeAllowPublicNoAuth
-  ) {
-    return disabled("UI is reachable beyond loopback");
-  }
-
-  let manager: URL;
-  try {
-    manager = new URL(options.managerUrl);
-  } catch {
-    return disabled("Manager URL is invalid");
-  }
-  if (
-    (manager.protocol !== "http:" && manager.protocol !== "https:")
-    || !isLoopbackHost(manager.hostname)
-    || manager.username
-    || manager.password
-  ) {
-    return disabled("Manager target is reachable beyond the loopback trust boundary");
-  }
-
-  return Object.freeze({
-    enabled: true,
-    uiOrigin,
-    adminToken: options.adminToken || undefined,
-    unsafeAllowPublicNoAuth,
-  });
+export interface UiMutationRequestTrust {
+  protocol: "http" | "https";
+  host: string | string[] | undefined;
+  origin: string | string[] | undefined;
+  secFetchSite?: string | string[];
 }
 
 export function isProtectedApiMutation(methodValue: string | undefined, urlValue: string | undefined): boolean {
@@ -73,58 +18,38 @@ export function isProtectedApiMutation(methodValue: string | undefined, urlValue
   }
 }
 
+/**
+ * Keep the UI proxy zero-config by deriving its self Origin from the request
+ * that reached the server. Manager performs the canonical authorization after
+ * this hop; this check only rejects obvious browser cross-origin mutations.
+ */
 export function authorizeUiAdminProxyMutation(
-  policy: UiAdminProxyPolicy,
-  originHeader: string | string[] | undefined,
-  secFetchSiteHeader?: string | string[],
+  request: UiMutationRequestTrust,
 ): { allowed: true } | { allowed: false; reason: string } {
-  if (!policy.enabled || !policy.uiOrigin) {
-    return { allowed: false, reason: policy.disabledReason || "UI mutation proxy is disabled" };
+  const host = singleHeader(request.host);
+  const origin = singleHeader(request.origin);
+  if (!host || !origin) {
+    return { allowed: false, reason: "UI mutation Origin is required" };
   }
-  if (typeof originHeader !== "string" || originHeader !== policy.uiOrigin) {
-    return { allowed: false, reason: "UI mutation Origin is missing or not self-origin" };
+
+  let selfOrigin: string;
+  try {
+    selfOrigin = new URL(`${request.protocol}://${host}`).origin;
+  } catch {
+    return { allowed: false, reason: "UI request Host is invalid" };
   }
-  if (
-    secFetchSiteHeader !== undefined
-    && (typeof secFetchSiteHeader !== "string" || secFetchSiteHeader.toLowerCase() !== "same-origin")
-  ) {
-    return { allowed: false, reason: "Cross-origin UI mutation proxy requests are forbidden" };
+  if (origin !== selfOrigin) {
+    return { allowed: false, reason: "Cross-origin UI mutation requests are forbidden" };
+  }
+
+  const secFetchSite = singleHeader(request.secFetchSite)?.toLowerCase();
+  if (secFetchSite !== undefined && secFetchSite !== "same-origin") {
+    return { allowed: false, reason: "Cross-origin UI mutation requests are forbidden" };
   }
   return { allowed: true };
 }
 
-export function isLoopbackHost(value: string): boolean {
-  let host = value.trim().toLowerCase();
-  if (host.startsWith("[") && host.endsWith("]")) host = host.slice(1, -1);
-  const zone = host.indexOf("%");
-  if (zone >= 0) host = host.slice(0, zone);
-  if (host === "localhost" || host === "::1" || host === "0:0:0:0:0:0:0:1") return true;
-  if (host.startsWith("::ffff:")) host = host.slice("::ffff:".length);
-  const octets = host.split(".");
-  return octets.length === 4
-    && octets.every((octet) => /^\d{1,3}$/.test(octet) && Number(octet) <= 255)
-    && Number(octets[0]) === 127;
-}
-
-function parseExactOrigin(value: string): string | undefined {
-  let parsed: URL;
-  try {
-    parsed = new URL(value);
-  } catch {
-    return undefined;
-  }
-  if (
-    (parsed.protocol !== "http:" && parsed.protocol !== "https:")
-    || parsed.username
-    || parsed.password
-    || parsed.pathname !== "/"
-    || parsed.search
-    || parsed.hash
-    || parsed.origin !== value
-  ) return undefined;
-  return parsed.origin;
-}
-
-function disabled(reason: string): UiAdminProxyPolicy {
-  return Object.freeze({ enabled: false, disabledReason: reason });
+function singleHeader(value: string | string[] | undefined): string | undefined {
+  if (typeof value !== "string" || !value || /[\r\n]/.test(value)) return undefined;
+  return value;
 }

--- a/homerail_cli/tests/static-ui-admin-proxy.integration.test.ts
+++ b/homerail_cli/tests/static-ui-admin-proxy.integration.test.ts
@@ -6,7 +6,6 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
-const TOKEN = "static-proxy-admin-token-0123456789abcdef";
 const children: ChildProcess[] = [];
 const servers: http.Server[] = [];
 const tempDirs: string[] = [];
@@ -51,7 +50,7 @@ describe("static Agent UI mutation proxy", () => {
     expect(upgradedPath).toBe("/api/voice/asr/realtime");
   }, 15_000);
 
-  it("rejects no-Origin/cross-origin requests and injects only for exact local self-Origin", async () => {
+  it("rejects no-Origin/cross-origin requests and proxies exact self-Origin without credentials", async () => {
     const received: Array<{ authorization?: string; origin?: string; method?: string }> = [];
     const manager = http.createServer((req, res) => {
       received.push({
@@ -86,7 +85,7 @@ describe("static Agent UI mutation proxy", () => {
       headers: { Origin: uiOrigin },
     })).status).toBe(200);
     expect(received[0]).toEqual({
-      authorization: `Bearer ${TOKEN}`,
+      authorization: undefined,
       origin: uiOrigin,
       method: "POST",
     });
@@ -95,7 +94,7 @@ describe("static Agent UI mutation proxy", () => {
     expect(received[1]?.authorization).toBeUndefined();
   }, 15_000);
 
-  it("fails a plaintext publicly bound mutation proxy closed even if the switch is forced on", async () => {
+  it("derives the self Origin for a publicly bound development server", async () => {
     let managerHits = 0;
     const manager = http.createServer((req, res) => {
       managerHits++;
@@ -112,8 +111,8 @@ describe("static Agent UI mutation proxy", () => {
       method: "POST",
       headers: { Origin: uiOrigin },
     });
-    expect(response.status).toBe(403);
-    expect(managerHits).toBe(0);
+    expect(response.status).toBe(200);
+    expect(managerHits).toBe(1);
   }, 15_000);
 
   it("rejects encoded traversal into a same-prefix sibling of the static root", async () => {
@@ -185,9 +184,6 @@ async function startStaticUi(options: {
       HOMERAIL_UI_HTTPS: "0",
       HOMERAIL_MANAGER_HTTP: options.managerUrl,
       HOMERAIL_MANAGER_WS: options.managerUrl.replace(/^http/, "ws"),
-      HOMERAIL_UI_ORIGIN: options.origin,
-      HOMERAIL_UI_ADMIN_PROXY_ENABLED: "1",
-      HOMERAIL_MANAGER_ADMIN_TOKEN: TOKEN,
     },
     stdio: ["ignore", "pipe", "pipe"],
   });

--- a/homerail_cli/tests/ui-admin-proxy.test.ts
+++ b/homerail_cli/tests/ui-admin-proxy.test.ts
@@ -1,97 +1,42 @@
 import { describe, expect, it } from "vitest";
-import { resolveUiAdminProxyProcessEnv } from "../src/commands/runtime.js";
 import {
   authorizeUiAdminProxyMutation,
-  createUiAdminProxyPolicy,
   isProtectedApiMutation,
 } from "../src/ui-admin-proxy.js";
 
-const TOKEN = "ui-proxy-admin-token-0123456789abcdef";
-
-describe("Agent UI admin proxy trust", () => {
-  it("enables the no-admin-token proxy with an exact self Origin", () => {
-    const env = resolveUiAdminProxyProcessEnv({
-      uiBindHost: "127.0.0.1",
-      uiPublicUrl: "https://localhost:19192",
-      managerUrl: "http://localhost:19191",
-      adminToken: TOKEN,
-    });
-    expect(env).toEqual({
-      HOMERAIL_UI_ORIGIN: "https://localhost:19192",
-      HOMERAIL_UI_ADMIN_PROXY_ENABLED: "1",
-      HOMERAIL_MANAGER_ADMIN_TOKEN: "",
-      HOMERAIL_UNSAFE_ALLOW_PUBLIC_MANAGER_WITHOUT_AUTH: "1",
-    });
-
-    const policy = createUiAdminProxyPolicy({
-      enabled: env.HOMERAIL_UI_ADMIN_PROXY_ENABLED === "1",
-      uiOrigin: env.HOMERAIL_UI_ORIGIN!,
-      uiBindHost: "127.0.0.1",
-      managerUrl: "http://localhost:19191",
-      adminToken: env.HOMERAIL_MANAGER_ADMIN_TOKEN,
-    });
-    expect(authorizeUiAdminProxyMutation(policy, "https://localhost:19192"))
-      .toEqual({ allowed: true });
+describe("Agent UI mutation proxy trust", () => {
+  it("derives local and LAN self Origins from each request", () => {
+    expect(authorizeUiAdminProxyMutation({
+      protocol: "https",
+      host: "localhost:19192",
+      origin: "https://localhost:19192",
+      secFetchSite: "same-origin",
+    })).toEqual({ allowed: true });
+    expect(authorizeUiAdminProxyMutation({
+      protocol: "http",
+      host: "homerail.lan:19193",
+      origin: "http://homerail.lan:19193",
+      secFetchSite: "same-origin",
+    })).toEqual({ allowed: true });
   });
 
-  it("rejects no-Origin curl and cross-origin browser equivalents", () => {
-    const policy = createUiAdminProxyPolicy({
-      enabled: true,
-      uiOrigin: "http://localhost:19193",
-      uiBindHost: "127.0.0.1",
-      managerUrl: "http://127.0.0.1:19191",
-      adminToken: TOKEN,
-    });
-    expect(authorizeUiAdminProxyMutation(policy, undefined)).toMatchObject({ allowed: false });
-    expect(authorizeUiAdminProxyMutation(policy, "https://evil.example"))
-      .toMatchObject({ allowed: false });
-    expect(authorizeUiAdminProxyMutation(policy, "http://localhost:19193", "cross-site"))
-      .toMatchObject({ allowed: false });
-  });
-
-  it("enables LAN UI mutation proxying without forwarding a token", () => {
-    expect(resolveUiAdminProxyProcessEnv({
-      uiBindHost: "0.0.0.0",
-      uiPublicUrl: "http://192.168.1.8:19193",
-      managerUrl: "http://127.0.0.1:19191",
-      adminToken: TOKEN,
-    })).toEqual({
-      HOMERAIL_UI_ORIGIN: "http://192.168.1.8:19193",
-      HOMERAIL_UI_ADMIN_PROXY_ENABLED: "1",
-      HOMERAIL_MANAGER_ADMIN_TOKEN: "",
-      HOMERAIL_UNSAFE_ALLOW_PUBLIC_MANAGER_WITHOUT_AUTH: "1",
-    });
-    expect(resolveUiAdminProxyProcessEnv({
-      uiBindHost: "127.0.0.1",
-      uiPublicUrl: "https://localhost:19192",
-      managerUrl: "http://192.168.1.8:19191",
-      adminToken: TOKEN,
-    }).HOMERAIL_UI_ADMIN_PROXY_ENABLED).toBe("0");
-  });
-
-  it("enables an explicitly unsafe public test proxy without forwarding a token", () => {
-    const env = resolveUiAdminProxyProcessEnv({
-      uiBindHost: "192.168.1.8",
-      uiPublicUrl: "http://192.168.1.8:19193",
-      managerUrl: "http://127.0.0.1:19191",
-      adminToken: TOKEN,
-      unsafeNoAdminToken: true,
-    });
-    expect(env).toEqual({
-      HOMERAIL_UI_ORIGIN: "http://192.168.1.8:19193",
-      HOMERAIL_UI_ADMIN_PROXY_ENABLED: "1",
-      HOMERAIL_MANAGER_ADMIN_TOKEN: "",
-      HOMERAIL_UNSAFE_ALLOW_PUBLIC_MANAGER_WITHOUT_AUTH: "1",
-    });
-    const policy = createUiAdminProxyPolicy({
-      enabled: true,
-      uiOrigin: env.HOMERAIL_UI_ORIGIN!,
-      uiBindHost: "192.168.1.8",
-      managerUrl: "http://127.0.0.1:19191",
-      unsafeAllowPublicNoAuth: true,
-    });
-    expect(authorizeUiAdminProxyMutation(policy, "http://192.168.1.8:19193", "same-origin"))
-      .toEqual({ allowed: true });
+  it("rejects missing and cross-origin browser mutations", () => {
+    expect(authorizeUiAdminProxyMutation({
+      protocol: "http",
+      host: "localhost:19193",
+      origin: undefined,
+    })).toMatchObject({ allowed: false });
+    expect(authorizeUiAdminProxyMutation({
+      protocol: "http",
+      host: "localhost:19193",
+      origin: "https://evil.example",
+    })).toMatchObject({ allowed: false });
+    expect(authorizeUiAdminProxyMutation({
+      protocol: "http",
+      host: "localhost:19193",
+      origin: "http://localhost:19193",
+      secFetchSite: "cross-site",
+    })).toMatchObject({ allowed: false });
   });
 
   it("covers every protected API mutation while leaving reads and non-API routes alone", () => {

--- a/homerail_manager/src/server/manager-agent-readiness.ts
+++ b/homerail_manager/src/server/manager-agent-readiness.ts
@@ -225,7 +225,9 @@ export function managerAgentReadiness(
     checks: {
       config: blockers.length === 0,
       docker_workspace: {
-        required: true,
+        // Docker is a DAG execution capability, not a prerequisite for using
+        // the host Manager Agent, settings, or text/voice interaction.
+        required: false,
         host_path: dockerWorkspaceRoot(),
         probe_endpoint: "/api/dag/docker-workspace-probe",
       },

--- a/homerail_manager/tests/manager-agent-readiness.test.ts
+++ b/homerail_manager/tests/manager-agent-readiness.test.ts
@@ -211,7 +211,7 @@ describe("/api/manager-agent/readiness", () => {
       worker_entry: workerEntry,
     });
     expect(body.data.checks.docker_workspace).toEqual({
-      required: true,
+      required: false,
       host_path: path.join(tmpHome, "workspace"),
       probe_endpoint: "/api/dag/docker-workspace-probe",
     });


### PR DESCRIPTION
## What changed

- make bundled Vite and static UI mutation proxies work without `HOMERAIL_UI_ADMIN_PROXY_ENABLED`, `HOMERAIL_UI_ORIGIN`, or the public no-auth proxy flag
- derive the browser self Origin from each request's protocol and Host while continuing to reject missing/cross-origin browser mutations
- stop forwarding or injecting legacy Manager admin credentials from UI processes
- classify Docker workspace access as an optional container-DAG capability instead of a Manager Agent prerequisite
- keep the Docker probe automatic, improve its localized guidance, and normalize plain API error objects so the UI never renders `[object Object]`
- hide internal blocker codes from onboarding while keeping the human-readable diagnostic message

## Why

Direct development-server startup could serve reads successfully but reject every UI mutation unless several hidden environment variables were kept perfectly synchronized. The same policy was evaluated independently by the runtime launcher, UI proxy, and Manager, so a valid loopback Manager topology could still fail at the UI layer with `loopback-safe admin proxy switch is disabled`.

Docker readiness was also presented as part of Manager Agent setup even though host Manager Agent interaction does not require Docker. This made a missing or late-connecting Node look like a globally unusable HomeRail installation.

## Security boundary

The proxy remains same-origin for browser mutations and Manager remains the canonical authorization boundary. Manager loopback defaults, cross-origin rejection, Docker mount containment, Worker/DAG credentials, and filesystem protections are unchanged. This PR removes deployment switches and duplicated credential forwarding rather than disabling the underlying Manager checks.

## User impact

- `vite --host --port <port>` works with only the Manager target configured
- LAN and localhost UI origins are derived automatically
- Manager Agent, settings, text, and voice stay usable without Docker
- Docker is checked automatically and shown as available or with install/start/permission guidance for container DAGs
- raw internal codes and `[object Object]` no longer appear in onboarding

## Validation

- `npm run ci`
  - Protocol: 304 passed
  - Plugin SDK: 35 passed
  - Manager: 1006 passed
  - Node: 188 passed, 1 skipped
  - Worker: 307 passed, 1 skipped
  - CLI: 249 passed
  - Agent UI: 375 passed
  - live contracts: 36 passed
- zero-config Vite smoke: same-origin POST returned 200; cross-origin POST returned 403
- static UI proxy integration tests cover localhost, public bind, WebSocket proxying, traversal, and malformed paths
- `git diff --check` and added-line privacy scan passed
