### PR TITLE
fix: bind production smoke to deployed release

### DIFF
--- a/scripts/lib/production-runtime.sh
+++ b/scripts/lib/production-runtime.sh
@@ -57,7 +57,8 @@ verify_production_dag_smoke() {
     echo "Production DAG mutation token is empty after service startup." >&2
     return 1
   fi
-  HOMERAIL_DAG_MUTATION_TOKEN="$token" \
+  HOMERAIL_REPO_ROOT="$production_root/current" \
+    HOMERAIL_DAG_MUTATION_TOKEN="$token" \
     "$production_root/current/runtime/node" \
     "$production_root/current/homerail_cli/dist/cli.js" \
     --base-url "$manager_url" \

--- a/scripts/production-deploy-contracts.test.mjs
+++ b/scripts/production-deploy-contracts.test.mjs
@@ -183,7 +183,7 @@ test("production DAG smoke helper enforces token presence and command success", 
     fs.mkdirSync(path.join(current, "assets", "orchestrations"), { recursive: true });
     fs.writeFileSync(fakeCli, "// fake cli\n");
     fs.writeFileSync(path.join(current, "assets", "orchestrations", "public-two-node.yaml.template"), "schema_version: 1\n");
-    fs.writeFileSync(fakeNode, `#!/usr/bin/env bash\nprintf '{"token":"%s","args":"%s"}\\n' "$HOMERAIL_DAG_MUTATION_TOKEN" "$*" > "$CAPTURE_PATH"\nexit "${'${FAKE_SMOKE_EXIT:-0}'}"\n`);
+    fs.writeFileSync(fakeNode, `#!/usr/bin/env bash\nprintf '{"token":"%s","repoRoot":"%s","args":"%s"}\\n' "$HOMERAIL_DAG_MUTATION_TOKEN" "$HOMERAIL_REPO_ROOT" "$*" > "$CAPTURE_PATH"\nexit "${'${FAKE_SMOKE_EXIT:-0}'}"\n`);
     fs.chmodSync(fakeNode, 0o755);
 
     const missing = invoke();
@@ -200,6 +200,7 @@ test("production DAG smoke helper enforces token presence and command success", 
     assert.equal(passed.status, 0, passed.stderr);
     const observed = JSON.parse(fs.readFileSync(capture, "utf8"));
     assert.equal(observed.token, "test-dag-token");
+    assert.equal(observed.repoRoot, current);
     assert.match(observed.args, /--base-url http:\/\/127\.0\.0\.1:39191/);
     assert.match(observed.args, /smoke dag/);
     assert.match(observed.args, /public-two-node\.yaml\.template/);


### PR DESCRIPTION
## Summary

- bind the deployment DAG smoke CLI to the immutable `current` release as its repository root
- keep the release-absolute built-in template path inside that validated boundary
- extend the behavior test to assert the exact repository root passed to the smoke child

## Root cause

The first real post-merge Docker Worker DAG gate reached a healthy Manager and connected Node, then correctly rolled back because the CLI still treated the Actions checkout as its repository root and rejected the template under the deployed release.

## Validation

- production deployment contract suite: 6 passed
- shell syntax checks passed
- `git diff --check`
- failed deployment rollback left the prior production release active and HTTPS healthy
