### PR TITLE
fix(ui): hide gamepad monitor behind debug API

### DIFF
--- a/agent-ui/src/components/agent/AgentVoiceCockpit.vue
+++ b/agent-ui/src/components/agent/AgentVoiceCockpit.vue
@@ -117,6 +117,7 @@ import {
   type NativeGamepadAnalogDetail,
   type NativeGamepadButtonDetail
 } from '@/utils/native-gamepad-events'
+import { installGamepadMonitorDebugApi } from '@/utils/gamepad-monitor-debug'
 import {
   nativeVoiceCaptureAvailable,
   nativeTtsPlaybackAvailable,
@@ -133,7 +134,6 @@ import {
   ChevronRight,
   AlertTriangle,
   EyeOff,
-  Gamepad2,
   Mic,
   MessageSquareText,
   PanelLeftOpen,
@@ -393,6 +393,7 @@ let lastSubmittedVoiceTranscriptKey = ''
 let lastSubmittedVoiceTranscriptAt = 0
 let managerStatusTimer = 0
 let voiceStatusUnsub: (() => void) | null = null
+let uninstallGamepadMonitorDebugApi: (() => void) | null = null
 let pluginRegistryUnsub: (() => void) | null = null
 let pluginRegistryStateUnsub: (() => void) | null = null
 let statusFocusApplied = false
@@ -1150,6 +1151,10 @@ onMounted(() => {
   startVoiceGamepadControl()
   void loadVoiceSessionShortcuts()
   installCodexVoiceTextBridge()
+  uninstallGamepadMonitorDebugApi = installGamepadMonitorDebugApi(
+    window,
+    setVoiceGamepadMonitorVisible,
+  )
   managerStatusTimer = window.setInterval(() => {
     void refreshManagerStatus()
     // 同时刷新 sidebar 会话列表，让用户在当前 session 时也能看到其他 session 的运行状态。
@@ -1264,6 +1269,8 @@ onUnmounted(() => {
   resetTtsAudioElement()
   setVoiceRootLock(false)
   uninstallCodexVoiceTextBridge()
+  uninstallGamepadMonitorDebugApi?.()
+  uninstallGamepadMonitorDebugApi = null
 })
 
 function installCodexVoiceTextBridge(): void {
@@ -3785,12 +3792,13 @@ function handleNativeVoiceGamepadAnalog(event: Event): void {
   scrollConversationBy(applyVoiceGamepadDeadzone(detail.scrollY ?? 0) * VOICE_THREAD_SCROLL_SPEED)
 }
 
-function toggleVoiceGamepadLiveView(): void {
-  voiceGamepadLiveVisible.value = !voiceGamepadLiveVisible.value
+function setVoiceGamepadMonitorVisible(visible?: boolean): boolean {
+  if (typeof visible === 'boolean') voiceGamepadLiveVisible.value = visible
   if (voiceGamepadLiveVisible.value) {
     const gamepad = currentVoiceGamepad()
     if (gamepad) updateVoiceGamepadConnection(gamepad)
   }
+  return voiceGamepadLiveVisible.value
 }
 
 function currentVoiceGamepadInputContext(): VoiceGamepadInputContext {
@@ -4943,22 +4951,6 @@ function summarizeTask(value: string): string {
         >
           <Sparkles class="h-4 w-4" />
           <span>{{ t('voice.onboarding.button') }}</span>
-        </button>
-        <button
-          class="voice-runtime-pill voice-runtime-pill--gamepad flex h-9 items-center rounded-full border px-3 text-xs"
-          :class="{
-            'border-[var(--hr-success-border)] bg-[var(--hr-success-soft)] text-[var(--hr-success)]': voiceGamepadConnected,
-            'border-[var(--hr-border)] bg-[var(--hr-surface-1)] text-[var(--hr-text-4)]': !voiceGamepadConnected,
-            'voice-runtime-pill--gamepad-live': voiceGamepadLiveVisible
-          }"
-          :title="
-            voiceGamepadLiveVisible ? t('voice.gamepad.hideMonitor') : voiceGamepadStatus || t('voice.gamepad.showMonitor')
-          "
-          type="button"
-          data-testid="voice-gamepad-toggle"
-          @click="toggleVoiceGamepadLiveView"
-        >
-          <Gamepad2 class="h-4 w-4" />
         </button>
       </AgentModeTopBar>
 
@@ -6211,15 +6203,6 @@ function summarizeTask(value: string): string {
   padding: 10px 4px 2px;
   color: var(--vc-danger);
   font-size: 12px;
-}
-
-.voice-runtime-pill--gamepad {
-  min-width: 42px;
-  justify-content: center;
-}
-
-.voice-runtime-pill--gamepad-live {
-  box-shadow: 0 0 0 1px var(--vc-accent-border), 0 0 26px var(--vc-accent-soft);
 }
 
 /* --------------------------------------------------------------------------

--- a/agent-ui/src/components/agent/AgentVoiceCockpitLayout.test.ts
+++ b/agent-ui/src/components/agent/AgentVoiceCockpitLayout.test.ts
@@ -73,4 +73,12 @@ describe('AgentVoiceCockpit responsive layout', () => {
     expect(cockpitSource).toContain("item.channel === 'progress' ? 'voice-thread-item--progress' : ''")
     expect(cockpitSource).toContain('>progress</span')
   })
+
+  it('keeps the gamepad monitor behind a console-only debug command', () => {
+    expect(cockpitSource).not.toContain('data-testid="voice-gamepad-toggle"')
+    expect(cockpitSource).not.toContain('toggleVoiceGamepadLiveView')
+    expect(cockpitSource).toContain('installGamepadMonitorDebugApi(')
+    expect(cockpitSource).toContain('setVoiceGamepadMonitorVisible')
+    expect(cockpitSource).toContain('uninstallGamepadMonitorDebugApi?.()')
+  })
 })

--- a/agent-ui/src/locales/en-US/voice.json
+++ b/agent-ui/src/locales/en-US/voice.json
@@ -275,8 +275,6 @@
   },
   "gamepad": {
     "generic": "Gamepad",
-    "hideMonitor": "Hide gamepad button monitor",
-    "showMonitor": "Show gamepad button monitor",
     "buttonStatus": "Gamepad button status",
     "monitoring": "Monitoring buttons",
     "connected": "Connected",

--- a/agent-ui/src/locales/zh-Hans/voice.json
+++ b/agent-ui/src/locales/zh-Hans/voice.json
@@ -275,8 +275,6 @@
   },
   "gamepad": {
     "generic": "手柄",
-    "hideMonitor": "隐藏手柄按键监视",
-    "showMonitor": "显示手柄按键监视",
     "buttonStatus": "手柄按键状态",
     "monitoring": "按键监视中",
     "connected": "已连接",

--- a/agent-ui/src/locales/zh-Hant/voice.json
+++ b/agent-ui/src/locales/zh-Hant/voice.json
@@ -275,8 +275,6 @@
   },
   "gamepad": {
     "generic": "手柄",
-    "hideMonitor": "隱藏手柄按鍵監視",
-    "showMonitor": "顯示手柄按鍵監視",
     "buttonStatus": "手柄按鍵狀態",
     "monitoring": "按鍵監視中",
     "connected": "已連接",

--- a/agent-ui/src/utils/gamepad-monitor-debug.test.ts
+++ b/agent-ui/src/utils/gamepad-monitor-debug.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  installGamepadMonitorDebugApi,
+  type HomeRailDebugHost,
+} from './gamepad-monitor-debug'
+
+describe('gamepad monitor debug API', () => {
+  it('opens, closes, and queries the monitor through the console command', () => {
+    const host: HomeRailDebugHost = {}
+    let visible = false
+    const command = vi.fn((next?: boolean) => {
+      if (typeof next === 'boolean') visible = next
+      return visible
+    })
+
+    const uninstall = installGamepadMonitorDebugApi(host, command)
+
+    expect(host.HomeRailDebug?.gamepadMonitor?.()).toBe(false)
+    expect(host.HomeRailDebug?.gamepadMonitor?.(true)).toBe(true)
+    expect(host.HomeRailDebug?.gamepadMonitor?.(false)).toBe(false)
+
+    uninstall()
+    expect(host.HomeRailDebug).toBeUndefined()
+  })
+
+  it('preserves other debug commands and does not remove replacements', () => {
+    const replacement = () => true
+    const host: HomeRailDebugHost = { HomeRailDebug: { keep: 'value' } }
+    const uninstall = installGamepadMonitorDebugApi(host, () => false)
+
+    host.HomeRailDebug!.gamepadMonitor = replacement
+    uninstall()
+
+    expect(host.HomeRailDebug).toEqual({ keep: 'value', gamepadMonitor: replacement })
+  })
+})

--- a/agent-ui/src/utils/gamepad-monitor-debug.ts
+++ b/agent-ui/src/utils/gamepad-monitor-debug.ts
@@ -1,0 +1,31 @@
+export interface HomeRailDebugApi {
+  gamepadMonitor?: (visible?: boolean) => boolean
+  [key: string]: unknown
+}
+
+export interface HomeRailDebugHost {
+  HomeRailDebug?: HomeRailDebugApi
+}
+
+export type GamepadMonitorCommand = (visible?: boolean) => boolean
+
+/**
+ * Installs the console-only gamepad monitor command without replacing other
+ * HomeRail debug tools. The returned cleanup only removes this installation.
+ */
+export function installGamepadMonitorDebugApi(
+  target: object,
+  command: GamepadMonitorCommand,
+): () => void {
+  const host = target as HomeRailDebugHost
+  const existing = host.HomeRailDebug
+  const debugApi = existing && typeof existing === 'object' ? existing : {}
+  debugApi.gamepadMonitor = command
+  host.HomeRailDebug = debugApi
+
+  return () => {
+    if (host.HomeRailDebug?.gamepadMonitor !== command) return
+    delete host.HomeRailDebug.gamepadMonitor
+    if (Object.keys(host.HomeRailDebug).length === 0) delete host.HomeRailDebug
+  }
+}


### PR DESCRIPTION
## Summary

- remove the gamepad monitor button from the main cockpit toolbar
- retain the monitor as a console-only debugging tool
- preserve and clean up the shared `HomeRailDebug` namespace safely
- remove button-only translations and styles

## Console commands

```js
HomeRailDebug.gamepadMonitor(true)  // open
HomeRailDebug.gamepadMonitor(false) // close
HomeRailDebug.gamepadMonitor()      // query
```

## Validation

- 9 targeted Vitest checks passed
- Agent UI typecheck passed
- Agent UI production build passed
- browser verification confirmed the button is absent and the debug command opens/closes the monitor