### PR TITLE
Add Early Access Desktop update settings

### DIFF
--- a/agent-ui/src/components/agent/settings/DesktopUpdateSettings.test.ts
+++ b/agent-ui/src/components/agent/settings/DesktopUpdateSettings.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, type App } from 'vue'
+import { i18n } from '@/plugins/i18n'
+import DesktopUpdateSettings from './DesktopUpdateSettings.vue'
+
+function updateStatus(overrides: Partial<DesktopUpdateStatus> = {}): DesktopUpdateStatus {
+  return {
+    supported: true,
+    state: 'not-available',
+    currentVersion: '0.1.0-alpha.1',
+    channel: 'stable',
+    ...overrides,
+  }
+}
+
+async function flushUi(): Promise<void> {
+  await Promise.resolve()
+  await nextTick()
+}
+
+describe('DesktopUpdateSettings', () => {
+  let app: App<Element> | null = null
+  let root: HTMLElement | null = null
+
+  beforeEach(() => {
+    i18n.global.locale.value = 'en-US'
+  })
+
+  afterEach(() => {
+    app?.unmount()
+    root?.remove()
+    app = null
+    root = null
+    Reflect.deleteProperty(window, 'homerailDesktop')
+    vi.restoreAllMocks()
+  })
+
+  function mount(bridge: HomeRailDesktopBridge): void {
+    Object.defineProperty(window, 'homerailDesktop', {
+      configurable: true,
+      value: bridge,
+    })
+    root = document.createElement('div')
+    document.body.appendChild(root)
+    app = createApp(DesktopUpdateSettings)
+    app.use(i18n)
+    app.mount(root)
+  }
+
+  it('shows the persisted channel and switches to Early Access through the desktop bridge', async () => {
+    const setUpdateChannel = vi.fn().mockResolvedValue(updateStatus({
+      channel: 'early-access',
+      state: 'checking',
+    }))
+    mount({
+      updateStatus: vi.fn().mockResolvedValue(updateStatus()),
+      setUpdateChannel,
+    })
+    await flushUi()
+
+    expect(root?.textContent).toContain('Desktop updates')
+    expect(root?.textContent).toContain('Installed version: 0.1.0-alpha.1')
+    expect(root?.querySelector('[data-testid="desktop-update-channel-stable"]')?.getAttribute('aria-checked')).toBe('true')
+
+    root?.querySelector<HTMLButtonElement>('[data-testid="desktop-update-channel-early-access"]')?.click()
+    await flushUi()
+
+    expect(setUpdateChannel).toHaveBeenCalledWith('early-access')
+    expect(root?.querySelector('[data-testid="desktop-update-channel-early-access"]')?.getAttribute('aria-checked')).toBe('true')
+  })
+
+  it('explains that switching a prerelease to Stable will not downgrade it', async () => {
+    mount({
+      updateStatus: vi.fn().mockResolvedValue(updateStatus({
+        channelNotice: 'waiting-for-newer-stable',
+      })),
+      setUpdateChannel: vi.fn(),
+    })
+    await flushUi()
+
+    expect(root?.querySelector('[data-testid="desktop-update-channel-notice"]')?.textContent)
+      .toContain('will not downgrade')
+  })
+
+  it('disables channel switching while an update is downloaded', async () => {
+    const setUpdateChannel = vi.fn()
+    mount({
+      updateStatus: vi.fn().mockResolvedValue(updateStatus({ state: 'downloaded' })),
+      setUpdateChannel,
+    })
+    await flushUi()
+
+    const earlyAccess = root?.querySelector<HTMLButtonElement>('[data-testid="desktop-update-channel-early-access"]')
+    expect(earlyAccess?.disabled).toBe(true)
+    earlyAccess?.click()
+    expect(setUpdateChannel).not.toHaveBeenCalled()
+  })
+
+  it('shows a channel switch failure instead of swallowing it', async () => {
+    mount({
+      updateStatus: vi.fn().mockResolvedValue(updateStatus()),
+      setUpdateChannel: vi.fn().mockRejectedValue(new Error('preference file is read-only')),
+    })
+    await flushUi()
+
+    root?.querySelector<HTMLButtonElement>('[data-testid="desktop-update-channel-early-access"]')?.click()
+    await flushUi()
+
+    expect(root?.querySelector('[data-testid="desktop-update-error"]')?.textContent)
+      .toContain('preference file is read-only')
+  })
+
+  it('stays hidden in the standalone web UI', async () => {
+    mount({})
+    await flushUi()
+    expect(root?.querySelector('[data-testid="desktop-update-settings"]')).toBeNull()
+  })
+})

