### PR TITLE
Fix Auto Fix secret-scan false positives

### DIFF
--- a/assets/orchestrations/auto-fix.yaml.template
+++ b/assets/orchestrations/auto-fix.yaml.template
@@ -787,22 +787,32 @@ spec:
                 return total - probability * Math.log2(probability);
               }, 0);
             };
-            const isObviousPlaceholder = (value) => {
-              if (value.length > 64) return false;
-              // A marker alone is too broad: require a bounded, low-entropy value as well.
-              const markers = new Set(['test', 'fake', 'dummy', 'example', 'placeholder', 'redacted', 'changeme', 'sample', 'fixture', 'mock']);
+            const placeholderMarkers = new Set(['test', 'fake', 'dummy', 'example', 'placeholder', 'redacted', 'changeme', 'sample', 'fixture', 'mock']);
+            const placeholderWords = new Set([...placeholderMarkers, 'sk', 'pk', 'api', 'key', 'apikey', 'token', 'local', 'dev', 'unit', 'e2e', 'notsecret', 'nosecret', 'notakey', 'nokey', 'testing', 'readiness']);
+            // Keep the exception narrow: explicit placeholder vocabulary is valid only in test-like files.
+            const isTestFixturePath = (file) => typeof file === 'string' && (
+              /(^|\/)(?:tests?|__tests__|fixtures?|examples?|samples?|mocks?)(?:\/|$)/i.test(file) ||
+              /(?:^|\/)[^/]+\.(?:test|spec)\.[^/]+$/i.test(file)
+            );
+            const isObviousPlaceholder = (value, file) => {
+              if (!isTestFixturePath(file) || value.length < 8 || value.length > 64) return false;
               const tokens = value.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
-              return tokens.some((token) => markers.has(token)) && entropy(value) <= 3.5;
+              const placeholderCounter = (token) => /^(?:0+|1+)$/.test(token) && token.length <= 6;
+              return tokens.length >= 2 && tokens.length <= 5 &&
+                tokens.some((token) => placeholderMarkers.has(token)) &&
+                tokens.every((token) => placeholderWords.has(token) || placeholderCounter(token)) &&
+                entropy(value) <= 3.5;
             };
-            const patchLocation = (value, index) => {
+            const patchContext = (value, index) => {
               const preceding = value.slice(0, index).split('\n');
               let file;
               for (const line of preceding) {
-                const match = /^diff --git a\/.+ b\/(.+)$/.exec(line);
-                if (match) file = match[1];
+                const match = /^diff --git a\/(.+?) b\/(.+)$/.exec(line);
+                if (match) file = match[2];
               }
-              return file ? ' (' + file + ', patch line ' + preceding.length + ')' : '';
+              return { file, line: preceding.length };
             };
+            const locationLabel = (context) => context.file ? ' (' + context.file + ', patch line ' + context.line + ')' : '';
             const safeText = (value, source) => {
               const forbidden = [
                 ['a local Windows path', /[A-Za-z]:\\(?:Users|Documents and Settings)\\/i],
@@ -813,12 +823,13 @@ spec:
               ];
               for (const [category, pattern] of forbidden) {
                 const match = pattern.exec(value);
-                if (match) fail('publication ' + source + patchLocation(value, match.index) + ' contains ' + category);
+                if (match) fail('publication ' + source + locationLabel(patchContext(value, match.index)) + ' contains ' + category);
               }
               const credentialAssignment = /\b(api[_-]?key|access[_-]?token|client[_-]?secret)\s*[:=]\s*["']?([A-Za-z0-9_./+=-]{12,})/gi;
               for (const match of value.matchAll(credentialAssignment)) {
-                if (!isObviousPlaceholder(match[2])) {
-                  fail('publication ' + source + patchLocation(value, match.index) + ' contains credential-like ' + match[1].toLowerCase() + ' assignment');
+                const context = patchContext(value, match.index);
+                if (source !== 'patch' || !isObviousPlaceholder(match[2], context.file)) {
+                  fail('publication ' + source + locationLabel(context) + ' contains credential-like ' + match[1].toLowerCase() + ' assignment');
                 }
               }
               const emails = value.match(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi) || [];
@@ -835,7 +846,11 @@ spec:
               if (!arbitration || arbitration.verdict !== 'approve') fail('approved Arbitration input is required');
               if (!summary || typeof summary.review_summary !== 'string' || typeof summary.markdown !== 'string') fail('PublicationSummary input is invalid');
               if (!summary.markdown.includes('#' + issue.issue) || !summary.markdown.includes(issue.revision)) fail('publication markdown must contain issue number and base revision');
-              safeText(JSON.stringify(summary), 'summary');
+              safeText(summary.review_summary, 'review summary');
+              safeText(summary.markdown, 'markdown');
+              if (typeof patch.explanation === 'string') safeText(patch.explanation, 'explanation');
+              for (const item of Array.isArray(patch.test_plan) ? patch.test_plan : []) safeText(String(item), 'test plan');
+              for (const item of patch.files_changed) safeText(String(item), 'changed file');
               safeText(patch.patch, 'patch');
               const result = {
                 status: 'ready', repo: issue.repo, issue: issue.issue, revision: issue.revision,

--- a/assets/orchestrations/auto-fix.yaml.template
+++ b/assets/orchestrations/auto-fix.yaml.template
@@ -842,15 +842,22 @@ spec:
               const arbitration = one(inputs.arbitration);
               const summary = one(inputs.summary);
               if (!issue || typeof issue.repo !== 'string' || !Number.isInteger(issue.issue) || typeof issue.revision !== 'string') fail('IssueContext input is invalid');
-              if (!patch || patch.status !== 'fixed' || typeof patch.patch !== 'string' || !patch.patch || !Array.isArray(patch.files_changed) || patch.files_changed.length < 1) fail('FixCandidate input is invalid');
+              if (
+                !patch || patch.status !== 'fixed' || typeof patch.patch !== 'string' || !patch.patch
+                || typeof patch.explanation !== 'string' || !patch.explanation
+                || !Array.isArray(patch.files_changed) || patch.files_changed.length < 1
+                || !patch.files_changed.every((item) => typeof item === 'string')
+                || !Array.isArray(patch.test_plan)
+                || !patch.test_plan.every((item) => typeof item === 'string')
+              ) fail('FixCandidate input is invalid');
               if (!arbitration || arbitration.verdict !== 'approve') fail('approved Arbitration input is required');
               if (!summary || typeof summary.review_summary !== 'string' || typeof summary.markdown !== 'string') fail('PublicationSummary input is invalid');
               if (!summary.markdown.includes('#' + issue.issue) || !summary.markdown.includes(issue.revision)) fail('publication markdown must contain issue number and base revision');
               safeText(summary.review_summary, 'review summary');
               safeText(summary.markdown, 'markdown');
-              if (typeof patch.explanation === 'string') safeText(patch.explanation, 'explanation');
-              for (const item of Array.isArray(patch.test_plan) ? patch.test_plan : []) safeText(String(item), 'test plan');
-              for (const item of patch.files_changed) safeText(String(item), 'changed file');
+              safeText(patch.explanation, 'explanation');
+              for (const item of patch.test_plan) safeText(item, 'test plan');
+              for (const item of patch.files_changed) safeText(item, 'changed file');
               safeText(patch.patch, 'patch');
               const result = {
                 status: 'ready', repo: issue.repo, issue: issue.issue, revision: issue.revision,

--- a/assets/orchestrations/auto-fix.yaml.template
+++ b/assets/orchestrations/auto-fix.yaml.template
@@ -803,17 +803,31 @@ spec:
                 tokens.every((token) => placeholderWords.has(token) || placeholderCounter(token)) &&
                 entropy(value) <= 3.5;
             };
-            const patchContext = (value, index) => {
-              const preceding = value.slice(0, index).split('\n');
+            const patchLocationResolver = (value) => {
               let file;
-              for (const line of preceding) {
+              let offset = 0;
+              const locations = value.split('\n').map((line, lineIndex) => {
                 const match = /^diff --git a\/(.+?) b\/(.+)$/.exec(line);
                 if (match) file = match[2];
-              }
-              return { file, line: preceding.length };
+                const location = { offset, file, line: lineIndex + 1 };
+                offset += line.length + 1;
+                return location;
+              });
+              return (index) => {
+                let low = 0;
+                let high = locations.length - 1;
+                while (low <= high) {
+                  const middle = (low + high) >>> 1;
+                  if (locations[middle].offset <= index) low = middle + 1;
+                  else high = middle - 1;
+                }
+                const location = locations[Math.max(0, high)];
+                return { file: location.file, line: location.line };
+              };
             };
             const locationLabel = (context) => context.file ? ' (' + context.file + ', patch line ' + context.line + ')' : '';
             const safeText = (value, source) => {
+              const locate = patchLocationResolver(value);
               const forbidden = [
                 ['a local Windows path', /[A-Za-z]:\\(?:Users|Documents and Settings)\\/i],
                 ['a local Unix path', /\/(?:Users|home|vol[0-9]*|mnt)\//],
@@ -823,11 +837,11 @@ spec:
               ];
               for (const [category, pattern] of forbidden) {
                 const match = pattern.exec(value);
-                if (match) fail('publication ' + source + locationLabel(patchContext(value, match.index)) + ' contains ' + category);
+                if (match) fail('publication ' + source + locationLabel(locate(match.index)) + ' contains ' + category);
               }
               const credentialAssignment = /\b(api[_-]?key|access[_-]?token|client[_-]?secret)\s*[:=]\s*["']?([A-Za-z0-9_./+=-]{12,})/gi;
               for (const match of value.matchAll(credentialAssignment)) {
-                const context = patchContext(value, match.index);
+                const context = locate(match.index);
                 if (source !== 'patch' || !isObviousPlaceholder(match[2], context.file)) {
                   fail('publication ' + source + locationLabel(context) + ' contains credential-like ' + match[1].toLowerCase() + ' assignment');
                 }

--- a/assets/orchestrations/auto-fix.yaml.template
+++ b/assets/orchestrations/auto-fix.yaml.template
@@ -779,18 +779,50 @@ spec:
             let stdin = '';
             const fail = (message) => { throw new Error(message); };
             const one = (value) => Array.isArray(value) ? value.at(-1) : undefined;
-            const safeText = (value) => {
+            const entropy = (value) => {
+              const counts = new Map();
+              for (const character of value) counts.set(character, (counts.get(character) || 0) + 1);
+              return [...counts.values()].reduce((total, count) => {
+                const probability = count / value.length;
+                return total - probability * Math.log2(probability);
+              }, 0);
+            };
+            const isObviousPlaceholder = (value) => {
+              if (value.length > 64) return false;
+              // A marker alone is too broad: require a bounded, low-entropy value as well.
+              const markers = new Set(['test', 'fake', 'dummy', 'example', 'placeholder', 'redacted', 'changeme', 'sample', 'fixture', 'mock']);
+              const tokens = value.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+              return tokens.some((token) => markers.has(token)) && entropy(value) <= 3.5;
+            };
+            const patchLocation = (value, index) => {
+              const preceding = value.slice(0, index).split('\n');
+              let file;
+              for (const line of preceding) {
+                const match = /^diff --git a\/.+ b\/(.+)$/.exec(line);
+                if (match) file = match[1];
+              }
+              return file ? ' (' + file + ', patch line ' + preceding.length + ')' : '';
+            };
+            const safeText = (value, source) => {
               const forbidden = [
-                /[A-Za-z]:\\(?:Users|Documents and Settings)\\/i,
-                /\/(?:Users|home|vol[0-9]*|mnt)\//,
-                /\b(?:10\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}|192\.168\.[0-9]{1,3}\.[0-9]{1,3}|172\.(?:1[6-9]|2[0-9]|3[01])\.[0-9]{1,3}\.[0-9]{1,3})\b/,
-                /-----BEGIN [A-Z ]+PRIVATE KEY-----/,
-                /\b(?:api[_-]?key|access[_-]?token|client[_-]?secret)\s*[:=]\s*["']?[A-Za-z0-9_./+=-]{12,}/i,
-                /\bgh[opsu]_[A-Za-z0-9]{20,}\b/,
+                ['a local Windows path', /[A-Za-z]:\\(?:Users|Documents and Settings)\\/i],
+                ['a local Unix path', /\/(?:Users|home|vol[0-9]*|mnt)\//],
+                ['a private network address', /\b(?:10\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}|192\.168\.[0-9]{1,3}\.[0-9]{1,3}|172\.(?:1[6-9]|2[0-9]|3[01])\.[0-9]{1,3}\.[0-9]{1,3})\b/],
+                ['private key material', /-----BEGIN [A-Z ]+PRIVATE KEY-----/],
+                ['a GitHub token', /\bgh[opsu]_[A-Za-z0-9]{20,}\b/],
               ];
-              if (forbidden.some((pattern) => pattern.test(value))) fail('publication contains local or credential material');
+              for (const [category, pattern] of forbidden) {
+                const match = pattern.exec(value);
+                if (match) fail('publication ' + source + patchLocation(value, match.index) + ' contains ' + category);
+              }
+              const credentialAssignment = /\b(api[_-]?key|access[_-]?token|client[_-]?secret)\s*[:=]\s*["']?([A-Za-z0-9_./+=-]{12,})/gi;
+              for (const match of value.matchAll(credentialAssignment)) {
+                if (!isObviousPlaceholder(match[2])) {
+                  fail('publication ' + source + patchLocation(value, match.index) + ' contains credential-like ' + match[1].toLowerCase() + ' assignment');
+                }
+              }
               const emails = value.match(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi) || [];
-              if (!emails.every((email) => /@users\.noreply\.github\.com$/i.test(email))) fail('publication contains a non-noreply email');
+              if (!emails.every((email) => /@users\.noreply\.github\.com$/i.test(email))) fail('publication ' + source + ' contains a non-noreply email');
             };
             process.stdin.on('data', (chunk) => { stdin += chunk; }).on('end', () => {
               const inputs = JSON.parse(stdin);
@@ -803,8 +835,8 @@ spec:
               if (!arbitration || arbitration.verdict !== 'approve') fail('approved Arbitration input is required');
               if (!summary || typeof summary.review_summary !== 'string' || typeof summary.markdown !== 'string') fail('PublicationSummary input is invalid');
               if (!summary.markdown.includes('#' + issue.issue) || !summary.markdown.includes(issue.revision)) fail('publication markdown must contain issue number and base revision');
-              safeText(JSON.stringify(summary));
-              safeText(patch.patch);
+              safeText(JSON.stringify(summary), 'summary');
+              safeText(patch.patch, 'patch');
               const result = {
                 status: 'ready', repo: issue.repo, issue: issue.issue, revision: issue.revision,
                 patch: patch.patch, explanation: patch.explanation, files_changed: patch.files_changed,

--- a/homerail_manager/tests/auto-fix-scenario.test.ts
+++ b/homerail_manager/tests/auto-fix-scenario.test.ts
@@ -243,6 +243,37 @@ describe("Auto Fix scenario asset", () => {
     expect(JSON.parse(result.stdout)).toMatchObject({ status: "ready", patch });
   });
 
+  it.each([
+    { field: "explanation", mutate: (candidate: Record<string, unknown>) => { candidate.explanation = { api_key: "hidden" }; } },
+    { field: "files_changed", mutate: (candidate: Record<string, unknown>) => { candidate.files_changed = [{ api_key: "hidden" }]; } },
+    { field: "test_plan", mutate: (candidate: Record<string, unknown>) => { candidate.test_plan = [{ api_key: "hidden" }]; } },
+  ])("rejects a non-string $field before publication scanning", ({ mutate }) => {
+    const canonical = compileWorkflowSource(fs.readFileSync(WORKFLOW_FILE, "utf8")).canonical!;
+    const commandNode = canonical.nodes.find((node) => node.id === "finalize_publication");
+    if (commandNode?.kind !== "command" || !commandNode.config.command) throw new Error("finalizer command is missing");
+    const revision = "f".repeat(40);
+    const candidate: Record<string, unknown> = {
+      status: "fixed",
+      patch: "diff --git a/a.txt b/a.txt\n--- a/a.txt\n+++ b/a.txt\n@@ -1 +1 @@\n-a\n+b\n",
+      explanation: "repair",
+      files_changed: ["a.txt"],
+      test_plan: ["focused"],
+    };
+    mutate(candidate);
+    const input = {
+      issue: [{ repo: "owner/repo", issue: 92, revision }],
+      patch: [candidate],
+      arbitration: [{ verdict: "approve", summary: "approved", blocking_defects: [] }],
+      summary: [{ review_summary: "approved by consensus", markdown: `# Auto Fix #92\n\nBase: ${revision}\n` }],
+    };
+    const result = spawnSync(process.execPath, commandNode.config.command.slice(1), {
+      cwd: os.tmpdir(), encoding: "utf8", input: JSON.stringify(input),
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("FixCandidate input is invalid");
+    expect(result.stderr).not.toContain("hidden");
+  });
+
   it("rejects real-looking credentials with a redacted, actionable location", () => {
     const canonical = compileWorkflowSource(fs.readFileSync(WORKFLOW_FILE, "utf8")).canonical!;
     const commandNode = canonical.nodes.find((node) => node.id === "finalize_publication");

--- a/homerail_manager/tests/auto-fix-scenario.test.ts
+++ b/homerail_manager/tests/auto-fix-scenario.test.ts
@@ -243,6 +243,35 @@ describe("Auto Fix scenario asset", () => {
     expect(JSON.parse(result.stdout)).toMatchObject({ status: "ready", patch });
   });
 
+  it("scans many test placeholders without rescanning the patch for every match", () => {
+    const canonical = compileWorkflowSource(fs.readFileSync(WORKFLOW_FILE, "utf8")).canonical!;
+    const commandNode = canonical.nodes.find((node) => node.id === "finalize_publication");
+    if (commandNode?.kind !== "command" || !commandNode.config.command) throw new Error("finalizer command is missing");
+    const revision = "1".repeat(40);
+    const additions = Array.from(
+      { length: 4_000 },
+      (_, index) => `+const fixture${index} = { api_key: 'test-api-key-0000' };`,
+    );
+    const patch = [
+      "diff --git a/tests/many.test.ts b/tests/many.test.ts",
+      "--- a/tests/many.test.ts",
+      "+++ b/tests/many.test.ts",
+      `@@ -0,0 +1,${additions.length} @@`,
+      ...additions,
+      "",
+    ].join("\n");
+    const input = {
+      issue: [{ repo: "owner/repo", issue: 92, revision }],
+      patch: [{ status: "fixed", patch, explanation: "repair", files_changed: ["tests/many.test.ts"], test_plan: [] }],
+      arbitration: [{ verdict: "approve", summary: "approved", blocking_defects: [] }],
+      summary: [{ review_summary: "approved by consensus", markdown: `# Auto Fix #92\n\nBase: ${revision}\n` }],
+    };
+    const result = spawnSync(process.execPath, commandNode.config.command.slice(1), {
+      cwd: os.tmpdir(), encoding: "utf8", input: JSON.stringify(input), timeout: 3_000,
+    });
+    expect(result.status, result.stderr).toBe(0);
+  });
+
   it.each([
     { field: "explanation", mutate: (candidate: Record<string, unknown>) => { candidate.explanation = { api_key: "hidden" }; } },
     { field: "files_changed", mutate: (candidate: Record<string, unknown>) => { candidate.files_changed = [{ api_key: "hidden" }]; } },

--- a/homerail_manager/tests/auto-fix-scenario.test.ts
+++ b/homerail_manager/tests/auto-fix-scenario.test.ts
@@ -217,4 +217,89 @@ describe("Auto Fix scenario asset", () => {
     });
   });
 
+  it("allows obvious test credential placeholders in a candidate patch", () => {
+    const canonical = compileWorkflowSource(fs.readFileSync(WORKFLOW_FILE, "utf8")).canonical!;
+    const commandNode = canonical.nodes.find((node) => node.id === "finalize_publication");
+    if (commandNode?.kind !== "command" || !commandNode.config.command) throw new Error("finalizer command is missing");
+    const revision = "b".repeat(40);
+    const patch = [
+      "diff --git a/example.test.ts b/example.test.ts",
+      "--- a/example.test.ts",
+      "+++ b/example.test.ts",
+      "@@ -0,0 +1 @@",
+      "+const credential = { api_key: 'test-api-key-0000' };",
+      "",
+    ].join("\n");
+    const input = {
+      issue: [{ repo: "owner/repo", issue: 92, revision }],
+      patch: [{ status: "fixed", patch, explanation: "repair", files_changed: ["example.test.ts"], test_plan: ["focused"] }],
+      arbitration: [{ verdict: "approve", summary: "approved", blocking_defects: [] }],
+      summary: [{ review_summary: "approved by consensus", markdown: `# Auto Fix #92\n\nBase: ${revision}\n` }],
+    };
+    const result = spawnSync(process.execPath, commandNode.config.command.slice(1), {
+      cwd: os.tmpdir(), encoding: "utf8", input: JSON.stringify(input),
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({ status: "ready", patch });
+  });
+
+  it("rejects real-looking credentials with a redacted, actionable location", () => {
+    const canonical = compileWorkflowSource(fs.readFileSync(WORKFLOW_FILE, "utf8")).canonical!;
+    const commandNode = canonical.nodes.find((node) => node.id === "finalize_publication");
+    if (commandNode?.kind !== "command" || !commandNode.config.command) throw new Error("finalizer command is missing");
+    const revision = "c".repeat(40);
+    const credential = ["r4Nd0m", "S3cr3t", "V4lu3", "9XyZ"].join("");
+    const patch = [
+      "diff --git a/src/config.ts b/src/config.ts",
+      "--- a/src/config.ts",
+      "+++ b/src/config.ts",
+      "@@ -0,0 +1 @@",
+      `+const client_secret = '${credential}';`,
+      "",
+    ].join("\n");
+    const input = {
+      issue: [{ repo: "owner/repo", issue: 92, revision }],
+      patch: [{ status: "fixed", patch, explanation: "repair", files_changed: ["src/config.ts"], test_plan: [] }],
+      arbitration: [{ verdict: "approve", summary: "approved", blocking_defects: [] }],
+      summary: [{ review_summary: "approved by consensus", markdown: `# Auto Fix #92\n\nBase: ${revision}\n` }],
+    };
+    const result = spawnSync(process.execPath, commandNode.config.command.slice(1), {
+      cwd: os.tmpdir(), encoding: "utf8", input: JSON.stringify(input),
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("publication patch (src/config.ts, patch line 5) contains credential-like client_secret assignment");
+    expect(result.stderr).not.toContain(credential);
+  });
+
+  it.each([
+    {
+      name: "private network address",
+      sensitive: ["192", "168", "100", "112"].join("."),
+      diagnostic: "contains a private network address",
+    },
+    {
+      name: "non-noreply email",
+      sensitive: ["local", "example.com"].join("@"),
+      diagnostic: "contains a non-noreply email",
+    },
+  ])("keeps $name publication protection strict", ({ sensitive, diagnostic }) => {
+    const canonical = compileWorkflowSource(fs.readFileSync(WORKFLOW_FILE, "utf8")).canonical!;
+    const commandNode = canonical.nodes.find((node) => node.id === "finalize_publication");
+    if (commandNode?.kind !== "command" || !commandNode.config.command) throw new Error("finalizer command is missing");
+    const revision = "d".repeat(40);
+    const patch = `diff --git a/a.txt b/a.txt\n--- a/a.txt\n+++ b/a.txt\n@@ -0,0 +1 @@\n+${sensitive}\n`;
+    const input = {
+      issue: [{ repo: "owner/repo", issue: 92, revision }],
+      patch: [{ status: "fixed", patch, explanation: "repair", files_changed: ["a.txt"], test_plan: [] }],
+      arbitration: [{ verdict: "approve", summary: "approved", blocking_defects: [] }],
+      summary: [{ review_summary: "approved by consensus", markdown: `# Auto Fix #92\n\nBase: ${revision}\n` }],
+    };
+    const result = spawnSync(process.execPath, commandNode.config.command.slice(1), {
+      cwd: os.tmpdir(), encoding: "utf8", input: JSON.stringify(input),
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(diagnostic);
+    expect(result.stderr).not.toContain(sensitive);
+  });
+
 });

--- a/homerail_manager/tests/auto-fix-scenario.test.ts
+++ b/homerail_manager/tests/auto-fix-scenario.test.ts
@@ -273,6 +273,44 @@ describe("Auto Fix scenario asset", () => {
 
   it.each([
     {
+      name: "placeholder outside a test fixture path",
+      file: "src/config.ts",
+      credential: ["test", "api", "key", "0000"].join("-"),
+    },
+    {
+      name: "marker-bearing value with an unrecognized secret token",
+      file: "tests/config.test.ts",
+      credential: ["sk", "test", "realcredential"].join("-"),
+    },
+  ])("rejects $name", ({ file, credential }) => {
+    const canonical = compileWorkflowSource(fs.readFileSync(WORKFLOW_FILE, "utf8")).canonical!;
+    const commandNode = canonical.nodes.find((node) => node.id === "finalize_publication");
+    if (commandNode?.kind !== "command" || !commandNode.config.command) throw new Error("finalizer command is missing");
+    const revision = "e".repeat(40);
+    const patch = [
+      `diff --git a/${file} b/${file}`,
+      `--- a/${file}`,
+      `+++ b/${file}`,
+      "@@ -0,0 +1 @@",
+      `+const api_key = '${credential}';`,
+      "",
+    ].join("\n");
+    const input = {
+      issue: [{ repo: "owner/repo", issue: 92, revision }],
+      patch: [{ status: "fixed", patch, explanation: "repair", files_changed: [file], test_plan: [] }],
+      arbitration: [{ verdict: "approve", summary: "approved", blocking_defects: [] }],
+      summary: [{ review_summary: "approved by consensus", markdown: `# Auto Fix #92\n\nBase: ${revision}\n` }],
+    };
+    const result = spawnSync(process.execPath, commandNode.config.command.slice(1), {
+      cwd: os.tmpdir(), encoding: "utf8", input: JSON.stringify(input),
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(`publication patch (${file}, patch line 5) contains credential-like api_key assignment`);
+    expect(result.stderr).not.toContain(credential);
+  });
+
+  it.each([
+    {
       name: "private network address",
       sensitive: ["192", "168", "100", "112"].join("."),
       diagnostic: "contains a private network address",

--- a/scripts/auto-fix-artifacts.test.mjs
+++ b/scripts/auto-fix-artifacts.test.mjs
@@ -52,7 +52,87 @@ test("validates exact patch bytes and normalized Markdown artifact bytes", () =>
         `${unsafeMarkdown}\n`,
       );
     },
-    /local or credential material/,
+    /private network address/,
+  );
+});
+
+test("allows obvious credential placeholders only in test fixture patches", () => {
+  const placeholder = ["test", "api", "key", "0000"].join("-");
+  const testFile = "tests/provider.test.ts";
+  const testPatch = [
+    `diff --git a/${testFile} b/${testFile}`,
+    `--- a/${testFile}`,
+    `+++ b/${testFile}`,
+    "@@ -0,0 +1 @@",
+    `+const api_key = '${placeholder}';`,
+    "",
+  ].join("\n");
+  validateAutoFixArtifacts(
+    command,
+    { ...publication, patch: testPatch, files_changed: [testFile] },
+    testPatch,
+    publication.markdown,
+  );
+
+  const productionFile = "src/provider.ts";
+  const productionPatch = testPatch
+    .replaceAll(testFile, productionFile);
+  assert.throws(
+    () => validateAutoFixArtifacts(
+      command,
+      { ...publication, patch: productionPatch, files_changed: [productionFile] },
+      productionPatch,
+      publication.markdown,
+    ),
+    (error) => {
+      assert.match(error.message, /src\/provider\.ts, patch line 5.*credential-like api_key assignment/);
+      assert.equal(error.message.includes(placeholder), false);
+      return true;
+    },
+  );
+});
+
+test("rejects marker-bearing secret-like values and redacts the value", () => {
+  const credential = ["sk", "test", "realcredential"].join("-");
+  const file = "tests/provider.test.ts";
+  const unsafePatch = [
+    `diff --git a/${file} b/${file}`,
+    `--- a/${file}`,
+    `+++ b/${file}`,
+    "@@ -0,0 +1 @@",
+    `+const client_secret = '${credential}';`,
+    "",
+  ].join("\n");
+  assert.throws(
+    () => validateAutoFixArtifacts(
+      command,
+      { ...publication, patch: unsafePatch, files_changed: [file] },
+      unsafePatch,
+      publication.markdown,
+    ),
+    (error) => {
+      assert.match(error.message, /tests\/provider\.test\.ts, patch line 5.*credential-like client_secret assignment/);
+      assert.equal(error.message.includes(credential), false);
+      return true;
+    },
+  );
+});
+
+test("scans publication fields before JSON escaping", () => {
+  const credential = ["r4Nd0m", "S3cr3t", "V4lu3", "9XyZ"].join("");
+  const unsafeExplanation = `Configuration uses api_key: "${credential}"`;
+  assert.throws(
+    () => validateAutoFixArtifacts(
+      command,
+      { ...publication, explanation: unsafeExplanation },
+      patch,
+      publication.markdown,
+    ),
+    (error) => {
+      assert.match(error.message, /publication explanation contains credential-like api_key assignment/);
+      assert.equal(error.message.includes(credential), false);
+      return true;
+    },
   );
 });
 

--- a/scripts/auto-fix-artifacts.test.mjs
+++ b/scripts/auto-fix-artifacts.test.mjs
@@ -92,6 +92,27 @@ test("allows obvious credential placeholders only in test fixture patches", () =
   );
 });
 
+test("scans many placeholder assignments without quadratic patch rescans", () => {
+  const additions = Array.from(
+    { length: 4_000 },
+    (_, index) => `+const fixture${index} = { api_key: 'test-api-key-0000' };`,
+  );
+  const patch = [
+    "diff --git a/tests/many.test.ts b/tests/many.test.ts",
+    "--- a/tests/many.test.ts",
+    "+++ b/tests/many.test.ts",
+    `@@ -0,0 +1,${additions.length} @@`,
+    ...additions,
+    "",
+  ].join("\n");
+  validateAutoFixArtifacts(
+    command,
+    { ...publication, patch, files_changed: ["tests/many.test.ts"] },
+    patch,
+    publication.markdown,
+  );
+});
+
 test("rejects marker-bearing secret-like values and redacts the value", () => {
   const credential = ["sk", "test", "realcredential"].join("-");
   const file = "tests/provider.test.ts";

--- a/scripts/validate-auto-fix-artifacts.mjs
+++ b/scripts/validate-auto-fix-artifacts.mjs
@@ -47,14 +47,27 @@ function isObviousPlaceholder(value, file) {
     && entropy(value) <= 3.5;
 }
 
-function patchContext(value, index) {
-  const preceding = value.slice(0, index).split("\n");
+function patchLocationResolver(value) {
   let file;
-  for (const line of preceding) {
+  let offset = 0;
+  const locations = value.split("\n").map((line, lineIndex) => {
     const match = /^diff --git a\/(.+?) b\/(.+)$/.exec(line);
     if (match) file = match[2];
-  }
-  return { file, line: preceding.length };
+    const location = { offset, file, line: lineIndex + 1 };
+    offset += line.length + 1;
+    return location;
+  });
+  return (index) => {
+    let low = 0;
+    let high = locations.length - 1;
+    while (low <= high) {
+      const middle = (low + high) >>> 1;
+      if (locations[middle].offset <= index) low = middle + 1;
+      else high = middle - 1;
+    }
+    const location = locations[Math.max(0, high)];
+    return { file: location.file, line: location.line };
+  };
 }
 
 function locationLabel(context) {
@@ -62,6 +75,7 @@ function locationLabel(context) {
 }
 
 function assertSafePublicationText(value, source) {
+  const locate = patchLocationResolver(value);
   const forbidden = [
     ["a local Windows path", /[A-Za-z]:\\(?:Users|Documents and Settings)\\/i],
     ["a local Unix path", /\/(?:Users|home|vol[0-9]*|mnt)\//],
@@ -72,12 +86,12 @@ function assertSafePublicationText(value, source) {
   for (const [category, pattern] of forbidden) {
     const match = pattern.exec(value);
     if (match) {
-      invariant(false, `Auto Fix publication ${source}${locationLabel(patchContext(value, match.index))} contains ${category}`);
+      invariant(false, `Auto Fix publication ${source}${locationLabel(locate(match.index))} contains ${category}`);
     }
   }
   const credentialAssignment = /\b(api[_-]?key|access[_-]?token|client[_-]?secret)\s*[:=]\s*["']?([A-Za-z0-9_./+=-]{12,})/gi;
   for (const match of value.matchAll(credentialAssignment)) {
-    const context = patchContext(value, match.index);
+    const context = locate(match.index);
     invariant(
       source === "patch" && isObviousPlaceholder(match[2], context.file),
       `Auto Fix publication ${source}${locationLabel(context)} contains credential-like ${match[1].toLowerCase()} assignment`,

--- a/scripts/validate-auto-fix-artifacts.mjs
+++ b/scripts/validate-auto-fix-artifacts.mjs
@@ -11,20 +11,82 @@ const safeRunId = /^[A-Za-z0-9][A-Za-z0-9._-]{0,199}$/;
 const safeRepo = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const exactRevision = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i;
 
-function assertSafePublicationText(value) {
+function entropy(value) {
+  const counts = new Map();
+  for (const character of value) counts.set(character, (counts.get(character) ?? 0) + 1);
+  return [...counts.values()].reduce((total, count) => {
+    const probability = count / value.length;
+    return total - probability * Math.log2(probability);
+  }, 0);
+}
+
+const placeholderMarkers = new Set([
+  "test", "fake", "dummy", "example", "placeholder", "redacted", "changeme", "sample", "fixture", "mock",
+]);
+const placeholderWords = new Set([
+  ...placeholderMarkers,
+  "sk", "pk", "api", "key", "apikey", "token", "local", "dev", "unit", "e2e",
+  "notsecret", "nosecret", "notakey", "nokey", "testing", "readiness",
+]);
+
+// A placeholder bypass must be both semantically explicit and confined to test-like code.
+function isTestFixturePath(file) {
+  return typeof file === "string" && (
+    /(^|\/)(?:tests?|__tests__|fixtures?|examples?|samples?|mocks?)(?:\/|$)/i.test(file)
+    || /(?:^|\/)[^/]+\.(?:test|spec)\.[^/]+$/i.test(file)
+  );
+}
+
+function isObviousPlaceholder(value, file) {
+  if (!isTestFixturePath(file) || value.length < 8 || value.length > 64) return false;
+  const tokens = value.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+  const placeholderCounter = (token) => /^(?:0+|1+)$/.test(token) && token.length <= 6;
+  return tokens.length >= 2 && tokens.length <= 5
+    && tokens.some((token) => placeholderMarkers.has(token))
+    && tokens.every((token) => placeholderWords.has(token) || placeholderCounter(token))
+    && entropy(value) <= 3.5;
+}
+
+function patchContext(value, index) {
+  const preceding = value.slice(0, index).split("\n");
+  let file;
+  for (const line of preceding) {
+    const match = /^diff --git a\/(.+?) b\/(.+)$/.exec(line);
+    if (match) file = match[2];
+  }
+  return { file, line: preceding.length };
+}
+
+function locationLabel(context) {
+  return context.file ? ` (${context.file}, patch line ${context.line})` : "";
+}
+
+function assertSafePublicationText(value, source) {
   const forbidden = [
-    /[A-Za-z]:\\(?:Users|Documents and Settings)\\/i,
-    /\/(?:Users|home|vol[0-9]*|mnt)\//,
-    /\b(?:10\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}|192\.168\.[0-9]{1,3}\.[0-9]{1,3}|172\.(?:1[6-9]|2[0-9]|3[01])\.[0-9]{1,3}\.[0-9]{1,3})\b/,
-    /-----BEGIN [A-Z ]+PRIVATE KEY-----/,
-    /\b(?:api[_-]?key|access[_-]?token|client[_-]?secret)\s*[:=]\s*["']?[A-Za-z0-9_./+=-]{12,}/i,
-    /\bgh[opsu]_[A-Za-z0-9]{20,}\b/,
+    ["a local Windows path", /[A-Za-z]:\\(?:Users|Documents and Settings)\\/i],
+    ["a local Unix path", /\/(?:Users|home|vol[0-9]*|mnt)\//],
+    ["a private network address", /\b(?:10\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}|192\.168\.[0-9]{1,3}\.[0-9]{1,3}|172\.(?:1[6-9]|2[0-9]|3[01])\.[0-9]{1,3}\.[0-9]{1,3})\b/],
+    ["private key material", /-----BEGIN [A-Z ]+PRIVATE KEY-----/],
+    ["a GitHub token", /\bgh[opsu]_[A-Za-z0-9]{20,}\b/],
   ];
-  invariant(!forbidden.some((pattern) => pattern.test(value)), "Auto Fix publication contains local or credential material");
+  for (const [category, pattern] of forbidden) {
+    const match = pattern.exec(value);
+    if (match) {
+      invariant(false, `Auto Fix publication ${source}${locationLabel(patchContext(value, match.index))} contains ${category}`);
+    }
+  }
+  const credentialAssignment = /\b(api[_-]?key|access[_-]?token|client[_-]?secret)\s*[:=]\s*["']?([A-Za-z0-9_./+=-]{12,})/gi;
+  for (const match of value.matchAll(credentialAssignment)) {
+    const context = patchContext(value, match.index);
+    invariant(
+      source === "patch" && isObviousPlaceholder(match[2], context.file),
+      `Auto Fix publication ${source}${locationLabel(context)} contains credential-like ${match[1].toLowerCase()} assignment`,
+    );
+  }
   const emails = value.match(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi) ?? [];
   invariant(
     emails.every((email) => /@users\.noreply\.github\.com$/i.test(email)),
-    "Auto Fix publication contains a non-noreply email address",
+    `Auto Fix publication ${source} contains a non-noreply email address`,
   );
 }
 
@@ -55,16 +117,21 @@ export function validateAutoFixArtifacts(command, publication, patch, markdown) 
     "auto-fix.md differs from the JSON markdown beyond artifact newline normalization",
   );
   invariant(Array.isArray(publication.files_changed) && publication.files_changed.length > 0 && publication.files_changed.length <= 100, "Auto Fix JSON files_changed is invalid");
+  invariant(publication.files_changed.every((item) => typeof item === "string"), "Auto Fix JSON files_changed entries are invalid");
   invariant(new Set(publication.files_changed).size === publication.files_changed.length, "Auto Fix JSON files_changed contains duplicates");
   invariant(Array.isArray(publication.test_plan) && publication.test_plan.length <= 30, "Auto Fix JSON test_plan is invalid");
+  invariant(publication.test_plan.every((item) => typeof item === "string"), "Auto Fix JSON test_plan entries are invalid");
   invariant(typeof publication.explanation === "string" && publication.explanation.length > 0, "Auto Fix JSON explanation is missing");
   invariant(typeof publication.review_summary === "string" && publication.review_summary.length > 0, "Auto Fix JSON review summary is missing");
   invariant(markdown.includes(`#${publication.issue}`), "Auto Fix markdown does not contain the issue number");
   invariant(markdown.includes(publication.revision), "Auto Fix markdown does not contain the base revision");
   invariant(!/GIT binary patch|Binary files .* differ/.test(patch), "Binary patches are not supported by Auto Fix");
-  assertSafePublicationText(JSON.stringify(publication));
-  assertSafePublicationText(patch);
-  assertSafePublicationText(markdown);
+  assertSafePublicationText(publication.explanation, "explanation");
+  assertSafePublicationText(publication.review_summary, "review summary");
+  for (const item of publication.files_changed) assertSafePublicationText(item, "changed file");
+  for (const item of publication.test_plan) assertSafePublicationText(item, "test plan");
+  assertSafePublicationText(patch, "patch");
+  assertSafePublicationText(markdown, "markdown");
 }
 
 function main(argv) {


### PR DESCRIPTION
## Summary

- allow credential placeholders only when the value uses an explicit bounded placeholder vocabulary and appears in a test, fixture, example, sample, or mock patch path
- keep production paths, unknown marker-bearing values, real credential shapes, private addresses, local paths, private keys, GitHub tokens, and personal emails blocked
- apply the same policy in the DAG finalizer and the runner-side artifact validator
- scan publication fields directly so JSON escaping cannot hide a credential-like assignment
- validate finalizer input types independently of the surrounding DAG schema
- build patch line/file indexes once and use binary search for every diagnostic instead of rescanning the full patch
- report source, repository-relative file, patch line, and identifier without echoing the matched value

## Root cause

Issue #92 completed implementation, two review rounds, quorum, arbitration, and publication, but its test-fixture API-key placeholder was rejected by the privacy gate. Review found the same old policy in the runner validator, a missing defense-in-depth type check in the finalizer command, and quadratic location lookup when a large patch contains many matches. The commits align both gates, narrow the exception to explicit test placeholders, validate finalizer inputs, and make diagnostic lookup O(N + M log N).

## Validation

- Auto Fix DAG finalizer: 15 passed
- Runner artifact/apply tests: 9 passed
- 4,000 placeholder matches in a bounded patch: about 20 ms in the focused runner test
- full CI passed on Linux Node 20/24, Windows Node 24, Agent UI, and Docker: https://github.com/xiaotianfotos/homerail/actions/runs/29976917020
- model-backed PR Review passed with quorum 3/3 and privacy clear: https://github.com/xiaotianfotos/homerail/actions/runs/29976952225
- actual 19-file Issue #92 candidate: accepted by the updated runner validator without exposing its matched value
- remaining review findings are low-severity diagnostics/maintainability suggestions; no high or medium findings
- git diff --check