### PR TITLE
fix(ci): normalize PR review results deterministically

### DIFF
--- a/assets/orchestrations/pr-review.yaml.template
+++ b/assets/orchestrations/pr-review.yaml.template
@@ -20,7 +20,7 @@ spec:
 
   pattern:
     id: pr-review-scenario
-    version: 1.7.1
+    version: 1.7.2
     source: HomeRail concrete scenario composed from budget-gate, orchestrator-workers, and quorum
     parameters:
       reviewer_count: 4
@@ -404,7 +404,7 @@ spec:
 
   artifacts:
     - name: pr-review.json
-      source: { type: handoff, node: refine, port: finalized }
+      source: { type: handoff, node: normalize_review, port: normalized }
       media_type: application/json
       contract: FinalReview
       required: true
@@ -1219,6 +1219,26 @@ spec:
         verification: {}
       outputs: { finalized: { contract: FinalReview }, failed: {} }
 
+    normalize_review:
+      kind: command
+      depends_on: [refine]
+      inputs:
+        review: { contract: FinalReview }
+      outputs: { normalized: { contract: FinalReview }, failed: {} }
+      config:
+        command:
+          - node
+          - -e
+          - >-
+            let s='';const last=(input,key)=>Array.isArray(input[key])?input[key].at(-1):undefined;process.stdin.on('data',chunk=>s+=chunk).on('end',()=>{const input=JSON.parse(s),review=last(input,'review');if(!review||typeof review!=='object'||!review.report||typeof review.report!=='object'||!review.quorum||typeof review.quorum!=='object')throw new Error('final review is missing');const findings=Array.isArray(review.report.findings)?review.report.findings:[];const actionable_count=findings.length;const status=review.quorum.passed===false?'inconclusive':actionable_count>0?'findings':'pass';process.stdout.write(JSON.stringify({...review,report:{...review.report,findings,actionable_count,status}}))});
+        stdin_field: "$inputs"
+        timeout_ms: 10000
+        capture_limit: 700000
+        success_port: normalized
+        failure_port: failed
+        parse_stdout: json
+        result_payload: value
+
     publish:
       kind: agent
       agent: publisher
@@ -1279,6 +1299,11 @@ spec:
       inputs: { result: {} }
 
     refinement_failed:
+      kind: terminal
+      outcome: failure
+      inputs: { result: {} }
+
+    normalization_failed:
       kind: terminal
       outcome: failure
       inputs: { result: {} }
@@ -1348,17 +1373,19 @@ spec:
     - { from: verification_quorum.accepted, to: quorum_result.accepted }
     - { from: verification_quorum.rejected, to: quorum_result.rejected }
     - { from: quorum_result.decided, to: refine.verification }
-    - { from: refine.finalized, to: publish.review }
+    - { from: refine.finalized, to: normalize_review.review }
+    - { from: normalize_review.normalized, to: publish.review }
     - { from: normalize_privacy_review.reviewed, to: publish.privacy }
     - { from: refine.failed, to: refinement_failed.result, condition: on_failure }
+    - { from: normalize_review.failed, to: normalization_failed.result, condition: on_failure }
     - { from: publish.published, to: publication_outcome.result }
     - { from: publication_outcome.accepted, to: done.result }
     - { from: publication_outcome.rejected, to: inconclusive.result }
     - { from: publish.failed, to: publication_failed.result, condition: on_failure }
 
   policies:
-    max_nodes: 36
-    max_edges: 64
+    max_nodes: 38
+    max_edges: 66
     max_parallelism: 5
     max_dispatches: 32
     max_handoffs: 64

