### PR TITLE
Fix production Worker image validation and database-safe rollback

### DIFF
--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -131,7 +131,7 @@ WORKER_METADATA="$(
 WORKER_SOURCE_FINGERPRINT="$(printf '%s\n' "$WORKER_METADATA" | sed -n '1p')"
 WORKER_PROTOCOL_VERSION="$(printf '%s\n' "$WORKER_METADATA" | sed -n '2p')"
 WORKER_VERSION="$(printf '%s\n' "$WORKER_METADATA" | sed -n '3p')"
-if [[ ! "$WORKER_SOURCE_FINGERPRINT" =~ ^[0-9a-f]{64}$ ]] \
+if [[ ! "$WORKER_SOURCE_FINGERPRINT" =~ ^[0-9a-f]{16}$ ]] \
   || [[ ! "$WORKER_PROTOCOL_VERSION" =~ ^[0-9A-Za-z._+-]+$ ]] \
   || [[ ! "$WORKER_VERSION" =~ ^[0-9A-Za-z._+-]+$ ]]; then
   echo "Production Worker image metadata is invalid." >&2

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -316,6 +316,7 @@ SERVICE_STOPPED_FOR_SNAPSHOT=0
 cleanup_deploy_temporaries() {
   local exit_status=$?
   rm -rf "$PROBE_HOME"
+  rm -f "$DATABASE_BACKUP" "$DATABASE_WAL_BACKUP"
   if [ "$SERVICE_STOPPED_FOR_SNAPSHOT" = "1" ]; then
     systemctl --user start "$SERVICE_NAME" >/dev/null 2>&1 || true
   fi

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -141,6 +141,7 @@ WORKER_IMAGE_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 mkdir -p "$PRODUCTION_ROOT/releases" "$PRODUCTION_ROOT/locks" "$HOMERAIL_HOME" "$(dirname "$UNIT_PATH")"
 HOMERAIL_HOME="$(realpath "$HOMERAIL_HOME")"
+chmod 700 "$PRODUCTION_ROOT/locks"
 chmod 700 "$HOMERAIL_HOME"
 
 # An enabled user unit starts during boot only when the account lingers without

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -19,6 +19,7 @@ DAG_COMMAND_ALLOWLIST="${HOMERAIL_PRODUCTION_DAG_COMMAND_ALLOWLIST:-node}"
 UI_HOST="${HOMERAIL_PRODUCTION_UI_HOST:-0.0.0.0}"
 UI_PORT="${HOMERAIL_PRODUCTION_UI_PORT:-19192}"
 UI_HTTP_PORT="${HOMERAIL_PRODUCTION_UI_HTTP_PORT:-19193}"
+HEALTH_ATTEMPTS="${HOMERAIL_PRODUCTION_HEALTH_ATTEMPTS:-60}"
 PUBLIC_HOST="${HOMERAIL_PRODUCTION_PUBLIC_HOST:-}"
 UI_URL="${HOMERAIL_PRODUCTION_UI_URL:-}"
 
@@ -60,6 +61,10 @@ for port in "$UI_PORT" "$UI_HTTP_PORT"; do
     exit 1
   fi
 done
+if [[ ! "$HEALTH_ATTEMPTS" =~ ^[0-9]+$ ]] || [ "$HEALTH_ATTEMPTS" -lt 1 ] || [ "$HEALTH_ATTEMPTS" -gt 300 ]; then
+  echo "HOMERAIL_PRODUCTION_HEALTH_ATTEMPTS must be an integer from 1 through 300." >&2
+  exit 1
+fi
 if [ -z "$UI_URL" ]; then
   if [[ "$PUBLIC_HOST" == *:* ]]; then
     UI_URL="https://[$PUBLIC_HOST]:$UI_PORT"
@@ -96,6 +101,43 @@ if [ -d "$SOURCE_ROOT/.git" ]; then
     exit 1
   fi
 fi
+
+NODE_BIN="$(command -v node)"
+WORKER_METADATA="$(
+  cd "$SOURCE_ROOT"
+  "$NODE_BIN" --input-type=module -e '
+    import fs from "node:fs";
+    import path from "node:path";
+    import { pathToFileURL } from "node:url";
+
+    const repoRoot = process.cwd();
+    const environmentModule = await import(pathToFileURL(
+      path.join(repoRoot, "homerail_manager", "dist", "server", "dag-environment.js"),
+    ).href);
+    const protocolModule = await import(pathToFileURL(
+      path.join(repoRoot, "homerail_protocol", "dist", "index.js"),
+    ).href);
+    const fingerprint = environmentModule.dagWorkerSourceFingerprint(repoRoot);
+    const workerPackage = JSON.parse(fs.readFileSync(
+      path.join(repoRoot, "homerail_worker", "package.json"),
+      "utf8",
+    ));
+    if (!fingerprint || typeof workerPackage.version !== "string" || !protocolModule.PROTOCOL_VERSION) {
+      throw new Error("Worker image metadata is incomplete.");
+    }
+    process.stdout.write(`${fingerprint}\n${protocolModule.PROTOCOL_VERSION}\n${workerPackage.version}\n`);
+  '
+)"
+WORKER_SOURCE_FINGERPRINT="$(printf '%s\n' "$WORKER_METADATA" | sed -n '1p')"
+WORKER_PROTOCOL_VERSION="$(printf '%s\n' "$WORKER_METADATA" | sed -n '2p')"
+WORKER_VERSION="$(printf '%s\n' "$WORKER_METADATA" | sed -n '3p')"
+if [[ ! "$WORKER_SOURCE_FINGERPRINT" =~ ^[0-9a-f]{64}$ ]] \
+  || [[ ! "$WORKER_PROTOCOL_VERSION" =~ ^[0-9A-Za-z._+-]+$ ]] \
+  || [[ ! "$WORKER_VERSION" =~ ^[0-9A-Za-z._+-]+$ ]]; then
+  echo "Production Worker image metadata is invalid." >&2
+  exit 1
+fi
+WORKER_IMAGE_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 mkdir -p "$PRODUCTION_ROOT/releases" "$PRODUCTION_ROOT/locks" "$HOMERAIL_HOME" "$(dirname "$UNIT_PATH")"
 HOMERAIL_HOME="$(realpath "$HOMERAIL_HOME")"