--- a/agent-ui/src/components/agent/settings/DesktopUpdateSettings.vue
+++ b/agent-ui/src/components/agent/settings/DesktopUpdateSettings.vue
@@ -1,0 +1,130 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { Check, FlaskConical, Loader2, ShieldCheck } from 'lucide-vue-next'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+const status = ref<DesktopUpdateStatus | null>(null)
+const bridgeAvailable = ref(false)
+const switching = ref(false)
+const localError = ref('')
+let removeListener: (() => void) | null = null
+
+const channelBusy = computed(() => {
+  if (switching.value) return true
+  return ['checking', 'available', 'downloading', 'downloaded'].includes(status.value?.state ?? '')
+})
+
+const statusText = computed(() => {
+  if (!status.value) return ''
+  return t(`settings.general.updates.state.${status.value.state}`)
+})
+
+function desktopBridge(): HomeRailDesktopBridge | null {
+  return typeof window === 'undefined' ? null : window.homerailDesktop ?? null
+}
+
+async function selectChannel(channel: DesktopUpdateChannel): Promise<void> {
+  const bridge = desktopBridge()
+  if (!bridge?.setUpdateChannel || channelBusy.value || status.value?.channel === channel) return
+  switching.value = true
+  localError.value = ''
+  try {
+    status.value = await bridge.setUpdateChannel(channel)
+  } catch (error) {
+    localError.value = error instanceof Error ? error.message : String(error)
+  } finally {
+    switching.value = false
+  }
+}
+
+onMounted(() => {
+  const bridge = desktopBridge()
+  bridgeAvailable.value = Boolean(bridge?.updateStatus && bridge?.setUpdateChannel)
+  if (!bridgeAvailable.value || !bridge?.updateStatus) return
+  removeListener = bridge.onUpdateStatus?.((nextStatus) => {
+    status.value = nextStatus
+  }) ?? null
+  void bridge.updateStatus()
+    .then((nextStatus) => {
+      status.value = nextStatus
+    })
+    .catch((error) => {
+      localError.value = error instanceof Error ? error.message : String(error)
+    })
+})
+
+onBeforeUnmount(() => {
+  removeListener?.()
+  removeListener = null
+})
+</script>
+
+<template>
+  <div
+    v-if="bridgeAvailable"
+    class="border-b border-[var(--hr-border)] pb-6"
+    data-testid="desktop-update-settings"
+  >
+    <div class="flex items-start gap-3">
+      <div class="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg border border-[var(--hr-border)] bg-[var(--hr-surface-1)] text-[var(--hr-text-2)]">
+        <Loader2 v-if="switching" class="h-4 w-4 animate-spin" />
+        <FlaskConical v-else class="h-4 w-4" />
+      </div>
+      <div class="min-w-0 flex-1">
+        <div class="text-sm font-medium text-[var(--hr-text-1)]">{{ t('settings.general.updates.title') }}</div>
+        <div class="mt-1 text-sm text-[var(--hr-text-3)]">{{ t('settings.general.updates.description') }}</div>
+
+        <div
+          class="mt-4 grid max-w-2xl gap-3 sm:grid-cols-2"
+          role="radiogroup"
+          :aria-label="t('settings.general.updates.title')"
+        >
+          <button
+            v-for="channel in (['stable', 'early-access'] as DesktopUpdateChannel[])"
+            :key="channel"
+            class="flex min-h-24 items-start gap-3 rounded-xl border px-4 py-3 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-60"
+            :class="status?.channel === channel
+              ? 'border-[var(--hr-settings-active-border)] bg-[var(--hr-settings-active)] text-[var(--hr-text-1)]'
+              : 'border-[var(--hr-settings-divider)] bg-[var(--hr-settings-card)] text-[var(--hr-text-2)] hover:border-[var(--hr-border-strong)] hover:bg-[var(--hr-settings-card-hover)]'"
+            :data-testid="`desktop-update-channel-${channel}`"
+            type="button"
+            role="radio"
+            :aria-checked="status?.channel === channel"
+            :disabled="channelBusy"
+            @click="selectChannel(channel)"
+          >
+            <ShieldCheck v-if="channel === 'stable'" class="mt-0.5 h-4 w-4 flex-shrink-0" />
+            <FlaskConical v-else class="mt-0.5 h-4 w-4 flex-shrink-0" />
+            <span class="min-w-0 flex-1">
+              <span class="block text-sm font-semibold">{{ t(`settings.general.updates.channels.${channel}.label`) }}</span>
+              <span class="mt-1 block text-xs leading-5 text-[var(--hr-text-3)]">
+                {{ t(`settings.general.updates.channels.${channel}.description`) }}
+              </span>
+            </span>
+            <Check v-if="status?.channel === channel" class="mt-0.5 h-4 w-4 flex-shrink-0 text-[var(--hr-accent)]" />
+          </button>
+        </div>
+
+        <p v-if="status" class="mt-3 text-xs text-[var(--hr-text-3)]" data-testid="desktop-update-state">
+          {{ t('settings.general.updates.currentVersion', { version: status.currentVersion }) }}
+          · {{ statusText }}
+        </p>
+        <p
+          v-if="status?.channelNotice === 'waiting-for-newer-stable'"
+          class="mt-2 text-xs leading-5 text-[var(--hr-warning)]"
+          data-testid="desktop-update-channel-notice"
+        >
+          {{ t('settings.general.updates.waitingForStable') }}
+        </p>
+        <p
+          v-if="localError || status?.error"
+          class="mt-2 break-words text-xs leading-5 text-[var(--hr-danger)]"
+          data-testid="desktop-update-error"
+        >
+          {{ t('settings.general.updates.error', { message: localError || status?.error }) }}
+        </p>
+      </div>
+    </div>
+  </div>
+</template>

