### PR TITLE
Fix production smoke template resolution

### DIFF
--- a/scripts/lib/production-runtime.sh
+++ b/scripts/lib/production-runtime.sh
@@ -65,7 +65,7 @@ verify_production_dag_smoke() {
     --request-timeout 180000 \
     --json \
     smoke dag \
-    --template "$production_root/current/assets/orchestrations/public-two-node.yaml.template" \
+    --template "assets/orchestrations/public-two-node.yaml.template" \
     --profile offline-deterministic \
     --timeout 120 \
     --interval 1

--- a/scripts/production-deploy-contracts.test.mjs
+++ b/scripts/production-deploy-contracts.test.mjs
@@ -203,7 +203,8 @@ test("production DAG smoke helper enforces token presence and command success", 
     assert.equal(observed.repoRoot, current);
     assert.match(observed.args, /--base-url http:\/\/127\.0\.0\.1:39191/);
     assert.match(observed.args, /smoke dag/);
-    assert.match(observed.args, /public-two-node\.yaml\.template/);
+    assert.match(observed.args, /--template assets\/orchestrations\/public-two-node\.yaml\.template/);
+    assert.doesNotMatch(observed.args, /--template \/.*public-two-node\.yaml\.template/);
     assert.match(observed.args, /offline-deterministic/);
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- send the production smoke template as a repository-relative path
- let the Manager resolve it inside its own versioned release root
- lock the relative-path contract with the production deployment test

## Root cause
The deployment CLI and Manager referenced the same release through different filesystem paths (a stable symlink versus the versioned release directory). Passing the CLI absolute path caused the Manager path-containment check to reject it even though both paths referenced the same content.

## Validation
- `bash -n scripts/lib/production-runtime.sh scripts/deploy-production.sh scripts/run-production-service.sh`
- `node --test scripts/production-deploy-contracts.test.mjs` (6 passed)
- `git diff --check`