@@ -164,6 +206,15 @@ WORKER_IMAGE="homerail-worker:production-$SHORT_REVISION"
 echo "Building production Worker image $WORKER_IMAGE"
 docker build \
   --label "org.homerail.production_revision=$REVISION" \
+  --label "org.homerail.worker.source_fingerprint=$WORKER_SOURCE_FINGERPRINT" \
+  --label "org.homerail.worker.protocol_version=$WORKER_PROTOCOL_VERSION" \
+  --label "org.opencontainers.image.version=$WORKER_VERSION" \
+  --label "org.opencontainers.image.revision=$REVISION" \
+  --label "org.opencontainers.image.created=$WORKER_IMAGE_CREATED" \
+  --build-arg "HOMERAIL_WORKER_SOURCE_FINGERPRINT=$WORKER_SOURCE_FINGERPRINT" \
+  --build-arg "HOMERAIL_WORKER_PROTOCOL_VERSION=$WORKER_PROTOCOL_VERSION" \
+  --build-arg "HOMERAIL_WORKER_VERSION=$WORKER_VERSION" \
+  --build-arg "HOMERAIL_WORKER_IMAGE_REVISION=$REVISION" \
   -t "$WORKER_IMAGE" \
   -f "$SOURCE_ROOT/homerail_worker/Dockerfile" \
   "$SOURCE_ROOT"
@@ -182,7 +233,7 @@ rsync -a --delete \
   --exclude '/agent-ui/test-results/' \
   "$SOURCE_ROOT/" "$STAGING/"
 mkdir -p "$STAGING/runtime"
-install -m 0755 "$(command -v node)" "$STAGING/runtime/node"
+install -m 0755 "$NODE_BIN" "$STAGING/runtime/node"
 if [ -n "$CODEX_BIN" ]; then
   cat > "$STAGING/runtime/codex" <<WRAPPER
 #!/bin/sh
@@ -232,7 +283,7 @@ Environment=HOMERAIL_PRODUCTION_PUBLIC_HOST=$PUBLIC_HOST
 Environment=PATH=$SERVICE_PATH
 $CODEX_UNIT_ENV
 # /bin/bash and %h exist before the data volume is mounted. Wait for the atomic
-# `current` release, then preserve the release working-directory contract.
+# current release, then preserve the release working-directory contract.
 ExecStart=/bin/bash -c 'release="\$HOMERAIL_PRODUCTION_ROOT/current"; until [ -x "\$release/scripts/run-production-service.sh" ]; do sleep 10; done; cd "\$release"; exec "\$release/scripts/run-production-service.sh"'
 Restart=always
 RestartSec=10
@@ -247,9 +298,69 @@ TasksMax=4096
 WantedBy=default.target
 UNIT
 chmod 0644 "$UNIT_PATH.tmp"
-mv "$UNIT_PATH.tmp" "$UNIT_PATH"
 
 PREVIOUS_TARGET="$(readlink "$PRODUCTION_ROOT/current" 2>/dev/null || true)"
