### PR TITLE
release: build Windows Alpha installers without Authenticode

### DIFF
--- a/.github/workflows/desktop-release-candidate.yml
+++ b/.github/workflows/desktop-release-candidate.yml
@@ -69,6 +69,17 @@ jobs:
           printf 'channel=%s\n' "$channel" >> "$GITHUB_OUTPUT"
           printf 'prerelease=%s\n' "$prerelease" >> "$GITHUB_OUTPUT"
 
+      - name: Require Alpha while Windows signing is unavailable
+        shell: bash
+        env:
+          RELEASE_CHANNEL: ${{ steps.release.outputs.channel }}
+        run: |
+          set -euo pipefail
+          if [[ "$RELEASE_CHANNEL" != "alpha" ]]; then
+            echo "Desktop Candidate currently supports Alpha only; Beta and Stable require trusted Windows Authenticode signing" >&2
+            exit 1
+          fi
+
       - name: Verify unified public package versions
         env:
           RELEASE_VERSION: ${{ steps.release.outputs.version }}
@@ -78,7 +89,7 @@ jobs:
           --version "$RELEASE_VERSION"
 
   build:
-    name: Build signed candidate (${{ matrix.label }})
+    name: Build candidate (${{ matrix.label }})
     needs: prepare
     environment:
       name: desktop-beta-signing
@@ -191,15 +202,22 @@ jobs:
           HOMERAIL_HOME: ${{ runner.temp }}/homerail-candidate-desktop-ci
         run: npm run ci
 
-      - name: Build and sign Windows installer
+      - name: Require Alpha for unsigned Windows installer
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if ($env:RELEASE_CHANNEL -ne 'alpha') {
+            throw "Unsigned Windows candidates are allowed only for Alpha; Beta and Stable require trusted Authenticode signing"
+          }
+
+      - name: Build unsigned Windows Alpha installer
         if: runner.os == 'Windows'
         working-directory: desktop
-        env:
-          WIN_CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
-          WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
         run: >-
           npm run dist -- --win nsis --x64 --publish never
-          --config.forceCodeSigning=true
+          --config.win.signExecutable=false
+          --config.win.verifyUpdateCodeSignature=false
           --config.publish.channel="$env:RELEASE_CHANNEL"
 
       - name: Prepare and verify Windows update metadata
@@ -218,23 +236,53 @@ jobs:
             throw "Windows update metadata verification failed"
           }
 
-      - name: Verify Windows package and signature
+      - name: Verify unsigned Windows Alpha package
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
+          $ErrorActionPreference = 'Stop'
           npm --prefix desktop run verify:package