--- a/agent-ui/src/components/agent/settings/GeneralSettings.vue
+++ b/agent-ui/src/components/agent/settings/GeneralSettings.vue
@@ -9,6 +9,7 @@ import {
   subscribeAppearanceRegistry,
   type AppearancePlugin,
 } from '@/appearance/appearance-registry'
+import DesktopUpdateSettings from './DesktopUpdateSettings.vue'
 
 const uiStore = useUiStore()
 const { locale, t } = useI18n()
@@ -124,5 +125,7 @@ function selectLocale(nextLocale: AppLocale): void {
         </div>
       </div>
     </div>
+
+    <DesktopUpdateSettings />
   </section>
 </template>

--- a/agent-ui/src/locales/en-US/settings.json
+++ b/agent-ui/src/locales/en-US/settings.json
@@ -50,6 +50,32 @@
         "zhHant": "Traditional Chinese",
         "enUS": "English"
       }
+    },
+    "updates": {
+      "title": "Desktop updates",
+      "description": "Choose which signed, published HomeRail Desktop releases this device can receive.",
+      "channels": {
+        "stable": {
+          "label": "Stable",
+          "description": "Receive final releases only. Alpha and Beta releases stay hidden."
+        },
+        "early-access": {
+          "label": "Early Access",
+          "description": "Follow the current Alpha train, then Beta and Stable without opting in again."
+        }
+      },
+      "currentVersion": "Installed version: {version}",
+      "waitingForStable": "This prerelease will stay installed until a newer Stable version is available. HomeRail will not downgrade it.",
+      "error": "Update channel change failed: {message}",
+      "state": {
+        "idle": "Ready to check",
+        "checking": "Checking for updates…",
+        "available": "Update found",
+        "downloading": "Downloading update…",
+        "downloaded": "Update downloaded; restart to install",
+        "not-available": "No newer update on this channel",
+        "error": "Update check failed"
+      }
     }
   },
   "environment": {

--- a/agent-ui/src/locales/zh-Hans/settings.json
+++ b/agent-ui/src/locales/zh-Hans/settings.json
@@ -50,6 +50,32 @@
         "zhHant": "繁体中文",
         "enUS": "英语"
       }
+    },
+    "updates": {
+      "title": "桌面版更新",
+      "description": "选择此设备可以接收哪些已签名且已公开发布的 HomeRail Desktop 版本。",
+      "channels": {
+        "stable": {
+          "label": "稳定版",
+          "description": "只接收正式版本，不会看到 Alpha 或 Beta 预发布版。"
+        },
+        "early-access": {
+          "label": "抢先体验",
+          "description": "跟随当前 Alpha 通道，未来会自然升级到 Beta 和稳定版，无需再次选择。"
+        }
+      },
+      "currentVersion": "当前安装版本：{version}",
+      "waitingForStable": "当前预发布版本会继续保留，直到出现版本号更高的稳定版；HomeRail 不会自动降级。",
+      "error": "更新通道切换失败：{message}",
+      "state": {
+        "idle": "可以检查更新",
+        "checking": "正在检查更新…",
+        "available": "发现新版本",
+        "downloading": "正在下载更新…",
+        "downloaded": "更新已下载，重启后安装",
+        "not-available": "此通道暂无更高版本",
+        "error": "更新检查失败"
+      }
     }
   },
   "environment": {

--- a/agent-ui/src/locales/zh-Hant/settings.json
+++ b/agent-ui/src/locales/zh-Hant/settings.json
@@ -50,6 +50,32 @@
         "zhHant": "繁體中文",
         "enUS": "英語"
       }