+PREVIOUS_RELEASE=""
+if [[ "$PREVIOUS_TARGET" == releases/* ]] && [ -d "$PRODUCTION_ROOT/$PREVIOUS_TARGET" ]; then
+  PREVIOUS_RELEASE="$PRODUCTION_ROOT/$PREVIOUS_TARGET"
+fi
+
+DATABASE_PATH="$HOMERAIL_HOME/manager/homerail.db"
+DATABASE_BACKUP="$PRODUCTION_ROOT/locks/homerail.db.pre-$SHORT_REVISION-$$"
+DATABASE_WAL_BACKUP="$DATABASE_BACKUP-wal"
+DATABASE_EXISTED=0
+PREVIOUS_DATABASE_COMPATIBLE=0
+PROBE_HOME="$PRODUCTION_ROOT/locks/database-probe-$SHORT_REVISION-$$"
+SERVICE_STOPPED_FOR_SNAPSHOT=0
+
+cleanup_deploy_temporaries() {
+  local exit_status=$?
+  rm -rf "$PROBE_HOME"
+  if [ "$SERVICE_STOPPED_FOR_SNAPSHOT" = "1" ]; then
+    systemctl --user start "$SERVICE_NAME" >/dev/null 2>&1 || true
+  fi
+  exit "$exit_status"
+}
+trap cleanup_deploy_temporaries EXIT
+
+# Stop the old release before snapshotting SQLite so the database and any WAL
+# file represent the same point in time. A failed rollout restores this pair
+# before an older release is allowed to start.
+systemctl --user stop "$SERVICE_NAME" >/dev/null 2>&1 || true
+SERVICE_STOPPED_FOR_SNAPSHOT=1
+if [ -f "$DATABASE_PATH" ]; then
+  DATABASE_EXISTED=1
+  cp -p "$DATABASE_PATH" "$DATABASE_BACKUP"
+  if [ -f "$DATABASE_PATH-wal" ]; then
+    cp -p "$DATABASE_PATH-wal" "$DATABASE_WAL_BACKUP"
+  fi
+fi
+
+# Probe rollback compatibility against a private copy. This catches an already
+# upgraded database before the deployment can switch back to code that refuses
+# to open it.
+if [ "$DATABASE_EXISTED" = "0" ]; then
+  PREVIOUS_DATABASE_COMPATIBLE=1
+elif [ -n "$PREVIOUS_RELEASE" ] \
+  && [ -x "$PREVIOUS_RELEASE/runtime/node" ] \
+  && [ -f "$PREVIOUS_RELEASE/homerail_manager/dist/persistence/db.js" ]; then
+  mkdir -p "$PROBE_HOME/manager"
+  cp -p "$DATABASE_BACKUP" "$PROBE_HOME/manager/homerail.db"
+  if [ -f "$DATABASE_WAL_BACKUP" ]; then
+    cp -p "$DATABASE_WAL_BACKUP" "$PROBE_HOME/manager/homerail.db-wal"
+  fi
+  if HOMERAIL_HOME="$PROBE_HOME" "$PREVIOUS_RELEASE/runtime/node" --input-type=module -e '
+    import { pathToFileURL } from "node:url";
+    const databaseModule = await import(pathToFileURL(process.argv[1]).href);
+    databaseModule.getDb();
+    databaseModule.closeDb();
+  ' "$PREVIOUS_RELEASE/homerail_manager/dist/persistence/db.js" >/dev/null 2>&1; then
+    PREVIOUS_DATABASE_COMPATIBLE=1
+  fi
+fi
+rm -rf "$PROBE_HOME"
+
+mv "$UNIT_PATH.tmp" "$UNIT_PATH"
 NEXT_TARGET="releases/$RELEASE_NAME"
 NEXT_LINK="$PRODUCTION_ROOT/.current-$RELEASE_NAME-$$"
 ln -s "$NEXT_TARGET" "$NEXT_LINK"
@@ -258,9 +369,10 @@ mv -Tf "$NEXT_LINK" "$PRODUCTION_ROOT/current"
 systemctl --user daemon-reload
 systemctl --user enable "$SERVICE_NAME" >/dev/null
 systemctl --user restart "$SERVICE_NAME"
+SERVICE_STOPPED_FOR_SNAPSHOT=0
 
 healthy=0
-for _ in $(seq 1 60); do
+for _ in $(seq 1 "$HEALTH_ATTEMPTS"); do
   if systemctl --user is-active --quiet "$SERVICE_NAME" \
     && curl -fsS --connect-timeout 3 --max-time 5 "$MANAGER_URL/health" >/dev/null \
     && curl -fkSs --connect-timeout 3 --max-time 5 "${UI_URL%/}/" >/dev/null \
@@ -283,29 +395,53 @@ fi
 
 if [ "$healthy" != "1" ]; then
   echo "Production health check failed for $REVISION; rolling back." >&2
-  if [ "$UNIT_EXISTED" = "1" ]; then
-    mv "$UNIT_BACKUP" "$UNIT_PATH"
-  else
-    rm -f "$UNIT_PATH" "$UNIT_BACKUP"
+  systemctl --user stop "$SERVICE_NAME" >/dev/null 2>&1 || true
+  rm -f "$DATABASE_PATH" "$DATABASE_PATH-wal" "$DATABASE_PATH-shm"
+  if [ "$DATABASE_EXISTED" = "1" ]; then
+    mkdir -p "$(dirname "$DATABASE_PATH")"
+    cp -p "$DATABASE_BACKUP" "$DATABASE_PATH.rollback-$$"
+    mv "$DATABASE_PATH.rollback-$$" "$DATABASE_PATH"
+    if [ -f "$DATABASE_WAL_BACKUP" ]; then
+      cp -p "$DATABASE_WAL_BACKUP" "$DATABASE_PATH-wal.rollback-$$"
+      mv "$DATABASE_PATH-wal.rollback-$$" "$DATABASE_PATH-wal"
+    fi
   fi
-  if [[ "$PREVIOUS_TARGET" == releases/* ]] && [ -d "$PRODUCTION_ROOT/$PREVIOUS_TARGET" ]; then
+  if [ "$PREVIOUS_DATABASE_COMPATIBLE" = "1" ] && [ -n "$PREVIOUS_RELEASE" ]; then
+    if [ "$UNIT_EXISTED" = "1" ]; then
+      mv "$UNIT_BACKUP" "$UNIT_PATH"
+    else
+      rm -f "$UNIT_PATH" "$UNIT_BACKUP"
+    fi
     ROLLBACK_LINK="$PRODUCTION_ROOT/.rollback-$$"
     ln -s "$PREVIOUS_TARGET" "$ROLLBACK_LINK"
     mv -Tf "$ROLLBACK_LINK" "$PRODUCTION_ROOT/current"
     systemctl --user daemon-reload
     systemctl --user restart "$SERVICE_NAME"
+  elif [ -n "$PREVIOUS_RELEASE" ]; then
+    echo "Previous release cannot open the pre-deployment database; refusing an incompatible code rollback." >&2
+    rm -f "$UNIT_BACKUP"
+    systemctl --user daemon-reload
+    systemctl --user restart "$SERVICE_NAME"
   else
+    rm -f "$UNIT_PATH" "$UNIT_BACKUP"
     systemctl --user daemon-reload
     systemctl --user stop "$SERVICE_NAME" || true
   fi
   journalctl --user-unit "$SERVICE_NAME" -n 80 --no-pager >&2 || true
+  rm -f "$DATABASE_BACKUP" "$DATABASE_WAL_BACKUP"
+  trap - EXIT
   exit 1
 fi
 
-rm -f "$UNIT_BACKUP"
+rm -f "$UNIT_BACKUP" "$DATABASE_BACKUP" "$DATABASE_WAL_BACKUP"
+trap - EXIT
 printf '%s\n' "$REVISION" > "$PRODUCTION_ROOT/last-successful-revision"
-mapfile -t OLD_RELEASES < <(find "$PRODUCTION_ROOT/releases" -mindepth 1 -maxdepth 1 -type d ! -name '.staging-*' -printf '%T@ %p\n' | sort -rn | tail -n +4 | cut -d' ' -f2-)
+OLD_RELEASES=("")
+while IFS= read -r old_release; do
+  [ -n "$old_release" ] && OLD_RELEASES+=("$old_release")
+done < <(find "$PRODUCTION_ROOT/releases" -mindepth 1 -maxdepth 1 -type d ! -name '.staging-*' -printf '%T@ %p\n' | sort -rn | tail -n +4 | cut -d' ' -f2-)
 for old_release in "${OLD_RELEASES[@]}"; do
+  [ -n "$old_release" ] || continue
   old_revision="$(tr -d '[:space:]' < "$old_release/REVISION" 2>/dev/null || true)"
   rm -rf "$old_release"
   if [[ "$old_revision" =~ ^[0-9a-f]{40}$ ]] \

--- a/scripts/production-deploy-contracts.test.mjs
+++ b/scripts/production-deploy-contracts.test.mjs
@@ -33,17 +33,30 @@ test("production deployment is atomic, health checked, and rollback capable", ()
   const runtime = fs.readFileSync(path.join(repoRoot, "scripts", "lib", "production-runtime.sh"), "utf8");
   assert.match(deploy, /flock -w 60/);
   assert.match(deploy, /homerail-worker:production-/);
+  assert.match(deploy, /org\.homerail\.worker\.source_fingerprint=\$WORKER_SOURCE_FINGERPRINT/);
+  assert.match(deploy, /org\.homerail\.worker\.protocol_version=\$WORKER_PROTOCOL_VERSION/);
+  assert.match(deploy, /org\.opencontainers\.image\.version=\$WORKER_VERSION/);
+  assert.match(deploy, /HOMERAIL_WORKER_SOURCE_FINGERPRINT=\$WORKER_SOURCE_FINGERPRINT/);
+  assert.match(deploy, /HOMERAIL_WORKER_PROTOCOL_VERSION=\$WORKER_PROTOCOL_VERSION/);
+  assert.match(deploy, /HOMERAIL_WORKER_VERSION=\$WORKER_VERSION/);
+  assert.match(deploy, /HOMERAIL_WORKER_IMAGE_REVISION=\$REVISION/);
   assert.match(deploy, /mv -Tf "\$NEXT_LINK" "\$PRODUCTION_ROOT\/current"/);
   assert.match(deploy, /systemctl --user restart/);
   assert.match(deploy, /rolling back/);
   assert.match(deploy, /PREVIOUS_TARGET/);
   assert.match(deploy, /UNIT_BACKUP/);
+  assert.match(deploy, /systemctl --user stop "\$SERVICE_NAME"/);
+  assert.match(deploy, /DATABASE_BACKUP/);
+  assert.match(deploy, /DATABASE_WAL_BACKUP/);
+  assert.match(deploy, /PREVIOUS_DATABASE_COMPATIBLE/);
+  assert.match(deploy, /refusing an incompatible code rollback/);
   assert.match(deploy, /loginctl show-user "\$DEPLOY_USER" --property=Linger --value/);
   assert.match(deploy, /sudo loginctl enable-linger \$DEPLOY_USER/);
   assert.match(deploy, /StartLimitIntervalSec=0/);
   assert.doesNotMatch(deploy, /StartLimitBurst=/);
   assert.match(deploy, /WorkingDirectory=%h/);
   assert.doesNotMatch(deploy, /WorkingDirectory=\$PRODUCTION_ROOT\/current/);
+  assert.doesNotMatch(deploy, /# `current` release/);
   assert.match(
     deploy,
     /ExecStart=\/bin\/bash -c 'release="\\\$HOMERAIL_PRODUCTION_ROOT\/current"; until \[ -x "\\\$release\/scripts\/run-production-service\.sh" \]; do sleep 10; done; cd "\\\$release"; exec "\\\$release\/scripts\/run-production-service\.sh"'/,
@@ -231,12 +244,13 @@ test("production DAG smoke helper enforces token presence and command success", 
   }
 });
 
-test("production deployment rolls back a failed DAG smoke and accepts a successful one", { skip: process.platform === "win32" }, () => {
+test("production deployment preserves database compatibility across success and rollback", { skip: process.platform === "win32" }, () => {
   const deployScript = path.join(repoRoot, "scripts", "deploy-production.sh");
   const revision = "a".repeat(40);
   const previousRevision = "b".repeat(40);
+  const workerFingerprint = "c".repeat(64);
 
-  const runDeployment = (smokeExit) => {
+  const runDeployment = (smokeExit, { previousDatabaseCompatible = true } = {}) => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-production-deploy-"));
     const sourceRoot = path.join(tempRoot, "source");
     const productionRoot = path.join(tempRoot, "production");
@@ -246,6 +260,8 @@ test("production deployment rolls back a failed DAG smoke and accepts a successf
     const resources = path.join(tempRoot, "resources");
     const unitPath = path.join(fakeHome, ".config", "systemd", "user", "homerail-production.service");
     const previousRelease = path.join(productionRoot, "releases", "previous");
+    const databasePath = path.join(home, "manager", "homerail.db");
+    const dockerBuildArgsPath = path.join(tempRoot, "docker-build-args.txt");
     const write = (relative, content, mode) => {
       const target = path.join(sourceRoot, relative);
       fs.mkdirSync(path.dirname(target), { recursive: true });
@@ -261,25 +277,53 @@ test("production deployment rolls back a failed DAG smoke and accepts a successf
 
     fs.mkdirSync(previousRelease, { recursive: true });
     fs.writeFileSync(path.join(previousRelease, "REVISION"), `${previousRevision}\n`);
+    fs.mkdirSync(path.join(previousRelease, "runtime"), { recursive: true });
+    fs.symlinkSync(process.execPath, path.join(previousRelease, "runtime", "node"));
+    fs.mkdirSync(path.join(previousRelease, "homerail_manager", "dist", "persistence"), { recursive: true });
+    fs.writeFileSync(path.join(previousRelease, "homerail_manager", "package.json"), '{"type":"module"}\n');
+    fs.writeFileSync(
+      path.join(previousRelease, "homerail_manager", "dist", "persistence", "db.js"),
+      previousDatabaseCompatible
+        ? "export function getDb() {};\nexport function closeDb() {};\n"
+        : 'export function getDb() { throw new Error("Database schema version is newer than supported version"); };\nexport function closeDb() {};\n',
+    );
     fs.symlinkSync("releases/previous", path.join(productionRoot, "current"));
     fs.mkdirSync(path.dirname(unitPath), { recursive: true });
     fs.writeFileSync(unitPath, "previous-unit\n");
     fs.mkdirSync(path.join(home, "manager", "secrets"), { recursive: true });
+    fs.writeFileSync(databasePath, "pre-deployment-database\n", { mode: 0o600 });
     fs.writeFileSync(path.join(home, "manager", "secrets", "dag-mutation.token"), "sandbox-token\n", { mode: 0o600 });
     fs.mkdirSync(resources, { recursive: true });
 
     write("homerail_manager/dist/index.js", "// manager\n");
+    write("homerail_manager/package.json", '{"type":"module"}\n');
+    write(
+      "homerail_manager/dist/server/dag-environment.js",
+      `export function dagWorkerSourceFingerprint() { return "${workerFingerprint}"; }\n`,
+    );
     write("homerail_node/dist/cli.js", "// node\n");
-    write("homerail_cli/dist/cli.js", "process.exit(Number(process.env.FAKE_SMOKE_EXIT || 0));\n");
+    write(
+      "homerail_cli/dist/cli.js",
+      'require("node:fs").appendFileSync(require("node:path").join(process.env.HOMERAIL_PRODUCTION_HOME, "manager", "homerail.db"), "rollout-write\\n");\n'
+        + "process.exit(Number(process.env.FAKE_SMOKE_EXIT || 0));\n",
+    );
+    write("homerail_protocol/package.json", '{"type":"module"}\n');
+    write("homerail_protocol/dist/index.js", 'export const PROTOCOL_VERSION = "0.1.0";\n');
+    write("homerail_worker/package.json", '{"version":"0.1.0"}\n');
     write("agent-ui/dist/index.html", "<!doctype html>\n");
     write("homerail_worker/Dockerfile", "FROM scratch\n");
     write("assets/orchestrations/public-two-node.yaml.template", "schema_version: 1\n");
     write("scripts/run-production-service.sh", "#!/usr/bin/env bash\nexit 0\n", 0o755);
     write("scripts/lib/production-runtime.sh", fs.readFileSync(path.join(repoRoot, "scripts", "lib", "production-runtime.sh"), "utf8"), 0o755);
 
-    fakeCommand("docker", `#!/usr/bin/env bash\nif [ "${'${1:-}'}" = network ] && [ "${'${2:-}'}" = inspect ] && [ "${'${3:-}'}" = bridge ]; then echo 172.17.0.1; fi\nexit 0\n`);
+    fakeCommand("docker", `#!/usr/bin/env bash\nif [ "${'${1:-}'}" = network ] && [ "${'${2:-}'}" = inspect ] && [ "${'${3:-}'}" = bridge ]; then echo 172.17.0.1; fi\nif [ "${'${1:-}'}" = build ]; then printf '%s\\n' "$@" > "$CAPTURE_DOCKER_BUILD_ARGS"; fi\nexit 0\n`);
     fakeCommand("codex", "#!/usr/bin/env bash\nexit 0\n");
+    fakeCommand("find", "#!/usr/bin/env bash\nexit 0\n");
+    fakeCommand("flock", "#!/usr/bin/env bash\nexit 0\n");
+    fakeCommand("install", `#!/usr/bin/env bash\nsource_path="${'${3:-}'}"; destination="${'${4:-}'}"; ln -s "$source_path" "$destination"\n`);
     fakeCommand("loginctl", "#!/usr/bin/env bash\nprintf 'yes\\n'\n");
+    fakeCommand("mv", `#!/usr/bin/env bash\nif [ "${'${1:-}'}" = -Tf ]; then source_path="$2"; destination="$3"; /bin/rm -f "$destination"; exec /bin/mv -f "$source_path" "$destination"; fi\nexec /bin/mv "$@"\n`);
+    fakeCommand("stat", `#!/usr/bin/env bash\ncase "${'${2:-}'}" in '%u') id -u ;; '%a') printf '755\\n' ;; *) exit 1 ;; esac\n`);
     fakeCommand("systemctl", "#!/usr/bin/env bash\nexit 0\n");
     fakeCommand("journalctl", "#!/usr/bin/env bash\nexit 0\n");
     fakeCommand("curl", `#!/usr/bin/env bash\nurl="${'${!#}'}"\ncase "$url" in */runtime/status) printf '{"connected_nodes":1}\\n' ;; esac\nexit 0\n`);
@@ -298,11 +342,13 @@ test("production deployment rolls back a failed DAG smoke and accepts a successf
         HOMERAIL_DEPLOY_REVISION: revision,
         HOMERAIL_PRODUCTION_PUBLIC_HOST: "production.test",
         HOMERAIL_PRODUCTION_ALLOW_INSECURE_REMOTE_WS: "1",
+        HOMERAIL_PRODUCTION_HEALTH_ATTEMPTS: "1",
         HOMERAIL_CODEX_BIN: path.join(fakeBin, "codex"),
         FAKE_SMOKE_EXIT: String(smokeExit),
+        CAPTURE_DOCKER_BUILD_ARGS: dockerBuildArgsPath,
       },
     });
-    return { result, tempRoot, productionRoot, unitPath };
+    return { result, tempRoot, productionRoot, unitPath, databasePath, dockerBuildArgsPath };
   };
 
   const failed = runDeployment(7);
@@ -312,16 +358,38 @@ test("production deployment rolls back a failed DAG smoke and accepts a successf
     assert.match(failed.result.stderr, /rolling back/);
     assert.equal(fs.readlinkSync(path.join(failed.productionRoot, "current")), "releases/previous");
     assert.equal(fs.readFileSync(failed.unitPath, "utf8"), "previous-unit\n");
+    assert.equal(fs.readFileSync(failed.databasePath, "utf8"), "pre-deployment-database\n");
     assert.equal(fs.existsSync(path.join(failed.productionRoot, "last-successful-revision")), false);
   } finally {
     fs.rmSync(failed.tempRoot, { recursive: true, force: true });
+  }
+
+  const incompatible = runDeployment(7, { previousDatabaseCompatible: false });
+  try {
+    assert.notEqual(incompatible.result.status, 0);
+    assert.match(incompatible.result.stderr, /refusing an incompatible code rollback/);
+    assert.notEqual(fs.readlinkSync(path.join(incompatible.productionRoot, "current")), "releases/previous");
+    assert.equal(fs.readFileSync(incompatible.databasePath, "utf8"), "pre-deployment-database\n");
+    assert.equal(fs.existsSync(path.join(incompatible.productionRoot, "last-successful-revision")), false);
+  } finally {
+    fs.rmSync(incompatible.tempRoot, { recursive: true, force: true });
   }
 
   const passed = runDeployment(0);
   try {
     assert.equal(passed.result.status, 0, passed.result.stderr);
     assert.equal(fs.readFileSync(path.join(passed.productionRoot, "last-successful-revision"), "utf8"), `${revision}\n`);
+    assert.equal(fs.readFileSync(passed.databasePath, "utf8"), "pre-deployment-database\nrollout-write\n");
     assert.notEqual(fs.readlinkSync(path.join(passed.productionRoot, "current")), "releases/previous");
+    const dockerBuildArgs = fs.readFileSync(passed.dockerBuildArgsPath, "utf8");
+    assert.match(dockerBuildArgs, new RegExp(`org\\.homerail\\.worker\\.source_fingerprint=${workerFingerprint}`));
+    assert.match(dockerBuildArgs, /org\.homerail\.worker\.protocol_version=0\.1\.0/);
+    assert.match(dockerBuildArgs, /org\.opencontainers\.image\.version=0\.1\.0/);
+    assert.match(dockerBuildArgs, new RegExp(`org\\.opencontainers\\.image\\.revision=${revision}`));
+    assert.match(dockerBuildArgs, new RegExp(`HOMERAIL_WORKER_SOURCE_FINGERPRINT=${workerFingerprint}`));
+    assert.match(dockerBuildArgs, /HOMERAIL_WORKER_PROTOCOL_VERSION=0\.1\.0/);
+    assert.match(dockerBuildArgs, /HOMERAIL_WORKER_VERSION=0\.1\.0/);
+    assert.match(dockerBuildArgs, new RegExp(`HOMERAIL_WORKER_IMAGE_REVISION=${revision}`));
     const unit = fs.readFileSync(passed.unitPath, "utf8");
     assert.match(unit, /StartLimitIntervalSec=0/);
     assert.doesNotMatch(unit, /StartLimitBurst=/);

--- a/scripts/production-deploy-contracts.test.mjs
+++ b/scripts/production-deploy-contracts.test.mjs
@@ -40,6 +40,8 @@ test("production deployment is atomic, health checked, and rollback capable", ()
   assert.match(deploy, /HOMERAIL_WORKER_PROTOCOL_VERSION=\$WORKER_PROTOCOL_VERSION/);
   assert.match(deploy, /HOMERAIL_WORKER_VERSION=\$WORKER_VERSION/);
   assert.match(deploy, /HOMERAIL_WORKER_IMAGE_REVISION=\$REVISION/);
+  assert.match(deploy, /HOMERAIL_PRODUCTION_HEALTH_ATTEMPTS:-60/);
+  assert.match(deploy, /HOMERAIL_PRODUCTION_HEALTH_ATTEMPTS must be an integer from 1 through 300/);
   assert.match(deploy, /mv -Tf "\$NEXT_LINK" "\$PRODUCTION_ROOT\/current"/);
   assert.match(deploy, /systemctl --user restart/);
   assert.match(deploy, /rolling back/);
@@ -50,6 +52,7 @@ test("production deployment is atomic, health checked, and rollback capable", ()
   assert.match(deploy, /DATABASE_WAL_BACKUP/);
   assert.match(deploy, /PREVIOUS_DATABASE_COMPATIBLE/);
   assert.match(deploy, /refusing an incompatible code rollback/);
+  assert.match(deploy, /chmod 700 "\$PRODUCTION_ROOT\/locks"/);
   assert.match(
     deploy,
     /cleanup_deploy_temporaries\(\)[\s\S]*rm -f "\$DATABASE_BACKUP" "\$DATABASE_WAL_BACKUP"/,
@@ -254,7 +257,10 @@ test("production deployment preserves database compatibility across success and 
   const previousRevision = "b".repeat(40);
   const workerFingerprint = "c".repeat(16);
 
-  const runDeployment = (smokeExit, { previousDatabaseCompatible = true } = {}) => {
+  const runDeployment = (smokeExit, {
+    previousDatabaseCompatible = true,
+    failUnitMove = false,
+  } = {}) => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-production-deploy-"));
     const sourceRoot = path.join(tempRoot, "source");
     const productionRoot = path.join(tempRoot, "production");
@@ -266,6 +272,12 @@ test("production deployment preserves database compatibility across success and 
     const previousRelease = path.join(productionRoot, "releases", "previous");
     const databasePath = path.join(home, "manager", "homerail.db");
     const dockerBuildArgsPath = path.join(tempRoot, "docker-build-args.txt");
+    const dockerRemovalsPath = path.join(tempRoot, "docker-removals.txt");
+    const systemctlLogPath = path.join(tempRoot, "systemctl.log");
+    const findOutputPath = path.join(tempRoot, "find-output.txt");
+    const duplicateOldRelease = path.join(productionRoot, "releases", "duplicate-old");
+    const unreferencedOldRelease = path.join(productionRoot, "releases", "unreferenced-old");
+    const unreferencedRevision = "d".repeat(40);
     const write = (relative, content, mode) => {
       const target = path.join(sourceRoot, relative);
       fs.mkdirSync(path.dirname(target), { recursive: true });
@@ -281,6 +293,20 @@ test("production deployment preserves database compatibility across success and 
 
     fs.mkdirSync(previousRelease, { recursive: true });
     fs.writeFileSync(path.join(previousRelease, "REVISION"), `${previousRevision}\n`);
+    fs.mkdirSync(duplicateOldRelease, { recursive: true });
+    fs.writeFileSync(path.join(duplicateOldRelease, "REVISION"), `${previousRevision}\n`);
+    fs.mkdirSync(unreferencedOldRelease, { recursive: true });
+    fs.writeFileSync(path.join(unreferencedOldRelease, "REVISION"), `${unreferencedRevision}\n`);
+    fs.writeFileSync(
+      findOutputPath,
+      [
+        `5 ${path.join(productionRoot, "releases", "newest-placeholder")}`,
+        `4 ${path.join(productionRoot, "releases", "newer-placeholder")}`,
+        `3 ${path.join(productionRoot, "releases", "third-placeholder")}`,
+        `2 ${duplicateOldRelease}`,
+        `1 ${unreferencedOldRelease}`,
+      ].join("\n") + "\n",
+    );
     fs.mkdirSync(path.join(previousRelease, "runtime"), { recursive: true });
     fs.symlinkSync(process.execPath, path.join(previousRelease, "runtime", "node"));
     fs.mkdirSync(path.join(previousRelease, "homerail_manager", "dist", "persistence"), { recursive: true });
@@ -296,6 +322,7 @@ test("production deployment preserves database compatibility across success and 
     fs.writeFileSync(unitPath, "previous-unit\n");
     fs.mkdirSync(path.join(home, "manager", "secrets"), { recursive: true });
     fs.writeFileSync(databasePath, "pre-deployment-database\n", { mode: 0o600 });
+    fs.writeFileSync(`${databasePath}-wal`, "pre-deployment-wal\n", { mode: 0o600 });
     fs.writeFileSync(path.join(home, "manager", "secrets", "dag-mutation.token"), "sandbox-token\n", { mode: 0o600 });
     fs.mkdirSync(resources, { recursive: true });
 
@@ -309,6 +336,8 @@ test("production deployment preserves database compatibility across success and 
     write(
       "homerail_cli/dist/cli.js",
       'require("node:fs").appendFileSync(require("node:path").join(process.env.HOMERAIL_PRODUCTION_HOME, "manager", "homerail.db"), "rollout-write\\n");\n'
+        + 'require("node:fs").appendFileSync(require("node:path").join(process.env.HOMERAIL_PRODUCTION_HOME, "manager", "homerail.db-wal"), "rollout-wal-write\\n");\n'
+        + 'require("node:fs").writeFileSync(require("node:path").join(process.env.HOMERAIL_PRODUCTION_HOME, "manager", "homerail.db-shm"), "rollout-shm\\n");\n'
         + "process.exit(Number(process.env.FAKE_SMOKE_EXIT || 0));\n",
     );
     write("homerail_protocol/package.json", '{"type":"module"}\n');
@@ -320,15 +349,15 @@ test("production deployment preserves database compatibility across success and 
     write("scripts/run-production-service.sh", "#!/usr/bin/env bash\nexit 0\n", 0o755);
     write("scripts/lib/production-runtime.sh", fs.readFileSync(path.join(repoRoot, "scripts", "lib", "production-runtime.sh"), "utf8"), 0o755);
 
-    fakeCommand("docker", `#!/usr/bin/env bash\nif [ "${'${1:-}'}" = network ] && [ "${'${2:-}'}" = inspect ] && [ "${'${3:-}'}" = bridge ]; then echo 172.17.0.1; fi\nif [ "${'${1:-}'}" = build ]; then printf '%s\\n' "$@" > "$CAPTURE_DOCKER_BUILD_ARGS"; fi\nexit 0\n`);
+    fakeCommand("docker", `#!/usr/bin/env bash\nif [ "${'${1:-}'}" = network ] && [ "${'${2:-}'}" = inspect ] && [ "${'${3:-}'}" = bridge ]; then echo 172.17.0.1; fi\nif [ "${'${1:-}'}" = build ]; then printf '%s\\n' "$@" > "$CAPTURE_DOCKER_BUILD_ARGS"; fi\nif [ "${'${1:-}'}" = image ] && [ "${'${2:-}'}" = rm ]; then printf '%s\\n' "${'${3:-}'}" >> "$CAPTURE_DOCKER_REMOVALS"; fi\nexit 0\n`);
     fakeCommand("codex", "#!/usr/bin/env bash\nexit 0\n");
-    fakeCommand("find", "#!/usr/bin/env bash\nexit 0\n");
+    fakeCommand("find", "#!/usr/bin/env bash\ncat \"$FAKE_FIND_OUTPUT\"\n");
     fakeCommand("flock", "#!/usr/bin/env bash\nexit 0\n");
     fakeCommand("install", `#!/usr/bin/env bash\nsource_path="${'${3:-}'}"; destination="${'${4:-}'}"; ln -s "$source_path" "$destination"\n`);
     fakeCommand("loginctl", "#!/usr/bin/env bash\nprintf 'yes\\n'\n");
-    fakeCommand("mv", `#!/usr/bin/env bash\nif [ "${'${1:-}'}" = -Tf ]; then source_path="$2"; destination="$3"; /bin/rm -f "$destination"; exec /bin/mv -f "$source_path" "$destination"; fi\nexec /bin/mv "$@"\n`);
+    fakeCommand("mv", `#!/usr/bin/env bash\nif [ "${'${FAIL_UNIT_MOVE:-0}'}" = 1 ] && [[ "${'${1:-}'}" == *.service.tmp ]]; then exit 19; fi\nif [ "${'${1:-}'}" = -Tf ]; then source_path="$2"; destination="$3"; /bin/rm -f "$destination"; exec /bin/mv -f "$source_path" "$destination"; fi\nexec /bin/mv "$@"\n`);
     fakeCommand("stat", `#!/usr/bin/env bash\ncase "${'${2:-}'}" in '%u') id -u ;; '%a') printf '755\\n' ;; *) exit 1 ;; esac\n`);
-    fakeCommand("systemctl", "#!/usr/bin/env bash\nexit 0\n");
+    fakeCommand("systemctl", "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"$CAPTURE_SYSTEMCTL\"\nexit 0\n");
     fakeCommand("journalctl", "#!/usr/bin/env bash\nexit 0\n");
     fakeCommand("curl", `#!/usr/bin/env bash\nurl="${'${!#}'}"\ncase "$url" in */runtime/status) printf '{"connected_nodes":1}\\n' ;; esac\nexit 0\n`);
     fakeCommand("rsync", `#!/usr/bin/env bash\nprevious=""\nfor arg in "$@"; do source_path="$previous"; destination="$arg"; previous="$arg"; done\nmkdir -p "$destination"\ncp -a "${'${source_path%/}'}/." "$destination/"\n`);
@@ -349,10 +378,26 @@ test("production deployment preserves database compatibility across success and 
         HOMERAIL_PRODUCTION_HEALTH_ATTEMPTS: "1",
         HOMERAIL_CODEX_BIN: path.join(fakeBin, "codex"),
         FAKE_SMOKE_EXIT: String(smokeExit),
+        FAIL_UNIT_MOVE: failUnitMove ? "1" : "0",
         CAPTURE_DOCKER_BUILD_ARGS: dockerBuildArgsPath,
+        CAPTURE_DOCKER_REMOVALS: dockerRemovalsPath,
+        CAPTURE_SYSTEMCTL: systemctlLogPath,
+        FAKE_FIND_OUTPUT: findOutputPath,
       },
     });