-          $installers = @(Get-ChildItem -Path desktop/dist-electron -Filter *.exe -File)
-          if ($installers.Count -eq 0) { throw "No Windows installer was produced" }
-          foreach ($installer in $installers) {
-            $signature = Get-AuthenticodeSignature -FilePath $installer.FullName
-            if ($null -eq $signature.SignerCertificate) {
-              throw "Missing Authenticode signature: $($installer.Name)"
-            }
-            if ($signature.Status -ne 'Valid') {
-              throw "Invalid Authenticode signature on $($installer.Name): $($signature.Status)"
-            }
-            Write-Host "Signed installer: $($installer.Name) ($($signature.Status))"
+          if ($LASTEXITCODE -ne 0) {
+            throw "Windows package verification failed"
           }
+
+          $installers = @(Get-ChildItem -Path desktop/dist-electron -Filter *.exe -File)
+          if ($installers.Count -ne 1) {
+            throw "Expected exactly one Windows installer, found $($installers.Count)"
+          }
+
+          $installer = $installers[0]
+          $signature = Get-AuthenticodeSignature -LiteralPath $installer.FullName
+          Write-Host "Authenticode status for $($installer.Name): $($signature.Status) ($($signature.StatusMessage))"
+          if ($signature.Status -ne 'NotSigned') {
+            throw "Windows Alpha installer must be explicitly unsigned; got $($signature.Status)"
+          }
+          if ($null -ne $signature.SignerCertificate) {
+            throw "Windows Alpha installer must not contain an Authenticode signer certificate"
+          }
+
+          $appUpdateConfig = 'desktop/dist-electron/win-unpacked/resources/app-update.yml'
+          if (-not (Test-Path -LiteralPath $appUpdateConfig -PathType Leaf)) {
+            throw "Packaged Windows updater config is missing: $appUpdateConfig"
+          }
+          $appUpdateYaml = [System.IO.File]::ReadAllText(
+            (Resolve-Path -LiteralPath $appUpdateConfig).Path
+          )
+          if ($appUpdateYaml -match '(?m)^\s*publisherName\s*:') {
+            throw "Unsigned Windows Alpha app-update.yml must not contain publisherName"
+          }
+          foreach ($expectedLine in @(
+            'provider: github',
+            'owner: xiaotianfotos',
+            'repo: homerail',
+            'channel: alpha'
+          )) {
+            $pattern = '(?m)^\s*' + [regex]::Escape($expectedLine) + '\s*$'
+            if ($appUpdateYaml -notmatch $pattern) {
+              throw "Unsigned Windows Alpha app-update.yml is missing expected update target: $expectedLine"
+            }
+          }
+          Write-Host "Verified explicitly unsigned Windows Alpha installer without updater publisherName"
 
       - name: Write Windows checksums
         if: runner.os == 'Windows'

--- a/.github/workflows/desktop-release-publish.yml
+++ b/.github/workflows/desktop-release-publish.yml
@@ -86,6 +86,9 @@ jobs:
           node - <<'NODE'
           const fs = require("node:fs");
           const manifest = JSON.parse(fs.readFileSync("candidate/release-manifest.json", "utf8"));
+          if (manifest.channel !== "alpha") {
+            throw new Error(`only Alpha candidates may be published while Windows installers are unsigned; got ${manifest.channel}`);
+          }
           if (manifest.source_commit !== process.env.EXPECTED_SOURCE_SHA) {
             throw new Error(`candidate source ${manifest.source_commit} does not match workflow ${process.env.EXPECTED_SOURCE_SHA}`);
           }

--- a/docs/desktop-release.md
+++ b/docs/desktop-release.md
@@ -19,8 +19,8 @@ and `latest`. These Desktop workflows do not publish npm packages.
 
 The release process intentionally separates three milestones:
 
-1. **Candidate**: signed artifacts exist privately as one immutable GitHub
-   Actions artifact.
+1. **Candidate**: platform-policy-verified artifacts exist privately as one
+   immutable GitHub Actions artifact.
 2. **Technical publish**: the exact candidate receives an annotated Git tag and
    a public GitHub prerelease, making it visible to `electron-updater`.
 3. **Announcement**: installed-update testing passed and the release is ready
@@ -40,8 +40,6 @@ Add these environment secrets:
 | Secret | Value |
 | --- | --- |
 | `HOMERAIL_DESKTOP_READ_TOKEN` | Fine-grained token with read-only Contents access to `xiaotianfotos/homerail_desktop` only |
-| `WIN_CSC_LINK` | Base64-encoded Windows code-signing PFX |
-| `WIN_CSC_KEY_PASSWORD` | Password for the Windows PFX |
 | `MAC_CSC_LINK` | Base64-encoded Developer ID Application P12 |
 | `MAC_CSC_KEY_PASSWORD` | Password for the Mac P12 |
 | `APPLE_API_KEY_P8` | Base64-encoded App Store Connect `.p8` key |
@@ -56,6 +54,12 @@ releases.
 Both workflow environments set `deployment: false`. They retain environment
 secrets and approvals without creating public Deployment records for signing or
 release administration.
+
+The Candidate workflow intentionally reads no Windows code-signing secrets.
+Legacy self-signed secrets, if they still exist in the GitHub environment, are
+not injected into this build. Windows Alpha packaging is unsigned under the
+temporary policy below. macOS still requires Developer ID signing and Apple
+notarization.
 
 Keep all certificate passwords, private keys, and repository tokens out of Git.
 The candidate workflow writes the Apple API key only to the ephemeral macOS
@@ -98,7 +102,8 @@ The workflow:
    versions;
 2. checks out the private Desktop source by full commit SHA;
 3. builds Windows x64 and macOS arm64 on isolated hosted runners;
-4. signs Windows, signs and notarizes macOS, and verifies both packages;
+4. verifies an explicitly unsigned Windows Alpha installer, and signs,
+   notarizes, and verifies the macOS package;
 5. asks the pinned Desktop release tooling to prepare and verify channel-specific
    metadata against the packaged files;
 6. creates platform checksums and a combined release manifest;
@@ -111,13 +116,45 @@ aliases let a persisted Early Access installation traverse Alpha → Beta → St
 without relying on updater fallback behavior. Every emitted metadata file is
 covered by both the platform checksum list and the combined candidate manifest.
 
+### Windows Alpha signing policy
+
+Windows installers are explicitly unsigned while HomeRail is in Alpha. The
+Candidate workflow passes `win.signExecutable=false` and
+`win.verifyUpdateCodeSignature=false` only on the Windows Alpha
+electron-builder command. It does not disable updater signature verification
+globally in Desktop production code. Both the early Prepare gate and the
+Windows build gate reject any non-Alpha version; Beta and Stable require
+trusted Windows signing.
+
+The Windows gate requires exactly one NSIS installer, verifies its
+Authenticode status is `NotSigned` with no signer certificate, and rejects a
+packaged `app-update.yml` containing `publisherName`. Users should expect
+Windows SmartScreen and an **Unknown Publisher** warning. Update integrity
+currently depends on delivery from the GitHub Release and electron-updater's
+SHA-512 metadata check, supplemented by the candidate SHA-256 manifests. That
+does not authenticate a publisher and is weaker than trusted Authenticode, so
+this exception is only permitted for Alpha.
+
+Omitting `publisherName` also preserves a migration path to a future
+trusted-signed Windows build. An unsigned Alpha can discover and install that
+signed build, but the first update from an unsigned Alpha to a signed installer
+does not verify that installer with Authenticode; the old client's updater
+configuration still relies on GitHub and SHA-512 for that hop. After the signed
+version is installed, its own `app-update.yml` can restore `publisherName` and
+signature verification for subsequent updates.
+
+[SignPath Foundation](https://signpath.org/) is a possible no-cost signing path
+for qualifying open-source projects. HomeRail has not been applied for or
+approved, so it is a future option rather than a current release capability.
+
 The candidate does not create a Git tag or GitHub Release.
 
 The hosted Windows build gate runs the complete public Node 24 CI suite and the
-private Desktop CI suite before packaging. After signing and static package
-verification, it uses an isolated temporary profile to silently install the
-NSIS package, execute the packaged CLI and verify its release version, keep the
-Desktop process alive for a bounded startup smoke, and silently uninstall it.
+private Desktop CI suite before packaging. After unsigned-policy and static
+package verification, it uses an isolated temporary profile to silently install
+the NSIS package, execute the packaged CLI and verify its release version, keep
+the Desktop process alive for a bounded startup smoke, and silently uninstall
+it.
 This non-interactive runner smoke does not prove that a visible GUI rendered,
 that onboarding works, or that an installed update preserves real user data. It
 does not replace the following acceptance checks on a real Windows machine.
@@ -125,8 +162,9 @@ does not replace the following acceptance checks on a real Windows machine.
 After the hosted-runner gates pass, download the candidate from the workflow
 run and perform direct-install checks:
 
-- Windows: install the NSIS package, launch HomeRail, complete onboarding,
-  restart, and uninstall once.
+- Windows: acknowledge the expected SmartScreen / Unknown Publisher warning,
+  install the NSIS package, launch HomeRail, complete onboarding, restart, and
+  uninstall once.
 - macOS: mount the DMG, install HomeRail, confirm Gatekeeper accepts it, launch,
   complete onboarding, quit, and relaunch.
 - Both: verify the packaged CLI, Manager/Node/Worker startup, settings
@@ -154,8 +192,12 @@ job:
 4. refuses to replace an existing tag or release;
 5. creates an annotated `v<version>` tag at the candidate's public source
    commit;
-6. creates a GitHub prerelease for Alpha or Beta, or a normal release for
-   Stable, using the exact candidate files without rebuilding.
+6. creates a GitHub prerelease for the exact Alpha candidate without
+   rebuilding.
+
+The Publish workflow rejects a non-Alpha manifest before any tag or release
+lookup or creation. Beta and Stable publishing remain blocked until trusted
+Windows signing is implemented and the policy is deliberately updated.
 
 This is the point at which the tag is created. Do not create the version tag
 when merging code or starting a candidate build.
@@ -173,8 +215,9 @@ The first two Alpha releases establish the update baseline:
 4. Build and direct-install-test `0.1.0-alpha.2`.
 5. Technically publish Alpha.2.
 6. Confirm the Alpha.1 installations discover, download, and install Alpha.2.
-7. Verify the version, signatures, services, onboarding state, settings, data,
-   CLI, and Realtime Voice after the update.
+7. Verify the version, expected Windows unsigned status, macOS signature and
+   notarization, services, onboarding state, settings, data, CLI, and Realtime
+   Voice after the update.
 8. Announce Alpha.2 only after both platforms pass.
 
 Technical publish is necessarily public because the GitHub update provider
@@ -198,7 +241,7 @@ Create the version tag only when all of these are true:
 - release notes and the source commits in `release-manifest.json` were reviewed;
 - the publishing environment approval is intentional.
 
-Beta additionally requires a reliable Alpha upgrade history, stable
-configuration/data migrations, no known data-loss or security issue, and a
-substantially frozen core feature set. Stable is not part of the current
-release plan.
+Beta additionally requires trusted Windows signing, a reliable Alpha upgrade
+history, stable configuration/data migrations, no known data-loss or security
+issue, and a substantially frozen core feature set. Stable likewise requires
+trusted Windows signing and is not part of the current release plan.

--- a/scripts/desktop-release-contracts.test.mjs
+++ b/scripts/desktop-release-contracts.test.mjs
@@ -32,6 +32,22 @@ const currentPublicVersion = JSON.parse(
   fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"),
 ).version;
 
+function workflowStep(workflow, name) {
+  const marker = `      - name: ${name}\n`;
+  const start = workflow.indexOf(marker);
+  assert.notEqual(start, -1, `missing workflow step: ${name}`);
+  const next = workflow.indexOf("\n      - name: ", start + marker.length);
+  return workflow.slice(start, next === -1 ? undefined : next);
+}
+
+function candidateStep(name) {
+  return workflowStep(candidateWorkflow, name);
+}
+
+function publishStep(name) {
+  return workflowStep(publishWorkflow, name);
+}
+
 test("release versions follow the unified Codex-style SemVer train", () => {
   assert.deepEqual(classifyReleaseVersion("0.1.0-alpha.1"), {
     version: "0.1.0-alpha.1",
@@ -184,7 +200,7 @@ test("candidate build is manual, owner-only, main-only, and creates no public re
   assert.match(candidateWorkflow, /cancel-in-progress: false/);
 });
 
-test("candidate uses protected signing without Deployment records", () => {
+test("candidate uses protected release environment without Deployment records", () => {
   assert.match(
     candidateWorkflow,
     /environment:\n\s+name: desktop-beta-signing\n\s+deployment: false/,
@@ -198,10 +214,8 @@ test("candidate uses protected signing without Deployment records", () => {
   assert.doesNotMatch(candidateWorkflow, /runs-on:.*self-hosted/);
 });
 
-test("candidate signs, notarizes, verifies, and creates channel metadata", () => {
+test("candidate signs macOS, explicitly leaves Windows Alpha unsigned, and creates metadata", () => {
   for (const secret of [
-    "WIN_CSC_LINK",
-    "WIN_CSC_KEY_PASSWORD",
     "MAC_CSC_LINK",
     "MAC_CSC_KEY_PASSWORD",
     "APPLE_API_KEY_P8",
@@ -211,22 +225,53 @@ test("candidate signs, notarizes, verifies, and creates channel metadata", () =>
   ]) {
     assert.match(candidateWorkflow, new RegExp(`secrets\\.${secret}`));
   }
-  assert.equal((candidateWorkflow.match(/--config\.forceCodeSigning=true/g) ?? []).length, 2);
-  assert.match(candidateWorkflow, /--config\.mac\.notarize=true/);
+  assert.doesNotMatch(candidateWorkflow, /WIN_CSC_LINK|WIN_CSC_KEY_PASSWORD/);
+  assert.doesNotMatch(candidateWorkflow, /Build signed candidate/);
+
+  const prepareGuard = candidateStep("Require Alpha while Windows signing is unavailable");
+  assert.match(prepareGuard, /\[\[ "\$RELEASE_CHANNEL" != "alpha" \]\]/);
+  assert.match(prepareGuard, /Beta and Stable require trusted Windows Authenticode signing/);
+
+  const windowsGuard = candidateStep("Require Alpha for unsigned Windows installer");
+  assert.match(windowsGuard, /if: runner\.os == 'Windows'/);
+  assert.match(windowsGuard, /if \(\$env:RELEASE_CHANNEL -ne 'alpha'\)/);
+  assert.match(windowsGuard, /Beta and Stable require trusted Authenticode signing/);
+
+  const windowsBuild = candidateStep("Build unsigned Windows Alpha installer");
+  assert.match(windowsBuild, /--config\.win\.signExecutable=false/);
+  assert.match(windowsBuild, /--config\.win\.verifyUpdateCodeSignature=false/);
+  assert.match(windowsBuild, /--config\.publish\.channel=/);
+  assert.doesNotMatch(windowsBuild, /forceCodeSigning|WIN_CSC/);
+  assert.equal(
+    (candidateWorkflow.match(/--config\.win\.signExecutable=false/g) ?? []).length,
+    1,
+  );
+  assert.equal(
+    (
+      candidateWorkflow.match(/--config\.win\.verifyUpdateCodeSignature=false/g)
+      ?? []
+    ).length,
+    1,
+  );
+
+  const macBuild = candidateStep("Build, sign, and notarize macOS app");
+  assert.match(macBuild, /--config\.forceCodeSigning=true/);
+  assert.match(macBuild, /--config\.mac\.notarize=true/);
+  assert.equal((candidateWorkflow.match(/--config\.forceCodeSigning=true/g) ?? []).length, 1);
   assert.equal((candidateWorkflow.match(/--config\.publish\.channel=/g) ?? []).length, 2);
   assert.match(candidateWorkflow, /verify:update-metadata/);
   assert.match(candidateWorkflow, /metadata_release_channel=stable/);
   assert.match(candidateWorkflow, /'latest\.yml', 'alpha\.yml', 'beta\.yml'/);
   assert.match(candidateWorkflow, /"latest-mac\.yml" "alpha-mac\.yml" "beta-mac\.yml"/);
   assert.match(candidateWorkflow, /asset_name="\$\{asset#\.\/\}"/);
-  assert.match(candidateWorkflow, /Get-AuthenticodeSignature/);
-  assert.match(candidateWorkflow, /codesign --verify --deep --strict/);
-  assert.match(candidateWorkflow, /xcrun stapler validate/);
-  assert.match(candidateWorkflow, /spctl --assess/);
+  const macVerification = candidateStep("Verify macOS package, signature, and notarization");
+  assert.match(macVerification, /codesign --verify --deep --strict/);
+  assert.match(macVerification, /xcrun stapler validate/);
+  assert.match(macVerification, /spctl --assess/);
   assert.match(candidateWorkflow, /release-candidate\.mjs create/);
 });
 
-test("Windows candidate runs Node 24 CI before signing and smoke-tests NSIS", () => {
+test("Windows candidate runs Node 24 CI before building and smoke-testing unsigned Alpha", () => {
   assert.match(candidateWorkflow, /RELEASE_NODE_VERSION: 24\.18\.0/);
   assert.match(candidateWorkflow, /name: Run public Windows Node 24 CI/);
   assert.match(candidateWorkflow, /npm --prefix homerail-source run ci/);
@@ -237,31 +282,103 @@ test("Windows candidate runs Node 24 CI before signing and smoke-tests NSIS", ()
   assert.match(candidateWorkflow, /VITEST_MAX_WORKERS: "1"/);
   assert.match(candidateWorkflow, /VITEST_TEST_TIMEOUT: "15000"/);
   assert.match(candidateWorkflow, /VITEST_HOOK_TIMEOUT: "30000"/);
-  assert.match(candidateWorkflow, /if \(\$signature\.Status -ne 'Valid'\)/);
-  assert.match(candidateWorkflow, /-ArgumentList @\('\/S', "\/D=\$installRoot"\)/);
-  assert.match(candidateWorkflow, /--user-data-dir=\$electronUserData/);
-  assert.match(candidateWorkflow, /Installed CLI version .* does not match/);
-  assert.match(candidateWorkflow, /Silent NSIS uninstall left HomeRail\.exe installed/);
-  assert.match(candidateWorkflow, /\$_\.Name -match '\\\.\(exe\|blockmap\)\$'/);
+
+  const packageVerificationStep = candidateStep("Verify unsigned Windows Alpha package");
+  assert.match(packageVerificationStep, /npm --prefix desktop run verify:package/);
+  assert.match(packageVerificationStep, /if \(\$LASTEXITCODE -ne 0\)/);
+  assert.match(packageVerificationStep, /\$installers\.Count -ne 1/);
+  assert.match(
+    packageVerificationStep,
+    /Get-AuthenticodeSignature -LiteralPath \$installer\.FullName/,
+  );
+  assert.match(packageVerificationStep, /\$signature\.StatusMessage/);
+  assert.match(packageVerificationStep, /if \(\$signature\.Status -ne 'NotSigned'\)/);
+  assert.match(
+    packageVerificationStep,
+    /if \(\$null -ne \$signature\.SignerCertificate\)/,
+  );
+  assert.match(
+    packageVerificationStep,
+    /desktop\/dist-electron\/win-unpacked\/resources\/app-update\.yml/,
+  );
+  assert.match(
+    packageVerificationStep,
+    /\[System\.IO\.File\]::ReadAllText\([\s\S]*Resolve-Path[\s\S]*\.Path/,
+  );
+  assert.ok(
+    packageVerificationStep.includes(
+      "if ($appUpdateYaml -match '(?m)^\\s*publisherName\\s*:')",
+    ),
+  );
+  assert.match(packageVerificationStep, /must not contain publisherName/);
+  for (const expectedUpdateTarget of [
+    "provider: github",
+    "owner: xiaotianfotos",
+    "repo: homerail",
+    "channel: alpha",
+  ]) {
+    assert.match(packageVerificationStep, new RegExp(expectedUpdateTarget));
+  }
+  assert.match(packageVerificationStep, /\[regex\]::Escape\(\$expectedLine\)/);
+  assert.match(packageVerificationStep, /\$appUpdateYaml -notmatch \$pattern/);
+
+  const checksumStep = candidateStep("Write Windows checksums");
+  assert.match(checksumStep, /Get-FileHash -Algorithm SHA256/);
+  assert.match(checksumStep, /SHA256SUMS-windows\.txt/);
+  assert.match(checksumStep, /\$_\.Name -match '\\\.\(exe\|blockmap\)\$'/);
+  assert.match(checksumStep, /"\$env:RELEASE_CHANNEL\.yml"/);
+
+  const installSmokeStep = candidateStep("Smoke-test silent Windows installation");
+  assert.match(installSmokeStep, /-ArgumentList @\('\/S', "\/D=\$installRoot"\)/);
+  assert.match(installSmokeStep, /--user-data-dir=\$electronUserData/);
+  assert.match(installSmokeStep, /Installed CLI version .* does not match/);
+  assert.match(installSmokeStep, /Start-Sleep -Seconds 12/);
+  assert.match(installSmokeStep, /Silent NSIS uninstall left HomeRail\.exe installed/);
+
+  const uploadStep = candidateStep("Upload Windows candidate assets");
+  assert.match(uploadStep, /desktop\/dist-electron\/\*\.exe/);
+  assert.match(uploadStep, /desktop\/dist-electron\/\*\.blockmap/);
+  assert.match(uploadStep, /desktop\/dist-electron\/\*\.yml/);
+  assert.match(uploadStep, /desktop\/dist-electron\/SHA256SUMS-windows\.txt/);
+  assert.match(uploadStep, /if-no-files-found: error/);
 
   const install = candidateWorkflow.indexOf("Install locked dependencies");
   const publicCi = candidateWorkflow.indexOf("Run public Windows Node 24 CI");
   const publicCliVersion = candidateWorkflow.indexOf("Verify public Windows CLI release version");
   const desktopCi = candidateWorkflow.indexOf("Run Desktop Windows CI");
-  const build = candidateWorkflow.indexOf("Build and sign Windows installer");
+  const guard = candidateWorkflow.indexOf("Require Alpha for unsigned Windows installer");
+  const build = candidateWorkflow.indexOf("Build unsigned Windows Alpha installer");
   const metadata = candidateWorkflow.indexOf("Prepare and verify Windows update metadata");
-  const packageVerification = candidateWorkflow.indexOf("Verify Windows package and signature");
+  const packageVerification = candidateWorkflow.indexOf("Verify unsigned Windows Alpha package");
   const checksums = candidateWorkflow.indexOf("Write Windows checksums");
   const installSmoke = candidateWorkflow.indexOf("Smoke-test silent Windows installation");
+  const upload = candidateWorkflow.indexOf("Upload Windows candidate assets");
+  for (const index of [
+    install,
+    publicCi,
+    publicCliVersion,
+    desktopCi,
+    guard,
+    build,
+    metadata,
+    packageVerification,
+    checksums,
+    installSmoke,
+    upload,
+  ]) {
+    assert.notEqual(index, -1);
+  }
   assert.ok(
     install < publicCi
       && publicCi < publicCliVersion
       && publicCliVersion < desktopCi
-      && desktopCi < build
+      && desktopCi < guard
+      && guard < build
       && build < metadata
       && metadata < packageVerification
       && packageVerification < checksums
-      && checksums < installSmoke,
+      && checksums < installSmoke
+      && installSmoke < upload,
   );
 });
 
@@ -284,6 +401,43 @@ test("publish consumes a successful candidate without rebuilding it", () => {
   assert.match(publishWorkflow, /--verify-tag/);
   assert.match(publishWorkflow, /--prerelease/);
   assert.doesNotMatch(publishWorkflow, /npm (?:ci|run)|electron-builder|forceCodeSigning/);
+
+  const candidateVerification = publishStep(
+    "Verify candidate identity, assets, and checksums",
+  );
+  const manifestRead = candidateVerification.indexOf(
+    'JSON.parse(fs.readFileSync("candidate/release-manifest.json", "utf8"))',
+  );
+  const alphaGuard = candidateVerification.indexOf(
+    'if (manifest.channel !== "alpha")',
+  );
+  const tagCheck = publishWorkflow.indexOf(
+    "Refuse to replace an existing tag or release",
+  );
+  const tagCreation = publishWorkflow.indexOf("Create immutable annotated tag");
+  const releaseCreation = publishWorkflow.indexOf(
+    "Publish exact candidate as a GitHub release",
+  );
+  assert.match(
+    candidateVerification,
+    /only Alpha candidates may be published while Windows installers are unsigned/,
+  );
+  for (const index of [
+    manifestRead,
+    alphaGuard,
+    tagCheck,
+    tagCreation,
+    releaseCreation,
+  ]) {
+    assert.notEqual(index, -1);
+  }
+  assert.ok(
+    manifestRead < alphaGuard
+      && publishWorkflow.indexOf("Verify candidate identity, assets, and checksums")
+        < tagCheck
+      && tagCheck < tagCreation
+      && tagCreation < releaseCreation,
+  );
 });
 
 test("release docs preserve candidate, publish, update-test, and fix-forward boundaries", () => {
@@ -298,6 +452,27 @@ test("release docs preserve candidate, publish, update-test, and fix-forward bou
   assert.match(releaseDocs, /byte-identical Alpha and Beta compatibility metadata/);
   assert.match(releaseDocs, /complete public Node 24 CI suite/);
   assert.match(releaseDocs, /does not replace.*real Windows machine/s);
+  assert.match(releaseDocs, /SmartScreen/);
+  assert.match(releaseDocs, /Unknown Publisher/);
+  assert.match(releaseDocs, /GitHub Release[\s\S]*SHA-512/);
+  assert.match(releaseDocs, /weaker than trusted Authenticode/i);
+  assert.match(releaseDocs, /only permitted for Alpha/i);
+  assert.match(releaseDocs, /Beta and Stable[\s\S]*trusted Windows signing/i);
+  assert.match(releaseDocs, /SignPath Foundation/);
+  assert.match(releaseDocs, /not been applied for or\s+approved/i);
+  assert.match(
+    releaseDocs,
+    /first update from an unsigned Alpha to a signed installer[\s\S]*does not verify that installer with Authenticode/i,
+  );
+  assert.match(
+    releaseDocs,
+    /signed\s+version is installed[\s\S]*app-update\.yml[\s\S]*publisherName/i,
+  );
+  assert.match(
+    releaseDocs,
+    /only on the Windows Alpha\s+electron-builder command/i,
+  );
+  assert.doesNotMatch(releaseDocs, /WIN_CSC_LINK|WIN_CSC_KEY_PASSWORD/);
 });
 
 test("candidate pins a merged Desktop commit before installing or signing", () => {
@@ -415,6 +590,19 @@ test("candidate manifest is reproducibly verified and detects artifact tampering
     ];
     const create = spawnSync(process.execPath, createArgs, { encoding: "utf8" });
     assert.equal(create.status, 0, create.stderr);
+
+    const releaseNotes = fs.readFileSync(
+      path.join(candidateDir, "release-notes.md"),
+      "utf8",
+    );
+    assert.match(releaseNotes, /Windows: explicitly unsigned Alpha installer/);
+    assert.match(releaseNotes, /macOS: Developer ID signed and Apple-notarized/);
+    assert.match(releaseNotes, /platform-specific release gates/);
+    assert.doesNotMatch(releaseNotes, /This is a signed HomeRail Desktop/);
+    assert.doesNotMatch(
+      releaseNotes,
+      /passed build-time signature, notarization, package/,
+    );
 
     const verify = spawnSync(
       process.execPath,

--- a/scripts/desktop-release/release-candidate.mjs
+++ b/scripts/desktop-release/release-candidate.mjs
@@ -275,18 +275,24 @@ function writeCandidate(args) {
   );
 
   const phase = manifest.prerelease ? `${args.channel} prerelease` : "stable release";
+  const windowsPolicyNote =
+    args.channel === "alpha"
+      ? "- Windows: explicitly unsigned Alpha installer, verified as unsigned under the Alpha release policy."
+      : `- Windows: trusted Authenticode signing is required for this ${phase}.`;
   fs.writeFileSync(
     path.join(candidateDir, "release-notes.md"),
     [
       `# HomeRail ${args.version}`,
       "",
-      `This is a signed HomeRail Desktop ${phase}.`,
+      `This HomeRail Desktop ${phase} passed its platform-specific release gates.`,
       "",
       `- HomeRail commit: \`${args["source-commit"]}\``,
       `- Desktop commit: \`${args["desktop-commit"]}\``,
       `- Candidate workflow run: \`${args["run-id"]}\``,
+      windowsPolicyNote,
+      "- macOS: Developer ID signed and Apple-notarized.",
       "",
-      "The candidate passed build-time signature, notarization, package, and checksum verification.",
+      "The candidate passed build-time package, update-metadata, checksum, and applicable platform signing-policy verification.",
       "Public announcement remains a separate decision after installed-update testing.",
       "",
     ].join("\n"),


### PR DESCRIPTION
## Summary

- build Windows x64 NSIS installers explicitly without Authenticode only for the current Alpha train
- keep macOS arm64 Developer ID signing, notarization, and verification unchanged
- verify the Windows installer is exactly one `NotSigned` executable with no signer certificate
- verify packaged Windows updater configuration targets `github/xiaotianfotos/homerail` on `alpha` and contains no `publisherName`
- update public release notes and documentation so they do not imply that every platform is signed

## Release policy

Beta and Stable remain hard-blocked until HomeRail has trusted Windows signing:

1. Candidate Prepare rejects a non-Alpha release before either platform build starts.
2. The Windows job defensively rejects a non-Alpha release immediately before the unsigned build.
3. Publish rejects a non-Alpha candidate manifest before any tag or release lookup or creation.

The Windows Alpha build passes only these per-build electron-builder overrides:

- `win.signExecutable=false`
- `win.verifyUpdateCodeSignature=false`

Desktop updater production code is not globally changed. macOS still requires `forceCodeSigning=true`, Developer ID signing, Apple notarization, `codesign`, `stapler`, and `spctl`.

## Updater migration boundary

The unsigned Alpha package has no `publisherName` in `app-update.yml`. It can therefore update to a future SignPath- or otherwise trusted-signed installer, but that first unsigned-to-signed hop is authenticated only by the GitHub Release and electron-updater SHA-512 metadata; the old Alpha client does not validate the new installer with Authenticode. After the signed version is installed, its own `app-update.yml` can restore `publisherName` and signature verification for later updates.

## Release notes

Candidate release notes now state the platform facts separately:

- Windows Alpha is explicitly unsigned and verified under the Alpha release policy.
- macOS is Developer ID signed and Apple-notarized.

The previous all-platform `signed HomeRail Desktop` and generalized signature-verification claims are removed.

## Validation

- Node `v24.14.0`: `node --test scripts/desktop-release-contracts.test.mjs` — **17/17 passed**
- Ruby YAML parse of both Candidate and Publish workflows — **passed**
- `git diff --check` — **passed**
- locked dependency installation — **passed**
- full local `npm run ci`:
  - all package typechecks and builds passed
  - Agent UI production build passed
  - Protocol tests passed: **304/304**
  - Plugin SDK tests passed: **35/35**
  - the first Manager run inherited a non-temporary local `HOMERAIL_HOME`, hit its safety guard plus sandbox-denied Docker access, and timed out in HTTP/subprocess cases
  - an isolated retry with Candidate-style temporary `HOMERAIL_HOME`, one Vitest worker, and extended timeouts again passed the preceding stages, but Manager did not reach a terminal result within the 30-minute local boundary and was stopped; this is reported as a local environment/suite timeout, not a passing full CI result

## Required post-merge verification

Before any tag or Publish action, dispatch a fresh GitHub-hosted Desktop Release Candidate from `main`. The Windows job must prove the real packaged output is unsigned, has the exact Alpha updater target without `publisherName`, passes metadata/package/checksum gates, and completes silent install/start/CLI/uninstall smoke. A real Windows machine must still cover SmartScreen / Unknown Publisher, visible GUI/onboarding, data preservation, Realtime Voice, and installed-update behavior.

This PR does not trigger a Candidate, create a tag, create or modify a GitHub Release, or run Publish.
