### PR TITLE
ci: restrict workflows to repository owner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,9 @@ name: CI
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
+    # Draft PRs can receive any number of pushes without starting runners.
+    # Mark the PR ready once the change is coherent, or dispatch manually.
+    types: [opened, reopened, ready_for_review]
     paths-ignore:
       - "**/*.md"
       - "docs/**"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,16 @@ name: CI
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - ".github/ISSUE_TEMPLATE/**"
   push:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - ".github/ISSUE_TEMPLATE/**"
   workflow_dispatch:
     inputs:
       live_patterns:
@@ -35,14 +43,19 @@ jobs:
   core-linux:
     name: Core (Linux, Node ${{ matrix.node-version }})
     if: >-
-      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+      github.actor == 'xiaotianfotos' &&
+      (github.event_name != 'pull_request' ||
+        (github.event.pull_request.user.login == 'xiaotianfotos' &&
+         github.event.pull_request.draft == false)) &&
       (github.event_name != 'workflow_dispatch' || !inputs.live_patterns)
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20, 24]
+        # PRs validate the primary runtime, main validates compatibility, and
+        # a manual non-live run retains the complete compatibility matrix.
+        node-version: ${{ fromJSON(github.event_name == 'pull_request' && '[24]' || github.event_name == 'push' && '[20]' || '[20,24]') }}
     steps:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -73,8 +86,9 @@ jobs:
   core-windows:
     name: Core (Windows, Node 24)
     if: >-
-      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
-      (github.event_name != 'workflow_dispatch' || !inputs.live_patterns)
+      github.actor == 'xiaotianfotos' &&
+      (github.event_name == 'push' ||
+        (github.event_name == 'workflow_dispatch' && !inputs.live_patterns))
     runs-on: windows-latest
     timeout-minutes: 25
     steps:
@@ -113,8 +127,11 @@ jobs:
   agent-ui-coverage:
     name: Agent UI coverage
     if: >-
-      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
-      (github.event_name != 'workflow_dispatch' || !inputs.live_patterns)
+      github.actor == 'xiaotianfotos' &&
+      ((github.event_name == 'pull_request' &&
+        github.event.pull_request.user.login == 'xiaotianfotos' &&
+        github.event.pull_request.draft == false) ||
+       (github.event_name == 'workflow_dispatch' && !inputs.live_patterns))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -144,8 +161,11 @@ jobs:
   docker-smoke:
     name: Docker smoke
     if: >-
-      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
-      (github.event_name != 'workflow_dispatch' || !inputs.live_patterns)
+      github.actor == 'xiaotianfotos' &&
+      ((github.event_name == 'pull_request' &&
+        github.event.pull_request.user.login == 'xiaotianfotos' &&
+        github.event.pull_request.draft == false) ||
+       (github.event_name == 'workflow_dispatch' && !inputs.live_patterns))
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -26,6 +26,7 @@ jobs:
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.actor.login == 'xiaotianfotos' &&
        github.event.workflow_run.head_branch == 'main' &&
        github.event.workflow_run.head_repository.full_name == github.repository) ||
       (github.event_name == 'workflow_dispatch' && github.actor == 'xiaotianfotos')

--- a/.github/workflows/pr-closeout.yml
+++ b/.github/workflows/pr-closeout.yml
@@ -27,6 +27,7 @@ concurrency:
 jobs:
   closeout:
     name: HomeRail PR Closeout
+    if: github.actor == 'xiaotianfotos'
     runs-on: [self-hosted, Linux, X64, homerail-live]
     timeout-minutes: 15
     env:

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -2,7 +2,12 @@ name: HomeRail PR Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    # Review once per coherent PR instead of on every pushed commit.
+    types: [opened, reopened, ready_for_review]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - ".github/ISSUE_TEMPLATE/**"
   workflow_dispatch:
     inputs:
       repo:

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -33,11 +33,12 @@ jobs:
   review:
     name: HomeRail PR Review
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' &&
-       github.event.pull_request.draft == false &&
-       github.event.pull_request.head.repo.full_name == github.repository &&
-       github.actor == 'xiaotianfotos')
+      github.actor == 'xiaotianfotos' &&
+      (github.event_name == 'workflow_dispatch' ||
+       (github.event_name == 'pull_request' &&
+        github.event.pull_request.user.login == 'xiaotianfotos' &&
+        github.event.pull_request.draft == false &&
+        github.event.pull_request.head.repo.full_name == github.repository))
     runs-on: [self-hosted, Linux, X64, homerail-pr-review]
     timeout-minutes: 90
     env:


### PR DESCRIPTION
## Summary

- require `xiaotianfotos` as both workflow actor and PR author
- run PR checks only when a PR is opened, reopened, or marked ready; pushes to an existing PR no longer trigger CI
- run Linux Node 24, UI coverage, and Docker smoke on owner-authored PRs
- defer Windows and Node 20 compatibility validation to `main` pushes
- retain the full compatibility matrix for manual non-live runs
- skip documentation-only changes, including PR Review
- restrict PR review, closeout, and deploy workflows to the repository owner

## Intended workflow

1. Open changes as a draft PR.
2. Push freely without starting runners.
3. Mark the coherent change ready once to run PR validation.
4. Re-draft and mark ready again, or dispatch manually, only when a later change needs another validation.

## Repository setting

Fork workflow approval now requires approval for all external contributors.

## Validation

- `actionlint` passed for all modified workflows
- `git diff --check` passed