### PR TITLE
Add Early Access Desktop update channel

### DIFF
--- a/.github/workflows/desktop-beta-release.yml
+++ b/.github/workflows/desktop-beta-release.yml
@@ -1,10 +1,10 @@
-name: Desktop Beta Release
+name: Desktop Alpha/Beta Release
 
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: Beta version, for example 0.1.0-beta.1
+        description: "Prerelease version (current train: 0.1.0-alpha.1)"
         type: string
         required: true
       desktop_ref:
@@ -32,23 +32,25 @@ jobs:
     outputs:
       version: ${{ steps.release.outputs.version }}
       tag: ${{ steps.release.outputs.tag }}
+      channel: ${{ steps.release.outputs.channel }}
     steps:
-      - name: Validate beta version
+      - name: Validate Alpha/Beta SemVer
         id: release
         shell: bash
         env:
           REQUESTED_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          if [[ ! "$REQUESTED_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-beta\.[0-9]+$ ]]; then
-            echo "version must look like 0.1.0-beta.1" >&2
+          if [[ ! "$REQUESTED_VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-(alpha|beta)\.(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*$ ]]; then
+            echo "version must be legal Alpha/Beta SemVer, for example 0.1.0-alpha.1 or 0.1.0-alpha.3.1" >&2
             exit 1
           fi
           printf 'version=%s\n' "$REQUESTED_VERSION" >> "$GITHUB_OUTPUT"
-          printf 'tag=desktop-v%s\n' "$REQUESTED_VERSION" >> "$GITHUB_OUTPUT"
+          printf 'tag=v%s\n' "$REQUESTED_VERSION" >> "$GITHUB_OUTPUT"
+          printf 'channel=%s\n' "${BASH_REMATCH[4]}" >> "$GITHUB_OUTPUT"
 
   build:
-    name: Build signed desktop beta (${{ matrix.label }})
+    name: Build signed desktop prerelease (${{ matrix.label }})
     needs: prepare
     environment: desktop-beta-signing
     strategy:
@@ -57,14 +59,15 @@ jobs:
         include:
           - label: Windows x64
             os: windows-latest
-            artifact: desktop-beta-windows-x64
+            artifact: desktop-prerelease-windows-x64
           - label: macOS arm64
             os: macos-15
-            artifact: desktop-beta-macos-arm64
+            artifact: desktop-prerelease-macos-arm64
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     env:
       HOMERAIL_SOURCE_DIR: ${{ github.workspace }}/homerail-source
+      UPDATE_CHANNEL: ${{ needs.prepare.outputs.channel }}
     steps:
       - name: Check out HomeRail runtime source
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -110,7 +113,10 @@ jobs:
         env:
           WIN_CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
           WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
-        run: npm run dist -- --win nsis --x64 --publish never --config.forceCodeSigning=true
+        run: >-
+          npm run dist -- --win nsis --x64 --publish never
+          --config.forceCodeSigning=true
+          --config.publish.channel="${{ needs.prepare.outputs.channel }}"
 
       - name: Verify Windows package and signature
         if: runner.os == 'Windows'
@@ -134,8 +140,9 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
+          $metadataName = "$env:UPDATE_CHANNEL.yml"
           $files = @(Get-ChildItem -Path desktop/dist-electron -File | Where-Object {
-            $_.Name -match '\.(exe|blockmap)$' -or $_.Name -eq 'latest.yml'
+            $_.Name -match '\.(exe|blockmap)$' -or $_.Name -eq $metadataName
           } | Sort-Object Name)
           if ($files.Count -eq 0) { throw "No Windows release assets were produced" }
           $lines = foreach ($file in $files) {
@@ -176,6 +183,7 @@ jobs:
           --config.mac.notarize=true
           --config.mac.entitlements="$GITHUB_WORKSPACE/homerail-source/scripts/desktop-release/entitlements.mac.plist"
           --config.mac.entitlementsInherit="$GITHUB_WORKSPACE/homerail-source/scripts/desktop-release/entitlements.mac.plist"
+          --config.publish.channel="${{ needs.prepare.outputs.channel }}"
 
       - name: Verify macOS package, signature, and notarization
         if: runner.os == 'macOS'
@@ -211,11 +219,19 @@ jobs:
           while IFS= read -r asset; do
             shasum -a 256 "$asset" >> SHA256SUMS-macos.txt
             found=1
-          done < <(find . -maxdepth 1 -type f \( -name '*.dmg' -o -name '*.zip' -o -name '*.blockmap' -o -name 'latest-mac.yml' \) -print | sort)
+          done < <(find . -maxdepth 1 -type f \( -name '*.dmg' -o -name '*.zip' -o -name '*.blockmap' -o -name "$UPDATE_CHANNEL-mac.yml" \) -print | sort)
           if [[ $found -eq 0 ]]; then
             echo "No macOS release assets were produced" >&2
             exit 1
           fi
+
+      - name: Verify channel metadata and same-build checksums
+        working-directory: desktop
+        run: >-
+          npm run verify:update-metadata --
+          --dist dist-electron
+          --channel "${{ needs.prepare.outputs.channel }}"
+          --platform "${{ runner.os == 'macOS' && 'macos' || 'windows' }}"
 
       - name: Upload Windows release assets
         if: runner.os == 'Windows'
@@ -225,7 +241,7 @@ jobs:
           path: |
             desktop/dist-electron/*.exe
             desktop/dist-electron/*.blockmap
-            desktop/dist-electron/latest.yml
+            desktop/dist-electron/${{ needs.prepare.outputs.channel }}.yml
             desktop/dist-electron/SHA256SUMS-windows.txt
           if-no-files-found: error
           retention-days: 7
@@ -239,7 +255,7 @@ jobs:
             desktop/dist-electron/*.dmg
             desktop/dist-electron/*.zip
             desktop/dist-electron/*.blockmap
-            desktop/dist-electron/latest-mac.yml
+            desktop/dist-electron/${{ needs.prepare.outputs.channel }}-mac.yml
             desktop/dist-electron/SHA256SUMS-macos.txt
           if-no-files-found: error
           retention-days: 7
@@ -254,13 +270,13 @@ jobs:
       - name: Download Windows assets
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
-          name: desktop-beta-windows-x64
+          name: desktop-prerelease-windows-x64
           path: release-assets/windows
 
       - name: Download macOS assets
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
-          name: desktop-beta-macos-arm64
+          name: desktop-prerelease-macos-arm64
           path: release-assets/macos
 
       - name: Validate release asset boundary
@@ -269,7 +285,7 @@ jobs:
           set -euo pipefail
           while IFS= read -r asset; do
             case "${asset##*/}" in
-              *.exe|*.dmg|*.zip|*.blockmap|latest.yml|latest-mac.yml|SHA256SUMS-*.txt) ;;
+              *.exe|*.dmg|*.zip|*.blockmap|alpha.yml|alpha-mac.yml|beta.yml|beta-mac.yml|SHA256SUMS-*.txt) ;;
               *) echo "Unexpected release asset: $asset" >&2; exit 1 ;;
             esac
           done < <(find release-assets -type f -print | sort)
@@ -280,6 +296,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
           RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+          UPDATE_CHANNEL: ${{ needs.prepare.outputs.channel }}
           DESKTOP_REF: ${{ inputs.desktop_ref }}
         run: |
           set -euo pipefail
@@ -293,6 +310,6 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --target "$GITHUB_SHA" \
             --title "HomeRail Desktop $RELEASE_VERSION" \
-            --notes "Draft beta built from HomeRail $GITHUB_SHA and homerail_desktop $DESKTOP_REF. Install and test both platforms before publishing." \
+            --notes "Draft $UPDATE_CHANNEL built from HomeRail $GITHUB_SHA and homerail_desktop $DESKTOP_REF. Install and test both platforms before publishing." \
             --draft \
             --prerelease

--- a/agent-ui/src/components/agent/settings/DesktopUpdateSettings.test.ts
+++ b/agent-ui/src/components/agent/settings/DesktopUpdateSettings.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, type App } from 'vue'
+import { i18n } from '@/plugins/i18n'
+import DesktopUpdateSettings from './DesktopUpdateSettings.vue'
+
+function updateStatus(overrides: Partial<DesktopUpdateStatus> = {}): DesktopUpdateStatus {
+  return {
+    supported: true,
+    state: 'not-available',
+    currentVersion: '0.1.0-alpha.1',
+    channel: 'stable',
+    ...overrides,
+  }
+}
+
+async function flushUi(): Promise<void> {
+  await Promise.resolve()
+  await nextTick()
+}
+
+describe('DesktopUpdateSettings', () => {
+  let app: App<Element> | null = null
+  let root: HTMLElement | null = null
+
+  beforeEach(() => {
+    i18n.global.locale.value = 'en-US'
+  })
+
+  afterEach(() => {
+    app?.unmount()
+    root?.remove()
+    app = null
+    root = null
+    Reflect.deleteProperty(window, 'homerailDesktop')
+    vi.restoreAllMocks()
+  })
+
+  function mount(bridge: HomeRailDesktopBridge): void {
+    Object.defineProperty(window, 'homerailDesktop', {
+      configurable: true,
+      value: bridge,
+    })
+    root = document.createElement('div')
+    document.body.appendChild(root)
+    app = createApp(DesktopUpdateSettings)
+    app.use(i18n)
+    app.mount(root)
+  }
+
+  it('shows the persisted channel and switches to Early Access through the desktop bridge', async () => {
+    const setUpdateChannel = vi.fn().mockResolvedValue(updateStatus({
+      channel: 'early-access',
+      state: 'checking',
+    }))
+    mount({
+      updateStatus: vi.fn().mockResolvedValue(updateStatus()),
+      setUpdateChannel,
+    })
+    await flushUi()
+
+    expect(root?.textContent).toContain('Desktop updates')
+    expect(root?.textContent).toContain('Installed version: 0.1.0-alpha.1')
+    expect(root?.querySelector('[data-testid="desktop-update-channel-stable"]')?.getAttribute('aria-checked')).toBe('true')
+
+    root?.querySelector<HTMLButtonElement>('[data-testid="desktop-update-channel-early-access"]')?.click()
+    await flushUi()
+
+    expect(setUpdateChannel).toHaveBeenCalledWith('early-access')
+    expect(root?.querySelector('[data-testid="desktop-update-channel-early-access"]')?.getAttribute('aria-checked')).toBe('true')
+  })
+
+  it('explains that switching a prerelease to Stable will not downgrade it', async () => {
+    mount({
+      updateStatus: vi.fn().mockResolvedValue(updateStatus({
+        channelNotice: 'waiting-for-newer-stable',
+      })),
+      setUpdateChannel: vi.fn(),
+    })
+    await flushUi()
+
+    expect(root?.querySelector('[data-testid="desktop-update-channel-notice"]')?.textContent)
+      .toContain('will not downgrade')
+  })
+
+  it('disables channel switching while an update is downloaded', async () => {
+    const setUpdateChannel = vi.fn()
+    mount({
+      updateStatus: vi.fn().mockResolvedValue(updateStatus({ state: 'downloaded' })),
+      setUpdateChannel,
+    })
+    await flushUi()
+
+    const earlyAccess = root?.querySelector<HTMLButtonElement>('[data-testid="desktop-update-channel-early-access"]')
+    expect(earlyAccess?.disabled).toBe(true)
+    earlyAccess?.click()
+    expect(setUpdateChannel).not.toHaveBeenCalled()
+  })
+
+  it('shows a channel switch failure instead of swallowing it', async () => {
+    mount({
+      updateStatus: vi.fn().mockResolvedValue(updateStatus()),
+      setUpdateChannel: vi.fn().mockRejectedValue(new Error('preference file is read-only')),
+    })
+    await flushUi()
+
+    root?.querySelector<HTMLButtonElement>('[data-testid="desktop-update-channel-early-access"]')?.click()
+    await flushUi()
+
+    expect(root?.querySelector('[data-testid="desktop-update-error"]')?.textContent)
+      .toContain('preference file is read-only')
+  })
+
+  it('stays hidden in the standalone web UI', async () => {
+    mount({})
+    await flushUi()
+    expect(root?.querySelector('[data-testid="desktop-update-settings"]')).toBeNull()
+  })
+})

