### PR TITLE
fix: avoid production deploy cache restore hangs

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -42,15 +42,8 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          cache: npm
-          cache-dependency-path: |
-            homerail_protocol/package-lock.json
-            homerail_plugin_sdk/package-lock.json
-            homerail_manager/package-lock.json
-            homerail_node/package-lock.json
-            homerail_worker/package-lock.json
-            homerail_cli/package-lock.json
-            agent-ui/package-lock.json
+          # Deployment must not depend on Actions cache availability. The
+          # following install step remains deterministic through package locks.
 
       - name: Install dependencies
         run: npm run install:all

--- a/scripts/production-deploy-contracts.test.mjs
+++ b/scripts/production-deploy-contracts.test.mjs
@@ -20,6 +20,8 @@ test("deploys only a successful main CI revision on the isolated deploy runner",
   assert.match(workflow, /ref: \$\{\{ github\.event\.workflow_run\.head_sha/);
   assert.match(workflow, /persist-credentials: false/);
   assert.match(workflow, /cancel-in-progress: false/);
+  assert.doesNotMatch(workflow, /cache:\s*npm/);
+  assert.doesNotMatch(workflow, /cache-dependency-path:/);
 });
 
 test("production deployment is atomic, health checked, and rollback capable", () => {


### PR DESCRIPTION
## Summary

- stop restoring the global npm cache in the dedicated production deployment workflow
- keep dependency installation lockfile-driven through the existing `npm run install:all` step
- add a deployment contract that prevents the cache dependency from returning

## Root cause

The post-merge production deployment downloaded a large npm cache, then `actions/setup-node` reported an authenticated cache-restore failure and remained stuck before dependency installation. The release switch and production service were never touched.

## Validation

- production deployment contract suite: 6 passed
- `git diff --check`
- existing production service remained active and HTTPS healthy after the canceled pre-deploy job
