### PR TITLE
Fix Windows Candidate version validation

### DIFF
--- a/.github/workflows/desktop-release-candidate.yml
+++ b/.github/workflows/desktop-release-candidate.yml
@@ -138,7 +138,7 @@ jobs:
           node homerail-source/scripts/desktop-release/validate-unified-version.mjs
           --public-root homerail-source
           --desktop-root desktop
-          --version "$RELEASE_VERSION"
+          --version "${{ needs.prepare.outputs.version }}"
 
       - name: Verify Desktop commit is merged to main
         shell: bash

--- a/scripts/desktop-release-contracts.test.mjs
+++ b/scripts/desktop-release-contracts.test.mjs
@@ -173,6 +173,10 @@ test("candidate build is manual, owner-only, main-only, and creates no public re
   );
   assert.match(candidateWorkflow, /desktop_sha must be a full lowercase 40-character commit SHA/);
   assert.match(candidateWorkflow, /validate-unified-version\.mjs/);
+  assert.match(
+    candidateWorkflow,
+    /--desktop-root desktop\n\s+--version "\$\{\{ needs\.prepare\.outputs\.version \}\}"/,
+  );
   assert.doesNotMatch(candidateWorkflow, /npm --prefix desktop version/);
   assert.doesNotMatch(candidateWorkflow, /gh release create|git tag|git\/refs/);
   assert.match(candidateWorkflow, /name: desktop-release-candidate/);


### PR DESCRIPTION
## What changed

- pass the immutable Candidate version output directly to the cross-platform unified-version validator
- add a release contract assertion that prevents the Windows build step from using Bash-only environment-variable syntax

## Root cause

The build matrix used `"$RELEASE_VERSION"` in a step whose default shell is PowerShell on Windows. PowerShell therefore passed an empty value and the first `0.1.0-alpha.1` Candidate failed with `missing value for --version`.

## Validation

- release contract tests: 17/17 passed
- `git diff --check`
- failure reproduced by Candidate run [30186414597](https://github.com/xiaotianfotos/homerail/actions/runs/30186414597), Windows job `89751894946`