--- a/agent-ui/src/components/agent/settings/DesktopUpdateSettings.vue
+++ b/agent-ui/src/components/agent/settings/DesktopUpdateSettings.vue
@@ -1,0 +1,130 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { Check, FlaskConical, Loader2, ShieldCheck } from 'lucide-vue-next'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+const status = ref<DesktopUpdateStatus | null>(null)
+const bridgeAvailable = ref(false)
+const switching = ref(false)
+const localError = ref('')
+let removeListener: (() => void) | null = null
+
+const channelBusy = computed(() => {
+  if (switching.value) return true
+  return ['checking', 'available', 'downloading', 'downloaded'].includes(status.value?.state ?? '')
+})
+
+const statusText = computed(() => {
+  if (!status.value) return ''
+  return t(`settings.general.updates.state.${status.value.state}`)
+})
+
+function desktopBridge(): HomeRailDesktopBridge | null {
+  return typeof window === 'undefined' ? null : window.homerailDesktop ?? null
+}
+
+async function selectChannel(channel: DesktopUpdateChannel): Promise<void> {
+  const bridge = desktopBridge()
+  if (!bridge?.setUpdateChannel || channelBusy.value || status.value?.channel === channel) return
+  switching.value = true
+  localError.value = ''
+  try {
+    status.value = await bridge.setUpdateChannel(channel)
+  } catch (error) {
+    localError.value = error instanceof Error ? error.message : String(error)
+  } finally {
+    switching.value = false
+  }
+}
+
+onMounted(() => {
+  const bridge = desktopBridge()
+  bridgeAvailable.value = Boolean(bridge?.updateStatus && bridge?.setUpdateChannel)
+  if (!bridgeAvailable.value || !bridge?.updateStatus) return
+  removeListener = bridge.onUpdateStatus?.((nextStatus) => {
+    status.value = nextStatus
+  }) ?? null
+  void bridge.updateStatus()
+    .then((nextStatus) => {
+      status.value = nextStatus
+    })
+    .catch((error) => {
+      localError.value = error instanceof Error ? error.message : String(error)
+    })
+})
+
+onBeforeUnmount(() => {
+  removeListener?.()
+  removeListener = null
+})
+</script>
+
+<template>
+  <div
+    v-if="bridgeAvailable"
+    class="border-b border-[var(--hr-border)] pb-6"
+    data-testid="desktop-update-settings"
+  >
+    <div class="flex items-start gap-3">
+      <div class="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg border border-[var(--hr-border)] bg-[var(--hr-surface-1)] text-[var(--hr-text-2)]">
+        <Loader2 v-if="switching" class="h-4 w-4 animate-spin" />
+        <FlaskConical v-else class="h-4 w-4" />
+      </div>
+      <div class="min-w-0 flex-1">
+        <div class="text-sm font-medium text-[var(--hr-text-1)]">{{ t('settings.general.updates.title') }}</div>
+        <div class="mt-1 text-sm text-[var(--hr-text-3)]">{{ t('settings.general.updates.description') }}</div>
+
+        <div
+          class="mt-4 grid max-w-2xl gap-3 sm:grid-cols-2"
+          role="radiogroup"
+          :aria-label="t('settings.general.updates.title')"
+        >
+          <button
+            v-for="channel in (['stable', 'early-access'] as DesktopUpdateChannel[])"
+            :key="channel"
+            class="flex min-h-24 items-start gap-3 rounded-xl border px-4 py-3 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-60"
+            :class="status?.channel === channel
+              ? 'border-[var(--hr-settings-active-border)] bg-[var(--hr-settings-active)] text-[var(--hr-text-1)]'
+              : 'border-[var(--hr-settings-divider)] bg-[var(--hr-settings-card)] text-[var(--hr-text-2)] hover:border-[var(--hr-border-strong)] hover:bg-[var(--hr-settings-card-hover)]'"
+            :data-testid="`desktop-update-channel-${channel}`"
+            type="button"
+            role="radio"
+            :aria-checked="status?.channel === channel"
+            :disabled="channelBusy"
+            @click="selectChannel(channel)"
+          >
+            <ShieldCheck v-if="channel === 'stable'" class="mt-0.5 h-4 w-4 flex-shrink-0" />
+            <FlaskConical v-else class="mt-0.5 h-4 w-4 flex-shrink-0" />
+            <span class="min-w-0 flex-1">
+              <span class="block text-sm font-semibold">{{ t(`settings.general.updates.channels.${channel}.label`) }}</span>
+              <span class="mt-1 block text-xs leading-5 text-[var(--hr-text-3)]">
+                {{ t(`settings.general.updates.channels.${channel}.description`) }}
+              </span>
+            </span>
+            <Check v-if="status?.channel === channel" class="mt-0.5 h-4 w-4 flex-shrink-0 text-[var(--hr-accent)]" />
+          </button>
+        </div>
+
+        <p v-if="status" class="mt-3 text-xs text-[var(--hr-text-3)]" data-testid="desktop-update-state">
+          {{ t('settings.general.updates.currentVersion', { version: status.currentVersion }) }}
+          · {{ statusText }}
+        </p>
+        <p
+          v-if="status?.channelNotice === 'waiting-for-newer-stable'"
+          class="mt-2 text-xs leading-5 text-[var(--hr-warning)]"
+          data-testid="desktop-update-channel-notice"
+        >
+          {{ t('settings.general.updates.waitingForStable') }}
+        </p>
+        <p
+          v-if="localError || status?.error"
+          class="mt-2 break-words text-xs leading-5 text-[var(--hr-danger)]"
+          data-testid="desktop-update-error"
+        >
+          {{ t('settings.general.updates.error', { message: localError || status?.error }) }}
+        </p>
+      </div>
+    </div>
+  </div>
+</template>