+    },
+    "updates": {
+      "title": "桌面版更新",
+      "description": "選擇此裝置可以接收哪些已簽署且已公開發佈的 HomeRail Desktop 版本。",
+      "channels": {
+        "stable": {
+          "label": "穩定版",
+          "description": "只接收正式版本，不會看到 Alpha 或 Beta 預發佈版。"
+        },
+        "early-access": {
+          "label": "搶先體驗",
+          "description": "跟隨目前 Alpha 通道，未來會自然升級到 Beta 和穩定版，無需再次選擇。"
+        }
+      },
+      "currentVersion": "目前安裝版本：{version}",
+      "waitingForStable": "目前預發佈版本會繼續保留，直到出現版本號更高的穩定版；HomeRail 不會自動降級。",
+      "error": "更新通道切換失敗：{message}",
+      "state": {
+        "idle": "可以檢查更新",
+        "checking": "正在檢查更新…",
+        "available": "找到新版本",
+        "downloading": "正在下載更新…",
+        "downloaded": "更新已下載，重新啟動後安裝",
+        "not-available": "此通道暫無更高版本",
+        "error": "更新檢查失敗"
+      }
     }
   },
   "environment": {

--- a/agent-ui/src/types/homerail-desktop.d.ts
+++ b/agent-ui/src/types/homerail-desktop.d.ts
@@ -10,10 +10,14 @@ declare global {
     | 'not-available'
     | 'error'
 
+  type DesktopUpdateChannel = 'stable' | 'early-access'
+
   interface DesktopUpdateStatus {
     supported: boolean
     state: DesktopUpdateState
     currentVersion: string
+    channel: DesktopUpdateChannel
+    channelNotice?: 'waiting-for-newer-stable'
     update?: {
       version?: string
       releaseName?: string | null
@@ -34,6 +38,7 @@ declare global {
     version?: () => Promise<unknown>
     updateStatus?: () => Promise<DesktopUpdateStatus>
     checkForUpdates?: () => Promise<DesktopUpdateStatus>
+    setUpdateChannel?: (channel: DesktopUpdateChannel) => Promise<DesktopUpdateStatus>
     installUpdate?: () => Promise<DesktopUpdateStatus>
     onUpdateStatus?: (handler: (status: DesktopUpdateStatus) => void) => () => void
   }


### PR DESCRIPTION
## Summary
- add a simple **Stable / Early Access** selector to Desktop General Settings
- keep the setting hidden in standalone web and expose only the narrow `setUpdateChannel` bridge type
- disable switching while an update operation is busy and surface updater errors/status
- explain the no-downgrade behavior when the installed prerelease is newer than available Stable
- add English, Simplified Chinese, and Traditional Chinese copy plus component coverage

## Cross-repo dependencies
Counterpart private Desktop updater PR: https://github.com/xiaotianfotos/homerail_desktop/pull/15

Recommended merge order: **private Desktop PR first, then this public UI PR**. The UI checks the bridge at runtime, so it remains hidden until the Desktop side is available.

The complete Alpha Candidate/Publish pipeline is being implemented separately on `codex/alpha-release-pipeline`. It will own the unified SemVer tag/channel metadata workflow and replace the old desktop Beta workflow/docs; this PR intentionally contains no workflow or release-document changes.

## Product contract
- Stable is the default; Early Access is a persistent opt-in managed by the private Desktop updater.
- Current project phase is Alpha, beginning with package/release `0.1.0-alpha.1` and Git tag `v0.1.0-alpha.1`.
- Future progression is Alpha → Beta → Stable. Early Access should continue through that progression without another opt-in; Beta and Stable are reserved and are not being published by this PR.
- Switching from a newer prerelease to Stable never silently downgrades.

## Validation
- Agent UI typecheck: pass
- focused Desktop update settings tests: 5 passed
- Agent UI full unit suite: 87 files / 460 tests passed
- Agent UI production build: pass (existing chunk/browserslist warnings only)
- `git diff --check`: pass

## Manual acceptance still required
- signed Windows x64 and macOS arm64 install/upgrade matrix with the private updater and separate release-pipeline PRs integrated
- verify Stable/Early Access switching, no-downgrade explanation, restart-to-install, and persistence after relaunch

No signing or release workflow was triggered, no Release was published, and no signing secret was read or modified.