### PR TITLE
Fix live DAG node logs and handoff following

### DIFF
--- a/agent-ui/src/api/services/dag-api.test.ts
+++ b/agent-ui/src/api/services/dag-api.test.ts
@@ -170,6 +170,23 @@ describe('DAG API', () => {
             content: { type: 'content', content: 'Verified' }
           },
           {
+            role: 'worker',
+            type: 'response',
+            timestamp: '2026-07-10T00:00:02Z',
+            targetId: 'worker-1',
+            content: {
+              text: 'Persisted worker response',
+              run_id: 'run-1',
+              node_id: 'plan',
+              session_id: 'session-1'
+            }
+          },
+          {
+            role: 'manager',
+            type: 'response',
+            content: { text: 'Not a node response' }
+          },
+          {
             targetId: 'worker-1',
             content: { event: 'thinking', summary: 'Checking behavior' }
           },
@@ -198,21 +215,26 @@ describe('DAG API', () => {
 
     const messages = await getDagNodeChat('run-1', 'plan')
 
-    expect(messages).toHaveLength(5)
+    expect(messages).toHaveLength(6)
     expect(messages[0]).toMatchObject({
       type: 'text',
       content: 'Implemented',
       worker_id: 'worker-1'
     })
     expect(messages[1]).toMatchObject({ type: 'text', content: 'Verified' })
-    expect(messages[2]).toMatchObject({ type: 'thinking', content: 'Checking behavior' })
-    expect(messages[3]).toMatchObject({
+    expect(messages[2]).toMatchObject({
+      type: 'text',
+      content: 'Persisted worker response',
+      worker_id: 'worker-1'
+    })
+    expect(messages[3]).toMatchObject({ type: 'thinking', content: 'Checking behavior' })
+    expect(messages[4]).toMatchObject({
       type: 'tool_use',
       message_id: 'tool-1',
       tool_name: 'handoff',
       tool_input: { artifact: 'review' }
     })
-    expect(messages[4]).toMatchObject({
+    expect(messages[5]).toMatchObject({
       type: 'tool_result',
       message_id: 'tool-1',
       tool_result: 'done',

--- a/agent-ui/src/api/services/dag-api.ts
+++ b/agent-ui/src/api/services/dag-api.ts
@@ -193,7 +193,22 @@ function transformChatEntries(entries: any[]): DAGChatMessage[] {
     const event = content.event || content.type
     const timestamp = entry.timestamp ? new Date(entry.timestamp).toISOString() : new Date().toISOString()
 
-    if (event === 'text' || event === 'content') {
+    // Worker sendContent() persists ordinary assistant output as a response
+    // envelope without an event discriminator:
+    // { role: "worker", type: "response", content: { text, run_id, node_id } }.
+    // Keep the discriminator-based stream formats, but also accept that
+    // production persistence contract without treating prompts/debug entries
+    // as assistant messages.
+    const isPersistedWorkerText = !event
+      && entry?.type === 'response'
+      && typeof content.text === 'string'
+      && (
+        entry?.role === 'worker'
+        || entry?.role === 'node'
+        || (typeof content.run_id === 'string' && typeof content.node_id === 'string')
+      )
+
+    if (event === 'text' || event === 'content' || isPersistedWorkerText) {
       // worker 的 sendContent 发 {type:"content", data:{text,...}} 或 stream {event:"text"...}
       const text = content.text ?? (typeof content.content === 'string' ? content.content : '')
       if (text) {

--- a/agent-ui/src/components/agent/dag-runtime/DagRuntimeOverlay.vue
+++ b/agent-ui/src/components/agent/dag-runtime/DagRuntimeOverlay.vue
@@ -365,6 +365,22 @@ watch(() => store.nodes.length, () => {
   if (view.value === 'dag_graph' && !focusedNodeId.value) initNodeFocus()
 })
 
+// The store follows a live handoff only when the user was already following
+// the active node. Mirror that authoritative selection into the overlay's
+// keyboard focus and, when open, the detail drawer.
+watch(
+  () => store.selectedNodeId,
+  (nodeId) => {
+    if (view.value !== 'dag_graph') return
+    if (!nodeId) {
+      if (selectedNodeId.value) selectedNodeId.value = null
+      return
+    }
+    focusedNodeId.value = nodeId
+    if (selectedNodeId.value) selectedNodeId.value = nodeId
+  },
+)
+
 watch(
   () => props.initialRunId,
   (runId) => {

--- a/agent-ui/src/composables/useDagNodeMessages.test.ts
+++ b/agent-ui/src/composables/useDagNodeMessages.test.ts
@@ -87,4 +87,52 @@ describe('useDagNodeMessages realtime invalidation', () => {
 
     expect(api.getDagNodeChat).toHaveBeenCalledTimes(1)
   })
+
+  it('refreshes periodically while chat invalidations continue without a quiet gap', async () => {
+    const Harness = defineComponent({
+      setup() {
+        useDagNodeMessages(ref('run-live'), ref('review'), ref(false))
+        return () => h('div')
+      },
+    })
+    root = document.createElement('div')
+    document.body.appendChild(root)
+    app = createApp(Harness)
+    app.mount(root)
+    await nextTick()
+    await vi.waitFor(() => expect(api.getDagNodeChat).toHaveBeenCalledTimes(1))
+
+    for (let elapsed = 0; elapsed < 1_200; elapsed += 50) {
+      eventBus.emit('dag:node_chat_updated', {
+        runId: 'run-live',
+        nodeId: 'review',
+        timestamp: new Date().toISOString(),
+      })
+      await vi.advanceTimersByTimeAsync(50)
+    }
+
+    expect(api.getDagNodeChat.mock.calls.length).toBeGreaterThanOrEqual(4)
+    expect(api.getDagNodeChat.mock.calls.length).toBeLessThanOrEqual(6)
+  })
+
+  it('loads the next node immediately when live selection follows a handoff', async () => {
+    const nodeId = ref<string | null>('review')
+    const Harness = defineComponent({
+      setup() {
+        useDagNodeMessages(ref('run-live'), nodeId, ref(false))
+        return () => h('div')
+      },
+    })
+    root = document.createElement('div')
+    document.body.appendChild(root)
+    app = createApp(Harness)
+    app.mount(root)
+    await nextTick()
+    await vi.waitFor(() => expect(api.getDagNodeChat).toHaveBeenCalledWith('run-live', 'review'))
+
+    nodeId.value = 'implement'
+    await nextTick()
+
+    expect(api.getDagNodeChat).toHaveBeenLastCalledWith('run-live', 'implement')
+  })
 })

--- a/agent-ui/src/composables/useDagNodeMessages.ts
+++ b/agent-ui/src/composables/useDagNodeMessages.ts
@@ -25,8 +25,13 @@ export function useDagNodeMessages(
   const loading = ref(false)
   const error = ref<string | null>(null)
   const nodeName = ref('')
+  const REFRESH_INTERVAL_MS = 300
   let refreshTimer: number | undefined
+  let refreshInFlight = false
+  let refreshPending = false
+  let lastRefreshStartedAt = Number.NEGATIVE_INFINITY
   let requestGeneration = 0
+  let disposed = false
 
   // ==========================================================================
   // 获取聊天记录
@@ -54,14 +59,34 @@ export function useDagNodeMessages(
     }
   }
 
+  function runScheduledRefresh() {
+    refreshTimer = undefined
+    if (disposed || refreshInFlight) return
+
+    const runId = dagRunId.value
+    const nodeId = selectedNodeId.value
+    if (!runId || !nodeId) {
+      refreshPending = false
+      return
+    }
+
+    refreshPending = false
+    refreshInFlight = true
+    lastRefreshStartedAt = Date.now()
+    void fetchChat(runId, nodeId, isSelectedManager.value, true).finally(() => {
+      refreshInFlight = false
+      if (refreshPending && !disposed) scheduleRefresh()
+    })
+  }
+
   function scheduleRefresh() {
-    if (refreshTimer !== undefined) window.clearTimeout(refreshTimer)
-    refreshTimer = window.setTimeout(() => {
-      refreshTimer = undefined
-      const runId = dagRunId.value
-      const nodeId = selectedNodeId.value
-      if (runId && nodeId) void fetchChat(runId, nodeId, isSelectedManager.value, true)
-    }, 100)
+    if (disposed) return
+    refreshPending = true
+    if (refreshTimer !== undefined || refreshInFlight) return
+
+    const elapsed = Date.now() - lastRefreshStartedAt
+    const delay = Math.max(0, REFRESH_INTERVAL_MS - elapsed)
+    refreshTimer = window.setTimeout(runScheduledRefresh, delay)
   }
 
   // ==========================================================================
@@ -71,6 +96,11 @@ export function useDagNodeMessages(
   watch(
     [selectedNodeId, dagRunId],
     ([nodeId, runId]) => {
+      refreshPending = false
+      if (refreshTimer !== undefined) {
+        window.clearTimeout(refreshTimer)
+        refreshTimer = undefined
+      }
       if (!nodeId || !runId) {
         messages.value = []
         nodeName.value = ''
@@ -109,6 +139,7 @@ export function useDagNodeMessages(
   eventBus.on('dag:node_chat_updated', onNodeChatUpdated)
 
   onUnmounted(() => {
+    disposed = true
     eventBus.off('dag:node_message', onNodeMessage)
     eventBus.off('dag:node_chat_updated', onNodeChatUpdated)
     if (refreshTimer !== undefined) window.clearTimeout(refreshTimer)

--- a/agent-ui/src/stores/agent/dag-events.test.ts
+++ b/agent-ui/src/stores/agent/dag-events.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { nextTick, ref } from 'vue'
 import { clearAllListeners, eventBus } from '@/utils/eventBus'
-import type { DAGExecution, DAGTaskNode } from '@/api/types/dag.types'
+import type { DAGEdge, DAGExecution, DAGTaskNode } from '@/api/types/dag.types'
 import { bindAgentDagEvents } from './dag-events'
 
 const ws = vi.hoisted(() => ({
@@ -29,10 +29,10 @@ const api = vi.hoisted(() => ({ getDagStatus: vi.fn() }))
 vi.mock('@/api/clients/events-ws', () => ({ voiceWs: ws }))
 vi.mock('@/api/services/dag-api', () => ({ getDagStatus: api.getDagStatus }))
 
-function taskNode(status: DAGTaskNode['status'] = 'ready'): DAGTaskNode {
+function taskNode(status: DAGTaskNode['status'] = 'ready', id = 'review'): DAGTaskNode {
   return {
-    id: 'review',
-    name: 'Review',
+    id,
+    name: id,
     status,
     agent_id: 'reviewer',
     agent_name: 'Reviewer',
@@ -52,9 +52,18 @@ function execution(status: DAGExecution['status'] = 'running'): DAGExecution {
   }
 }
 
-function bind() {
+function bind(options: {
+  nodes?: DAGTaskNode[]
+  edges?: DAGEdge[]
+  selectedNodeId?: string | null
+} = {}) {
   const dagExecution = ref<DAGExecution | null>(execution())
-  const nodes = ref<DAGTaskNode[]>(dagExecution.value!.nodes)
+  const nodes = ref<DAGTaskNode[]>(options.nodes ?? dagExecution.value!.nodes)
+  const edges = ref<DAGEdge[]>(options.edges ?? [])
+  const selectedNodeId = ref<string | null>(options.selectedNodeId ?? null)
+  const selectNode = vi.fn((nodeId: string | null) => {
+    selectedNodeId.value = nodeId
+  })
   const setDagExecution = vi.fn((next: DAGExecution) => {
     dagExecution.value = next
     nodes.value = next.nodes
@@ -63,16 +72,16 @@ function bind() {
     currentRunId: ref<string | null>('run-live'),
     dagExecution,
     nodes,
-    edges: ref([]),
-    selectedNodeId: ref<string | null>(null),
+    edges,
+    selectedNodeId,
     chatMessages: ref([]),
     wsStreamedCount: ref(0),
     persist: vi.fn(),
     setDagExecution,
-    selectNode: vi.fn(),
+    selectNode,
   })
   controller.initialize()
-  return { dagExecution, nodes, setDagExecution, controller }
+  return { dagExecution, nodes, selectedNodeId, selectNode, setDagExecution, controller }
 }
 
 describe('agent DAG websocket events', () => {
@@ -165,5 +174,46 @@ describe('agent DAG websocket events', () => {
     expect(ws.stateHandler).toBeUndefined()
     expect(state.dagExecution.value?.status).toBe('running')
     expect(ws.connect).toHaveBeenCalledOnce()
+  })
+
+  it('follows a handoff from the active node to its newly dispatched successor', async () => {
+    const state = bind({
+      nodes: [taskNode('running', 'review'), taskNode('pending', 'implement')],
+      edges: [{ id: 'review-implement', source: 'review', target: 'implement', condition: 'success' }],
+      selectedNodeId: 'review',
+    })
+
+    ws.wildcardHandler?.({
+      type: 'dag:handoff',
+      payload: { runId: 'run-live', fromNode: 'review', port: 'done' },
+    })
+    await nextTick()
+    expect(state.selectedNodeId.value).toBe('review')
+
+    ws.wildcardHandler?.({
+      type: 'dag:node_dispatched',
+      payload: { runId: 'run-live', nodeId: 'implement' },
+    })
+    await nextTick()
+
+    expect(state.selectNode).toHaveBeenCalledWith('implement')
+    expect(state.selectedNodeId.value).toBe('implement')
+  })
+
+  it('does not steal a manual selection of a historical node', async () => {
+    const state = bind({
+      nodes: [taskNode('completed', 'review'), taskNode('pending', 'implement')],
+      edges: [{ id: 'review-implement', source: 'review', target: 'implement', condition: 'success' }],
+      selectedNodeId: 'review',
+    })
+
+    ws.wildcardHandler?.({
+      type: 'dag:node_dispatched',
+      payload: { runId: 'run-live', nodeId: 'implement' },
+    })
+    await nextTick()
+
+    expect(state.selectNode).not.toHaveBeenCalled()
+    expect(state.selectedNodeId.value).toBe('review')
   })
 })

--- a/agent-ui/src/stores/agent/dag-events.ts
+++ b/agent-ui/src/stores/agent/dag-events.ts
@@ -30,6 +30,7 @@ export function bindAgentDagEvents(ctx: AgentDagEventBindings): AgentDagEventCon
   let reconnectRefreshTimer: ReturnType<typeof setTimeout> | null = null
   let reconnectRefreshInFlight: Promise<void> | null = null
   let reconnectRefreshPending = false
+  let pendingActiveFollowFromNode: string | null = null
   const cleanupHandlers: Array<() => void> = []
 
   function eventRunId(data: any): string | undefined {
@@ -300,13 +301,62 @@ export function bindAgentDagEvents(ctx: AgentDagEventBindings): AgentDagEventCon
       }),
       watch(
         () => ctx.nodes.value.map(n => ({ id: n.id, status: n.status })),
-        (newNodes) => {
-          const runningNode = newNodes.find(n => n.status === 'running')
-          if (runningNode && !ctx.selectedNodeId.value) {
-            ctx.selectNode(runningNode.id)
+        (newNodes, previousNodes) => {
+          const selectedId = ctx.selectedNodeId.value
+          const previousSelected = previousNodes?.find(n => n.id === selectedId)
+          const currentSelected = newNodes.find(n => n.id === selectedId)
+          const isLive = (status?: DAGNodeStatus) => (
+            status === 'running' || status === 'waiting_for_command' || status === 'ready'
+          )
+
+          // Remember that the user was following the active node even if the
+          // handoff and downstream dispatch arrive in separate websocket turns.
+          if (
+            selectedId
+            && isLive(previousSelected?.status)
+            && !isLive(currentSelected?.status)
+          ) {
+            pendingActiveFollowFromNode = selectedId
+          }
+
+          const liveNodes = newNodes.filter(n => isLive(n.status))
+          if (!selectedId) {
+            const preferred = liveNodes.find(n => n.status === 'running')
+              ?? liveNodes.find(n => n.status === 'waiting_for_command')
+              ?? liveNodes[0]
+            if (preferred) ctx.selectNode(preferred.id)
+            return
+          }
+
+          if (pendingActiveFollowFromNode !== selectedId || liveNodes.length === 0) return
+
+          const newlyLiveIds = new Set(liveNodes
+            .filter(node => !isLive(previousNodes?.find(previous => previous.id === node.id)?.status))
+            .map(node => node.id))
+          const directSuccessor = ctx.edges.value.find(edge => (
+            edge.source === selectedId && newlyLiveIds.has(edge.target)
+          ))?.target
+          const nextNode = liveNodes.find(node => node.id === directSuccessor)
+            ?? liveNodes.find(node => newlyLiveIds.has(node.id) && node.status === 'running')
+            ?? liveNodes.find(node => newlyLiveIds.has(node.id))
+            ?? liveNodes.find(node => node.status === 'running')
+            ?? liveNodes[0]
+
+          if (nextNode.id !== selectedId) {
+            pendingActiveFollowFromNode = null
+            ctx.selectNode(nextNode.id)
           }
         },
       ),
+      watch(ctx.selectedNodeId, (nodeId, previousNodeId) => {
+        if (
+          pendingActiveFollowFromNode
+          && nodeId !== previousNodeId
+          && nodeId !== pendingActiveFollowFromNode
+        ) {
+          pendingActiveFollowFromNode = null
+        }
+      }),
     )
     voiceWs.connect()
   }
@@ -316,6 +366,7 @@ export function bindAgentDagEvents(ctx: AgentDagEventBindings): AgentDagEventCon
     initialized = false
     lifecycle++
     reconnectRefreshPending = false
+    pendingActiveFollowFromNode = null
     reconnectRefreshInFlight = null
     if (reconnectRefreshTimer) {
       clearTimeout(reconnectRefreshTimer)


### PR DESCRIPTION
## Summary

- render persisted Worker response text that does not carry a stream `event`/`type` discriminator
- replace trailing-only chat refresh debounce with bounded 300 ms coalescing so continuous output remains visible
- follow active-node handoffs into the downstream node and keep an open detail drawer synchronized
- preserve manual selection when the user is inspecting a historical node
- add regression coverage for production chat envelopes, continuous invalidation streams, and split handoff/dispatch timing

## Root cause

Production `sendContent()` entries are persisted as response envelopes containing `content.text`, `run_id`, and `node_id`, but the UI only accepted synthetic stream payloads with `event: text` or `type: content`. In addition, every chat invalidation reset a trailing debounce timer, so a continuously emitting task could starve refreshes indefinitely. Finally, node auto-selection only ran when no node was selected, while the full-screen overlay kept a separate local selection that did not mirror store updates.

## Impact

Node logs now update throughout long-running tasks, ordinary assistant text is no longer omitted, and an open node drawer follows a live handoff without stealing an intentional historical-node selection.

## Validation

- `npm test` — 80 test files, 418 tests passed
- `npm run typecheck`
- `npm run build`
- browser regression against historical run `64bc51a3221adceb230420b4`: 173 renderable `fix` messages including previously omitted plain text
- 24 invalidations over 1.2 seconds produced 5 bounded UI refreshes
- browser-level `handoff` → `node_dispatched` event flow moved the open drawer from `fix` to `fix_gate`
