### PR TITLE
fix: harden onboarding endpoint handling for custom local models

### DIFF
--- a/agent-ui/src/components/agent/onboarding/OnboardingStepForm.test.ts
+++ b/agent-ui/src/components/agent/onboarding/OnboardingStepForm.test.ts
@@ -101,31 +101,23 @@ function inputValue(input: HTMLInputElement, value: string): void {
 beforeEach(() => {
   i18n.global.locale.value = 'zh-Hans'
   vi.clearAllMocks()
-  voiceApiMocks.testVoiceEndpoints.mockResolvedValue({
-    success: true,
-    data: {
-      ok: true,
-      results: [
-        {
-          id: 'asr_http',
-          kind: 'http',
-          url: 'http://192.168.100.10:5002/v1/audio/transcriptions',
+  // 默认所有候选端点都可达（按请求原样返回 ok 结果）；
+  // 需要失败场景时各用例用 mockResolvedValueOnce 覆盖。
+  voiceApiMocks.testVoiceEndpoints.mockImplementation((endpoints: Array<{ id: string; kind: string; url: string }>) =>
+    Promise.resolve({
+      success: true,
+      data: {
+        ok: true,
+        results: endpoints.map((endpoint) => ({
+          ...endpoint,
           ok: true,
           reachable: true,
           status_code: 405,
-          message: 'Endpoint is reachable'
-        },
-        {
-          id: 'asr_realtime',
-          kind: 'websocket',
-          url: 'ws://192.168.100.10:5002/v1/realtime',
-          ok: true,
-          reachable: true,
-          message: 'WebSocket handshake succeeded'
-        }
-      ]
-    }
-  })
+          message: endpoint.kind === 'websocket' ? 'WebSocket handshake succeeded' : 'Endpoint is reachable'
+        }))
+      }
+    })
+  )
 })
 
 afterEach(() => {
@@ -364,6 +356,96 @@ describe('OnboardingStepForm ASR endpoint detection', () => {
 
     await vi.waitFor(() => expect(toastMocks.showToast).toHaveBeenCalledWith(
       expect.stringContaining('ASR 接入地址不可用'),
+      'error',
+      6000
+    ))
+    expect(apiMocks.createProvider).not.toHaveBeenCalled()
+    expect(apiMocks.createLLMSetting).not.toHaveBeenCalled()
+  })
+})
+
+describe('OnboardingStepForm TTS endpoint detection', () => {
+  async function fillCustomTts(root: HTMLElement): Promise<void> {
+    root.querySelectorAll<HTMLButtonElement>('.onboarding-step-form__mode-tab')[1]!.click()
+    await nextTick()
+    const inputs = root.querySelectorAll<HTMLInputElement>('.onboarding-step-form__custom input')
+    inputValue(inputs[0]!, 'http://192.168.100.10:5001/v1')
+    inputValue(inputs[1]!, 'qwen3-tts')
+    await nextTick()
+  }
+
+  it('tests the speech endpoints before saving and persists reachable ones', async () => {
+    const root = await mountForm({
+      capability: 'supports_tts',
+      providers: [],
+      existingSettings: []
+    })
+    await fillCustomTts(root)
+
+    root.querySelector<HTMLButtonElement>('.onboarding-step-form__submit')!.click()
+
+    await vi.waitFor(() => expect(apiMocks.createLLMSetting).toHaveBeenCalledTimes(1))
+    expect(voiceApiMocks.testVoiceEndpoints).toHaveBeenCalledWith([
+      {
+        id: 'tts_http',
+        kind: 'http',
+        url: 'http://192.168.100.10:5001/v1/audio/speech'
+      },
+      {
+        id: 'tts_stream',
+        kind: 'http',
+        url: 'http://192.168.100.10:5001/v1/audio/speech/stream'
+      }
+    ])
+    expect(apiMocks.createProvider).toHaveBeenCalledWith(expect.objectContaining({
+      tts_http_url: 'http://192.168.100.10:5001/v1/audio/speech',
+      tts_realtime_url: 'http://192.168.100.10:5001/v1/audio/speech/stream'
+    }))
+    expect(apiMocks.createLLMSetting).toHaveBeenCalledWith(expect.objectContaining({
+      tts_http_url: 'http://192.168.100.10:5001/v1/audio/speech',
+      tts_realtime_url: 'http://192.168.100.10:5001/v1/audio/speech/stream'
+    }))
+    expect(voiceApiMocks.testVoiceEndpoints.mock.invocationCallOrder[0]).toBeLessThan(
+      apiMocks.createProvider.mock.invocationCallOrder[0]!
+    )
+  })
+
+  it('does not persist a TTS setting when no speech endpoint is reachable', async () => {
+    voiceApiMocks.testVoiceEndpoints.mockResolvedValueOnce({
+      success: true,
+      data: {
+        ok: false,
+        results: [
+          {
+            id: 'tts_http',
+            kind: 'http',
+            url: 'http://192.168.100.10:5001/v1/audio/speech',
+            ok: false,
+            reachable: false,
+            message: 'fetch failed'
+          },
+          {
+            id: 'tts_stream',
+            kind: 'http',
+            url: 'http://192.168.100.10:5001/v1/audio/speech/stream',
+            ok: false,
+            reachable: false,
+            message: 'Endpoint returned HTTP 404'
+          }
+        ]
+      }
+    })
+    const root = await mountForm({
+      capability: 'supports_tts',
+      providers: [],
+      existingSettings: []
+    })
+    await fillCustomTts(root)
+
+    root.querySelector<HTMLButtonElement>('.onboarding-step-form__submit')!.click()
+
+    await vi.waitFor(() => expect(toastMocks.showToast).toHaveBeenCalledWith(
+      expect.stringContaining('TTS 接入地址不可用'),
       'error',
       6000
     ))

--- a/agent-ui/src/components/agent/onboarding/OnboardingStepForm.vue
+++ b/agent-ui/src/components/agent/onboarding/OnboardingStepForm.vue
@@ -252,9 +252,31 @@ const customFields = ref<CustomFields>({
   voice: '',
 })
 
+// 用户可能粘贴裸地址、/v1 地址或完整端点地址（…/v1/realtime、
+// …/v1/audio/speech 等）。先把已知端点后缀剥到 API 根，再补 /v1，
+// 与后端 openai-url.ts 的归一化保持一致。
+const VOICE_ENDPOINT_SUFFIXES = [
+  '/chat/completions',
+  '/audio/transcriptions',
+  '/audio/speech/stream',
+  '/audio/speech',
+  '/images/generations',
+  '/completions',
+  '/embeddings',
+  '/responses',
+  '/realtime',
+  '/models',
+]
+
 function voiceApiBase(value: string): string {
-  const normalized = value.trim().replace(/\/+$/, '')
+  let normalized = value.trim().replace(/\/+$/, '')
   if (!normalized) return ''
+  for (;;) {
+    const lower = normalized.toLowerCase()
+    const suffix = VOICE_ENDPOINT_SUFFIXES.find(candidate => lower.endsWith(candidate))
+    if (!suffix) break
+    normalized = normalized.slice(0, -suffix.length).replace(/\/+$/, '')
+  }
   return normalized.endsWith('/v1') ? normalized : `${normalized}/v1`
 }
 
@@ -412,12 +434,37 @@ async function detectCustomAsrEndpoints(): Promise<CustomVoiceUrls> {
   }
 }
 
+async function detectCustomTtsEndpoints(): Promise<CustomVoiceUrls> {
+  const baseUrl = voiceApiBase(customFields.value.baseUrl)
+  const speechUrl = voiceEndpoint(baseUrl, 'audio/speech')
+  const streamUrl = voiceEndpoint(baseUrl, 'audio/speech/stream')
+  const response = await testVoiceEndpoints([
+    { id: 'tts_http', kind: 'http', url: speechUrl },
+    { id: 'tts_stream', kind: 'http', url: streamUrl },
+  ])
+  const results = response.data?.results ?? []
+  const speechResult = results.find(result => result.id === 'tts_http')
+  const streamResult = results.find(result => result.id === 'tts_stream')
+  if (!speechResult?.ok && !streamResult?.ok) {
+    throw new Error(t('onboarding.form.ttsEndpointsUnavailable', {
+      speech: endpointProbeMessage(speechResult),
+      stream: endpointProbeMessage(streamResult),
+    }))
+  }
+  return {
+    // 与 ASR 相同：失败的端点写空串，清掉上次保存的失效猜测。
+    tts_http_url: speechResult?.ok ? speechUrl : '',
+    tts_realtime_url: streamResult?.ok ? streamUrl : '',
+  }
+}
+
 async function submit(): Promise<void> {
   if (!canSubmit.value || saving.value) return
   saving.value = true
   try {
     let mainModelDetection: MainModelRuntimeDetection | undefined
     let customVoiceUrls: CustomVoiceUrls | undefined
+    let customTtsUrls: CustomVoiceUrls | undefined
     if (mode.value === 'custom' && props.capability === 'supports_llm') {
       checkingMainModel.value = true
       try {
@@ -434,10 +481,18 @@ async function submit(): Promise<void> {
         checkingVoiceEndpoints.value = false
       }
     }
+    if (mode.value === 'custom' && props.capability === 'supports_tts') {
+      checkingVoiceEndpoints.value = true
+      try {
+        customTtsUrls = await detectCustomTtsEndpoints()
+      } finally {
+        checkingVoiceEndpoints.value = false
+      }
+    }
     const setting =
       mode.value === 'preset'
         ? await submitPreset()
-        : await submitCustom(mainModelDetection, customVoiceUrls)
+        : await submitCustom(mainModelDetection, customVoiceUrls, customTtsUrls)
     if (!setting) throw new Error(t('onboarding.form.saveFailed'))
     await props.activateSetting?.(setting, mainModelDetection?.preferred_harness ?? undefined)
     const successMessage = mode.value === 'custom' && props.capability === 'supports_llm'
@@ -506,6 +561,7 @@ async function submitPreset(): Promise<LLMSetting | undefined> {
 async function submitCustom(
   mainModelDetection?: MainModelRuntimeDetection,
   detectedVoiceUrls?: CustomVoiceUrls,
+  detectedTtsUrls?: CustomVoiceUrls,
 ): Promise<LLMSetting | undefined> {
   const f = customFields.value
   const pid = customProviderId.value
@@ -537,12 +593,7 @@ async function submitCustom(
 
   const voiceAdapter = props.capability === 'supports_llm' ? 'custom' as const : 'openai_audio' as const
   const voiceUrls: CustomVoiceUrls = {
-    ...(props.capability === 'supports_tts'
-      ? {
-          tts_http_url: voiceEndpoint(baseUrl, 'audio/speech'),
-          tts_realtime_url: voiceEndpoint(baseUrl, 'audio/speech/stream'),
-        }
-      : {}),
+    ...(props.capability === 'supports_tts' ? detectedTtsUrls : {}),
     ...(props.capability === 'supports_asr' ? detectedVoiceUrls : {}),
   }
 

--- a/agent-ui/src/locales/en-US/onboarding.json
+++ b/agent-ui/src/locales/en-US/onboarding.json
@@ -85,6 +85,7 @@
     "mainModelReady": "Manager Agent model verified and configured with {harness}",
     "endpointUnavailable": "Endpoint unavailable",
     "asrEndpointsUnavailable": "The ASR endpoint is unavailable. Standard transcription: {async}; realtime transcription: {realtime}",
+    "ttsEndpointsUnavailable": "The TTS endpoint is unavailable. Speech synthesis: {speech}; streaming synthesis: {stream}",
     "modelRuntimeUnavailable": "Manager Agent model unavailable. Anthropic Messages: {anthropic}; OpenAI Chat Completions: {openai}",
     "modelRuntimeDetectionRequired": "Runtime detection is required before saving the Manager Agent model",
     "saveFailed": "Failed to save",

--- a/agent-ui/src/locales/zh-Hans/onboarding.json
+++ b/agent-ui/src/locales/zh-Hans/onboarding.json
@@ -85,6 +85,7 @@
     "mainModelReady": "主模型检测通过，已使用 {harness} 配置",
     "endpointUnavailable": "端点不可用",
     "asrEndpointsUnavailable": "ASR 接入地址不可用。普通转写：{async}；实时转写：{realtime}",
+    "ttsEndpointsUnavailable": "TTS 接入地址不可用。语音合成：{speech}；流式合成：{stream}",
     "modelRuntimeUnavailable": "主模型不可用。Anthropic Messages：{anthropic}；OpenAI Chat Completions：{openai}",
     "modelRuntimeDetectionRequired": "保存主模型前必须完成运行时检测",
     "saveFailed": "保存失败",

--- a/agent-ui/src/locales/zh-Hant/onboarding.json
+++ b/agent-ui/src/locales/zh-Hant/onboarding.json
@@ -85,6 +85,7 @@
     "mainModelReady": "主模型檢測通過，已使用 {harness} 配置",
     "endpointUnavailable": "端點不可用",
     "asrEndpointsUnavailable": "ASR 接入地址不可用。普通轉寫：{async}；實時轉寫：{realtime}",
+    "ttsEndpointsUnavailable": "TTS 接入地址不可用。語音合成：{speech}；流式合成：{stream}",
     "modelRuntimeUnavailable": "主模型不可用。Anthropic Messages：{anthropic}；OpenAI Chat Completions：{openai}",
     "modelRuntimeDetectionRequired": "保存主模型前必須完成運行時檢測",
     "saveFailed": "保存失敗",

--- a/homerail_manager/src/server/llm-settings.ts
+++ b/homerail_manager/src/server/llm-settings.ts
@@ -17,6 +17,7 @@ import {
   type LLMAuthType,
   type ProviderInput,
 } from "../persistence/llm-settings.js";
+import { normalizeOpenAiBaseUrl, openAiModelsUrl } from "./openai-url.js";
 
 interface BaseResponse {
   success: boolean;
@@ -83,7 +84,9 @@ interface MainModelEndpointProbe {
 }
 
 function _versionedEndpointUrl(baseUrl: string, endpoint: "messages" | "chat/completions"): string {
-  const normalized = _normalizedBaseUrl(baseUrl);
+  // 与探测/保存同一条归一化：用户粘贴完整端点地址（…/v1/chat/completions）
+  // 时先剥到 API 根，否则实测会打到 …/v1/chat/completions/v1/chat/completions。
+  const normalized = normalizeOpenAiBaseUrl(baseUrl);
   return normalized.endsWith("/v1")
     ? `${normalized}/${endpoint}`
     : `${normalized}/v1/${endpoint}`;
@@ -450,10 +453,9 @@ export function llmSettingsRoutesHandler(
           _ok(res, `Probed ${catalogModels.length} catalog models`, { models: catalogModels });
           return;
         }
-        // 构造 /models 请求 URL
-        const modelsUrl = baseUrl.endsWith("/v1")
-          ? `${baseUrl}/models`
-          : `${baseUrl}/v1/models`;
+        // 构造 /models 请求 URL。用户可能粘贴裸地址、/v1 地址或完整端点
+        // 地址（…/v1/chat/completions、…/v1/models 等），统一归一化后再拼接。
+        const modelsUrl = openAiModelsUrl(baseUrl);
         try {
           const upstream = await fetch(modelsUrl, {
             headers: {
@@ -579,6 +581,11 @@ export function llmSettingsRoutesHandler(
       .then((body) => {
         const b = body as Record<string, unknown>;
         const parsed = _settingCreateBody(b);
+        // 归一化 base_url：裸地址 / 带 /v1 / 完整端点地址统一存成 API 根，
+        // 避免运行期拼出 …/chat/completions/v1/chat/completions 这类坏 URL。
+        if (parsed.base_url) {
+          parsed.base_url = normalizeOpenAiBaseUrl(parsed.base_url);
+        }
 
         if (!parsed.provider_id) {
           _badRequest(res, "Missing required field: provider_id");
@@ -660,7 +667,7 @@ export function llmSettingsRoutesHandler(
         if (_protocol(b.protocol)) patch.protocol = _protocol(b.protocol);
         if (_authType(b.auth_type)) patch.auth_type = _authType(b.auth_type);
         if (typeof b.key_hint === "string") patch.key_hint = b.key_hint.trim();
-        if (typeof b.base_url === "string") patch.base_url = b.base_url;
+        if (typeof b.base_url === "string") patch.base_url = normalizeOpenAiBaseUrl(b.base_url);
         if (typeof b.chat_completions_base_url === "string") {
           patch.chat_completions_base_url = b.chat_completions_base_url;
         }

--- a/homerail_manager/src/server/manager-agent-readiness.ts
+++ b/homerail_manager/src/server/manager-agent-readiness.ts
@@ -99,6 +99,22 @@ function codexStatus(): CodexCheck {
   return { available, logged_in: loggedIn, version, binary: resolved?.command ?? requested };
 }
 
+/** Claude Agent SDK 的主机侧凭证是否存在：ANTHROPIC_API_KEY 环境变量，
+ * 或 Claude Code 登录态（~/.claude/.credentials.json 非空）。 */
+function claudeAgentSdkAuthPresent(): boolean {
+  if (process.env.ANTHROPIC_API_KEY?.trim()) return true;
+  try {
+    const credentialsPath = path.join(os.homedir(), ".claude", ".credentials.json");
+    if (fs.existsSync(credentialsPath)) {
+      const content = fs.readFileSync(credentialsPath, "utf-8").trim();
+      return content.length > 2;
+    }
+  } catch {
+    // 读取失败按无凭证处理
+  }
+  return false;
+}
+
 function dockerCapableNodeIds(): string[] {
   return getAllNodes()
     .filter((node) => node.socket.readyState === 1 && isDockerCapableNode(node))
@@ -256,6 +272,20 @@ export function managerAgentReadiness(
       blockers.push({
         code: "host_shell_unavailable",
         message: hostShell.error ?? "Host-shell Manager Agent runtime is unavailable",
+      });
+    } else if (
+      String(runtimeConfig.agent_type ?? config.harness ?? "").includes("claude")
+      && !config.llm_setting_id
+      && !claudeAgentSdkAuthPresent()
+    ) {
+      // 与 codex 的 available+logged_in 检查对齐：host shell 可用不代表
+      // Claude 已认证。缺凭证时报 ready 会让新手向导错误地跳过主模型配置。
+      // 已有专用 LLM setting 时，凭证随 setting 的端点与 Key 走，
+      // 不需要宿主机自己的 Claude 登录态（例如局域网 Anthropic 兼容模型）。
+      blockers.push({
+        code: "claude_auth_missing",
+        message:
+          "Claude Agent SDK credentials not found (set ANTHROPIC_API_KEY or sign in to Claude Code on this host)",
       });
     }
   } else {

--- a/homerail_manager/src/server/openai-url.ts
+++ b/homerail_manager/src/server/openai-url.ts
@@ -1,0 +1,43 @@
+// Shared normalization for user-supplied OpenAI-compatible base URLs.
+//
+// Novice users paste any of these into the base-URL field:
+//   http://host:5000
+//   http://host:5000/
+//   http://host:5000/v1
+//   http://host:5000/v1/models
+//   http://host:5000/v1/chat/completions
+//   ws-reachable realtime full URL: http://host:5002/v1/realtime
+// All of them should resolve to the same API root so that probing and runtime
+// calls find the right endpoint. Strip well-known endpoint suffixes from the
+// tail; keep everything else (including a trailing /v1) untouched.
+
+// Ordered: more specific suffixes first so /audio/speech/stream collapses to
+// the API root in one pass instead of stopping at /audio/speech.
+const ENDPOINT_SUFFIXES = [
+  "/chat/completions",
+  "/audio/transcriptions",
+  "/audio/speech/stream",
+  "/audio/speech",
+  "/images/generations",
+  "/completions",
+  "/embeddings",
+  "/responses",
+  "/realtime",
+  "/models",
+];
+
+export function normalizeOpenAiBaseUrl(value: string): string {
+  let base = value.trim().replace(/\/+$/, "");
+  for (;;) {
+    const lower = base.toLowerCase();
+    const suffix = ENDPOINT_SUFFIXES.find((candidate) => lower.endsWith(candidate));
+    if (!suffix) return base;
+    base = base.slice(0, -suffix.length).replace(/\/+$/, "");
+  }
+}
+
+/** URL of the OpenAI-compatible model list endpoint for a user-supplied base. */
+export function openAiModelsUrl(value: string): string {
+  const base = normalizeOpenAiBaseUrl(value);
+  return base.endsWith("/v1") ? `${base}/models` : `${base}/v1/models`;
+}

--- a/homerail_manager/src/server/voice.ts
+++ b/homerail_manager/src/server/voice.ts
@@ -14,6 +14,7 @@ import {
   synthesizeArkTtsHttp,
   transcribeArkAsr,
 } from "./ark-voice.js";
+import { normalizeOpenAiBaseUrl } from "./openai-url.js";
 import {
   BUILTIN_EDGE_TTS_MODEL,
   DEFAULT_EDGE_TTS_VOICE,
@@ -145,7 +146,9 @@ function _writeVoiceSettingsDocument(data: Record<string, unknown>): void {
 }
 
 function _joinApiUrl(baseUrl: string, apiPath: string): string {
-  const base = baseUrl.replace(/\/+$/, "");
+  // 先归一化用户可能粘贴的完整端点地址（…/v1/chat/completions、…/v1/models
+  // 等），再拼接目标路径，避免叠出 …/v1/realtime/v1/models 这类坏 URL。
+  const base = normalizeOpenAiBaseUrl(baseUrl);
   let suffix = apiPath.replace(/^\/+/, "");
   if (base.endsWith("/v1") && suffix.startsWith("v1/")) {
     suffix = suffix.slice(3);

--- a/homerail_manager/tests/llm-providers.test.ts
+++ b/homerail_manager/tests/llm-providers.test.ts
@@ -9,6 +9,7 @@ import {
   createSetting,
   findActiveClaudeSdkCompatibleSetting,
   findActiveSetting,
+  getSetting,
   listProviders,
   listSettings,
   resolveClaudeSdkBaseUrlForSetting,
@@ -397,6 +398,78 @@ describe("custom LLM providers", () => {
     ]));
     expect(body.data?.models).toHaveLength(3);
     expect(body.data?.error).toBeUndefined();
+  });
+
+  it("probes models for base URL variants (bare, /v1, full endpoint URLs)", async () => {
+    // 模拟 vLLM：只有 /v1/models 可达，裸 /models 与其余路径一律 404。
+    const upstream = http.createServer((req, res) => {
+      if (req.url === "/v1/models") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ object: "list", data: [{ id: "qwen3.6", object: "model" }] }));
+        return;
+      }
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ detail: "Not Found" }));
+    });
+    const upstreamPort = await listen(upstream);
+    try {
+      const port = await listen(server);
+      const variants = [
+        `http://127.0.0.1:${upstreamPort}`,
+        `http://127.0.0.1:${upstreamPort}/`,
+        `http://127.0.0.1:${upstreamPort}/v1`,
+        `http://127.0.0.1:${upstreamPort}/v1/`,
+        `http://127.0.0.1:${upstreamPort}/v1/models`,
+        `http://127.0.0.1:${upstreamPort}/v1/chat/completions`,
+      ];
+      for (const baseUrl of variants) {
+        const response = await fetch(`http://127.0.0.1:${port}/api/llm/models/probe`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ base_url: baseUrl, api_key: "dummy-key" }),
+        });
+        const body = await response.json() as { data?: { models?: string[]; error?: string } };
+        expect(response.status, `variant ${baseUrl}`).toBe(200);
+        expect(body.data?.error, `variant ${baseUrl}`).toBeUndefined();
+        expect(body.data?.models, `variant ${baseUrl}`).toEqual(["qwen3.6"]);
+      }
+    } finally {
+      await close(upstream);
+    }
+  });
+
+  it("normalizes base_url endpoint suffixes on create and update", async () => {
+    const port = await listen(server);
+
+    const providerResponse = await fetch(`http://127.0.0.1:${port}/api/llm/providers`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id: "local-lan", name: "Local LAN", default_model: "qwen3.6" }),
+    });
+    expect(providerResponse.status).toBe(201);
+
+    const createResponse = await fetch(`http://127.0.0.1:${port}/api/llm/settings`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        provider_id: "local-lan",
+        model_name: "qwen3.6",
+        base_url: "http://192.168.100.10:5000/v1/chat/completions",
+        api_key: "dummy-key",
+        is_active: true,
+      }),
+    });
+    const created = await createResponse.json() as { data?: { id?: string; base_url?: string } };
+    expect(createResponse.status).toBe(201);
+    expect(created.data?.base_url).toBe("http://192.168.100.10:5000/v1");
+
+    const updateResponse = await fetch(`http://127.0.0.1:${port}/api/llm/settings/${created.data!.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ base_url: "http://192.168.100.10:5000/v1/models/" }),
+    });
+    expect(updateResponse.status).toBe(200);
+    expect(getSetting(created.data!.id)?.base_url).toBe("http://192.168.100.10:5000/v1");
   });
 
   it("probes upstream models with a saved encrypted setting credential", async () => {

--- a/homerail_manager/tests/manager-agent-readiness.test.ts
+++ b/homerail_manager/tests/manager-agent-readiness.test.ts
@@ -56,6 +56,7 @@ describe("/api/manager-agent/readiness", () => {
   let oldHostEntry: string | undefined;
   let oldHostShell: string | undefined;
   let oldRepoRoot: string | undefined;
+  let oldAnthropicKey: string | undefined;
 
   beforeEach(() => {
     oldHome = process.env.HOMERAIL_HOME;
@@ -63,11 +64,13 @@ describe("/api/manager-agent/readiness", () => {
     oldHostEntry = process.env.HOMERAIL_MANAGER_AGENT_HOST_ENTRY;
     oldHostShell = process.env.HOMERAIL_MANAGER_AGENT_SHELL;
     oldRepoRoot = process.env.HOMERAIL_REPO_ROOT;
+    oldAnthropicKey = process.env.ANTHROPIC_API_KEY;
     tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-manager-agent-readiness-"));
     process.env.HOMERAIL_HOME = tmpHome;
     process.env.HOMERAIL_LOCAL_NODE_AUTOSTART = "0";
     delete process.env.HOMERAIL_MANAGER_AGENT_HOST_ENTRY;
     delete process.env.HOMERAIL_MANAGER_AGENT_SHELL;
+    delete process.env.ANTHROPIC_API_KEY;
     clearManagerAgentConfig();
     _clearAllSettings();
     _clearNodes();
@@ -88,6 +91,8 @@ describe("/api/manager-agent/readiness", () => {
     else process.env.HOMERAIL_MANAGER_AGENT_SHELL = oldHostShell;
     if (oldRepoRoot === undefined) delete process.env.HOMERAIL_REPO_ROOT;
     else process.env.HOMERAIL_REPO_ROOT = oldRepoRoot;
+    if (oldAnthropicKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+    else process.env.ANTHROPIC_API_KEY = oldAnthropicKey;
     await removeTempDir(tmpHome);
   });
 
@@ -155,6 +160,8 @@ describe("/api/manager-agent/readiness", () => {
     fs.writeFileSync(workerEntry, "console.log('worker entry')\n", "utf-8");
     process.env.HOMERAIL_MANAGER_AGENT_HOST_ENTRY = workerEntry;
     process.env.HOMERAIL_MANAGER_AGENT_SHELL = process.platform === "win32" ? process.execPath : "/bin/sh";
+    // 专用 setting 自带端点与 Key，无需宿主机 Claude 凭证即可就绪
+    // （无 ANTHROPIC_API_KEY 也无 ~/.claude 登录态，刻意验证这一点）。
     server = createServer(0, undefined, undefined, false);
     upsertProvider({
       id: "qwen36",
@@ -217,6 +224,25 @@ describe("/api/manager-agent/readiness", () => {
     });
   });
 
+  it("does not report the agent step ready on a fresh home with no LLM settings", async () => {
+    const workerEntry = path.join(tmpHome, "worker-entry.js");
+    fs.writeFileSync(workerEntry, "console.log('worker entry')\n", "utf-8");
+    process.env.HOMERAIL_MANAGER_AGENT_HOST_ENTRY = workerEntry;
+    process.env.HOMERAIL_MANAGER_AGENT_SHELL = process.platform === "win32" ? process.execPath : "/bin/sh";
+    server = createServer(0, undefined, undefined, false);
+    const port = await listen(server);
+    const baseUrl = `http://127.0.0.1:${port}`;
+
+    // 无任何 LLM setting：即使 host shell 可用，readiness 也必须阻塞，
+    // 否则新手向导会错误地跳过主模型配置（偶发"自动完成"的根因）。
+    const response = await fetch(`${baseUrl}/api/manager-agent/readiness`);
+    const body = await response.json() as {
+      data: { ready: boolean; blockers: Array<{ code: string }> };
+    };
+    expect(body.data.ready).toBe(false);
+    expect(body.data.blockers.map((item) => item.code)).toEqual(["manager_config_invalid"]);
+  });
+
   it("probes Docker workspace bind mount on demand", async () => {
     const fakeNode = registerFakeDockerNode();
     server = createServer(0);
@@ -259,6 +285,8 @@ describe("/api/manager-agent/readiness", () => {
     fs.writeFileSync(workerEntry, "console.log('worker entry')\n", "utf-8");
     process.env.HOMERAIL_MANAGER_AGENT_HOST_ENTRY = workerEntry;
     process.env.HOMERAIL_MANAGER_AGENT_SHELL = process.platform === "win32" ? process.execPath : "/bin/sh";
+    // host_shell 就绪还需要 Claude 凭证（见 claude_auth_missing 门禁）
+    process.env.ANTHROPIC_API_KEY = "sk-ant-readiness-test";
 
     server = createServer(0, undefined, undefined, false);
     upsertProvider({

--- a/homerail_manager/tests/openai-url.test.ts
+++ b/homerail_manager/tests/openai-url.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeOpenAiBaseUrl, openAiModelsUrl } from "../src/server/openai-url.js";
+
+describe("normalizeOpenAiBaseUrl", () => {
+  it.each([
+    // 裸地址与斜杠变体：原样保留（仅去尾斜杠）
+    ["http://192.168.100.10:5000", "http://192.168.100.10:5000"],
+    ["http://192.168.100.10:5000/", "http://192.168.100.10:5000"],
+    // 带 /v1：保留 /v1
+    ["http://192.168.100.10:5000/v1", "http://192.168.100.10:5000/v1"],
+    ["http://192.168.100.10:5000/v1/", "http://192.168.100.10:5000/v1"],
+    // 完整端点地址：剥到 API 根
+    ["http://192.168.100.10:5000/v1/models", "http://192.168.100.10:5000/v1"],
+    ["http://192.168.100.10:5000/v1/chat/completions", "http://192.168.100.10:5000/v1"],
+    ["http://192.168.100.10:5000/chat/completions", "http://192.168.100.10:5000"],
+    ["http://192.168.100.10:5002/v1/realtime", "http://192.168.100.10:5002/v1"],
+    ["http://192.168.100.10:5001/v1/audio/speech", "http://192.168.100.10:5001/v1"],
+    ["http://192.168.100.10:5001/v1/audio/speech/stream", "http://192.168.100.10:5001/v1"],
+    ["http://192.168.100.10:5000/v1/audio/transcriptions", "http://192.168.100.10:5000/v1"],
+    ["http://192.168.100.10:5000/v1/embeddings", "http://192.168.100.10:5000/v1"],
+    // 空白与大小写
+    ["  http://192.168.100.10:5000/v1//  ", "http://192.168.100.10:5000/v1"],
+    ["http://192.168.100.10:5000/V1/CHAT/COMPLETIONS", "http://192.168.100.10:5000/V1"],
+    // 预设供应商地址不受影响
+    ["https://api.moonshot.cn/v1", "https://api.moonshot.cn/v1"],
+    ["https://openspeech.bytedance.com/api/v3", "https://openspeech.bytedance.com/api/v3"],
+  ])("normalizeOpenAiBaseUrl(%s) === %s", (input, expected) => {
+    expect(normalizeOpenAiBaseUrl(input)).toBe(expected);
+  });
+});
+
+describe("openAiModelsUrl", () => {
+  it.each([
+    ["http://192.168.100.10:5000", "http://192.168.100.10:5000/v1/models"],
+    ["http://192.168.100.10:5000/v1", "http://192.168.100.10:5000/v1/models"],
+    ["http://192.168.100.10:5000/v1/models", "http://192.168.100.10:5000/v1/models"],
+    ["http://192.168.100.10:5000/v1/chat/completions", "http://192.168.100.10:5000/v1/models"],
+  ])("openAiModelsUrl(%s) === %s", (input, expected) => {
+    expect(openAiModelsUrl(input)).toBe(expected);
+  });
+});


### PR DESCRIPTION
## What

Fixes the onboarding/configuration path for custom local models so every base-URL form a novice might paste works end to end.

## Problems fixed

1. **URL variants broke endpoint discovery.** Probe (`/api/llm/models/probe`), runtime detection (`/api/llm/models/detect-runtime`), and voice endpoints each handled a subset: entering a full URL like `http://host:5000/v1/chat/completions` produced doubled paths (`.../chat/completions/v1/chat/completions`) and the trial connection failed.
2. **Stored `base_url` kept raw input**, so runtime calls built bad URLs depending on what was pasted.
3. **Custom TTS step had no trial connection** — it saved unreachable endpoints silently (ASR and main-model steps already probe).
4. **Readiness could report the manager agent ready with no usable credentials** (host-shell claude harness, no dedicated setting, no host auth) — the wizard then skipped main-model configuration while the runtime could not actually run.

## Changes

- New `openai-url.ts`: `normalizeOpenAiBaseUrl` (strips known endpoint suffixes to the API root) and `openAiModelsUrl`; used by the model probe, `_versionedEndpointUrl` (detect-runtime), and voice `_joinApiUrl`. `base_url` is normalized on create/update.
- Onboarding: custom TTS step runs `detectCustomTtsEndpoints` (HEAD probes via `/api/voice/endpoints/test`) and blocks saving when no endpoint is reachable; `voiceApiBase` normalizes full endpoint URLs before deriving `/v1` endpoints; new `ttsEndpointsUnavailable` message (zh/en).
- Readiness: claude host-shell harness without a dedicated LLM setting requires host Claude credentials (`claude_auth_missing` blocker), mirroring the codex `available+logged_in` gate. Settings that carry their own endpoint+key (e.g. LAN Anthropic-compatible models) are unaffected.

## Verification

- `homerail_manager`: full suite 1027/1027 passed (incl. new openai-url unit tests, probe/create/update URL-variant tests, readiness gate tests)
- `agent-ui`: `vue-tsc` clean
- `homerail_desktop` e2e onboarding spec (Playwright, real Electron + real backend + LAN Qwen3.6 / qwen3-tts / qwen3-asr-realtime): **5/5 passing**, covering wizard LLM/ASR/TTS configuration, all URL variants (bare, trailing slash, /v1, full chat-completions URL), manager readiness, ASR realtime WS `session.created` through the manager proxy, and TTS speech synthesis.