### PR TITLE
fix(worker): separate Claude raw traces from control telemetry

### DIFF
--- a/homerail_cli/src/commands/evidence.ts
+++ b/homerail_cli/src/commands/evidence.ts
@@ -63,10 +63,11 @@ export function registerEvidenceCommands(program: Command): void {
     .command("trace <runId>")
     .description("Show execution trace for a DAG run")
     .option("--node <id>", "Filter to a specific node ID")
-    .action(async (runId: string, opts: { node?: string }) => {
+    .option("--raw", "Print the complete local Claude SDK JSONL trace (requires --node)")
+    .action(async (runId: string, opts: { node?: string; raw?: boolean }) => {
       const globalOpts = program.opts<GlobalOpts>();
       const client = getClient(globalOpts);
-      process.exitCode = await cmdTrace(client, runId, opts.node, !!globalOpts.json);
+      process.exitCode = await cmdTrace(client, runId, opts.node, !!globalOpts.json, opts.raw === true);
     });
 
   program

--- a/homerail_cli/src/commands/trace.ts
+++ b/homerail_cli/src/commands/trace.ts
@@ -261,6 +261,39 @@ function eventTimestamp(event: ToolAuditRecord): number {
   return typeof ts === "number" && Number.isFinite(ts) ? ts : 0;
 }
 
+function localClaudeSdkTracePath(runId: string, nodeId: string): string {
+  const safeRunId = safeAuditRunId(runId);
+  const safeNodeId = safeAuditRunId(nodeId);
+  return path.join(
+    getHomerailHome(),
+    "workspace",
+    safeRunId,
+    ".homerail-runtime",
+    "audit",
+    "claude-sdk-traces",
+    safeRunId,
+    `${safeNodeId}.jsonl`,
+  );
+}
+
+function printRawClaudeSdkTrace(runId: string, nodeId: string, json: boolean): number {
+  const filePath = localClaudeSdkTracePath(runId, nodeId);
+  if (!fs.existsSync(filePath)) {
+    console.error(`Error: no local Claude SDK raw trace for ${runId}/${nodeId}`);
+    console.error(`  Expected: ${filePath}`);
+    return 1;
+  }
+  const raw = fs.readFileSync(filePath, "utf8");
+  if (json) {
+    console.log(JSON.stringify(readJsonl(filePath), null, 2));
+  } else {
+    // Preserve the exact durable JSONL records. Default `trace` output remains
+    // the compact Manager-backed summary; raw output is explicit and local.
+    console.log(raw.replace(/\n$/, ""));
+  }
+  return 0;
+}
+
 function nodeIdsFromStatus(data: Record<string, unknown>): string[] {
   const execution = data.execution as Record<string, unknown> | undefined;
   const nodes = execution?.nodes;
@@ -353,7 +386,15 @@ export async function cmdTrace(
   runId: string,
   nodeFilter: string | undefined,
   json: boolean,
+  raw = false,
 ): Promise<number> {
+  if (raw) {
+    if (!nodeFilter) {
+      console.error("Error: --raw requires --node <id>");
+      return 1;
+    }
+    return printRawClaudeSdkTrace(runId, nodeFilter, json);
+  }
   let nodeIds: string[];
 
   if (nodeFilter) {

--- a/homerail_cli/tests/evidence-commands.test.ts
+++ b/homerail_cli/tests/evidence-commands.test.ts
@@ -660,6 +660,49 @@ describe("trace command", () => {
     expect(output).not.toContain("should-not-render");
     expect(process.exitCode).toBe(0);
   });
+
+  it("prints the complete local Claude SDK trace only when --raw is explicit", async () => {
+    const traceDir = path.join(
+      tempHome,
+      "workspace",
+      "run-raw",
+      ".homerail-runtime",
+      "audit",
+      "claude-sdk-traces",
+      "run-raw",
+    );
+    fs.mkdirSync(traceDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(traceDir, "triage.jsonl"),
+      [
+        JSON.stringify({ record_type: "query_start", prompt: "diagnose" }),
+        JSON.stringify({
+          record_type: "sdk_message",
+          sequence: 1,
+          message: { type: "system", subtype: "thinking_tokens" },
+        }),
+      ].join("\n") + "\n",
+    );
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "homerail",
+      "trace",
+      "run-raw",
+      "--node",
+      "triage",
+      "--raw",
+    ]);
+
+    const output = logSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+    expect(output).toContain('"record_type":"query_start"');
+    expect(output).toContain('"subtype":"thinking_tokens"');
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(0);
+  });
 });
 
 // -- Stats -------------------------------------------------------------------

--- a/homerail_manager/src/orchestration/ws-dispatch-adapter.ts
+++ b/homerail_manager/src/orchestration/ws-dispatch-adapter.ts
@@ -610,6 +610,10 @@ export class WsDispatchAdapter implements DAGDispatcher {
       env: {
         ...(this.provisionerOpts?.env ?? {}),
         ...(agentBackend ? { AGENT_BACKEND: agentBackend } : {}),
+        // Worker workspaces are host-backed and survive container cleanup.
+        // Keep high-volume audit/SDK traces there instead of the ephemeral
+        // container home, but outside the model-owned workspace policy.
+        HOMERAIL_AUDIT_DIR: "/workspace/.homerail-runtime/audit",
         MANAGER_WORKER_WS_URL: this.getManagerWorkerWsUrl(workerId),
         HOMERAIL_WORKER_ID: workerId,
       },

--- a/homerail_worker/src/__tests__/audit.test.ts
+++ b/homerail_worker/src/__tests__/audit.test.ts
@@ -15,6 +15,9 @@ import {
   writeTranscriptChecksum,
   logError,
   checkAuditCompleteness,
+  claudeSdkTracePath,
+  createClaudeSdkTraceWriter,
+  readClaudeSdkTrace,
   readToolEvents,
 } from "../audit/index.js";
 
@@ -114,6 +117,49 @@ describe("audit writers", () => {
     it("rejects unsafe run IDs before creating audit files", () => {
       expect(() => createAuditWriters("../run", dir)).toThrow(/file-safe identifier/);
       expect(existsSync(join(dir, "..", "run.jsonl"))).toBe(false);
+    });
+  });
+
+  describe("Claude SDK trace writer", () => {
+    it("stores complete redacted SDK records outside the Manager transcript", async () => {
+      const writer = createClaudeSdkTraceWriter("run-trace", "node-a", {
+        baseDir: dir,
+        redact: (value) => JSON.parse(JSON.stringify(value).split("secret-value").join("***")),
+      });
+
+      await writer.write({
+        record_type: "query_start",
+        prompt: "use secret-value",
+      });
+      await writer.write({
+        record_type: "sdk_message",
+        sequence: 1,
+        message: { type: "system", subtype: "thinking_tokens" },
+      });
+      await writer.close();
+
+      expect(writer.filePath).toBe(claudeSdkTracePath("run-trace", "node-a", dir));
+      const records = readClaudeSdkTrace("run-trace", "node-a", dir);
+      expect(records).toHaveLength(2);
+      expect(records[0]).toMatchObject({
+        schema_version: "homerail.claude-sdk-trace/v1",
+        run_id: "run-trace",
+        node_id: "node-a",
+        record_type: "query_start",
+        prompt: "use ***",
+      });
+      expect(records[1]).toMatchObject({
+        record_type: "sdk_message",
+        sequence: 1,
+        message: { type: "system", subtype: "thinking_tokens" },
+      });
+    });
+
+    it("rejects unsafe run and node identifiers", () => {
+      expect(() => createClaudeSdkTraceWriter("../run", "node-a", { baseDir: dir }))
+        .toThrow(/file-safe identifier/);
+      expect(() => createClaudeSdkTraceWriter("run-a", "../node", { baseDir: dir }))
+        .toThrow(/file-safe identifier/);
     });
   });
 

--- a/homerail_worker/src/__tests__/claude-sdk.test.ts
+++ b/homerail_worker/src/__tests__/claude-sdk.test.ts
@@ -107,6 +107,157 @@ describe("ClaudeSdkAdapter", () => {
     ]);
   });
 
+  it("suppresses per-token thinking diagnostics and reports one aggregate count", async () => {
+    const thinkingTokenMessages = Array.from({ length: 10_000 }, () => ({
+      type: "system",
+      subtype: "thinking_tokens",
+    }));
+    vi.doMock("@anthropic-ai/claude-agent-sdk", () =>
+      makeFakeSdk([
+        ...thinkingTokenMessages,
+        {
+          type: "assistant",
+          message: {
+            content: [{ type: "text", text: "Finished reasoning." }],
+            stop_reason: "end_turn",
+          },
+        },
+        { type: "result", subtype: "success", is_error: false },
+      ]),
+    );
+
+    const { ClaudeSdkAdapter } = await import("../agent/claude-sdk.js");
+    const adapter = new ClaudeSdkAdapter();
+    const events: AgentEvent[] = [];
+    const rawTrace: Array<Record<string, unknown>> = [];
+    for await (const event of adapter.run("test", [], {
+      ...ctx,
+      rawTraceSink: {
+        async write(record) {
+          rawTrace.push(record);
+        },
+      },
+    })) events.push(event);
+
+    const sdkMessageDebugEvents = events.filter(
+      (event) => event.type === "debug" && event.message === "sdk_message",
+    );
+    expect(sdkMessageDebugEvents).toHaveLength(2);
+    expect(events).toContainEqual(expect.objectContaining({
+      type: "debug",
+      message: "thinking_tokens_aggregated",
+      data: {
+        count: 10_000,
+        total: 10_000,
+        through_sequence: 10_000,
+      },
+    }));
+    expect(rawTrace).toHaveLength(10_004);
+    expect(rawTrace[0]).toMatchObject({ record_type: "query_start", prompt: "test" });
+    expect(rawTrace.filter((record) => (
+      record.record_type === "sdk_message"
+      && (record.message as Record<string, unknown>)?.subtype === "thinking_tokens"
+    ))).toHaveLength(10_000);
+    expect(rawTrace.at(-1)).toMatchObject({
+      record_type: "query_end",
+      message_count: 10_002,
+      suppressed_thinking_token_debug_count: 10_000,
+    });
+    expect(events).toContainEqual({ type: "text", text: "Finished reasoning." });
+    expect(events).toContainEqual(expect.objectContaining({
+      type: "debug",
+      message: "query_done",
+      data: expect.objectContaining({
+        message_count: 10_002,
+        suppressed_thinking_token_debug_count: 10_000,
+        raw_trace_configured: true,
+        raw_trace_records_written: 10_004,
+        raw_trace_write_failures: 0,
+      }),
+    }));
+  });
+
+  it("keeps the agent running when the raw trace sink fails", async () => {
+    vi.doMock("@anthropic-ai/claude-agent-sdk", () =>
+      makeFakeSdk([
+        {
+          type: "assistant",
+          message: {
+            content: [{ type: "text", text: "Still completed." }],
+            stop_reason: "end_turn",
+          },
+        },
+        { type: "result", subtype: "success", is_error: false },
+      ]),
+    );
+
+    const { ClaudeSdkAdapter } = await import("../agent/claude-sdk.js");
+    const adapter = new ClaudeSdkAdapter();
+    const events: AgentEvent[] = [];
+    let writes = 0;
+    for await (const event of adapter.run("test", [], {
+      ...ctx,
+      rawTraceSink: {
+        async write() {
+          writes += 1;
+          throw new Error("trace disk unavailable");
+        },
+      },
+    })) events.push(event);
+
+    expect(writes).toBe(1);
+    expect(events).toContainEqual({ type: "text", text: "Still completed." });
+    expect(events.filter(
+      (event) => event.type === "debug" && event.message === "raw_trace_write_failed",
+    )).toHaveLength(1);
+    expect(events).toContainEqual(expect.objectContaining({
+      type: "debug",
+      message: "query_done",
+      data: expect.objectContaining({
+        raw_trace_configured: true,
+        raw_trace_records_written: 0,
+        raw_trace_write_failures: 1,
+        raw_trace_last_error: "trace disk unavailable",
+      }),
+    }));
+  });
+
+  it("closes the raw trace when the consumer stops after a handoff event", async () => {
+    vi.doMock("@anthropic-ai/claude-agent-sdk", () =>
+      makeFakeSdk([
+        {
+          type: "assistant",
+          message: {
+            content: [{ type: "text", text: "Handoff accepted." }],
+            stop_reason: "tool_use",
+          },
+        },
+        { type: "result", subtype: "success", is_error: false },
+      ]),
+    );
+
+    const { ClaudeSdkAdapter } = await import("../agent/claude-sdk.js");
+    const adapter = new ClaudeSdkAdapter();
+    const rawTrace: Array<Record<string, unknown>> = [];
+    for await (const event of adapter.run("test", [], {
+      ...ctx,
+      rawTraceSink: {
+        async write(record) {
+          rawTrace.push(record);
+        },
+      },
+    })) {
+      if (event.type === "progress") break;
+    }
+
+    expect(rawTrace).toHaveLength(3);
+    expect(rawTrace.at(-1)).toMatchObject({
+      record_type: "query_end",
+      termination: "consumer_closed",
+      message_count: 1,
+    });
+  });
+
   it("maps MCP tool results carried by SDK user messages", async () => {
     vi.doMock("@anthropic-ai/claude-agent-sdk", () =>
       makeFakeSdk([

--- a/homerail_worker/src/__tests__/runtime-pattern-tools.test.ts
+++ b/homerail_worker/src/__tests__/runtime-pattern-tools.test.ts
@@ -141,6 +141,28 @@ describe("runtime pattern worker tools", () => {
     }
   });
 
+  it("ignores runtime-owned audit traces in workspace policy snapshots", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-workspace-runtime-audit-"));
+    try {
+      fs.mkdirSync(path.join(root, "src"));
+      fs.writeFileSync(path.join(root, "src", "code.ts"), "unchanged");
+      const policy = { writable_paths: ["src"], readonly_paths: [] };
+      const before = snapshotWorkspace(root, policy);
+      fs.mkdirSync(path.join(root, ".homerail-runtime", "audit"), { recursive: true });
+      fs.writeFileSync(
+        path.join(root, ".homerail-runtime", "audit", "claude-sdk.jsonl"),
+        '{"record_type":"sdk_message"}\n',
+      );
+
+      const result = verifyWorkspacePolicy(before, snapshotWorkspace(root, policy), policy);
+      expect(result.valid).toBe(true);
+      expect(result.changed_paths).toEqual([]);
+      expect(result.before_hash).toBe(result.after_hash);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("rejects workspace symlinks that escape the policy root", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-workspace-symlink-"));
     const outside = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-workspace-outside-"));

--- a/homerail_worker/src/agent/claude-sdk.ts
+++ b/homerail_worker/src/agent/claude-sdk.ts
@@ -451,6 +451,31 @@ export class ClaudeSdkAdapter implements AgentClient {
     const accumulatedUsage: AgentUsage = {};
     let finalDurationMs: number | undefined;
     let finalNumTurns: number | undefined;
+    let messageCount = 0;
+    let suppressedThinkingTokenDebugCount = 0;
+    let pendingThinkingTokenDebugCount = 0;
+    let rawTraceTerminalWritten = false;
+    const rawTraceConfigured = context.rawTraceSink !== undefined;
+    let rawTraceSink = context.rawTraceSink;
+    let rawTraceRecordsWritten = 0;
+    let rawTraceWriteFailures = 0;
+    let rawTraceLastError: string | null = null;
+    const writeRawTrace = async (record: Record<string, unknown>): Promise<string | null> => {
+      if (!rawTraceSink) return null;
+      try {
+        await rawTraceSink.write(record);
+        rawTraceRecordsWritten += 1;
+        return null;
+      } catch (error) {
+        rawTraceWriteFailures += 1;
+        rawTraceLastError = error instanceof Error ? error.message : String(error);
+        // Do not retry every provider event after a local trace failure. The
+        // final aggregate reports that the trace is incomplete while the
+        // model and Manager control plane remain available.
+        rawTraceSink = undefined;
+        return rawTraceLastError;
+      }
+    };
     try {
       const effectiveModel = context.model || this.model;
       const authEnv = this.buildClaudeEnv(context, effectiveModel);
@@ -567,6 +592,26 @@ export class ClaudeSdkAdapter implements AgentClient {
         };
       }
 
+      const rawTraceStartError = await writeRawTrace({
+        record_type: "query_start",
+        prompt,
+        system_prompt: context.systemPrompt ?? null,
+        system_prompt_mode: systemPromptMode,
+        model: effectiveModel,
+        thinking_budget: effectiveThinkingBudget,
+        builtin_tools: builtinTools,
+        dag_tool_names: tools.map((tool) => tool.name),
+        session_id: context.sessionId ?? null,
+      });
+      if (rawTraceStartError) {
+        yield {
+          type: "debug",
+          source: "claude-sdk",
+          message: "raw_trace_write_failed",
+          data: { error: rawTraceStartError },
+        };
+      }
+
       yield {
         type: "debug",
         source: "claude-sdk",
@@ -603,7 +648,6 @@ export class ClaudeSdkAdapter implements AgentClient {
 
       const query = sdk.query({ prompt: inputQueue, options });
       const transportGuard = createSdkTransportGuard(abortController);
-      let messageCount = 0;
       try {
         const iterator = query[Symbol.asyncIterator]();
         while (true) {
@@ -633,48 +677,79 @@ export class ClaudeSdkAdapter implements AgentClient {
           }
           const msg = next.value;
           if (msg.type === "result") inputQueue.close();
-        messageCount += 1;
-        const stderrChunk = stderrTail.trim();
-        if (stderrChunk) {
-          yield {
-            type: "debug",
-            source: "claude-sdk",
-            message: "claude_code_stderr",
-            data: { sequence: messageCount, tail: stderrChunk.slice(-2000) },
-          };
-          stderrTail = "";
-        }
-        // Extract usage from this message. Per-message usage on assistant
-        // turns is additive (each turn's input/output); the result message
-        // carries an aggregate we prefer when present.
-        const msgUsage = msg.message?.usage ?? msg.usage;
-        let usageChanged = false;
-        if (msgUsage) {
-          usageChanged = true;
-          if (msg.type === "result") {
-            // Result message carries the authoritative aggregate — replace.
-            accumulatedUsage.input_tokens = msgUsage.input_tokens ?? accumulatedUsage.input_tokens;
-            accumulatedUsage.output_tokens = msgUsage.output_tokens ?? accumulatedUsage.output_tokens;
-            accumulatedUsage.cache_read_input_tokens = msgUsage.cache_read_input_tokens ?? accumulatedUsage.cache_read_input_tokens;
-            accumulatedUsage.cache_creation_input_tokens = msgUsage.cache_creation_input_tokens ?? accumulatedUsage.cache_creation_input_tokens;
-            finalDurationMs = msg.duration_ms;
-            finalNumTurns = msg.num_turns;
-          } else {
-            // Per-turn delta — accumulate.
-            accumulatedUsage.input_tokens = (accumulatedUsage.input_tokens ?? 0) + (msgUsage.input_tokens ?? 0);
-            accumulatedUsage.output_tokens = (accumulatedUsage.output_tokens ?? 0) + (msgUsage.output_tokens ?? 0);
-            accumulatedUsage.cache_read_input_tokens = (accumulatedUsage.cache_read_input_tokens ?? 0) + (msgUsage.cache_read_input_tokens ?? 0);
-            accumulatedUsage.cache_creation_input_tokens = (accumulatedUsage.cache_creation_input_tokens ?? 0) + (msgUsage.cache_creation_input_tokens ?? 0);
+          messageCount += 1;
+          const rawTraceMessageError = await writeRawTrace({
+            record_type: "sdk_message",
+            sequence: messageCount,
+            message: msg as unknown as Record<string, unknown>,
+          });
+          if (rawTraceMessageError) {
+            yield {
+              type: "debug",
+              source: "claude-sdk",
+              message: "raw_trace_write_failed",
+              data: { sequence: messageCount, error: rawTraceMessageError },
+            };
           }
-        }
-        // Emit a usage event inline (carrying the running total) so the
-        // prompt-runner has up-to-date totals even when the agent yields
-        // early via handoff and the outer loop breaks before we reach the
-        // post-loop aggregate emission below.
-        if (usageChanged) {
-          yield { type: "usage", usage: { ...accumulatedUsage } };
-        }
-        yield this.debugMessageEvent(msg, messageCount);
+          const stderrChunk = stderrTail.trim();
+          if (stderrChunk) {
+            yield {
+              type: "debug",
+              source: "claude-sdk",
+              message: "claude_code_stderr",
+              data: { sequence: messageCount, tail: stderrChunk.slice(-2000) },
+            };
+            stderrTail = "";
+          }
+          // Extract usage from this message. Per-message usage on assistant
+          // turns is additive (each turn's input/output); the result message
+          // carries an aggregate we prefer when present.
+          const msgUsage = msg.message?.usage ?? msg.usage;
+          let usageChanged = false;
+          if (msgUsage) {
+            usageChanged = true;
+            if (msg.type === "result") {
+              // Result message carries the authoritative aggregate — replace.
+              accumulatedUsage.input_tokens = msgUsage.input_tokens ?? accumulatedUsage.input_tokens;
+              accumulatedUsage.output_tokens = msgUsage.output_tokens ?? accumulatedUsage.output_tokens;
+              accumulatedUsage.cache_read_input_tokens = msgUsage.cache_read_input_tokens ?? accumulatedUsage.cache_read_input_tokens;
+              accumulatedUsage.cache_creation_input_tokens = msgUsage.cache_creation_input_tokens ?? accumulatedUsage.cache_creation_input_tokens;
+              finalDurationMs = msg.duration_ms;
+              finalNumTurns = msg.num_turns;
+            } else {
+              // Per-turn delta — accumulate.
+              accumulatedUsage.input_tokens = (accumulatedUsage.input_tokens ?? 0) + (msgUsage.input_tokens ?? 0);
+              accumulatedUsage.output_tokens = (accumulatedUsage.output_tokens ?? 0) + (msgUsage.output_tokens ?? 0);
+              accumulatedUsage.cache_read_input_tokens = (accumulatedUsage.cache_read_input_tokens ?? 0) + (msgUsage.cache_read_input_tokens ?? 0);
+              accumulatedUsage.cache_creation_input_tokens = (accumulatedUsage.cache_creation_input_tokens ?? 0) + (msgUsage.cache_creation_input_tokens ?? 0);
+            }
+          }
+          // Emit a usage event inline (carrying the running total) so the
+          // prompt-runner has up-to-date totals even when the agent yields
+          // early via handoff and the outer loop breaks before we reach the
+          // post-loop aggregate emission below.
+          if (usageChanged) {
+            yield { type: "usage", usage: { ...accumulatedUsage } };
+          }
+          if (this.shouldEmitSdkMessageDebug(msg)) {
+            if (pendingThinkingTokenDebugCount > 0) {
+              yield {
+                type: "debug",
+                source: "claude-sdk",
+                message: "thinking_tokens_aggregated",
+                data: {
+                  count: pendingThinkingTokenDebugCount,
+                  total: suppressedThinkingTokenDebugCount,
+                  through_sequence: messageCount - 1,
+                },
+              };
+              pendingThinkingTokenDebugCount = 0;
+            }
+            yield this.debugMessageEvent(msg, messageCount);
+          } else {
+            suppressedThinkingTokenDebugCount += 1;
+            pendingThinkingTokenDebugCount += 1;
+          }
           const events = this.mapSdkMessage(msg);
           for (const event of events) yield event;
         }
@@ -690,20 +765,62 @@ export class ClaudeSdkAdapter implements AgentClient {
       if (hasUsage) {
         yield { type: "usage", usage: accumulatedUsage };
       }
+      if (pendingThinkingTokenDebugCount > 0) {
+        yield {
+          type: "debug",
+          source: "claude-sdk",
+          message: "thinking_tokens_aggregated",
+          data: {
+            count: pendingThinkingTokenDebugCount,
+            total: suppressedThinkingTokenDebugCount,
+            through_sequence: messageCount,
+          },
+        };
+        pendingThinkingTokenDebugCount = 0;
+      }
+      rawTraceTerminalWritten = true;
+      const rawTraceEndError = await writeRawTrace({
+        record_type: "query_end",
+        termination: "completed",
+        message_count: messageCount,
+        suppressed_thinking_token_debug_count: suppressedThinkingTokenDebugCount,
+        usage: hasUsage ? accumulatedUsage : null,
+        duration_ms: finalDurationMs ?? null,
+        num_turns: finalNumTurns ?? null,
+      });
+      if (rawTraceEndError) {
+        yield {
+          type: "debug",
+          source: "claude-sdk",
+          message: "raw_trace_write_failed",
+          data: { error: rawTraceEndError },
+        };
+      }
       yield {
         type: "debug",
         source: "claude-sdk",
         message: "query_done",
         data: {
           message_count: messageCount,
+          suppressed_thinking_token_debug_count: suppressedThinkingTokenDebugCount,
           stderr_tail: stderrTail.trim().slice(-2000) || null,
           usage: hasUsage ? accumulatedUsage : null,
           duration_ms: finalDurationMs ?? null,
           num_turns: finalNumTurns ?? null,
+          raw_trace_configured: rawTraceConfigured,
+          raw_trace_records_written: rawTraceRecordsWritten,
+          raw_trace_write_failures: rawTraceWriteFailures,
+          raw_trace_last_error: rawTraceLastError,
         },
       };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
+      rawTraceTerminalWritten = true;
+      await writeRawTrace({
+        record_type: "query_error",
+        error: msg,
+        stderr_tail: stderrTail.trim().slice(-2000) || null,
+      });
       inputQueue.close(err instanceof Error ? err : new Error(msg));
       if (handoffStopRequested) {
         yield {
@@ -736,6 +853,21 @@ export class ClaudeSdkAdapter implements AgentClient {
         }
       }
     } finally {
+      if (!rawTraceTerminalWritten) {
+        const hasUsage = accumulatedUsage.input_tokens !== undefined
+          || accumulatedUsage.output_tokens !== undefined
+          || accumulatedUsage.cache_read_input_tokens !== undefined
+          || accumulatedUsage.cache_creation_input_tokens !== undefined;
+        await writeRawTrace({
+          record_type: "query_end",
+          termination: "consumer_closed",
+          message_count: messageCount,
+          suppressed_thinking_token_debug_count: suppressedThinkingTokenDebugCount,
+          usage: hasUsage ? accumulatedUsage : null,
+          duration_ms: finalDurationMs ?? null,
+          num_turns: finalNumTurns ?? null,
+        });
+      }
       inputQueue.close();
       if (timeout) clearTimeout(timeout);
       if (context.abortSignal && externalAbortHandler) {
@@ -790,6 +922,22 @@ export class ClaudeSdkAdapter implements AgentClient {
         raw_top_usage: rawTopUsage ?? null,
       },
     };
+  }
+
+  private shouldEmitSdkMessageDebug(msg: SdkMessage): boolean {
+    // Some Anthropic-compatible endpoints emit one system message for every
+    // thinking-token update. Persisting those otherwise-empty diagnostics can
+    // generate thousands of websocket events and starve Manager status and
+    // cancellation requests. Usage is handled separately above, so suppress
+    // only successful, token-only progress messages while retaining errors,
+    // text, tools, results, and the final aggregate query_done diagnostic.
+    return !(
+      msg.type === "system"
+      && msg.subtype === "thinking_tokens"
+      && !msg.error
+      && (msg.errors?.length ?? 0) === 0
+      && msg.is_error !== true
+    );
   }
 
   private buildClaudeEnv(context: AgentRunContext, effectiveModel: string): {

--- a/homerail_worker/src/agent/types.ts
+++ b/homerail_worker/src/agent/types.ts
@@ -44,6 +44,14 @@ export interface AgentUsage {
   cache_creation_input_tokens?: number;
 }
 
+/**
+ * Turn-local sink for complete backend-native trace records. Implementations
+ * must keep these records outside the Manager control-plane event stream.
+ */
+export interface AgentRawTraceSink {
+  write(record: Record<string, unknown>): Promise<void>;
+}
+
 /** Events emitted by an agent during execution. */
 export type AgentEvent =
   | { type: "text"; text: string }
@@ -115,4 +123,6 @@ export interface AgentRunContext {
   skillProjection?: AgentSkillProjection;
   /** Turn-scoped environment assembled from encrypted credential references. */
   environmentVariables?: Readonly<Record<string, string>>;
+  /** Optional durable backend-native trace sink owned by the prompt runner. */
+  rawTraceSink?: AgentRawTraceSink;
 }

--- a/homerail_worker/src/audit/claude-sdk-trace-writer.ts
+++ b/homerail_worker/src/audit/claude-sdk-trace-writer.ts
@@ -1,0 +1,100 @@
+/**
+ * Claude SDK raw trace writer.
+ *
+ * Persists the complete, redacted SDK stream outside the Manager control
+ * plane so high-frequency provider diagnostics cannot starve scheduling,
+ * status, or cancellation requests.
+ */
+
+import { once } from "node:events";
+import { createWriteStream, mkdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { Writable } from "node:stream";
+import { homerailPath } from "../platform/paths.js";
+import type { AgentRawTraceSink } from "../agent/types.js";
+import { redactTelemetry } from "homerail-protocol";
+import { assertSafeRunId } from "./tool-event-writer.js";
+
+export interface ClaudeSdkTraceWriter extends AgentRawTraceSink {
+  readonly filePath: string;
+  close(): Promise<void>;
+}
+
+export interface ClaudeSdkTraceWriterOptions {
+  baseDir?: string;
+  redact?: (value: unknown) => unknown;
+}
+
+function traceRoot(baseDir?: string): string {
+  return baseDir ?? homerailPath("audit");
+}
+
+function safeNodeId(nodeId: string): string {
+  return assertSafeRunId(nodeId);
+}
+
+export function claudeSdkTracePath(runId: string, nodeId: string, baseDir?: string): string {
+  return join(
+    traceRoot(baseDir),
+    "claude-sdk-traces",
+    assertSafeRunId(runId),
+    `${safeNodeId(nodeId)}.jsonl`,
+  );
+}
+
+export function createClaudeSdkTraceWriter(
+  runId: string,
+  nodeId: string,
+  options: ClaudeSdkTraceWriterOptions = {},
+): ClaudeSdkTraceWriter {
+  const safeRunId = assertSafeRunId(runId);
+  const safeNode = safeNodeId(nodeId);
+  const filePath = claudeSdkTracePath(safeRunId, safeNode, options.baseDir);
+  mkdirSync(join(traceRoot(options.baseDir), "claude-sdk-traces", safeRunId), { recursive: true });
+  const stream: Writable = createWriteStream(filePath, { flags: "a", mode: 0o600 });
+  let streamError: Error | null = null;
+  let closed = false;
+  stream.on("error", (error) => {
+    streamError = error;
+  });
+
+  return {
+    filePath,
+    async write(record: Record<string, unknown>): Promise<void> {
+      if (closed) throw new Error("Claude SDK trace writer is closed");
+      if (streamError) throw streamError;
+      const redacted = options.redact
+        ? options.redact(record)
+        : redactTelemetry(record);
+      const line = `${JSON.stringify({
+        schema_version: "homerail.claude-sdk-trace/v1",
+        run_id: safeRunId,
+        node_id: safeNode,
+        ts: Date.now(),
+        ...(redacted as Record<string, unknown>),
+      })}\n`;
+      if (!stream.write(line)) await once(stream, "drain");
+      if (streamError) throw streamError;
+    },
+    async close(): Promise<void> {
+      if (closed) return;
+      closed = true;
+      await new Promise<void>((resolve, reject) => {
+        stream.end(resolve);
+        stream.once("error", reject);
+      });
+    },
+  };
+}
+
+export function readClaudeSdkTrace(
+  runId: string,
+  nodeId: string,
+  baseDir?: string,
+): Array<Record<string, unknown>> {
+  const raw = readFileSync(claudeSdkTracePath(runId, nodeId, baseDir), "utf8");
+  return raw
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}

--- a/homerail_worker/src/audit/index.ts
+++ b/homerail_worker/src/audit/index.ts
@@ -47,6 +47,15 @@ export function createAuditWriters(
 
 export type { TranscriptWriter } from "./transcript-writer.js";
 export {
+  claudeSdkTracePath,
+  createClaudeSdkTraceWriter,
+  readClaudeSdkTrace,
+} from "./claude-sdk-trace-writer.js";
+export type {
+  ClaudeSdkTraceWriter,
+  ClaudeSdkTraceWriterOptions,
+} from "./claude-sdk-trace-writer.js";
+export {
   hasToolEventsForRun,
   legacyToolEventsPath,
   readToolEvents,

--- a/homerail_worker/src/index.ts
+++ b/homerail_worker/src/index.ts
@@ -359,6 +359,7 @@ client.on("task", async (msg) => {
       wsSend: (d) => client.send(d),
       onTerminalMessage: (data) => deferredTerminalMessages.push(data),
       agentBackend: backend,
+      auditDir: process.env.HOMERAIL_AUDIT_DIR,
       abortSignal: abortController.signal,
       turnController,
       credentialBrokerCall: callCredentialBroker,

--- a/homerail_worker/src/prompt-runner.ts
+++ b/homerail_worker/src/prompt-runner.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+  DEFAULT_MANAGER_AGENT_RUNTIME_AGENT_TYPE,
   normalizeManagerAgentRuntimeAgentType,
   validateDagActorSurfaceMediaV1,
   type DagActorCheckpointV1,
@@ -28,6 +29,10 @@ import { createDagTools, createDagToolsState, deliverInbox } from "./dag-tools/i
 import type { DagToolsState } from "./dag-tools/index.js";
 import { createAuditWriters } from "./audit/index.js";
 import type { AuditWriters } from "./audit/index.js";
+import {
+  createClaudeSdkTraceWriter,
+  type ClaudeSdkTraceWriter,
+} from "./audit/claude-sdk-trace-writer.js";
 import { appendTranscriptEntry, redactAgentContext, saveSession } from "./session/session-store.js";
 import { redactTelemetry } from "./telemetry-redaction.js";
 import { snapshotWorkspace, verifyWorkspacePolicy, type WorkspaceSnapshot } from "./workspace-policy.js";
@@ -331,6 +336,21 @@ export async function runPrompt(
   } catch {
     // Non-fatal — audit is best-effort
   }
+  let claudeSdkTrace: ClaudeSdkTraceWriter | null = null;
+  const effectiveAgentBackend = normalizeManagerAgentRuntimeAgentType(
+    agentBackend ?? process.env.AGENT_BACKEND ?? DEFAULT_MANAGER_AGENT_RUNTIME_AGENT_TYPE,
+  ) ?? DEFAULT_MANAGER_AGENT_RUNTIME_AGENT_TYPE;
+  if (effectiveAgentBackend === "claude-sdk") {
+    try {
+      claudeSdkTrace = createClaudeSdkTraceWriter(job.runId, job.dagConfig.node_id, {
+        baseDir: auditDir,
+        redact: redactForTurn,
+      });
+    } catch {
+      // The trace is durable observability, not part of the scheduling path.
+      // Failure to open it must not prevent the agent turn from running.
+    }
+  }
 
   // Write initial transcript entry
   audit?.transcript.write({
@@ -446,6 +466,7 @@ export async function runPrompt(
       allowedBuiltinTools: job.dagConfig.allowed_builtin_tools,
       skillProjection: job.skillProjection,
       environmentVariables: job.credentialEnv,
+      rawTraceSink: claudeSdkTrace ?? undefined,
     };
     try {
       saveSession({
@@ -669,12 +690,10 @@ export async function runPrompt(
   );
 
   // Close audit writers
-  try {
-    await audit?.transcript.close();
-    await audit?.toolEvents.close();
-  } catch {
-    // Best-effort cleanup
-  }
+  await Promise.allSettled([
+    ...(audit ? [audit.transcript.close(), audit.toolEvents.close()] : []),
+    ...(claudeSdkTrace ? [claudeSdkTrace.close()] : []),
+  ]);
 
   function sendNodeError(message: string) {
     const redactedMessage = String(redactForTurn(message));

--- a/homerail_worker/src/workspace-policy.ts
+++ b/homerail_worker/src/workspace-policy.ts
@@ -16,7 +16,10 @@ export interface WorkspacePolicyResult {
   after_hash: string;
 }
 
-const IGNORED_DIRECTORIES = new Set([".git", "node_modules"]);
+// Runtime-owned metadata lives in .homerail-runtime on the host-backed
+// workspace mount. It is not model output and must not trip readonly policy
+// checks when audit writers append transcripts or raw SDK traces.
+const IGNORED_DIRECTORIES = new Set([".git", ".homerail-runtime", "node_modules"]);
 
 function normalizedPolicyPath(value: string): string {
   const normalized = value.replace(/\\/g, "/").replace(/^\.\//, "").replace(/\/$/, "");


### PR DESCRIPTION
## Summary

- persist the complete redacted Claude SDK stream as host-backed JSONL outside the Manager control plane
- suppress per-token `thinking_tokens` debug events and emit low-frequency aggregate progress instead
- preserve a terminal trace record when a DAG handoff closes the SDK consumer early
- keep `hr trace` compact by default and add explicit `--raw --node <id>` access to the local SDK trace
- make trace write failures best-effort so observability cannot block DAG execution

## Root cause

Some Anthropic-compatible endpoints emit one SDK system message per thinking token. Forwarding every message through Worker WebSocket telemetry and Manager SQLite persistence can starve status and cancellation requests. The common handoff path also closes the async generator before the normal `query_done` event, so a final-only aggregate was insufficient.

This change separates durable raw traces from normalized control-plane telemetry and flushes aggregate thinking progress before semantic SDK messages.

## Impact

Manager scheduling, status, and cancellation remain responsive during long reasoning runs, while operators retain a complete redacted SDK record for diagnosis and replay.

Raw traces are stored under:

`HOMERAIL_HOME/workspace/<run>/.homerail-runtime/audit/claude-sdk-traces/<run>/<node>.jsonl`

## Validation

- Worker: 314 passed, 1 skipped
- CLI: 251 passed
- Manager: 1049 passed
- Worker, CLI, and Manager typechecks passed
- real Qwen3.6 Claude-harness smoke: 525 raw records retained, including 430 thinking-token notifications; zero per-token thinking debug records persisted by Manager; terminal `consumer_closed` record present

Closes #94
