### PR TITLE
Harden DAG session-store permissions

### DIFF
--- a/homerail_manager/src/persistence/dag-session-files.ts
+++ b/homerail_manager/src/persistence/dag-session-files.ts
@@ -1,8 +1,18 @@
 import { randomUUID } from "node:crypto";
-import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  appendFileSync,
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { getSessionStoreRoot } from "../config/env.js";
 import { redactTelemetry } from "homerail-protocol";
+
+const PRIVATE_DIRECTORY_MODE = 0o700;
+const PRIVATE_FILE_MODE = 0o600;
 
 export interface SessionTranscriptEntry {
   uuid?: string;
@@ -46,6 +56,30 @@ function safeSegment(value: string, label: string): string {
 
 function sessionRoot(sessionId: string, baseDir?: string): string {
   return join(sessionDir(baseDir), safeSegment(sessionId, "sessionId"));
+}
+
+function enforcePrivateMode(path: string, mode: number): void {
+  if (process.platform === "win32") return;
+  try {
+    chmodSync(path, mode);
+  } catch {
+    // Best effort on filesystems that do not support POSIX modes.
+  }
+}
+
+function ensurePrivateSessionRoot(sessionId: string, baseDir?: string): string {
+  const dir = sessionRoot(sessionId, baseDir);
+  mkdirSync(dir, { recursive: true, mode: PRIVATE_DIRECTORY_MODE });
+  enforcePrivateMode(dir, PRIVATE_DIRECTORY_MODE);
+  return dir;
+}
+
+function writePrivateFile(path: string, content: string): void {
+  writeFileSync(path, content, {
+    encoding: "utf-8",
+    mode: PRIVATE_FILE_MODE,
+  });
+  enforcePrivateMode(path, PRIVATE_FILE_MODE);
 }
 
 function transcriptPath(sessionId: string, baseDir?: string): string {
@@ -124,8 +158,7 @@ export function appendSessionTranscriptEntry(
     ? entry.sessionId.trim()
     : "";
   if (!sessionId) throw new Error("sessionId must be non-empty");
-  const dir = sessionRoot(sessionId, baseDir);
-  mkdirSync(dir, { recursive: true });
+  ensurePrivateSessionRoot(sessionId, baseDir);
   const normalized: SessionTranscriptEntry = {
     ...entry,
     content: redactTelemetry(entry.content),
@@ -136,11 +169,13 @@ export function appendSessionTranscriptEntry(
   const path = transcriptPath(sessionId, baseDir);
   appendFileSync(path, `${JSON.stringify(normalized)}\n`, {
     encoding: "utf-8",
-    mode: 0o600,
+    mode: PRIVATE_FILE_MODE,
   });
-  if (!existsSync(sessionPath(sessionId, baseDir))) {
-    writeFileSync(
-      sessionPath(sessionId, baseDir),
+  enforcePrivateMode(path, PRIVATE_FILE_MODE);
+  const snapshotPath = sessionPath(sessionId, baseDir);
+  if (!existsSync(snapshotPath)) {
+    writePrivateFile(
+      snapshotPath,
       JSON.stringify({
         sessionId,
         runId: entry.runId,
@@ -149,8 +184,9 @@ export function appendSessionTranscriptEntry(
         toolCallState: { inFlight: false },
         timestamp: normalized.timestamp,
       }, null, 2),
-      "utf-8",
     );
+  } else {
+    enforcePrivateMode(snapshotPath, PRIVATE_FILE_MODE);
   }
   return normalized;
 }
@@ -184,12 +220,10 @@ export function checkpointForkSession(
     },
   }));
 
-  const dir = sessionRoot(request.newSessionId, baseDir);
-  mkdirSync(dir, { recursive: true });
-  writeFileSync(
+  ensurePrivateSessionRoot(request.newSessionId, baseDir);
+  writePrivateFile(
     transcriptPath(request.newSessionId, baseDir),
     forkedEntries.map((entry) => JSON.stringify(entry)).join("\n") + "\n",
-    "utf-8",
   );
 
   const parentSnapshot = loadSessionSnapshot(request.parentSessionId, baseDir);
@@ -202,7 +236,10 @@ export function checkpointForkSession(
     forkedFromEntryUuid: checkpoint.entryUuid,
     timestamp: Date.now(),
   };
-  writeFileSync(sessionPath(request.newSessionId, baseDir), JSON.stringify(nextSnapshot, null, 2), "utf-8");
+  writePrivateFile(
+    sessionPath(request.newSessionId, baseDir),
+    JSON.stringify(nextSnapshot, null, 2),
+  );
 
   return {
     entryUuid: checkpoint.entryUuid,
@@ -216,8 +253,7 @@ export function appendSessionTranscriptForTest(
   entries: Array<Partial<SessionTranscriptEntry>>,
   baseDir?: string,
 ): void {
-  const dir = sessionRoot(sessionId, baseDir);
-  mkdirSync(dir, { recursive: true });
+  ensurePrivateSessionRoot(sessionId, baseDir);
   const normalized = entries.map((entry) => ({
     uuid: entry.uuid ?? randomUUID(),
     type: entry.type ?? "test",
@@ -225,14 +261,12 @@ export function appendSessionTranscriptForTest(
     timestamp: typeof entry.timestamp === "number" ? entry.timestamp : Date.now(),
     ...entry,
   }));
-  writeFileSync(
+  writePrivateFile(
     transcriptPath(sessionId, baseDir),
     normalized.map((entry) => JSON.stringify(entry)).join("\n") + "\n",
-    "utf-8",
   );
-  writeFileSync(
+  writePrivateFile(
     sessionPath(sessionId, baseDir),
     JSON.stringify({ sessionId, messages: [], toolCallState: { inFlight: false }, timestamp: Date.now() }, null, 2),
-    "utf-8",
   );
 }

--- a/homerail_manager/tests/persistence-contracts.test.ts
+++ b/homerail_manager/tests/persistence-contracts.test.ts
@@ -12,11 +12,13 @@ import { closeDb, getDb } from "../src/persistence/db.js";
 import { createInitialDagRunRound } from "../src/persistence/dag-run-rounds.js";
 import {
   appendSessionTranscriptEntry,
+  checkpointForkSession,
   loadSessionTranscript,
 } from "../src/persistence/dag-session-files.js";
 import { createChangeRun } from "../src/persistence/change-runs.js";
 import { createChange, createProject, updateProject } from "../src/persistence/projects-changes.js";
 import {
+  ensureRunDir,
   listPersistedRunIdsByStatus,
   listPersistedRunSummaries,
   loadPersistedRunControlState,
@@ -166,6 +168,18 @@ describe("SQLite persistence contracts", () => {
     }]);
   });
 
+  it("reports zero nodes for a minimal persisted run", () => {
+    ensureRunDir("minimal-run");
+
+    expect(listPersistedRunSummaries()).toEqual([
+      expect.objectContaining({
+        runId: "minimal-run",
+        nodeCount: 0,
+        status: "active",
+      }),
+    ]);
+  });
+
   it("installs indexes for status filtering and updated-time run ordering", () => {
     const db = getDb();
     expect(db.prepare("SELECT MAX(version) AS version FROM schema_migrations").get())
@@ -222,6 +236,54 @@ describe("SQLite persistence contracts", () => {
     expect(finalBytes.split("\n").filter(Boolean)).toHaveLength(2);
     expect(loadSessionTranscript("append-only", baseDir)).toEqual([first, second]);
   });
+
+  it.runIf(process.platform !== "win32")(
+    "creates and repairs private session-store paths",
+    () => {
+      const baseDir = path.join(tmpHome, "private-session-store");
+      const sessionId = "private-session";
+      const sessionRoot = path.join(baseDir, sessionId);
+      const transcript = path.join(sessionRoot, "transcript.jsonl");
+      const snapshot = path.join(sessionRoot, "session.json");
+
+      appendSessionTranscriptEntry({
+        type: "assistant",
+        sessionId,
+        content: { text: "first" },
+        timestamp: 1,
+      }, baseDir);
+
+      expect(fs.statSync(sessionRoot).mode & 0o777).toBe(0o700);
+      expect(fs.statSync(transcript).mode & 0o777).toBe(0o600);
+      expect(fs.statSync(snapshot).mode & 0o777).toBe(0o600);
+
+      fs.chmodSync(sessionRoot, 0o755);
+      fs.chmodSync(transcript, 0o644);
+      fs.chmodSync(snapshot, 0o644);
+      appendSessionTranscriptEntry({
+        type: "assistant",
+        sessionId,
+        content: { text: "second" },
+        timestamp: 2,
+      }, baseDir);
+
+      expect(fs.statSync(sessionRoot).mode & 0o777).toBe(0o700);
+      expect(fs.statSync(transcript).mode & 0o777).toBe(0o600);
+      expect(fs.statSync(snapshot).mode & 0o777).toBe(0o600);
+
+      checkpointForkSession({
+        runId: "run-private-fork",
+        nodeId: "worker",
+        parentSessionId: sessionId,
+        newSessionId: "private-fork",
+        last: 1,
+      }, baseDir);
+      const forkRoot = path.join(baseDir, "private-fork");
+      expect(fs.statSync(forkRoot).mode & 0o777).toBe(0o700);
+      expect(fs.statSync(path.join(forkRoot, "transcript.jsonl")).mode & 0o777).toBe(0o600);
+      expect(fs.statSync(path.join(forkRoot, "session.json")).mode & 0o777).toBe(0o600);
+    },
+  );
 
   it("rejects invalid status and missing required secret payloads in compatibility records", () => {
     expect(() => upsertCompatRecord("nodes", {


### PR DESCRIPTION
## Summary

- create DAG session directories with private `0700` permissions
- create transcript and session snapshot files with private `0600` permissions
- repair permissive modes on an existing session when it is appended again
- keep checkpoint-forked transcripts and snapshots private
- lock the minimal persisted-run summary contract at `nodeCount: 0`

## Why

PR #124 moved transcript writes to append-only storage and explicitly used `0600` for newly created transcript files. Other session-store creation paths still used Node's default file mode, which can become `0644` under a common `022` umask. The `mode` option also does not repair an existing permissive file.

This follow-up centralizes private session-store creation and applies best-effort POSIX mode repair to paths touched by normal writes, while retaining Windows compatibility.

## Impact

- New and checkpoint-forked session stores are private by default.
- Existing session directories and files are repaired when that session receives another transcript entry.
- There is no startup scan or rewrite of inactive historical sessions.
- Windows behavior is unchanged because POSIX chmod enforcement is skipped there.

## Validation

- focused persistence contracts: 9 passed
- Manager full suite: 1,133 passed
- `npm run ci`: 2,758 passed, 2 skipped, 0 failed

## Relationship to #124

This follow-up was identified during the review of #124. After #124 merged, the single follow-up commit was rebased onto the latest `main`; the PR now contains only the two intended session-store and contract-test files.
