### PR TITLE
perf: bound DAG persistence hot paths

### DIFF
--- a/homerail_manager/src/persistence/dag-actor-leases.ts
+++ b/homerail_manager/src/persistence/dag-actor-leases.ts
@@ -764,6 +764,25 @@ export function listExpiredDagActorLeases(input: {
   `).all(now, limit) as DagActorLeaseRow[]).map(leaseFromRow);
 }
 
+export function listExpiredTerminalDagActorRuntimes(input: {
+  now?: number;
+  limit?: number;
+} = {}): DagActorLeaseRecord[] {
+  const now = assertNow(input.now);
+  const limit = normalizeListLimit(input.limit);
+  return (getDb().prepare(`
+    SELECT runtime.*
+    FROM dag_actor_runtimes runtime
+    INNER JOIN dag_runs run ON run.run_id = runtime.run_id
+    WHERE runtime.state IN ('dormant', 'retired')
+      AND runtime.pinned = 0
+      AND runtime.retained_until <= ?
+      AND run.status IN ('completed', 'cancelled', 'failed')
+    ORDER BY runtime.retained_until, runtime.run_id, runtime.actor_id
+    LIMIT ?
+  `).all(now, limit) as DagActorLeaseRow[]).map(leaseFromRow);
+}
+
 function normalizeCheckpointStringArray(value: unknown, label: string): string[] {
   if (!Array.isArray(value) || value.length > MAX_DAG_ACTOR_CHECKPOINT_ITEMS) {
     throw new Error(`${label} must contain at most ${MAX_DAG_ACTOR_CHECKPOINT_ITEMS} strings`);

--- a/homerail_manager/src/persistence/dag-session-files.ts
+++ b/homerail_manager/src/persistence/dag-session-files.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { getSessionStoreRoot } from "../config/env.js";
 import { redactTelemetry } from "homerail-protocol";
@@ -134,8 +134,10 @@ export function appendSessionTranscriptEntry(
     timestamp: typeof entry.timestamp === "number" ? entry.timestamp : Date.now(),
   };
   const path = transcriptPath(sessionId, baseDir);
-  const previous = existsSync(path) ? readFileSync(path, "utf-8") : "";
-  writeFileSync(path, `${previous}${JSON.stringify(normalized)}\n`, "utf-8");
+  appendFileSync(path, `${JSON.stringify(normalized)}\n`, {
+    encoding: "utf-8",
+    mode: 0o600,
+  });
   if (!existsSync(sessionPath(sessionId, baseDir))) {
     writeFileSync(
       sessionPath(sessionId, baseDir),

--- a/homerail_manager/src/persistence/db.ts
+++ b/homerail_manager/src/persistence/db.ts
@@ -1919,6 +1919,32 @@ function validateVoiceArtifactSchemaV32(db: SqliteDatabase): void {
   }
 }
 
+function validateDagRunHotPathIndexesV33(db: SqliteDatabase): void {
+  const expected = new Map<string, readonly string[]>([
+    ["idx_dag_runs_updated", ["updated_at", "run_id"]],
+    ["idx_dag_runs_status_updated", ["status", "updated_at", "run_id"]],
+  ]);
+  const indexes = new Set(
+    (db.prepare("PRAGMA index_list(dag_runs)").all() as Array<{ name: string }>)
+      .map((entry) => entry.name),
+  );
+  for (const [name, expectedColumns] of expected) {
+    if (!indexes.has(name)) {
+      throw new Error(`Schema migration 33 is incomplete: index ${name} is missing`);
+    }
+    const actualColumns = (db.prepare(`PRAGMA index_info(${name})`).all() as Array<{
+      seqno: number;
+      name: string;
+    }>).sort((left, right) => left.seqno - right.seqno).map((entry) => entry.name);
+    if (
+      actualColumns.length !== expectedColumns.length
+      || actualColumns.some((column, position) => column !== expectedColumns[position])
+    ) {
+      throw new Error(`Schema migration 33 is incomplete: index ${name} has invalid columns`);
+    }
+  }
+}
+
 function validateGenerativeUiSchemaV3(db: SqliteDatabase): void {
   const requiredColumns: Record<string, readonly string[]> = {
     generative_ui_documents: [
@@ -4081,6 +4107,18 @@ const SCHEMA_MIGRATIONS: readonly SchemaMigration[] = [
       `);
     },
     validate: validateVoiceArtifactSchemaV32,
