### PR TITLE
Fix nested HTML Artifact canvas fill

### DIFF
--- a/agent-ui/src/components/generative-ui/A2uiNode.ts
+++ b/agent-ui/src/components/generative-ui/A2uiNode.ts
@@ -365,10 +365,21 @@ function renderNode(
     const direction = component.component === 'Row'
       ? 'row'
       : component.component === 'List' && component.direction === 'horizontal' ? 'row' : 'column'
+    const directHtmlArtifacts = component.component === 'Column'
+      && ancestors.length === 0
+      && Array.isArray(component.children)
+      ? component.children.filter(id => {
+          const candidate = typeof id === 'string' ? runtime.components.get(id) : undefined
+          return candidate?.component === 'HrArtifact'
+            && candidate.kind === 'html'
+            && isSafeGenerativeUiPreviewUri(text(candidate.uri, runtime, scope))
+        })
+      : []
     return h('div', nodeAttrs({
       'data-direction': direction,
       'data-justify': 'justify' in component && JUSTIFY_VALUES.has(String(component.justify)) ? component.justify : 'start',
       'data-align': ALIGN_VALUES.has(String(component.align)) ? component.align : 'stretch',
+      ...(directHtmlArtifacts.length === 1 ? { 'data-fill-html-artifact': directHtmlArtifacts[0] } : {}),
     }), children(component.children))
   }
   if (component.component === 'Card') return h('article', nodeAttrs(), [child(component.child)])
