### PR TITLE
Recover persistent production service after reboot

### DIFF
--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -53,6 +53,14 @@ The installation also provides:
 - a LAN-facing HTTPS UI;
 - a dedicated Manager port bound to the Docker bridge interface;
 
+The deployment verifies that systemd user lingering is enabled for the runner
+account. This lets the production service start after a reboot without an
+interactive login. If the production volume or Docker bridge is not ready when
+the user manager starts, the service waits for the atomic `current` release and
+keeps retrying at a bounded interval instead of exhausting systemd's start
+limit. A delayed data mount therefore does not leave Manager permanently
+stopped after a power interruption.
+
 This Manager is also the single durable automation control plane. PR Review and
 Auto Fix use separate Actions runner processes so they can execute concurrently,
 but both submit to this service and retain their DAG history in its database.

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -101,6 +101,20 @@ mkdir -p "$PRODUCTION_ROOT/releases" "$PRODUCTION_ROOT/locks" "$HOMERAIL_HOME" "
 HOMERAIL_HOME="$(realpath "$HOMERAIL_HOME")"
 chmod 700 "$HOMERAIL_HOME"
 
+# An enabled user unit starts during boot only when the account lingers without
+# an interactive login. Fail deployment instead of accepting a service that
+# silently disappears after the next reboot.
+DEPLOY_USER="$(id -un)"
+if ! command -v loginctl >/dev/null 2>&1; then
+  echo "Production deployment requires loginctl to verify systemd user lingering." >&2
+  exit 1
+fi
+LINGER_STATE="$(loginctl show-user "$DEPLOY_USER" --property=Linger --value 2>/dev/null || true)"
+if [ "$LINGER_STATE" != "yes" ]; then
+  echo "Production service requires user lingering; run: sudo loginctl enable-linger $DEPLOY_USER" >&2
+  exit 1
+fi
+
 # systemd user services do not inherit interactive-shell Node initialization.
 # Resolve an optional Codex entry point now; the release later wraps it with
 # the exact Node binary copied into runtime/ instead of trusting its shebang or
@@ -191,14 +205,16 @@ fi
 cat > "$UNIT_PATH.tmp" <<UNIT
 [Unit]
 Description=HomeRail persistent production service
-After=network-online.target docker.service
+After=network-online.target
 Wants=network-online.target
-StartLimitIntervalSec=120
-StartLimitBurst=5
+# A boot-time data mount or Docker daemon may appear after the user manager.
+# Keep retrying instead of entering a permanent failed state after five starts.
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple
-WorkingDirectory=$PRODUCTION_ROOT/current
+# The production volume may not exist when the lingering user manager starts.
+WorkingDirectory=%h
 Environment=HOMERAIL_PRODUCTION_ROOT=$PRODUCTION_ROOT
 Environment=HOMERAIL_HOME=$HOMERAIL_HOME
 Environment=HOMERAIL_PRODUCTION_RESOURCES=$RESOURCE_ROOT
@@ -215,9 +231,11 @@ Environment=HOMERAIL_PRODUCTION_UI_HTTP_PORT=$UI_HTTP_PORT
 Environment=HOMERAIL_PRODUCTION_PUBLIC_HOST=$PUBLIC_HOST
 Environment=PATH=$SERVICE_PATH
 $CODEX_UNIT_ENV
-ExecStart=$PRODUCTION_ROOT/current/scripts/run-production-service.sh
+# /bin/bash and %h exist before the data volume is mounted. Wait for the atomic
+# `current` release, then preserve the release working-directory contract.
+ExecStart=/bin/bash -c 'release="\$HOMERAIL_PRODUCTION_ROOT/current"; until [ -x "\$release/scripts/run-production-service.sh" ]; do sleep 10; done; cd "\$release"; exec "\$release/scripts/run-production-service.sh"'
 Restart=always
-RestartSec=5
+RestartSec=10
 KillMode=control-group
 TimeoutStopSec=120
 Nice=5