--- a/homerail_manager/tests/pr-review-scenario.test.ts
+++ b/homerail_manager/tests/pr-review-scenario.test.ts
@@ -143,7 +143,7 @@ describe("PR Review scenario assets", () => {
       }),
       expect.objectContaining({
         name: "pr-review.json",
-        source: { type: "handoff", node: "refine", port: "finalized" },
+        source: { type: "handoff", node: "normalize_review", port: "normalized" },
         contract: "FinalReview",
       }),
       expect.objectContaining({
@@ -220,6 +220,20 @@ describe("PR Review scenario assets", () => {
       mode: "any",
       field: "passed",
       passed_port: "decided",
+    });
+    expect(nodes.find((node) => node.id === "normalize_review")).toMatchObject({
+      kind: "command",
+      depends_on: ["refine"],
+      inputs: [expect.objectContaining({ name: "review", contract: "FinalReview" })],
+      outputs: expect.arrayContaining([
+        expect.objectContaining({ name: "normalized", contract: "FinalReview" }),
+      ]),
+      config: expect.objectContaining({
+        success_port: "normalized",
+        failure_port: "failed",
+        parse_stdout: "json",
+        result_payload: "value",
+      }),
     });
     expect(nodes.find((node) => node.id === "publication_outcome")?.config).toMatchObject({
       field: "quorum.passed",
@@ -656,6 +670,75 @@ describe("PR Review scenario assets", () => {
     expect(JSON.stringify(advisory)).not.toContain(privateEmail);
   });
 
+  it("deterministically normalizes final review status from findings and quorum", () => {
+    const source = fs.readFileSync(
+      path.resolve(process.cwd(), "..", "assets", "orchestrations", "pr-review.yaml.template"),
+      "utf8",
+    );
+    const workflow = compileWorkflowSource(source);
+    const normalizer = workflow.canonical?.nodes.find((node) => node.id === "normalize_review");
+    const command = normalizer?.config?.command as unknown[] | undefined;
+    const code = String(command?.[2] ?? "");
+    const execute = (review: Record<string, unknown>) => {
+      const result = spawnSync(process.execPath, ["-e", code], {
+        encoding: "utf8",
+        input: JSON.stringify({ review: [review] }),
+      });
+      expect(result.status).toBe(0);
+      return JSON.parse(result.stdout) as {
+        report: Record<string, unknown>;
+        quorum: Record<string, unknown>;
+      };
+    };
+    const finding = {
+      category: "security",
+      severity: "low",
+      title: "Debug API remains available",
+      file: "agent-ui/src/debug.ts",
+      line: 12,
+      evidence: "The debug command is registered.",
+      recommendation: "Confirm the intended production support contract.",
+      confidence: "high",
+    };
+    const contradictoryPass = {
+      report: {
+        ...passingReviewReport(),
+        status: "pass",
+        actionable_count: 0,
+        findings: [finding],
+      },
+      quorum: { passed: true, successes: 3, total: 3, threshold: 2 },
+    };
+    expect(execute(contradictoryPass)).toMatchObject({
+      report: {
+        status: "findings",
+        actionable_count: 1,
+        findings: [finding],
+      },
+      quorum: contradictoryPass.quorum,
+    });
+
+    const contradictoryFindings = {
+      report: {
+        ...passingReviewReport(),
+        status: "findings",
+        actionable_count: 7,
+        findings: [],
+      },
+      quorum: { passed: true, successes: 2, total: 3, threshold: 2 },
+    };
+    expect(execute(contradictoryFindings)).toMatchObject({
+      report: { status: "pass", actionable_count: 0, findings: [] },
+    });
+
+    expect(execute({
+      ...contradictoryPass,
+      quorum: { passed: false, successes: 1, total: 3, threshold: 2 },
+    })).toMatchObject({
+      report: { status: "inconclusive", actionable_count: 1, findings: [finding] },
+    });
+  });
+
   it("keeps the trusted automatic GitHub adapter thin and the privacy advisory non-blocking", () => {
     const workflow = fs.readFileSync(path.resolve(process.cwd(), "..", ".github", "workflows", "pr-review.yml"), "utf8");
     const runner = fs.readFileSync(path.resolve(process.cwd(), "..", "scripts", "run-dag-patterns-live-runner.sh"), "utf8");
@@ -843,6 +926,11 @@ describe("PR Review scenario assets", () => {
     handoffActiveRun("pr-review-runtime", "refine", "finalized", finalReview);
     expect(executor.tick("pr-review-runtime")).toBeGreaterThan(0);
     expect(dispatcher.dispatched.at(-1)?.nodeId).toBe("publish");
+    expect(loadRunSnapshot("pr-review-runtime")?.handoffs).toContainEqual(expect.objectContaining({
+      fromNode: "normalize_review",
+      port: "normalized",
+      content: finalReview,
+    }));
 
     handoffActiveRun("pr-review-runtime", "publish", "published", {
       run_id: "pr-review-runtime",


### PR DESCRIPTION
## Summary

- add a deterministic `normalize_review` command after the model-driven refiner
- derive `actionable_count` from `findings.length`
- force report status to `pass`, `findings`, or `inconclusive` from findings and quorum state
- publish and persist only the normalized `FinalReview`

## Root cause

PR #91 exposed a contract inconsistency in the review harness: the refiner emitted `status: pass` while retaining one finding and `actionable_count: 1`. The deterministic artifact validator correctly rejected that contradictory report, causing the review check to fail even though the DAG completed.

This change keeps review judgment in the model layer but moves the structural invariant into a deterministic DAG node.

## Validation

- `npm --prefix homerail_manager test -- --run tests/pr-review-scenario.test.ts`
- 13/13 PR Review scenario tests passed
- regression coverage includes contradictory pass/findings output, the inverse mismatch, and rejected quorum handling