+  },
+  {
+    version: 33,
+    up: (db) => {
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_dag_runs_updated
+          ON dag_runs(updated_at DESC, run_id);
+        CREATE INDEX IF NOT EXISTS idx_dag_runs_status_updated
+          ON dag_runs(status, updated_at DESC, run_id);
+      `);
+    },
+    validate: validateDagRunHotPathIndexesV33,
   },
 ];
 

--- a/homerail_manager/src/persistence/store.ts
+++ b/homerail_manager/src/persistence/store.ts
@@ -369,6 +369,178 @@ export function loadRunMetadata(runId: string): PersistedRunMetadata | undefined
   return row ? parseJsonRow<PersistedRunMetadata>(row.metadata) : undefined;
 }
 
+export interface PersistedRunControlState {
+  status: DagRunStatus;
+  nodeStates: Record<string, string>;
+}
+
+export interface PersistedRunSummary {
+  runId: string;
+  workflowId?: string;
+  workflowName?: string;
+  nodeCount?: number;
+  status: DagRunStatus;
+  currentRound?: PersistedCurrentDagRunRound;
+  createdAt: number;
+  completedAt?: number;
+}
+
+interface PersistedRunSummaryRow {
+  run_id: string;
+  workflow_id: string | null;
+  workflow_name: string | null;
+  status: DagRunStatus;
+  created_at: number;
+  completed_at: number | null;
+  graph: string | null;
+  node_states: string | null;
+  round_id: string | null;
+  ordinal: number | null;
+  round_status: PersistedCurrentDagRunRound["status"] | null;
+  target_actor_ids_json: string | null;
+  await_node_id: string | null;
+  opened_at: number | null;
+  closed_at: number | null;
+  expires_at: number | null;
+}
+
+function _nodeCountFromExpandedColumns(row: PersistedRunSummaryRow): number | undefined {
+  if (row.graph) {
+    const graph = parseJsonRow<unknown>(row.graph);
+    if (
+      graph
+      && typeof graph === "object"
+      && !Array.isArray(graph)
+      && Array.isArray((graph as { nodes?: unknown }).nodes)
+    ) {
+      return (graph as { nodes: unknown[] }).nodes.length;
+    }
+  }
+  if (row.node_states) {
+    const nodeStates = parseJsonRow<unknown>(row.node_states);
+    if (nodeStates && typeof nodeStates === "object" && !Array.isArray(nodeStates)) {
+      return Object.keys(nodeStates).length;
+    }
+  }
+  return undefined;
+}
+
+function _currentRoundFromSummaryRow(
+  row: PersistedRunSummaryRow,
+): PersistedCurrentDagRunRound | undefined {
+  if (
+    row.round_id === null
+    || row.ordinal === null
+    || row.round_status === null
+    || row.target_actor_ids_json === null
+    || row.opened_at === null
+  ) {
+    return undefined;
+  }
+  const targetActorIds = parseJsonRow<unknown>(row.target_actor_ids_json);
+  if (!Array.isArray(targetActorIds) || targetActorIds.some((value) => typeof value !== "string")) {
+    throw new Error(`DAG run round ${row.run_id}/${row.round_id} has invalid target_actor_ids_json`);
+  }
+  return {
+    round_id: row.round_id,
+    ordinal: row.ordinal,
+    status: row.round_status,
+    target_actor_ids: [...targetActorIds],
+    ...(row.await_node_id === null ? {} : { await_node_id: row.await_node_id }),
+    opened_at: row.opened_at,
+    ...(row.closed_at === null ? {} : { closed_at: row.closed_at }),
+    ...(row.expires_at === null ? {} : { expires_at: row.expires_at }),
+  };
+}
+
+export function listPersistedRunSummaries(): PersistedRunSummary[] {
+  const rows = getDb().prepare(`
+    SELECT
+      run.run_id,
+      run.workflow_id,
+      run.workflow_name,
+      run.status,
+      run.created_at,
+      run.completed_at,
+      run.graph,
+      run.node_states,
+      round.round_id,
+      round.ordinal,
+      round.status AS round_status,
+      round.target_actor_ids_json,
+      round.await_node_id,
+      round.opened_at,
+      round.closed_at,
+      round.expires_at
+    FROM dag_runs run
+    LEFT JOIN dag_run_rounds round
+      ON round.run_id = run.run_id
+      AND round.ordinal = (
+        SELECT MAX(latest.ordinal)
+        FROM dag_run_rounds latest
+        WHERE latest.run_id = run.run_id
+      )
+    ORDER BY run.updated_at DESC, run.run_id
+  `).all() as PersistedRunSummaryRow[];
+
+  return rows.map((row) => {
+    assertStatus("dag_run", row.status);
+    const currentRound = _currentRoundFromSummaryRow(row);
+    const nodeCount = _nodeCountFromExpandedColumns(row);
+    return {
+      runId: row.run_id,
+      ...(row.workflow_id === null ? {} : { workflowId: row.workflow_id }),
+      ...(row.workflow_name === null ? {} : { workflowName: row.workflow_name }),
+      ...(nodeCount === undefined ? {} : { nodeCount }),
+      status: row.status,
+      ...(currentRound ? { currentRound } : {}),
+      createdAt: row.created_at,
+      ...(row.completed_at === null ? {} : { completedAt: row.completed_at }),
+    };
+  });
+}
+
+export function loadPersistedRunControlState(runId: string): PersistedRunControlState | undefined {
+  _safeRunId(runId);
+  const row = getDb()
+    .prepare("SELECT status, node_states FROM dag_runs WHERE run_id = ?")
+    .get(runId) as { status: DagRunStatus; node_states: string | null } | undefined;
+  if (!row) return undefined;
+  assertStatus("dag_run", row.status);
+  if (row.node_states !== null) {
+    const nodeStates = parseJsonRow<unknown>(row.node_states);
+    if (nodeStates && typeof nodeStates === "object" && !Array.isArray(nodeStates)) {
+      return { status: row.status, nodeStates: nodeStates as Record<string, string> };
+    }
+  }
+  const legacy = loadRunMetadata(runId);
+  return legacy ? { status: legacy.status, nodeStates: legacy.nodeStates } : undefined;
+}
+
+export function getPersistedRunStatus(runId: string): DagRunStatus | undefined {
+  _safeRunId(runId);
+  const row = getDb()
+    .prepare("SELECT status FROM dag_runs WHERE run_id = ?")
+    .get(runId) as { status: DagRunStatus } | undefined;
+  if (!row) return undefined;
+  assertStatus("dag_run", row.status);
+  return row.status;
+}
+
+export function listPersistedRunIdsByStatus(statuses: readonly DagRunStatus[]): string[] {
+  if (statuses.length === 0) return [];
+  for (const status of statuses) assertStatus("dag_run", status);
+  const placeholders = statuses.map(() => "?").join(", ");
+  return (getDb()
+    .prepare(`
+      SELECT run_id FROM dag_runs
+      WHERE status IN (${placeholders})
+      ORDER BY updated_at DESC, run_id
+    `)
+    .all(...statuses) as Array<{ run_id: string }>)
+    .map((row) => row.run_id);
+}
+
 export function listPersistedRunIds(): string[] {
   return (getDb()
     .prepare("SELECT run_id FROM dag_runs ORDER BY updated_at DESC, run_id")

--- a/homerail_manager/src/runtime/active-runs.ts
+++ b/homerail_manager/src/runtime/active-runs.ts
@@ -55,7 +55,7 @@ import {
   serializeRunMetadata,
   loadRunMetadata,
   loadRunSnapshot,
-  listPersistedRunIds,
+  listPersistedRunIdsByStatus,
 } from "../persistence/store.js";
 import type {
   PersistedGraphData,
@@ -1196,7 +1196,7 @@ export interface ColdRecoverySummary {
  * in-memory store. Safe to call at startup. Idempotent. */
 export function recoverAllActiveRuns(): ColdRecoverySummary {
   const summary: ColdRecoverySummary = { recovered: [], failed: [], skipped: [] };
-  for (const runId of listPersistedRunIds()) {
+  for (const runId of listPersistedRunIdsByStatus(["active", "waiting"])) {
     try {
       const metadata = loadRunMetadata(runId);
       if (!metadata) {

--- a/homerail_manager/src/runtime/dag-actor-lease-reaper.ts
+++ b/homerail_manager/src/runtime/dag-actor-lease-reaper.ts
@@ -5,12 +5,16 @@ import {
   getDagActorLease,
   listDagProvisionedWorkers,
   listExpiredDagActorLeases,
+  listExpiredTerminalDagActorRuntimes,
   releaseDagActorLease,
   transitionDagProvisionedWorker,
 } from "../persistence/dag-actor-leases.js";
 import { listDagActors } from "../persistence/dag-actors.js";
-import { listPersistedRunIds, loadRunMetadata } from "../persistence/store.js";
-import type { DagRunStatus } from "../persistence/status.js";
+import {
+  getPersistedRunStatus,
+  listPersistedRunIdsByStatus,
+  loadPersistedRunControlState,
+} from "../persistence/store.js";
 import { getWorker } from "../worker/registry.js";
 import { loadDagActorLeaseSettings } from "../config/dag-actor-lease-settings.js";
 import {
@@ -54,10 +58,6 @@ function recordEntry(record: ReturnType<typeof listDagProvisionedWorkers>[number
   };
 }
 
-function runStatus(runId: string): DagRunStatus | undefined {
-  return loadRunMetadata(runId)?.status;
-}
-
 export async function reapDagActorLeases(
   options: DagActorLeaseReaperOptions = {},
 ): Promise<DagActorLeaseReaperReport> {
@@ -71,8 +71,7 @@ export async function reapDagActorLeases(
   };
 
   const renewalThreshold = Math.floor(loadDagActorLeaseSettings().worker_idle_ttl_ms / 2);
-  for (const runId of listPersistedRunIds()) {
-    if (runStatus(runId) !== "active") continue;
+  for (const runId of listPersistedRunIdsByStatus(["active"])) {
     for (const actor of listDagActors(runId)) {
       const lease = getDagActorLease({ run_id: runId, actor_id: actor.actor_id });
       if (!lease || lease.state !== "leased" || lease.pinned || lease.idle_deadline! - now > renewalThreshold) continue;
@@ -100,10 +99,10 @@ export async function reapDagActorLeases(
   for (const worker of pending) {
     if (worker.status === "active") {
       const lease = getDagActorLease({ run_id: worker.run_id, actor_id: worker.actor_id });
-      const metadata = loadRunMetadata(worker.run_id);
-      const status = metadata?.status;
+      const control = loadPersistedRunControlState(worker.run_id);
+      const status = control?.status;
       const activeNodeDisconnected = status === "active"
-        && metadata?.nodeStates[worker.node_id] === "RUNNING";
+        && control?.nodeStates[worker.node_id] === "RUNNING";
       const stillOwned = lease?.state === "leased"
         && lease.lease_generation === worker.lease_generation
         && (lease.target_type === "worker" || lease.target_type === "provisioned_worker")
@@ -175,7 +174,7 @@ export async function reapDagActorLeases(
   }
 
   for (const lease of listExpiredDagActorLeases({ now, limit: options.limit })) {
-    if (runStatus(lease.run_id) === "active") continue;
+    if (getPersistedRunStatus(lease.run_id) === "active") continue;
     try {
       // This versioned transition is the physical-generation fence. Once it
       // commits, late results from the released worker are no longer current.
@@ -213,15 +212,13 @@ export async function reapDagActorLeases(
     }
   }
 
-  for (const runId of listPersistedRunIds()) {
-    const status = runStatus(runId);
-    if (status === "active" || status === "waiting") continue;
-    for (const actor of listDagActors(runId)) {
-      const lease = getDagActorLease({ run_id: runId, actor_id: actor.actor_id });
-      if (!lease || lease.state === "leased" || lease.pinned || lease.retained_until! > now) continue;
-      if (deleteExpiredDagActorRuntime({ run_id: runId, actor_id: actor.actor_id, now }).deleted) {
-        report.runtimes_deleted++;
-      }
+  for (const runtime of listExpiredTerminalDagActorRuntimes({ now, limit: options.limit })) {
+    if (deleteExpiredDagActorRuntime({
+      run_id: runtime.run_id,
+      actor_id: runtime.actor_id,
+      now,
+    }).deleted) {
+      report.runtimes_deleted++;
     }
   }
   return report;

--- a/homerail_manager/src/server/routes.ts
+++ b/homerail_manager/src/server/routes.ts
@@ -2,7 +2,7 @@ import * as http from "node:http";
 import {
   loadRunMetadata,
   loadRunSnapshot,
-  listPersistedRunIds,
+  listPersistedRunSummaries,
   loadNodeUsages,
 } from "../persistence/store.js";
 import type { PersistedEvent, PersistedRunMetadata, PersistedRunSnapshot, NodeUsageRecord } from "../persistence/types.js";
@@ -416,20 +416,7 @@ export function inspectionRoutesHandler(
 
   // GET /api/runs
   if (pathname === "/api/runs" && req.method === "GET") {
-    const runIds = listPersistedRunIds();
-    const runs = runIds
-      .map((id) => loadRunMetadata(id))
-      .filter((m): m is NonNullable<typeof m> => !!m)
-      .map((m) => ({
-        runId: m.runId,
-        workflowId: m.workflowId,
-        workflowName: m.workflowName,
-        nodeCount: m.nodeCount,
-        status: m.status,
-        currentRound: m.currentRound,
-        createdAt: m.createdAt,
-        completedAt: m.completedAt,
-      }));
+    const runs = listPersistedRunSummaries();
     _ok(res, `Found ${runs.length} runs`, { runs, total: runs.length });
     return true;
   }

--- a/homerail_manager/tests/cold-recovery.test.ts
+++ b/homerail_manager/tests/cold-recovery.test.ts
@@ -10,7 +10,7 @@ import type {
 } from "../src/orchestration/dag-dispatcher.js";
 import { parseDAGYaml } from "../src/orchestration/yaml-loader.js";
 import { _clearListeners, subscribe } from "../src/events/bus.js";
-import { closeDb } from "../src/persistence/db.js";
+import { closeDb, getDb } from "../src/persistence/db.js";
 import { getDagSessionIndex, listDagSessionIndex, upsertDagSessionIndex } from "../src/persistence/dag-session-index.js";
 import {
   _clearAllPersistence,
@@ -251,6 +251,10 @@ describe("manager cold recovery", () => {
     run.completedAt = Date.now();
     // Re-serialize to persist the terminal status.
     writeRunMetadata("run-completed", serializeRunMetadata(run));
+    // A terminal row must be filtered by the indexed status column before the
+    // recovery path attempts to parse its potentially very large metadata.
+    getDb().prepare("UPDATE dag_runs SET metadata = ? WHERE run_id = ?")
+      .run("{ intentionally invalid terminal metadata", "run-completed");
 
     _clearActiveRuns();
     const summary = recoverAllActiveRuns();

--- a/homerail_manager/tests/dag-actor-lease-reaper.test.ts
+++ b/homerail_manager/tests/dag-actor-lease-reaper.test.ts
@@ -15,7 +15,7 @@ import {
   writeDagActorCheckpoint,
 } from "../src/persistence/dag-actor-leases.js";
 import { getDagActor, registerDagActor } from "../src/persistence/dag-actors.js";
-import { closeDb } from "../src/persistence/db.js";
+import { closeDb, getDb } from "../src/persistence/db.js";
 import { ensureRunDir, loadRunMetadata, writeRunMetadata } from "../src/persistence/store.js";
 import { reapDagActorLeases } from "../src/runtime/dag-actor-lease-reaper.js";
 import { _clearWorkers, registerWorker } from "../src/worker/registry.js";
@@ -263,7 +263,7 @@ describe("DAG actor lease reaper", () => {
   });
 
   it("deletes only terminal, retention-expired dormant runtime and checkpoints", async () => {
-    setRunStatus("completed");
+    setRunStatus("active");
     const lease = acquireDagActorLease({
       run_id: "run-reaper",
       actor_id: "actor-1",
@@ -301,9 +301,16 @@ describe("DAG actor lease reaper", () => {
       retention_ttl_ms: 10,
       now: now + 1,
     });
-
-    expect((await reapDagActorLeases({ now: now + 10 })).runtimes_deleted).toBe(0);
+    // Expired retention alone is insufficient while the owning run is active.
+    expect((await reapDagActorLeases({ now: now + 11 })).runtimes_deleted).toBe(0);
     expect(getLatestDagActorCheckpoint({ run_id: "run-reaper", actor_id: "actor-1" })).toBeDefined();
+
+    setRunStatus("completed");
+    // Once terminal, retention is selected from normalized status/lease
+    // columns and must not parse aggregate metadata on every reaper tick.
+    getDb().prepare("UPDATE dag_runs SET metadata = ? WHERE run_id = ?")
+      .run("{ intentionally invalid terminal metadata", "run-reaper");
+
     expect((await reapDagActorLeases({ now: now + 11 })).runtimes_deleted).toBe(1);
     expect(getDagActor("run-reaper", "actor-1")).toBeUndefined();
     expect(getLatestDagActorCheckpoint({ run_id: "run-reaper", actor_id: "actor-1" })).toBeUndefined();

--- a/homerail_manager/tests/persistence-contracts.test.ts
+++ b/homerail_manager/tests/persistence-contracts.test.ts
@@ -9,9 +9,19 @@ import {
   upsertCompatRecord,
 } from "../src/persistence/compat-records.js";
 import { closeDb, getDb } from "../src/persistence/db.js";
+import { createInitialDagRunRound } from "../src/persistence/dag-run-rounds.js";
+import {
+  appendSessionTranscriptEntry,
+  loadSessionTranscript,
+} from "../src/persistence/dag-session-files.js";
 import { createChangeRun } from "../src/persistence/change-runs.js";
 import { createChange, createProject, updateProject } from "../src/persistence/projects-changes.js";
-import { writeRunMetadata } from "../src/persistence/store.js";
+import {
+  listPersistedRunIdsByStatus,
+  listPersistedRunSummaries,
+  loadPersistedRunControlState,
+  writeRunMetadata,
+} from "../src/persistence/store.js";
 import { assertEpochMs, epochMsFromUnknown, nowEpochMs, nowIso } from "../src/persistence/time.js";
 
 describe("SQLite persistence contracts", () => {
@@ -100,6 +110,117 @@ describe("SQLite persistence contracts", () => {
       .get("event-1") as { event_type: string; event_data: string };
     expect(row.event_type).toBe("dag:engine_started");
     expect(JSON.parse(row.event_data)).toEqual({ runId: "run-1" });
+  });
+
+  it("serves run hot paths from expanded columns without parsing terminal metadata", () => {
+    const createdAt = Date.now();
+    writeRunMetadata("run-summary", {
+      runId: "run-summary",
+      workflowId: "workflow-summary",
+      workflowName: "Summary workflow",
+      createdAt,
+      completedAt: createdAt + 10,
+      status: "completed",
+      nodeStates: { research: "COMPLETED", review: "COMPLETED" },
+      handoffedNodes: ["research", "review"],
+      graph: {
+        nodes: [
+          { node_id: "research", name: "Research" },
+          { node_id: "review", name: "Review" },
+        ],
+        edges: [],
+      },
+    });
+    createInitialDagRunRound({
+      run_id: "run-summary",
+      round_id: "round-0001",
+      target_actor_ids: ["reviewer", "researcher"],
+      status: "completed",
+      opened_at: createdAt,
+      closed_at: createdAt + 10,
+    });
+    getDb().prepare("UPDATE dag_runs SET metadata = ? WHERE run_id = ?")
+      .run("{ intentionally invalid terminal metadata", "run-summary");
+
+    expect(listPersistedRunIdsByStatus(["active", "waiting"])).toEqual([]);
+    expect(loadPersistedRunControlState("run-summary")).toEqual({
+      status: "completed",
+      nodeStates: { research: "COMPLETED", review: "COMPLETED" },
+    });
+    expect(listPersistedRunSummaries()).toEqual([{
+      runId: "run-summary",
+      workflowId: "workflow-summary",
+      workflowName: "Summary workflow",
+      nodeCount: 2,
+      status: "completed",
+      currentRound: {
+        round_id: "round-0001",
+        ordinal: 1,
+        status: "completed",
+        target_actor_ids: ["researcher", "reviewer"],
+        opened_at: createdAt,
+        closed_at: createdAt + 10,
+      },
+      createdAt,
+      completedAt: createdAt + 10,
+    }]);
+  });
+
+  it("installs indexes for status filtering and updated-time run ordering", () => {
+    const db = getDb();
+    expect(db.prepare("SELECT MAX(version) AS version FROM schema_migrations").get())
+      .toEqual({ version: 33 });
+    expect(db.prepare("PRAGMA index_info(idx_dag_runs_updated)").all())
+      .toEqual([
+        expect.objectContaining({ seqno: 0, name: "updated_at" }),
+        expect.objectContaining({ seqno: 1, name: "run_id" }),
+      ]);
+    expect(db.prepare("PRAGMA index_info(idx_dag_runs_status_updated)").all())
+      .toEqual([
+        expect.objectContaining({ seqno: 0, name: "status" }),
+        expect.objectContaining({ seqno: 1, name: "updated_at" }),
+        expect.objectContaining({ seqno: 2, name: "run_id" }),
+      ]);
+
+    db.exec(`
+      DROP INDEX idx_dag_runs_updated;
+      DROP INDEX idx_dag_runs_status_updated;
+      DELETE FROM schema_migrations WHERE version = 33;
+    `);
+    closeDb();
+    const migrated = getDb();
+    expect(migrated.prepare("SELECT version FROM schema_migrations WHERE version = 33").get())
+      .toEqual({ version: 33 });
+    expect(migrated.prepare("PRAGMA index_info(idx_dag_runs_status_updated)").all())
+      .toHaveLength(3);
+  });
+
+  it("appends session transcript JSONL without changing existing entries", () => {
+    const baseDir = path.join(tmpHome, "session-store");
+    const first = appendSessionTranscriptEntry({
+      type: "assistant",
+      sessionId: "append-only",
+      content: { text: "first" },
+      timestamp: 1,
+    }, baseDir);
+    const firstBytes = fs.readFileSync(
+      path.join(baseDir, "append-only", "transcript.jsonl"),
+      "utf8",
+    );
+    const second = appendSessionTranscriptEntry({
+      type: "tool_result",
+      sessionId: "append-only",
+      content: { text: "second" },
+      timestamp: 2,
+    }, baseDir);
+    const finalBytes = fs.readFileSync(
+      path.join(baseDir, "append-only", "transcript.jsonl"),
+      "utf8",
+    );
+
+    expect(finalBytes.startsWith(firstBytes)).toBe(true);
+    expect(finalBytes.split("\n").filter(Boolean)).toHaveLength(2);
+    expect(loadSessionTranscript("append-only", baseDir)).toEqual([first, second]);
   });
 
   it("rejects invalid status and missing required secret payloads in compatibility records", () => {

--- a/homerail_manager/tests/run-list-api.test.ts
+++ b/homerail_manager/tests/run-list-api.test.ts
@@ -1,0 +1,92 @@
+import * as fs from "node:fs";
+import * as http from "node:http";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { closeDb, getDb } from "../src/persistence/db.js";
+import { writeRunMetadata } from "../src/persistence/store.js";
+import { createServer } from "../src/server/http.js";
+
+async function listen(server: http.Server): Promise<number> {
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address !== "object") throw new Error("server did not bind");
+  return address.port;
+}
+
+async function closeServer(server: http.Server | undefined): Promise<void> {
+  if (!server?.listening) return;
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+describe("GET /api/runs", () => {
+  let home: string;
+  let oldHome: string | undefined;
+  let server: http.Server | undefined;
+
+  beforeEach(() => {
+    closeDb();
+    oldHome = process.env.HOMERAIL_HOME;
+    home = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-run-list-api-"));
+    process.env.HOMERAIL_HOME = home;
+  });
+
+  afterEach(async () => {
+    await closeServer(server);
+    closeDb();
+    if (oldHome === undefined) delete process.env.HOMERAIL_HOME;
+    else process.env.HOMERAIL_HOME = oldHome;
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it("returns terminal summaries without loading aggregate metadata", async () => {
+    const createdAt = Date.now();
+    writeRunMetadata("large-terminal-run", {
+      runId: "large-terminal-run",
+      workflowId: "release-review",
+      workflowName: "Release review",
+      createdAt,
+      completedAt: createdAt + 25,
+      status: "completed",
+      nodeStates: { inspect: "COMPLETED" },
+      handoffedNodes: ["inspect"],
+      graph: {
+        nodes: [{ node_id: "inspect", name: "Inspect" }],
+        edges: [],
+      },
+    });
+    // If the route regresses to loadRunMetadata(), this row makes the request
+    // fail immediately instead of hiding the N+1 parse behind a fast fixture.
+    getDb().prepare("UPDATE dag_runs SET metadata = ? WHERE run_id = ?")
+      .run("{ intentionally invalid terminal metadata", "large-terminal-run");
+
+    server = createServer(0, undefined, undefined, false, { autoDetectCodex: false });
+    const port = await listen(server);
+    const response = await fetch(`http://127.0.0.1:${port}/api/runs`);
+    const body = await response.json() as {
+      success: boolean;
+      data: {
+        runs: Array<Record<string, unknown>>;
+        total: number;
+      };
+    };
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      success: true,
+      data: {
+        total: 1,
+        runs: [{
+          runId: "large-terminal-run",
+          workflowId: "release-review",
+          workflowName: "Release review",
+          nodeCount: 1,
+          status: "completed",
+          createdAt,
+          completedAt: createdAt + 25,
+        }],
+      },
+    });
+  });
+});