--- a/agent-ui/src/components/agent/settings/GeneralSettings.vue
+++ b/agent-ui/src/components/agent/settings/GeneralSettings.vue
@@ -9,6 +9,7 @@ import {
   subscribeAppearanceRegistry,
   type AppearancePlugin,
 } from '@/appearance/appearance-registry'
+import DesktopUpdateSettings from './DesktopUpdateSettings.vue'
 
 const uiStore = useUiStore()
 const { locale, t } = useI18n()
@@ -124,5 +125,7 @@ function selectLocale(nextLocale: AppLocale): void {
         </div>
       </div>
     </div>
+
+    <DesktopUpdateSettings />
   </section>
 </template>

--- a/agent-ui/src/locales/en-US/settings.json
+++ b/agent-ui/src/locales/en-US/settings.json
@@ -50,6 +50,32 @@
         "zhHant": "Traditional Chinese",
         "enUS": "English"
       }
+    },
+    "updates": {
+      "title": "Desktop updates",
+      "description": "Choose which signed, published HomeRail Desktop releases this device can receive.",
+      "channels": {
+        "stable": {
+          "label": "Stable",
+          "description": "Receive final releases only. Alpha and Beta releases stay hidden."
+        },
+        "early-access": {
+          "label": "Early Access",
+          "description": "Follow the current Alpha train, then Beta and Stable without opting in again."
+        }
+      },
+      "currentVersion": "Installed version: {version}",
+      "waitingForStable": "This prerelease will stay installed until a newer Stable version is available. HomeRail will not downgrade it.",
+      "error": "Update channel change failed: {message}",
+      "state": {
+        "idle": "Ready to check",
+        "checking": "Checking for updates…",
+        "available": "Update found",
+        "downloading": "Downloading update…",
+        "downloaded": "Update downloaded; restart to install",
+        "not-available": "No newer update on this channel",
+        "error": "Update check failed"
+      }
     }
   },
   "environment": {

--- a/agent-ui/src/locales/zh-Hans/settings.json
+++ b/agent-ui/src/locales/zh-Hans/settings.json
@@ -50,6 +50,32 @@
         "zhHant": "繁体中文",
         "enUS": "英语"
       }