-    return { result, tempRoot, productionRoot, unitPath, databasePath, dockerBuildArgsPath };
+    return {
+      result,
+      tempRoot,
+      productionRoot,
+      unitPath,
+      databasePath,
+      dockerBuildArgsPath,
+      dockerRemovalsPath,
+      systemctlLogPath,
+      duplicateOldRelease,
+      unreferencedOldRelease,
+      unreferencedRevision,
+    };
   };
 
   const failed = runDeployment(7);
@@ -363,6 +408,8 @@ test("production deployment preserves database compatibility across success and 
     assert.equal(fs.readlinkSync(path.join(failed.productionRoot, "current")), "releases/previous");
     assert.equal(fs.readFileSync(failed.unitPath, "utf8"), "previous-unit\n");
     assert.equal(fs.readFileSync(failed.databasePath, "utf8"), "pre-deployment-database\n");
+    assert.equal(fs.readFileSync(`${failed.databasePath}-wal`, "utf8"), "pre-deployment-wal\n");
+    assert.equal(fs.existsSync(`${failed.databasePath}-shm`), false);
     assert.equal(fs.existsSync(path.join(failed.productionRoot, "last-successful-revision")), false);
   } finally {
     fs.rmSync(failed.tempRoot, { recursive: true, force: true });
@@ -374,9 +421,24 @@ test("production deployment preserves database compatibility across success and 
     assert.match(incompatible.result.stderr, /refusing an incompatible code rollback/);
     assert.notEqual(fs.readlinkSync(path.join(incompatible.productionRoot, "current")), "releases/previous");
     assert.equal(fs.readFileSync(incompatible.databasePath, "utf8"), "pre-deployment-database\n");
+    assert.equal(fs.readFileSync(`${incompatible.databasePath}-wal`, "utf8"), "pre-deployment-wal\n");
+    assert.equal(fs.existsSync(`${incompatible.databasePath}-shm`), false);
     assert.equal(fs.existsSync(path.join(incompatible.productionRoot, "last-successful-revision")), false);
   } finally {
     fs.rmSync(incompatible.tempRoot, { recursive: true, force: true });
+  }
+
+  const interrupted = runDeployment(0, { failUnitMove: true });
+  try {
+    assert.notEqual(interrupted.result.status, 0);
+    assert.equal(fs.readlinkSync(path.join(interrupted.productionRoot, "current")), "releases/previous");
+    const systemctlLog = fs.readFileSync(interrupted.systemctlLogPath, "utf8");
+    assert.match(systemctlLog, /--user stop homerail-production\.service/);
+    assert.match(systemctlLog, /--user start homerail-production\.service/);
+    const lockEntries = fs.readdirSync(path.join(interrupted.productionRoot, "locks"));
+    assert.equal(lockEntries.some((name) => name.startsWith("homerail.db.pre-")), false);
+  } finally {
+    fs.rmSync(interrupted.tempRoot, { recursive: true, force: true });
   }
 
   const passed = runDeployment(0);
@@ -384,7 +446,13 @@ test("production deployment preserves database compatibility across success and 
     assert.equal(passed.result.status, 0, passed.result.stderr);
     assert.equal(fs.readFileSync(path.join(passed.productionRoot, "last-successful-revision"), "utf8"), `${revision}\n`);
     assert.equal(fs.readFileSync(passed.databasePath, "utf8"), "pre-deployment-database\nrollout-write\n");
+    assert.equal(fs.readFileSync(`${passed.databasePath}-wal`, "utf8"), "pre-deployment-wal\nrollout-wal-write\n");
     assert.notEqual(fs.readlinkSync(path.join(passed.productionRoot, "current")), "releases/previous");
+    assert.equal(fs.existsSync(passed.duplicateOldRelease), false);
+    assert.equal(fs.existsSync(passed.unreferencedOldRelease), false);
+    const dockerRemovals = fs.readFileSync(passed.dockerRemovalsPath, "utf8");
+    assert.match(dockerRemovals, new RegExp(`homerail-worker:production-${passed.unreferencedRevision.slice(0, 12)}`));
+    assert.doesNotMatch(dockerRemovals, new RegExp(`homerail-worker:production-${previousRevision.slice(0, 12)}`));
     const dockerBuildArgs = fs.readFileSync(passed.dockerBuildArgsPath, "utf8");
     assert.match(dockerBuildArgs, new RegExp(`org\\.homerail\\.worker\\.source_fingerprint=${workerFingerprint}`));
     assert.match(dockerBuildArgs, /org\.homerail\.worker\.protocol_version=0\.1\.0/);

--- a/scripts/production-deploy-contracts.test.mjs
+++ b/scripts/production-deploy-contracts.test.mjs
@@ -248,7 +248,7 @@ test("production deployment preserves database compatibility across success and 
   const deployScript = path.join(repoRoot, "scripts", "deploy-production.sh");
   const revision = "a".repeat(40);
   const previousRevision = "b".repeat(40);
-  const workerFingerprint = "c".repeat(64);
+  const workerFingerprint = "c".repeat(16);
 
   const runDeployment = (smokeExit, { previousDatabaseCompatible = true } = {}) => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-production-deploy-"));

--- a/scripts/production-deploy-contracts.test.mjs
+++ b/scripts/production-deploy-contracts.test.mjs
@@ -50,6 +50,10 @@ test("production deployment is atomic, health checked, and rollback capable", ()
   assert.match(deploy, /DATABASE_WAL_BACKUP/);
   assert.match(deploy, /PREVIOUS_DATABASE_COMPATIBLE/);
   assert.match(deploy, /refusing an incompatible code rollback/);
+  assert.match(
+    deploy,
+    /cleanup_deploy_temporaries\(\)[\s\S]*rm -f "\$DATABASE_BACKUP" "\$DATABASE_WAL_BACKUP"/,
+  );
   assert.match(deploy, /loginctl show-user "\$DEPLOY_USER" --property=Linger --value/);
   assert.match(deploy, /sudo loginctl enable-linger \$DEPLOY_USER/);
   assert.match(deploy, /StartLimitIntervalSec=0/);


### PR DESCRIPTION
## What changed

- build the production Worker image with the same source fingerprint, protocol, package version, revision, and creation metadata that Manager uses for compatibility checks
- stop the production service and snapshot the SQLite database plus WAL before switching releases
- probe the previous release against a private database copy before allowing an automatic code rollback
- restore the pre-deployment database on failure and retain the new code when the previous release cannot open that database schema
- remove executable backticks from the generated systemd unit heredoc and keep the script compatible with Bash 3 array handling
- expand the deployment contract test to cover successful rollout, database-restoring rollback, incompatible rollback refusal, interrupted deployment recovery, WAL restoration, cleanup, and Docker image metadata

## Root cause

The production image builder did not provide the Worker metadata introduced by the DAG environment readiness checks. Manager therefore classified the freshly built image as stale and the production smoke test failed.

The deploy script then rolled the release symlink back after the new Manager had applied schema migration 33. The previous release supported only schema 32, so it entered a permanent restart loop.

## Impact

Production deployments can pass the current Worker compatibility gate. Failed deployments restore their database snapshot and cannot automatically switch to code that is known to be incompatible with the pre-deployment database.

## Validation

- `bash -n scripts/deploy-production.sh`
- production deployment contracts: 6/6 passed
- live validator suite: 80 passed, 2 skipped
- `git diff --check`
- exact-head full CI (Linux Node 20/24, Windows Node 24, Docker Worker smoke, Agent UI): [30185458709](https://github.com/xiaotianfotos/homerail/actions/runs/30185458709)
- attached Ready-for-review CI: [30186052529](https://github.com/xiaotianfotos/homerail/actions/runs/30186052529)
- production deploy and real Worker DAG smoke on 192.168.100.112: [30184953039](https://github.com/xiaotianfotos/homerail/actions/runs/30184953039)