--- a/homerail_manager/tests/voice-artifacts.test.ts
+++ b/homerail_manager/tests/voice-artifacts.test.ts
@@ -149,7 +149,7 @@ describe("voice artifact publishing", () => {
     const artifact = publishVoiceArtifact({ session_id: "session-schema", source_path: "schema.html" });
 
     const db = getDb();
-    expect(db.prepare("SELECT MAX(version) AS version FROM schema_migrations").get()).toEqual({ version: 32 });
+    expect(db.prepare("SELECT MAX(version) AS version FROM schema_migrations").get()).toEqual({ version: 33 });
     expect(() => db.prepare(`
       UPDATE voice_artifact_revisions SET title = 'changed'
       WHERE session_id = ? AND artifact_id = ? AND revision = 1


### PR DESCRIPTION
## Summary

- add migration 33 indexes for run ordering and status-filtered recovery
- serve `/api/runs` from normalized columns and the latest durable round instead of parsing every aggregate metadata document
- limit cold recovery and actor lease reaping to the runs/runtimes that can require work
- append SessionStore JSONL entries without reading and rewriting the complete transcript
- add regression coverage for malformed terminal metadata, active-run retention, migration continuity, and the run-list HTTP route

## Why

Several frequently executed paths scaled with the entire retained DAG history. The run list performed an N+1 metadata read/parse, cold recovery parsed terminal runs, the lease reaper revisited aggregate metadata on every tick, and transcript append rewrote all previous bytes. Large retained histories therefore increased refresh latency and background I/O even when only a few runs were active.

This is the release-safe Stage 1 change only. It preserves run, chat, audit, artifact, and SessionStore history and does not alter workflow semantics or retention policy.

## Performance validation

Warm local measurements compare the former algorithms with the optimized paths on identical data:

| Fixture | Path | Before | After | Median improvement |
|---|---|---:|---:|---:|
| 67 real local runs / 12.8 MB metadata | run list | 41.10 ms | 2.75 ms | 15.0x |
| same | cold recovery selection | 43.48 ms | 1.43 ms | 30.5x |
| same | terminal reaper selection | 43.60 ms | 0.033 ms | 1321x |
| 144 synthetic runs / 100.8 MB metadata | run list | 119.34 ms | 17.65 ms | 6.8x |
| same | cold recovery selection | 119.88 ms | 7.30 ms | 16.4x |
| same | terminal reaper selection | 116.28 ms | 0.085 ms | 1368x |

The real `GET /api/runs` route measured 3.57 ms median and 4.95 ms p95 over 50 requests. It remained responsive at 4.64 ms while another SQLite connection held an uncommitted WAL write transaction.

A 64 MB transcript append changed from 148.50 ms to 0.013 ms in the local microbenchmark. Eight independent processes also appended 2,000 JSONL entries concurrently with 2,000 valid, unique records.

## Validation

- `npm run ci`: 2,720 passed, 2 skipped, 0 failed
- focused persistence/recovery/run-list suite: 32 passed
- isolated current-branch Manager/Node/Worker environment with a model-only Seed Home
- two-node Qwen3.6 review + independent verification DAG: completed 2/2 with structured contract-valid handoffs and final `pass`
- Manager cold restart retained the completed run, node states, round, and handoffs; the preserved Node reconnected automatically
- `git diff --check` and tracked privacy scan passed