+    },
+    "updates": {
+      "title": "桌面版更新",
+      "description": "选择此设备可以接收哪些已签名且已公开发布的 HomeRail Desktop 版本。",
+      "channels": {
+        "stable": {
+          "label": "稳定版",
+          "description": "只接收正式版本，不会看到 Alpha 或 Beta 预发布版。"
+        },
+        "early-access": {
+          "label": "抢先体验",
+          "description": "跟随当前 Alpha 通道，未来会自然升级到 Beta 和稳定版，无需再次选择。"
+        }
+      },
+      "currentVersion": "当前安装版本：{version}",
+      "waitingForStable": "当前预发布版本会继续保留，直到出现版本号更高的稳定版；HomeRail 不会自动降级。",
+      "error": "更新通道切换失败：{message}",
+      "state": {
+        "idle": "可以检查更新",
+        "checking": "正在检查更新…",
+        "available": "发现新版本",
+        "downloading": "正在下载更新…",
+        "downloaded": "更新已下载，重启后安装",
+        "not-available": "此通道暂无更高版本",
+        "error": "更新检查失败"
+      }
     }
   },
   "environment": {

--- a/agent-ui/src/locales/zh-Hant/settings.json
+++ b/agent-ui/src/locales/zh-Hant/settings.json
@@ -50,6 +50,32 @@
         "zhHant": "繁體中文",
         "enUS": "英語"
       }
