### PR TITLE
Fix deferred workspace read roots

### DIFF
--- a/homerail_worker/src/__tests__/workspace-read-policy.test.ts
+++ b/homerail_worker/src/__tests__/workspace-read-policy.test.ts
@@ -77,10 +77,58 @@ describe("Claude workspace read tool policy", () => {
     });
   });
 
+  it("defers missing declared roots until tool use and allows them after creation", async () => {
+    const hook = createWorkspaceReadToolHook(workspace, {
+      writable_paths: ["deferred"],
+      readonly_paths: [],
+    });
+
+    await expect(hook({
+      hook_event_name: "PreToolUse",
+      tool_name: "Read",
+      tool_input: { file_path: path.join(workspace, "deferred", "later.txt") },
+      tool_use_id: "tool-missing",
+    } as never, "tool-missing", { signal: new AbortController().signal })).resolves.toMatchObject({
+      hookSpecificOutput: { permissionDecision: "deny" },
+    });
+
+    fs.mkdirSync(path.join(workspace, "deferred"));
+    fs.writeFileSync(path.join(workspace, "deferred", "later.txt"), "later");
+
+    await expect(hook({
+      hook_event_name: "PreToolUse",
+      tool_name: "Read",
+      tool_input: { file_path: path.join(workspace, "deferred", "later.txt") },
+      tool_use_id: "tool-created",
+    } as never, "tool-created", { signal: new AbortController().signal })).resolves.toMatchObject({
+      hookSpecificOutput: { permissionDecision: "allow" },
+    });
+  });
+
+  it("denies a deferred declared root that is later created as an escaping symlink", async () => {
+    const hook = createWorkspaceReadToolHook(workspace, {
+      writable_paths: [],
+      readonly_paths: ["deferred-escape"],
+    });
+    fs.symlinkSync(
+      outside,
+      path.join(workspace, "deferred-escape"),
+      process.platform === "win32" ? "junction" : "dir",
+    );
+
+    await expect(hook({
+      hook_event_name: "PreToolUse",
+      tool_name: "Read",
+      tool_input: { file_path: path.join(workspace, "deferred-escape", "secret.txt") },
+      tool_use_id: "tool-deferred-escape",
+    } as never, "tool-deferred-escape", { signal: new AbortController().signal })).resolves.toMatchObject({
+      hookSpecificOutput: { permissionDecision: "deny" },
+    });
+  });
+
   it("does not change policy for non-read built-in tools", async () => {
     await expect(decide("Write", { file_path: "/outside", content: "x" })).resolves.toEqual({
       continue: true,
     });
   });
 });
-

--- a/homerail_worker/src/agent/workspace-read-policy.ts
+++ b/homerail_worker/src/agent/workspace-read-policy.ts
@@ -36,20 +36,44 @@ function safeGlobPattern(value: unknown): boolean {
     && !normalized.split("/").includes("..");
 }
 
-function resolvedPolicyRoots(workspace: string, access: DagWorkspaceAccess): string[] {
-  const workspaceRoot = realpathSync(path.resolve(workspace));
+function policyRootPaths(workspaceRoot: string, access: DagWorkspaceAccess): string[] {
   const roots = new Set<string>();
   for (const configured of [...access.writable_paths, ...(access.readonly_paths ?? [])]) {
     if (!safePolicyPath(configured)) {
       throw new Error(`workspace read policy path must be relative and traversal-free: ${configured}`);
     }
-    const root = realpathSync(path.resolve(workspaceRoot, configured));
-    if (!isWithin(workspaceRoot, root)) {
+    const rootPath = path.resolve(workspaceRoot, configured);
+    if (!isWithin(workspaceRoot, rootPath)) {
       throw new Error(`workspace read policy root escapes workspace: ${configured}`);
     }
-    roots.add(root);
+    try {
+      const root = realpathSync(rootPath);
+      if (!isWithin(workspaceRoot, root)) {
+        throw new Error(`workspace read policy root escapes workspace: ${configured}`);
+      }
+    } catch (error) {
+      if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) {
+        throw error;
+      }
+      // A writable path may be created later in the agent turn. Keep its
+      // lexical location now, then resolve and contain it at each tool call.
+    }
+    roots.add(rootPath);
   }
   return [...roots];
+}
+
+function isInsideResolvedPolicyRoot(
+  workspaceRoot: string,
+  policyRootPath: string,
+  target: string,
+): boolean {
+  try {
+    const root = realpathSync(policyRootPath);
+    return isWithin(workspaceRoot, root) && isWithin(root, target);
+  } catch {
+    return false;
+  }
 }
 
 function deny(reason: string): ReturnType<HookCallback> {
@@ -74,7 +98,7 @@ export function createWorkspaceReadToolHook(
   access: DagWorkspaceAccess,
 ): HookCallback {
   const workspaceRoot = realpathSync(path.resolve(workspace));
-  const allowedRoots = resolvedPolicyRoots(workspaceRoot, access);
+  const policyRoots = policyRootPaths(workspaceRoot, access);
   return async (input) => {
     const event = input as PreToolUseHookInput;
     const pathField = READ_TOOL_PATH_FIELDS.get(event.tool_name);
@@ -97,7 +121,7 @@ export function createWorkspaceReadToolHook(
     } catch {
       return deny(`${event.tool_name} target could not be resolved inside the declared workspace roots`);
     }
-    if (!allowedRoots.some((root) => isWithin(root, target))) {
+    if (!policyRoots.some((root) => isInsideResolvedPolicyRoot(workspaceRoot, root, target))) {
       return deny(`${event.tool_name} target is outside the declared workspace roots`);
     }
     return {
@@ -109,4 +133,3 @@ export function createWorkspaceReadToolHook(
     };
   };
 }
-


### PR DESCRIPTION
## Summary
- defer canonical resolution for declared workspace roots that do not exist yet
- re-resolve and contain every declared root at read/search tool-use time
- keep missing targets and symlink escapes fail-closed

## Context
The stable post-deploy PR Review of #103 completed successfully but retained one medium runtime finding: hook construction could throw ENOENT before an agent turn when a declared path such as .homerail-runtime is created later. The new regression test reproduced that exact startup failure before this fix.

## Validation
- workspace read policy: 6 passed
- Worker typecheck: passed
- Worker suite: 321 passed, 1 skipped
- CI run 29969125790: Linux Core, Agent UI coverage, and Docker smoke passed; Windows and Live DAG were correctly skipped by path gating
- stable PR Review run 29969125810 / DAG a2a034b3f36ea87b5ecabe53: 24/24 completed, quorum 3/3, 0 actionable findings, privacy clear
- stable Manager revision: 09c488afd82b04e0d5298dcd998561a92b7db677

This is a focused follow-up to #103.