@@ -712,7 +723,10 @@ function renderNode(
     const description = text(component.description, runtime, scope)
     const kind = component.kind === 'image' || component.kind === 'html' ? component.kind : 'file'
     if (!isSafeGenerativeUiPreviewUri(uri)) {
-      return h('div', { ...nodeAttrs(), 'data-unavailable': 'true' }, [h(File, { size: 18 }), h('span', title || 'Artifact unavailable')])
+      return h('div', {
+        ...nodeAttrs({ 'data-artifact-kind': kind }),
+        'data-unavailable': 'true',
+      }, [h(File, { size: 18 }), h('span', title || 'Artifact unavailable')])
     }
     const preview = () => runtime.openPreview({
       title: title || undefined,
@@ -721,7 +735,11 @@ function renderNode(
       layout: component.layout === 'portrait' ? 'portrait' : 'fluid',
     })
     if (kind === 'image') {
-      return h('button', { ...nodeAttrs(), type: 'button', onClick: preview }, [
+      return h('button', {
+        ...nodeAttrs({ 'data-artifact-kind': kind }),
+        type: 'button',
+        onClick: preview,
+      }, [
         h('img', {
           src: uri,
           alt: text(component.alt, runtime, scope) || title,
@@ -732,7 +750,7 @@ function renderNode(
       ])
     }
     if (kind === 'html') {
-      return h('div', nodeAttrs(), [
+      return h('div', nodeAttrs({ 'data-artifact-kind': kind }), [
         h('iframe', {
           src: uri,
           sandbox: 'allow-scripts',
@@ -748,7 +766,11 @@ function renderNode(
         }),
       ])
     }
-    return h('button', { ...nodeAttrs(), type: 'button', onClick: preview }, [
+    return h('button', {
+      ...nodeAttrs({ 'data-artifact-kind': kind }),
+      type: 'button',
+      onClick: preview,
+    }, [
       h(File, { size: 18, 'aria-hidden': true }),
       h('span', [h('strong', title || 'Artifact'), description ? h('small', description) : null]),
     ])

--- a/agent-ui/src/components/generative-ui/A2uiRenderer.test.ts
+++ b/agent-ui/src/components/generative-ui/A2uiRenderer.test.ts
@@ -243,7 +243,44 @@ describe('A2uiRenderer', () => {
     expect(artifact?.children).toHaveLength(1)
     expect(rendererSource).toContain('height: 100%;')
     expect(rendererSource).toContain('.homerail-a2ui > div.hr-a2ui__artifact { height: 100%; }')
-    expect(rendererSource).toContain('.homerail-a2ui > div.hr-a2ui__artifact > iframe { pointer-events: auto; }')
+    expect(rendererSource).toContain('.homerail-a2ui > div.hr-a2ui__artifact > iframe,')
+    expect(rendererSource).toContain('pointer-events: auto;')
+  })
+
+  it('lets one HTML Artifact nested below root content fill the remaining canvas height', () => {
+    const mounted = mount(surface([
+      { id: 'root', component: 'Column', children: ['title', 'preview'] },
+      { id: 'title', component: 'Text', text: 'Beijing weather · 5 day forecast' },
+      {
+        id: 'preview', component: 'HrArtifact', kind: 'html',
+        uri: '/api/voice-agent/sessions/session-one/artifacts/by-id/weather/preview',
+        title: 'Weather card',
+      },
+    ]))
+
+    const column = mounted.querySelector<HTMLElement>('.homerail-a2ui > .hr-a2ui__column')
+    const artifact = column?.querySelector<HTMLElement>(':scope > div.hr-a2ui__artifact')
+    expect(column?.dataset.fillHtmlArtifact).toBe('preview')
+    expect(artifact?.dataset.artifactKind).toBe('html')
+    expect(artifact?.querySelector('iframe')).toBeTruthy()
+    expect(rendererSource).toContain('.homerail-a2ui > .hr-a2ui__column[data-fill-html-artifact]')
+    expect(rendererSource).toContain("div.hr-a2ui__artifact[data-artifact-kind='html']")
+  })
+
+  it('does not promote multiple nested HTML Artifacts into one primary preview', () => {
+    const mounted = mount(surface([
+      { id: 'root', component: 'Column', children: ['first', 'second'] },
+      {
+        id: 'first', component: 'HrArtifact', kind: 'html',
+        uri: '/api/voice-agent/sessions/session-one/artifacts/by-id/first/preview',
+      },
+      {
+        id: 'second', component: 'HrArtifact', kind: 'html',
+        uri: '/api/voice-agent/sessions/session-one/artifacts/by-id/second/preview',
+      },
+    ]))
+
+    expect(mounted.querySelector('.homerail-a2ui > .hr-a2ui__column')?.hasAttribute('data-fill-html-artifact')).toBe(false)
   })
 
   it('renders passive Actor media, metrics, comparisons, timelines, and routes without active controls', () => {

--- a/agent-ui/src/components/generative-ui/A2uiRenderer.vue
+++ b/agent-ui/src/components/generative-ui/A2uiRenderer.vue
@@ -519,8 +519,19 @@ button.hr-a2ui__artifact { display: grid; width: 100%; padding: 0; text-align: l
 .hr-a2ui__artifact p { color: var(--hr-text-3); font-size: 12px; }
 div.hr-a2ui__artifact { display: grid; min-height: 220px; }
 .homerail-a2ui > div.hr-a2ui__artifact { height: 100%; }
+.homerail-a2ui > .hr-a2ui__column[data-fill-html-artifact] {
+  height: 100%;
+  min-height: 0;
+}
+.homerail-a2ui > .hr-a2ui__column[data-fill-html-artifact] > div.hr-a2ui__artifact[data-artifact-kind='html'] {
+  min-height: 0;
+  flex: 1 1 220px;
+}
 .hr-a2ui__artifact iframe { width: 100%; height: 100%; min-height: 180px; border: 0; background: #fff; pointer-events: none; }
-.homerail-a2ui > div.hr-a2ui__artifact > iframe { pointer-events: auto; }
+.homerail-a2ui > div.hr-a2ui__artifact > iframe,
+.homerail-a2ui > .hr-a2ui__column[data-fill-html-artifact] > div.hr-a2ui__artifact[data-artifact-kind='html'] > iframe {
+  pointer-events: auto;
+}
 .hr-a2ui__artifact[data-unavailable='true'] { display: flex; min-height: 92px; align-items: center; gap: 12px; padding: 16px; }
 
 .hr-a2ui__link {


### PR DESCRIPTION
## Summary
- recognize a single safe HTML Artifact directly under the root A2UI Column as the primary preview
- let it consume the remaining canvas height without stretching multi-Artifact layouts
- keep the promoted iframe interactive for internal scrolling
- add nested and multi-Artifact regression coverage

## Root cause
The prior fill rule only matched an HrArtifact rendered directly below .homerail-a2ui. Generated views commonly wrap a title and the Artifact in a root Column, so the preview fell back to its fixed 220px minimum height.

## Verification
- local Chromium at DPR 2: Artifact 220px -> 565.6px; iframe 218px -> 563.6px in the same 640px card
- npm test -- src/components/generative-ui/A2uiRenderer.test.ts (13 passed)
- npm run typecheck
- npm run build