+    },
+    "updates": {
+      "title": "桌面版更新",
+      "description": "選擇此裝置可以接收哪些已簽署且已公開發佈的 HomeRail Desktop 版本。",
+      "channels": {
+        "stable": {
+          "label": "穩定版",
+          "description": "只接收正式版本，不會看到 Alpha 或 Beta 預發佈版。"
+        },
+        "early-access": {
+          "label": "搶先體驗",
+          "description": "跟隨目前 Alpha 通道，未來會自然升級到 Beta 和穩定版，無需再次選擇。"
+        }
+      },
+      "currentVersion": "目前安裝版本：{version}",
+      "waitingForStable": "目前預發佈版本會繼續保留，直到出現版本號更高的穩定版；HomeRail 不會自動降級。",
+      "error": "更新通道切換失敗：{message}",
+      "state": {
+        "idle": "可以檢查更新",
+        "checking": "正在檢查更新…",
+        "available": "找到新版本",
+        "downloading": "正在下載更新…",
+        "downloaded": "更新已下載，重新啟動後安裝",
+        "not-available": "此通道暫無更高版本",
+        "error": "更新檢查失敗"
+      }
     }
   },
   "environment": {

--- a/agent-ui/src/types/homerail-desktop.d.ts
+++ b/agent-ui/src/types/homerail-desktop.d.ts
@@ -10,10 +10,14 @@ declare global {
     | 'not-available'
     | 'error'
 
+  type DesktopUpdateChannel = 'stable' | 'early-access'
+
   interface DesktopUpdateStatus {
     supported: boolean
     state: DesktopUpdateState
     currentVersion: string
+    channel: DesktopUpdateChannel
+    channelNotice?: 'waiting-for-newer-stable'
     update?: {
       version?: string
       releaseName?: string | null
@@ -34,6 +38,7 @@ declare global {
     version?: () => Promise<unknown>
     updateStatus?: () => Promise<DesktopUpdateStatus>
     checkForUpdates?: () => Promise<DesktopUpdateStatus>
+    setUpdateChannel?: (channel: DesktopUpdateChannel) => Promise<DesktopUpdateStatus>
     installUpdate?: () => Promise<DesktopUpdateStatus>
     onUpdateStatus?: (handler: (status: DesktopUpdateStatus) => void) => () => void
   }

--- a/docs/desktop-beta-release.md
+++ b/docs/desktop-beta-release.md
@@ -1,9 +1,49 @@
-# Desktop Beta release
+# Desktop prerelease updates (Alpha is current)
 
-HomeRail Desktop Beta releases are built manually from the public `homerail`
-repository. The workflow checks out the private `homerail_desktop` repository,
-builds Windows x64 and macOS arm64 packages in parallel, and creates a draft
-prerelease. It never publishes a release automatically.
+HomeRail uses one SemVer version across the repository. The current public
+release train starts at package/release version `0.1.0-alpha.1`, followed by
+`0.1.0-alpha.2` and so on. A same-Alpha repair may use a legal SemVer such as
+`0.1.0-alpha.3.1`. Beta (`0.1.0-beta.1`) and Stable (`0.1.0`) are reserved
+future stages; documenting them does not mean they are ready to publish.
+
+The Git tag is the same version with a single `v` prefix, for example
+`v0.1.0-alpha.1`. The package version and GitHub Release title omit `v`.
+Prefixes such as `desktop-v` and `rust-v` are forbidden: electron-updater
+6.8.9 rejects those tags as invalid SemVer while scanning the GitHub release
+feed.
+
+The manual workflow checks out the private `homerail_desktop` repository,
+builds signed Windows x64 and macOS arm64 packages in parallel, and creates a
+draft prerelease. It never publishes a release automatically.
+
+## Update channels
+
+The Desktop UI offers two persisted choices:
+
+- **Stable** (default for a final installed version) uses `latest.yml` on
+  Windows and `latest-mac.yml` on macOS. It never accepts a prerelease.
+- **Early Access** (the migration default for an installed prerelease) follows
+  Alpha, then Beta, then Stable without asking the user to opt in again. Alpha
+  releases use `alpha.yml` / `alpha-mac.yml`; Beta releases use `beta.yml` /
+  `beta-mac.yml`.
+
+electron-updater changes the requested metadata name as a prerelease moves from
+Alpha to Beta; a Beta install stays on Beta and never receives Alpha. When
+Early Access reaches a final release, it keeps the saved preference so the next
+Alpha can be discovered. A future Stable release must therefore upload
+canonical `latest.yml` / `latest-mac.yml` plus byte-identical Alpha and Beta
+compatibility metadata (`alpha.yml`, `beta.yml`, and their `-mac` forms)
+produced from that same build. The private desktop script
+`scripts/update-metadata.mjs` verifies every referenced artifact checksum and
+creates only those Stable aliases.
+
+Downgrades are always disabled. Switching an Alpha or Beta install to Stable
+does not install an older final version; the UI explains that it will wait for
+a newer Stable version.
+
+GitHub draft releases are invisible to electron-updater. A signed draft becomes
+available to installed applications only after a human publishes it. Alpha and
+Beta releases must remain marked as prereleases when published.
 
 ## One-time GitHub setup
 
@@ -30,28 +70,47 @@ Keep all certificate passwords and private keys out of Git. The workflow
 decodes the Apple API key into the ephemeral macOS runner and removes it after
 the notarization attempt.
 
-## Build a beta
+## Build an Alpha draft
 
-1. Open **Actions → Desktop Beta Release → Run workflow**.
+1. Open **Actions → Desktop Alpha/Beta Release → Run workflow**.
 2. Select the HomeRail revision to package.
-3. Enter a version such as `0.1.0-beta.1`.
-4. Enter a `homerail_desktop` commit SHA. `main` is accepted for convenience,
-   but a full commit SHA is recommended for a reproducible release.
+3. Enter `0.1.0-alpha.1` (or the next Alpha SemVer).
+4. Enter a full `homerail_desktop` commit SHA. `main` is accepted for
+   convenience, but a commit SHA is reproducible.
 5. Approve the `desktop-beta-signing` environment deployment.
-6. Wait for both signed builds and the draft-release job.
+6. Confirm both signed builds and the draft-release job succeed.
 
-The result is a draft prerelease named `HomeRail Desktop <version>`. Only users
-with write access can see a draft release.
+The workflow derives tag `v0.1.0-alpha.1` and channel `alpha`; callers cannot
+provide an arbitrary tag or metadata channel. It passes the channel to the
+locked electron-builder, verifies `alpha.yml` and `alpha-mac.yml`, checks that
+their SHA-512 values match artifacts from the same build, includes installers
+and blockmaps in the checksum manifests, and uploads only the explicit asset
+allowlist.
 
-## Test before publishing
+The result is a draft prerelease named `HomeRail Desktop 0.1.0-alpha.1`. Only
+users with write access can see the draft, and no installed app can update from
+it.
 
-- Windows: install the public self-signed certificate on the test machine,
-  install the NSIS package, launch HomeRail, complete onboarding, and uninstall
-  it once.
-- macOS: mount the DMG, install HomeRail, confirm Gatekeeper accepts it, launch
-  it, complete onboarding, and quit/relaunch it once.
-- Install the next draft beta over the first one to verify the upgrade path and
-  persisted HomeRail data.
+## Signed-install acceptance before publishing
 
-After both platforms pass, edit the draft release in GitHub and publish it as a
-prerelease. Do not publish a beta that has only been tested on one platform.
+Use signed installations on both operating systems. Do not claim these checks
+from an unsigned local package or from metadata-only tests.
+
+| Installed preference/version | Published releases | Expected result |
+| --- | --- | --- |
+| Stable / final | newer final | Downloads the final update |
+| Stable / final | Alpha or Beta only | No update |
+| Early Access / `0.1.0-alpha.1` | `0.1.0-alpha.2` | Downloads Alpha 2 |
+| Early Access / latest Alpha | `0.1.0-beta.1` | Downloads Beta 1 |
+| Early Access / Alpha or Beta | `0.1.0` | Downloads Stable |
+| Early Access / `0.1.0` after that upgrade | next train Alpha | Still opted in and downloads it |
+
+Also switch a prerelease install to Stable while no higher final version
+exists. It must not downgrade, and Settings must show the waiting explanation.
+
+On Windows, install the NSIS package, launch HomeRail, complete onboarding,
+exercise “Restart to update,” and uninstall once. On macOS, install from the
+DMG, confirm Gatekeeper acceptance, launch and complete onboarding, exercise
+“Restart to update,” and quit/relaunch once. Publish the draft prerelease only
+after both platforms pass. Publishing and the future full Stable release flow
+are outside this workflow.

--- a/scripts/desktop-beta-release-contracts.test.mjs
+++ b/scripts/desktop-beta-release-contracts.test.mjs
@@ -10,7 +10,7 @@ const workflow = fs.readFileSync(
   "utf8",
 ).replace(/\r\n/g, "\n");
 
-test("desktop beta release is manual, owner-only, and draft-only", () => {
+test("desktop prerelease is manual, owner-only, and draft-only", () => {
   assert.match(workflow, /workflow_dispatch:/);
   assert.doesNotMatch(workflow, /^\s{2}(?:push|pull_request|schedule):/m);
   assert.match(workflow, /if: github\.actor == 'xiaotianfotos'/);
@@ -21,7 +21,7 @@ test("desktop beta release is manual, owner-only, and draft-only", () => {
   assert.match(workflow, /cancel-in-progress: false/);
 });
 
-test("desktop beta release uses isolated hosted builders and a read-only private checkout", () => {
+test("desktop prerelease uses isolated hosted builders and a read-only private checkout", () => {
   assert.match(workflow, /os: windows-latest/);
   assert.match(workflow, /os: macos-15/);
   assert.match(workflow, /repository: xiaotianfotos\/homerail_desktop/);
@@ -29,6 +29,24 @@ test("desktop beta release uses isolated hosted builders and a read-only private
   assert.equal((workflow.match(/persist-credentials: false/g) ?? []).length, 2);
   assert.doesNotMatch(workflow, /runs-on:.*self-hosted/);
   assert.match(workflow, /HOMERAIL_SOURCE_DIR: \$\{\{ github\.workspace \}\}\/homerail-source/);
+});
+
+test("release versions use updater-compatible unified SemVer tags", () => {
+  assert.match(workflow, /0\.1\.0-alpha\.1/);
+  assert.match(workflow, /\(alpha\|beta\)/);
+  assert.match(workflow, /printf 'tag=v%s\\n' "\$REQUESTED_VERSION"/);
+  assert.match(workflow, /printf 'channel=%s\\n' "\$\{BASH_REMATCH\[4\]\}"/);
+  assert.doesNotMatch(workflow, /desktop-v/);
+  assert.doesNotMatch(workflow, /rust-v/);
+});
+
+test("locked builder receives the channel and only matching metadata is uploaded", () => {
+  assert.equal((workflow.match(/--config\.publish\.channel=/g) ?? []).length, 2);
+  assert.match(workflow, /verify:update-metadata/);
+  assert.match(workflow, /needs\.prepare\.outputs\.channel \}\}\.yml/);
+  assert.match(workflow, /needs\.prepare\.outputs\.channel \}\}-mac\.yml/);
+  assert.match(workflow, /alpha\.yml\|alpha-mac\.yml\|beta\.yml\|beta-mac\.yml/);
+  assert.doesNotMatch(workflow, /desktop\/dist-electron\/latest(?:-mac)?\.yml/);
 });
 
 test("both packages must be signed and macOS must be notarized", () => {
@@ -86,4 +104,17 @@ test("tracked release configuration contains no machine-local identity", () => {
   assert.doesNotMatch(tracked, /\b(?:10|192\.168|172\.(?:1[6-9]|2[0-9]|3[01]))\.[0-9]{1,3}\.[0-9]{1,3}\b/);
   assert.doesNotMatch(tracked, /\/(?:Users|home|vol[0-9]*)\//);
   assert.doesNotMatch(tracked, /@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/);
+});
+
+test("release documentation states the current Alpha and draft visibility boundaries", () => {
+  const docs = fs.readFileSync(
+    path.join(repoRoot, "docs", "desktop-beta-release.md"),
+    "utf8",
+  );
+  assert.match(docs, /current public\s+release train starts at package\/release version `0\.1\.0-alpha\.1`/);
+  assert.match(docs, /`v0\.1\.0-alpha\.1`/);
+  assert.match(docs, /Prefixes such as `desktop-v` and `rust-v` are forbidden/);
+  assert.match(docs, /draft releases are invisible to electron-updater/);
+  assert.match(docs, /`latest\.yml` \/ `latest-mac\.yml` plus byte-identical Alpha and Beta/s);
+  assert.match(docs, /Beta .* and Stable .* are reserved/s);
 });


### PR DESCRIPTION
## Summary
- add a simple **Stable / Early Access** Desktop setting, narrow bridge types, and en-US/zh-Hans/zh-Hant copy
- explain the no-downgrade behavior when a prerelease build is newer than the available Stable build
- require updater-parseable `v<SemVer>` tags and explicit Alpha/Beta metadata from the same signed build
- document the current Alpha phase, Draft visibility boundary, channel contract, and manual upgrade matrix

## Cross-repo dependency
Counterpart private Desktop PR: will be linked here immediately after its Draft PR is created.

Recommended merge order: **private Desktop PR first, then this public PR**. The public settings UI treats the new bridge as optional, while the updater workflow calls the private repository metadata verifier.

## Version and channel contract
- Current first public train: package/release `0.1.0-alpha.1`, Git tag `v0.1.0-alpha.1`; legal same-train repairs include `0.1.0-alpha.3.1`.
- Future order is Alpha → Beta → Stable. Beta and Stable support are reserved here and do not mean they are being published now.
- `desktop-v...` and `rust-v...` are intentionally rejected because electron-updater GitHubProvider requires a SemVer tag.
- Stable uses `latest`; prereleases use `alpha` / `beta`. Stable metadata also carries byte-identical Alpha/Beta compatibility aliases so persisted Early Access users remain opted in after reaching Stable.
- GitHub Draft Releases remain invisible to electron-updater; this change does not publish a release.

## Validation
- Agent UI typecheck: pass
- Agent UI full unit suite: 87 files / 460 tests passed
- focused Desktop settings tests: 8 passed
- Agent UI production build: pass (warnings only)
- workflow/docs release-contract tests: 9 passed
- workflow YAML parse and `git diff --check`: pass

## Manual acceptance still required
- signed Windows x64 and macOS arm64 install/upgrade matrix: Stable→Stable, Stable hides Alpha/Beta, Alpha.1→Alpha.2, Alpha→Beta, Alpha/Beta→Stable, persisted Early Access→next Alpha, and prerelease→Stable with no downgrade
- confirm Draft Releases stay invisible and published prerelease/stable assets install correctly

No signing or release workflow was triggered, no Release was published, and no signing secret was read or modified.