### PR TITLE
CLI rejects blank setting IDs before runtime requests

### DIFF
--- a/homerail_cli/src/command-options.ts
+++ b/homerail_cli/src/command-options.ts
@@ -1,0 +1,9 @@
+import { InvalidArgumentError } from "commander";
+
+export function parseSettingIdOption(value: string): string {
+  const settingId = value.trim();
+  if (!settingId) {
+    throw new InvalidArgumentError("--setting-id must not be empty or whitespace");
+  }
+  return settingId;
+}

--- a/homerail_cli/src/commands/dag-run-template.ts
+++ b/homerail_cli/src/commands/dag-run-template.ts
@@ -8,6 +8,7 @@ import {
 } from "homerail-protocol";
 
 import type { BaseResponse, HomeRailClient } from "../client.js";
+import { parseSettingIdOption } from "../command-options.js";
 import { getClient } from "../index.js";
 import {
   manualCloseoutEnvelope,
@@ -351,7 +352,7 @@ export function registerDagRunTemplateCommands(dag: Command, program: Command): 
     .description("Resolve structured input, sync a tracked DAG template, and start a run")
     .requiredOption("--input <json>", "Structured template input JSON")
     .option("--profile <profile>", "Runtime profile id")
-    .option("--setting-id <id>", "Database LLM setting id")
+    .option("--setting-id <id>", "Database LLM setting id", parseSettingIdOption)
     .option("--run-id <id>", "Explicit run id")
     .option("--wait", "Wait for terminal status and declared artifacts", false)
     .option("--timeout <sec>", "Wait timeout in seconds", "1800")

--- a/homerail_cli/src/commands/run.ts
+++ b/homerail_cli/src/commands/run.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { getClient } from "../index.js";
 import type { BaseResponse } from "../client.js";
+import { parseSettingIdOption } from "../command-options.js";
 import { orchestrationsDir, resolveTemplatePath } from "./templates.js";
 
 export function registerRunCommand(program: Command): void {
@@ -14,7 +15,7 @@ export function registerRunCommand(program: Command): void {
     .option("--workflow <workflow_id>", "Run a DAG workflow synced in the Manager database")
     .option("--sync", "Sync the template to the Manager database before running it")
     .option("--profile <profile>", "Runtime profile id, or a profile YAML file to sync before running")
-    .option("--setting-id <id>", "Database LLM setting id for this DAG run")
+    .option("--setting-id <id>", "Database LLM setting id for this DAG run", parseSettingIdOption)
     .action(
       async (
         template: string | undefined,

--- a/homerail_cli/src/commands/smoke.ts
+++ b/homerail_cli/src/commands/smoke.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { parseSettingIdOption } from "../command-options.js";
 import { getClient } from "../index.js";
 import type { BaseResponse } from "../client.js";
 import { dockerReadiness } from "./doctor.js";
@@ -63,7 +64,7 @@ export function registerSmokeCommand(program: Command): void {
     .requiredOption("--template <path>", "DAG YAML path or .yaml.template path")
     .option("--prompt <text>", "Smoke prompt", DEFAULT_PROMPT)
     .option("--profile <profile>", "Runtime profile; only agent_type selection is supported", process.env.HOMERAIL_SMOKE_PROFILE)
-    .option("--setting-id <id>", "Database LLM setting id for this DAG run")
+    .option("--setting-id <id>", "Database LLM setting id for this DAG run", parseSettingIdOption)
     .option("--no-wait", "Only start the run; do not wait for terminal status")
     .option("--interval <sec>", "Polling interval while waiting", "3")
     .option("--timeout <sec>", "Maximum wait time", "300")
@@ -262,7 +263,7 @@ export function registerSmokeCommand(program: Command): void {
     .description("Ask the configured Manager Agent to start a deterministic DAG and verify the returned run")
     .option("--message <text>", "Manager Agent smoke prompt")
     .option("--project-id <id>", "Project id used for the Manager Agent session", "manager-agent-smoke")
-    .option("--setting-id <id>", "Override Manager LLM setting id for this smoke")
+    .option("--setting-id <id>", "Override Manager LLM setting id for this smoke", parseSettingIdOption)
     .option("--provider <id>", "Override Manager provider id for this smoke")
     .option("--model <name>", "Override Manager model name for this smoke")
     .option("--no-expect-run", "Do not require a run_id in the Manager Agent response")

--- a/homerail_cli/tests/commands.test.ts
+++ b/homerail_cli/tests/commands.test.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, 
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Readable } from "node:stream";
+import type { Command } from "commander";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createProgram } from "../src/index.js";
 import { readLineFromStdin, redactSecret } from "../src/commands/llm-settings.js";
@@ -227,6 +228,55 @@ describe("stop command", () => {
 });
 
 describe("run command", () => {
+  it("keeps the Manager default model selection when --setting-id is absent", async () => {
+    mockFetch({
+      success: true,
+      message: "Run started",
+      data: { run_id: "default-setting-run" },
+    });
+
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "hr",
+      "run",
+      "test-template",
+      "--prompt",
+      "use the default model",
+    ]);
+
+    const request = vi.mocked(globalThis.fetch).mock.calls[0]?.[1];
+    expect(JSON.parse(String(request?.body))).toEqual({
+      prompt: "use the default model",
+      yamlPath: "test-template",
+    });
+  });
+
+  it("normalizes a non-blank --setting-id before sending the run request", async () => {
+    mockFetch({
+      success: true,
+      message: "Run started",
+      data: { run_id: "explicit-setting-run" },
+    });
+
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "hr",
+      "run",
+      "test-template",
+      "--prompt",
+      "use the explicit model",
+      "--setting-id",
+      "  llm-setting-1  ",
+    ]);
+
+    const request = vi.mocked(globalThis.fetch).mock.calls[0]?.[1];
+    expect(JSON.parse(String(request?.body))).toMatchObject({
+      llm_setting_id: "llm-setting-1",
+    });
+  });
+
   it("sends create-and-run request and prints run ID", async () => {
     mockFetch({
       success: true,
@@ -409,6 +459,40 @@ default:
 
     exitSpy.mockRestore();
     errSpy.mockRestore();
+  });
+});
+
+describe("--setting-id option guard", () => {
+  const cases: Array<[string, string[]]> = [
+    ["run", ["run", "test-template", "--prompt", "test", "--setting-id", ""]],
+    ["smoke dag", ["smoke", "dag", "--template", "test-template", "--setting-id", "   "]],
+    ["smoke manager-agent", ["smoke", "manager-agent", "--setting-id", "\t"]],
+    [
+      "dag run-template",
+      ["dag", "run-template", "pr-review", "--input", "{\"repo\":\"owner/repo\",\"pr\":1}", "--setting-id", "\n"],
+    ],
+  ];
+
+  it.each(cases)("rejects an explicit blank value for %s before any request", async (_name, args) => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const errorOutput: string[] = [];
+    const program = createProgram();
+    const overrideExit = (command: Command): void => {
+      command.exitOverride();
+      command.configureOutput({
+        writeErr: (value) => errorOutput.push(value),
+      });
+      command.commands.forEach(overrideExit);
+    };
+    overrideExit(program);
+
+    await expect(program.parseAsync(["node", "hr", ...args])).rejects.toMatchObject({
+      code: "commander.invalidArgument",
+      exitCode: 1,
+    });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(errorOutput.join("")).toContain("--setting-id must not be empty or whitespace");
   });
 });
 


### PR DESCRIPTION
## Summary

- reject explicit empty or whitespace-only `--setting-id` values during CLI option parsing
- apply the shared guard to `run`, `dag run-template`, `smoke dag`, and `smoke manager-agent`
- preserve Manager default model selection when the flag is absent and normalize valid IDs

## Safety

Validation completes before any command action, HTTP or PR metadata lookup, DAG creation, or potentially billable Manager request.

## Validation

Using Node 24 after synchronizing the Windows WebSocket cleanup from `main`:

- CLI typecheck — PASS
- CLI build — PASS
- complete CLI tests — 19 files, 255/255 PASS
- built CLI exits 1 for whitespace-only `--setting-id` before contacting Manager

This PR does not change versions or release metadata.