--- a/scripts/production-deploy-contracts.test.mjs
+++ b/scripts/production-deploy-contracts.test.mjs
@@ -38,6 +38,17 @@ test("production deployment is atomic, health checked, and rollback capable", ()
   assert.match(deploy, /rolling back/);
   assert.match(deploy, /PREVIOUS_TARGET/);
   assert.match(deploy, /UNIT_BACKUP/);
+  assert.match(deploy, /loginctl show-user "\$DEPLOY_USER" --property=Linger --value/);
+  assert.match(deploy, /sudo loginctl enable-linger \$DEPLOY_USER/);
+  assert.match(deploy, /StartLimitIntervalSec=0/);
+  assert.doesNotMatch(deploy, /StartLimitBurst=/);
+  assert.match(deploy, /WorkingDirectory=%h/);
+  assert.doesNotMatch(deploy, /WorkingDirectory=\$PRODUCTION_ROOT\/current/);
+  assert.match(
+    deploy,
+    /ExecStart=\/bin\/bash -c 'release="\\\$HOMERAIL_PRODUCTION_ROOT\/current"; until \[ -x "\\\$release\/scripts\/run-production-service\.sh" \]; do sleep 10; done; cd "\\\$release"; exec "\\\$release\/scripts\/run-production-service\.sh"'/,
+  );
+  assert.doesNotMatch(deploy, /After=network-online\.target docker\.service/);
   assert.match(deploy, /curl -fkSs/);
   assert.match(deploy, /connected_nodes/);
   assert.match(deploy, /grep -Fxl -- "\$old_revision"/);
@@ -267,6 +278,8 @@ test("production deployment rolls back a failed DAG smoke and accepts a successf
     write("scripts/lib/production-runtime.sh", fs.readFileSync(path.join(repoRoot, "scripts", "lib", "production-runtime.sh"), "utf8"), 0o755);
 
     fakeCommand("docker", `#!/usr/bin/env bash\nif [ "${'${1:-}'}" = network ] && [ "${'${2:-}'}" = inspect ] && [ "${'${3:-}'}" = bridge ]; then echo 172.17.0.1; fi\nexit 0\n`);
+    fakeCommand("codex", "#!/usr/bin/env bash\nexit 0\n");
+    fakeCommand("loginctl", "#!/usr/bin/env bash\nprintf 'yes\\n'\n");
     fakeCommand("systemctl", "#!/usr/bin/env bash\nexit 0\n");
     fakeCommand("journalctl", "#!/usr/bin/env bash\nexit 0\n");
     fakeCommand("curl", `#!/usr/bin/env bash\nurl="${'${!#}'}"\ncase "$url" in */runtime/status) printf '{"connected_nodes":1}\\n' ;; esac\nexit 0\n`);
@@ -285,7 +298,7 @@ test("production deployment rolls back a failed DAG smoke and accepts a successf
         HOMERAIL_DEPLOY_REVISION: revision,
         HOMERAIL_PRODUCTION_PUBLIC_HOST: "production.test",
         HOMERAIL_PRODUCTION_ALLOW_INSECURE_REMOTE_WS: "1",
-        HOMERAIL_CODEX_BIN: "/bin/true",
+        HOMERAIL_CODEX_BIN: path.join(fakeBin, "codex"),
         FAKE_SMOKE_EXIT: String(smokeExit),
       },
     });
@@ -309,6 +322,14 @@ test("production deployment rolls back a failed DAG smoke and accepts a successf
     assert.equal(passed.result.status, 0, passed.result.stderr);
     assert.equal(fs.readFileSync(path.join(passed.productionRoot, "last-successful-revision"), "utf8"), `${revision}\n`);
     assert.notEqual(fs.readlinkSync(path.join(passed.productionRoot, "current")), "releases/previous");
+    const unit = fs.readFileSync(passed.unitPath, "utf8");
+    assert.match(unit, /StartLimitIntervalSec=0/);
+    assert.doesNotMatch(unit, /StartLimitBurst=/);
+    assert.match(unit, /WorkingDirectory=%h/);
+    assert.match(
+      unit,
+      /ExecStart=\/bin\/bash -c 'release="\$HOMERAIL_PRODUCTION_ROOT\/current"; until \[ -x "\$release\/scripts\/run-production-service\.sh" \]; do sleep 10; done; cd "\$release"; exec "\$release\/scripts\/run-production-service\.sh"'/,
+    );
   } finally {
     fs.rmSync(passed.tempRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- make the persistent systemd user service survive a delayed production-volume mount after reboot
- start from the stable user home, wait for the atomic `current` release, then restore the release working directory before launching HomeRail
- disable the short systemd start-rate limit so a temporarily unavailable Docker bridge cannot leave production permanently failed
- verify systemd user lingering during deployment and document the reboot contract

## Incident

After a power interruption, the lingering user manager started before the production data volume was ready. The unit referenced the release directly in both `WorkingDirectory` and `ExecStart`, failed with `203/EXEC`, exhausted five starts, and remained failed after the volume became available.

## Verification

- production deployment contracts: 6 passed
- complete live-validator: 73 passed
- `bash -n` for deployment/service scripts
- `systemd-analyze verify --user` for the generated unit shape
- applied the equivalent unit to the production host with zero active DAG runs; Manager health, one connected Node, and the HTTPS UI all passed after restart

No database, model settings, credentials, or persistent Home data are changed.
