### PR TITLE
release: restrict candidate metadata uploads

### DIFF
--- a/.github/workflows/desktop-release-candidate.yml
+++ b/.github/workflows/desktop-release-candidate.yml
@@ -505,7 +505,9 @@ jobs:
           path: |
             desktop/dist-electron/*.exe
             desktop/dist-electron/*.blockmap
-            desktop/dist-electron/*.yml
+            desktop/dist-electron/latest.yml
+            desktop/dist-electron/alpha.yml
+            desktop/dist-electron/beta.yml
             desktop/dist-electron/SHA256SUMS-windows.txt
           if-no-files-found: error
           retention-days: 30
@@ -519,7 +521,9 @@ jobs:
             desktop/dist-electron/*.dmg
             desktop/dist-electron/*.zip
             desktop/dist-electron/*.blockmap
-            desktop/dist-electron/*.yml
+            desktop/dist-electron/latest-mac.yml
+            desktop/dist-electron/alpha-mac.yml
+            desktop/dist-electron/beta-mac.yml
             desktop/dist-electron/SHA256SUMS-macos.txt
           if-no-files-found: error
           retention-days: 30

--- a/scripts/desktop-release-contracts.test.mjs
+++ b/scripts/desktop-release-contracts.test.mjs
@@ -268,6 +268,11 @@ test("candidate signs macOS, explicitly leaves Windows Alpha unsigned, and creat
   assert.match(macVerification, /codesign --verify --deep --strict/);
   assert.match(macVerification, /xcrun stapler validate/);
   assert.match(macVerification, /spctl --assess/);
+  const macUpload = candidateStep("Upload macOS candidate assets");
+  for (const metadata of ["latest-mac.yml", "alpha-mac.yml", "beta-mac.yml"]) {
+    assert.match(macUpload, new RegExp(`desktop/dist-electron/${metadata}`));
+  }
+  assert.doesNotMatch(macUpload, /desktop\/dist-electron\/\*\.yml/);
   assert.match(candidateWorkflow, /release-candidate\.mjs create/);
 });
 
@@ -338,7 +343,10 @@ test("Windows candidate runs Node 24 CI before building and smoke-testing unsign
   const uploadStep = candidateStep("Upload Windows candidate assets");
   assert.match(uploadStep, /desktop\/dist-electron\/\*\.exe/);
   assert.match(uploadStep, /desktop\/dist-electron\/\*\.blockmap/);
-  assert.match(uploadStep, /desktop\/dist-electron\/\*\.yml/);
+  for (const metadata of ["latest.yml", "alpha.yml", "beta.yml"]) {
+    assert.match(uploadStep, new RegExp(`desktop/dist-electron/${metadata}`));
+  }
+  assert.doesNotMatch(uploadStep, /desktop\/dist-electron\/\*\.yml/);
   assert.match(uploadStep, /desktop\/dist-electron\/SHA256SUMS-windows\.txt/);
   assert.match(uploadStep, /if-no-files-found: error/);
 


### PR DESCRIPTION
Fixes Candidate run 30190037251 assemble failure caused by builder-debug.yml entering the macOS artifact.

Changes:
- replace broad YAML upload globs with explicit Windows and macOS update metadata allowlists
- add release contract coverage that rejects broad YAML upload globs

Validation:
- 17/17 desktop release contract tests pass
- workflow YAML parses
- git diff --check passes

The immutable Candidate boundary remains strict; debug metadata is excluded rather than accepted.