### PR TITLE
fix: run Codex shims in GUI-launched environments

### DIFF
--- a/agent-ui/src/api/services/voice-agent-api.ts
+++ b/agent-ui/src/api/services/voice-agent-api.ts
@@ -277,6 +277,18 @@ export interface CodexStatus {
   available: boolean
   logged_in: boolean
   version?: string
+  semantic_version?: string
+  binary?: string
+  diagnostics?: Array<{
+    code:
+      | 'codex_binary_not_found'
+      | 'codex_binary_unusable'
+      | 'codex_auth_missing'
+      | 'codex_version_unparseable'
+      | 'codex_version_too_old'
+      | 'codex_live_voice_feature_missing'
+    message: string
+  }>
 }
 
 export interface CodexModelServiceTier {
@@ -332,7 +344,7 @@ export interface ManagerAgentReadiness {
         voices: CodexLiveVoiceV3Voice[]
         default_voice: CodexLiveVoiceV3Voice
         stage?: string
-        reason?: 'missing' | 'unparseable' | 'too_old' | 'feature_missing'
+        reason?: 'missing' | 'unusable' | 'unparseable' | 'too_old' | 'feature_missing'
       }
     }
     docker_node?: {

--- a/homerail_manager/src/server/codex-appserver-client.ts
+++ b/homerail_manager/src/server/codex-appserver-client.ts
@@ -2,6 +2,7 @@ import { type ChildProcess, spawn } from "node:child_process";
 import { createInterface, type Interface as ReadlineInterface } from "node:readline";
 import {
   codexBinaryNotFoundMessage,
+  codexCommandEnvironment,
   resolveCodexBinary,
 } from "./codex-binary.js";
 import { managerAgentChildEnv } from "./host-codex-manager-agent.js";
@@ -71,10 +72,10 @@ export class CodexAppServerClient {
       this.options.args ?? ["app-server"],
       {
         cwd: this.options.cwd,
-        env: {
+        env: codexCommandEnvironment(resolved.command, {
           ...managerAgentChildEnv(),
           ...this.options.env,
-        },
+        }),
         stdio: ["pipe", "pipe", "pipe"],
         shell: resolved.needsShell,
         windowsHide: true,

--- a/homerail_manager/src/server/codex-appserver-client.ts
+++ b/homerail_manager/src/server/codex-appserver-client.ts
@@ -5,6 +5,7 @@ import {
   codexCommandForSpawn,
   codexCommandEnvironment,
   resolveUsableCodexBinary,
+  terminateCodexProcess,
 } from "./codex-binary.js";
 import { managerAgentChildEnv } from "./host-codex-manager-agent.js";
 import { MANAGER_RUNTIME_VERSION } from "../runtime-version.js";
@@ -45,6 +46,7 @@ export class CodexAppServerClient {
   private pending = new Map<number, PendingRequest>();
   private listeners = new Set<(message: CodexAppServerMessage) => void>();
   private closing = false;
+  private childNeedsShell = false;
   private readonly requestTimeoutMs: number;
   private readonly options: CodexAppServerClientOptions;
 
@@ -68,6 +70,7 @@ export class CodexAppServerClient {
     if (!resolved) throw new Error(codexBinaryNotFoundMessage(requested));
 
     this.closing = false;
+    this.childNeedsShell = resolved.needsShell;
     this.child = spawn(
       codexCommandForSpawn(resolved.command),
       this.options.args ?? ["app-server"],
@@ -164,11 +167,12 @@ export class CodexAppServerClient {
     this.readline = null;
     try {
       this.child?.stdin?.end();
-      this.child?.kill("SIGTERM");
+      if (this.child) terminateCodexProcess(this.child, this.childNeedsShell);
     } catch {
       // Best effort.
     }
     this.child = null;
+    this.childNeedsShell = false;
     this.rejectPending("Codex app-server closed");
   }
 

--- a/homerail_manager/src/server/codex-appserver-client.ts
+++ b/homerail_manager/src/server/codex-appserver-client.ts
@@ -3,7 +3,7 @@ import { createInterface, type Interface as ReadlineInterface } from "node:readl
 import {
   codexBinaryNotFoundMessage,
   codexCommandEnvironment,
-  resolveCodexBinary,
+  resolveUsableCodexBinary,
 } from "./codex-binary.js";
 import { managerAgentChildEnv } from "./host-codex-manager-agent.js";
 import { MANAGER_RUNTIME_VERSION } from "../runtime-version.js";
@@ -63,7 +63,7 @@ export class CodexAppServerClient {
       ?? process.env.HOMERAIL_CODEX_BIN
       ?? process.env.CODEX_BIN_PATH
       ?? "codex";
-    const resolved = resolveCodexBinary(requested);
+    const resolved = resolveUsableCodexBinary(requested);
     if (!resolved) throw new Error(codexBinaryNotFoundMessage(requested));
 
     this.closing = false;

--- a/homerail_manager/src/server/codex-appserver-client.ts
+++ b/homerail_manager/src/server/codex-appserver-client.ts
@@ -2,6 +2,7 @@ import { type ChildProcess, spawn } from "node:child_process";
 import { createInterface, type Interface as ReadlineInterface } from "node:readline";
 import {
   codexBinaryNotFoundMessage,
+  codexCommandForSpawn,
   codexCommandEnvironment,
   resolveUsableCodexBinary,
 } from "./codex-binary.js";
@@ -68,7 +69,7 @@ export class CodexAppServerClient {
 
     this.closing = false;
     this.child = spawn(
-      resolved.command,
+      codexCommandForSpawn(resolved.command),
       this.options.args ?? ["app-server"],
       {
         cwd: this.options.cwd,

--- a/homerail_manager/src/server/codex-binary.ts
+++ b/homerail_manager/src/server/codex-binary.ts
@@ -16,13 +16,20 @@ export interface CodexBinaryResolveOptions {
   env?: NodeJS.ProcessEnv;
   homeDir?: string;
   fileExists?: (filePath: string) => boolean;
+  readDirNames?: (directoryPath: string) => string[];
 }
 
 export interface CodexCommandRunOptions {
   timeoutMs?: number;
   platform?: NodeJS.Platform;
   env?: NodeJS.ProcessEnv;
+  nodeExecPath?: string;
   spawnSyncImpl?: typeof spawnSync;
+}
+
+export interface CodexCommandEnvironmentOptions {
+  platform?: NodeJS.Platform;
+  nodeExecPath?: string;
 }
 
 function isWindows(platform: NodeJS.Platform): boolean {
@@ -63,15 +70,35 @@ function existingFile(filePath: string, fileExists: (filePath: string) => boolea
   }
 }
 
-function defaultFileExists(filePath: string): boolean {
-  return fs.existsSync(filePath) && fs.statSync(filePath).isFile();
+function defaultFileExists(filePath: string, platform: NodeJS.Platform): boolean {
+  if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) return false;
+  if (!isWindows(platform)) fs.accessSync(filePath, fs.constants.X_OK);
+  return true;
+}
+
+function defaultReadDirNames(directoryPath: string): string[] {
+  return fs.readdirSync(directoryPath);
+}
+
+function existingDirectoryEntries(
+  directoryPath: string,
+  readDirNames: (directoryPath: string) => string[],
+): string[] {
+  try {
+    return readDirNames(directoryPath)
+      .slice(0, 64)
+      .sort((left, right) => right.localeCompare(left, undefined, { numeric: true }));
+  } catch {
+    return [];
+  }
 }
 
 function findExecutableOnPath(command: string, options: Required<CodexBinaryResolveOptions>): string | null {
-  const pathEnv = options.env.PATH ?? "";
+  const pathEnv = options.env.PATH ?? options.env.Path ?? options.env.path ?? "";
   const paths = pathApi(options.platform);
   const names = windowsExecutableNames(command, options.platform);
-  for (const dir of pathEnv.split(paths.delimiter)) {
+  for (const rawDir of pathEnv.split(paths.delimiter)) {
+    const dir = rawDir.trim().replace(/^"(.*)"$/, "$1");
     if (!dir) continue;
     for (const name of names) {
       const candidate = paths.join(dir, name);
@@ -82,26 +109,96 @@ function findExecutableOnPath(command: string, options: Required<CodexBinaryReso
   return null;
 }
 
+function codexCandidatesInDirectory(
+  directoryPath: string | undefined,
+  platform: NodeJS.Platform,
+): string[] {
+  if (!directoryPath) return [];
+  const paths = pathApi(platform);
+  if (!paths.isAbsolute(directoryPath)) return [];
+  return pathCandidates(paths.join(directoryPath, DEFAULT_CODEX_BIN), platform);
+}
+
+function versionedCodexCandidates(
+  root: string,
+  childPath: string[],
+  options: Required<CodexBinaryResolveOptions>,
+): string[] {
+  const paths = pathApi(options.platform);
+  return existingDirectoryEntries(root, options.readDirNames).flatMap((version) => (
+    codexCandidatesInDirectory(paths.join(root, version, ...childPath), options.platform)
+  ));
+}
+
 function commonCodexCandidates(options: Required<CodexBinaryResolveOptions>): string[] {
   const paths = pathApi(options.platform);
   const home = options.homeDir;
-  const candidates = [
-    paths.join(home, ".codex", "bin", "codex"),
-    "/opt/homebrew/bin/codex",
-    "/usr/local/bin/codex",
-    "/usr/bin/codex",
-  ];
+  const candidates: string[] = [];
+
+  const addDirectory = (directoryPath: string | undefined): void => {
+    candidates.push(...codexCandidatesInDirectory(directoryPath, options.platform));
+  };
+
+  addDirectory(paths.join(home, ".codex", "bin"));
+  addDirectory(paths.join(home, ".local", "bin"));
+  addDirectory(paths.join(home, ".npm-global", "bin"));
+  addDirectory(paths.join(home, ".volta", "bin"));
+  addDirectory(paths.join(home, ".bun", "bin"));
+  addDirectory(paths.join(home, ".asdf", "shims"));
+  addDirectory(paths.join(home, ".local", "share", "pnpm"));
+
+  addDirectory(options.env.NVM_BIN);
+  addDirectory(options.env.PNPM_HOME);
+  addDirectory(options.env.VOLTA_HOME ? paths.join(options.env.VOLTA_HOME, "bin") : undefined);
+  addDirectory(options.env.BUN_INSTALL ? paths.join(options.env.BUN_INSTALL, "bin") : undefined);
+  const npmPrefix = options.env.npm_config_prefix ?? options.env.NPM_CONFIG_PREFIX;
+  addDirectory(npmPrefix
+    ? paths.join(npmPrefix, isWindows(options.platform) ? "" : "bin")
+    : undefined);
 
   if (isWindows(options.platform)) {
     const appData = options.env.APPDATA;
     const localAppData = options.env.LOCALAPPDATA;
-    candidates.push(...pathCandidates(paths.join(home, ".codex", "bin", "codex"), options.platform));
-    if (appData) candidates.push(...pathCandidates(paths.join(appData, "npm", "codex"), options.platform));
+    if (appData) addDirectory(paths.join(appData, "npm"));
     if (localAppData) {
-      candidates.push(...pathCandidates(paths.join(localAppData, "Programs", "OpenAI", "Codex", "bin", "codex"), options.platform));
-      candidates.push(...pathCandidates(paths.join(localAppData, "Microsoft", "WindowsApps", "codex"), options.platform));
-      candidates.push(...pathCandidates(paths.join(localAppData, "pnpm", "codex"), options.platform));
-      candidates.push(...pathCandidates(paths.join(localAppData, "Volta", "bin", "codex"), options.platform));
+      addDirectory(paths.join(localAppData, "Programs", "OpenAI", "Codex", "bin"));
+      addDirectory(paths.join(localAppData, "Microsoft", "WindowsApps"));
+      addDirectory(paths.join(localAppData, "pnpm"));
+      addDirectory(paths.join(localAppData, "Volta", "bin"));
+    }
+    addDirectory(paths.join(home, ".volta", "bin"));
+  } else {
+    if (options.platform === "darwin") {
+      addDirectory(paths.join(home, "Library", "pnpm"));
+      candidates.push(
+        paths.join(home, "Applications", "Codex.app", "Contents", "Resources", "codex"),
+        paths.join(home, "Applications", "ChatGPT.app", "Contents", "Resources", "codex"),
+        "/Applications/Codex.app/Contents/Resources/codex",
+        "/Applications/ChatGPT.app/Contents/Resources/codex",
+        "/opt/homebrew/bin/codex",
+      );
+    }
+    candidates.push("/usr/local/bin/codex", "/usr/bin/codex");
+    candidates.push(
+      ...versionedCodexCandidates(paths.join(home, ".nvm", "versions", "node"), ["bin"], options),
+      ...versionedCodexCandidates(
+        paths.join(home, ".local", "share", "fnm", "node-versions"),
+        ["installation", "bin"],
+        options,
+      ),
+      ...versionedCodexCandidates(
+        paths.join(home, ".local", "share", "mise", "installs", "node"),
+        ["bin"],
+        options,
+      ),
+      ...versionedCodexCandidates(paths.join(home, ".asdf", "installs", "nodejs"), ["bin"], options),
+    );
+    if (options.platform === "darwin") {
+      candidates.push(...versionedCodexCandidates(
+        paths.join(home, "Library", "Application Support", "fnm", "node-versions"),
+        ["installation", "bin"],
+        options,
+      ));
     }
   }
 
@@ -109,12 +206,19 @@ function commonCodexCandidates(options: Required<CodexBinaryResolveOptions>): st
 }
 
 function resolveOptions(options: CodexBinaryResolveOptions): Required<CodexBinaryResolveOptions> {
+  const platform = options.platform ?? process.platform;
   return {
-    platform: options.platform ?? process.platform,
+    platform,
     env: options.env ?? process.env,
     homeDir: options.homeDir ?? os.homedir(),
-    fileExists: options.fileExists ?? defaultFileExists,
+    fileExists: options.fileExists ?? ((filePath) => defaultFileExists(filePath, platform)),
+    readDirNames: options.readDirNames ?? defaultReadDirNames,
   };
+}
+
+function requestedCodexBinary(options: Required<CodexBinaryResolveOptions>, requested?: string): string {
+  const values = [requested, options.env.HOMERAIL_CODEX_BIN, options.env.CODEX_BIN_PATH];
+  return values.find((value) => typeof value === "string" && value.trim())?.trim() ?? DEFAULT_CODEX_BIN;
 }
 
 export function resolveCodexBinary(
@@ -122,8 +226,7 @@ export function resolveCodexBinary(
   resolveOptionsInput: CodexBinaryResolveOptions = {},
 ): CodexBinaryResolution | null {
   const options = resolveOptions(resolveOptionsInput);
-  const effectiveRequested = requested ?? options.env.HOMERAIL_CODEX_BIN ?? options.env.CODEX_BIN_PATH ?? DEFAULT_CODEX_BIN;
-  const trimmed = effectiveRequested.trim() || DEFAULT_CODEX_BIN;
+  const trimmed = requestedCodexBinary(options, requested);
 
   if (isPathLike(trimmed, options.platform)) {
     for (const candidate of pathCandidates(trimmed, options.platform)) {
@@ -133,9 +236,16 @@ export function resolveCodexBinary(
     return null;
   }
 
+  const fromPath = findExecutableOnPath(trimmed, options);
+  if (fromPath) {
+    return {
+      command: fromPath,
+      requested: trimmed,
+      needsShell: windowsCommandNeedsShell(fromPath, options.platform),
+    };
+  }
+
   if (trimmed !== DEFAULT_CODEX_BIN) {
-    const fromPath = findExecutableOnPath(trimmed, options);
-    if (fromPath) return { command: fromPath, requested: trimmed, needsShell: windowsCommandNeedsShell(fromPath, options.platform) };
     return null;
   }
 
@@ -143,10 +253,31 @@ export function resolveCodexBinary(
     const found = existingFile(candidate, options.fileExists);
     if (found) return { command: found, requested: trimmed, needsShell: windowsCommandNeedsShell(found, options.platform) };
   }
-
-  const fromPath = findExecutableOnPath(trimmed, options);
-  if (fromPath) return { command: fromPath, requested: trimmed, needsShell: windowsCommandNeedsShell(fromPath, options.platform) };
   return null;
+}
+
+export function redactCodexDiagnosticText(value: string): string {
+  return value
+    .replace(/Bearer\s+[^\s]+/gi, "Bearer [REDACTED]")
+    .replace(/\bsk-[A-Za-z0-9._-]{8,}\b/g, "[REDACTED]")
+    .replace(/([?&](?:access_token|api[_-]?key|password|token)=)[^&\s]+/gi, "$1[REDACTED]");
+}
+
+export function codexBinaryDisplayPath(
+  command: string,
+  resolveOptionsInput: Pick<CodexBinaryResolveOptions, "platform" | "homeDir"> = {},
+): string {
+  const platform = resolveOptionsInput.platform ?? process.platform;
+  const homeDir = resolveOptionsInput.homeDir ?? os.homedir();
+  const paths = pathApi(platform);
+  let display = command;
+  if (paths.isAbsolute(command)) {
+    const relative = paths.relative(homeDir, command);
+    if (relative && relative !== ".." && !relative.startsWith(`..${paths.sep}`) && !paths.isAbsolute(relative)) {
+      display = `~${paths.sep}${relative}`;
+    }
+  }
+  return redactCodexDiagnosticText(display).slice(0, 512);
 }
 
 export function codexBinaryNotFoundMessage(
@@ -154,12 +285,41 @@ export function codexBinaryNotFoundMessage(
   resolveOptionsInput: CodexBinaryResolveOptions = {},
 ): string {
   const options = resolveOptions(resolveOptionsInput);
-  const effectiveRequested = requested ?? options.env.HOMERAIL_CODEX_BIN ?? options.env.CODEX_BIN_PATH ?? DEFAULT_CODEX_BIN;
-  const trimmed = effectiveRequested.trim() || DEFAULT_CODEX_BIN;
+  const trimmed = requestedCodexBinary(options, requested);
   if (isPathLike(trimmed, options.platform)) {
-    return `Codex binary not found at: ${trimmed}. Install codex or set HOMERAIL_CODEX_BIN.`;
+    return `Codex binary not found at: ${codexBinaryDisplayPath(trimmed, options)}. Install codex or set HOMERAIL_CODEX_BIN.`;
   }
   return "Codex binary not found. Install codex or set HOMERAIL_CODEX_BIN.";
+}
+
+export function codexCommandEnvironment(
+  command: string,
+  source: NodeJS.ProcessEnv = process.env,
+  options: CodexCommandEnvironmentOptions = {},
+): NodeJS.ProcessEnv {
+  const platform = options.platform ?? process.platform;
+  const paths = pathApi(platform);
+  const existingPath = source.PATH ?? source.Path ?? source.path ?? "";
+  const directories = [
+    isPathLike(command, platform) ? paths.dirname(command) : undefined,
+    paths.dirname(options.nodeExecPath ?? process.execPath),
+    ...existingPath.split(paths.delimiter),
+  ].filter((directory): directory is string => Boolean(directory));
+  const seen = new Set<string>();
+  const normalized = directories.filter((directory) => {
+    const key = isWindows(platform) ? directory.toLowerCase() : directory;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+  const env: NodeJS.ProcessEnv = { ...source };
+  if (isWindows(platform)) {
+    for (const key of Object.keys(env)) {
+      if (key.toLowerCase() === "path") delete env[key];
+    }
+  }
+  env.PATH = normalized.join(paths.delimiter);
+  return env;
 }
 
 function failedSpawnResult(error: unknown): SpawnSyncReturns<string> {
@@ -187,7 +347,10 @@ export function runCodexCommandSync(
     return (options.spawnSyncImpl ?? spawnSync)(command, args, {
       timeout: options.timeoutMs ?? 5_000,
       encoding: "utf-8",
-      env: options.env ?? process.env,
+      env: codexCommandEnvironment(command, options.env ?? process.env, {
+        platform: options.platform,
+        nodeExecPath: options.nodeExecPath,
+      }),
       shell: windowsCommandNeedsShell(command, options.platform ?? process.platform),
       windowsHide: true,
     });

--- a/homerail_manager/src/server/codex-binary.ts
+++ b/homerail_manager/src/server/codex-binary.ts
@@ -8,6 +8,8 @@ import * as os from "node:os";
 import * as path from "node:path";
 
 const DEFAULT_CODEX_BIN = "codex";
+const WINDOWS_SHELL_UNSAFE_PATH_PATTERN = /["^&|<>()%!]/;
+const WINDOWS_TASKKILL_TIMEOUT_MS = 5_000;
 
 export interface CodexBinaryResolution {
   command: string;
@@ -71,10 +73,21 @@ function windowsCommandNeedsShell(command: string, platform = process.platform):
   return isWindows(platform) && /\.(cmd|bat)$/i.test(command);
 }
 
+function windowsShellCommandIsSafe(
+  command: string,
+  platform: NodeJS.Platform,
+): boolean {
+  return !windowsCommandNeedsShell(command, platform)
+    || !WINDOWS_SHELL_UNSAFE_PATH_PATTERN.test(command);
+}
+
 export function codexCommandForSpawn(
   command: string,
   platform: NodeJS.Platform = process.platform,
 ): string {
+  if (!windowsShellCommandIsSafe(command, platform)) {
+    throw new Error("Codex Windows shim path contains unsupported shell metacharacters");
+  }
   if (!windowsCommandNeedsShell(command, platform) || !/\s/.test(command)) return command;
   return `"${command}"`;
 }
@@ -91,6 +104,7 @@ export function terminateCodexProcess(
       ["/pid", String(child.pid), "/T", "/F"],
       {
         stdio: "ignore",
+        timeout: WINDOWS_TASKKILL_TIMEOUT_MS,
         windowsHide: true,
       },
     );
@@ -317,6 +331,7 @@ export function resolveCodexBinaryCandidates(
 
   const seen = new Set<string>();
   return candidates.flatMap((command) => {
+    if (!windowsShellCommandIsSafe(command, options.platform)) return [];
     const key = isWindows(options.platform) ? command.toLowerCase() : command;
     if (seen.has(key)) return [];
     seen.add(key);
@@ -357,19 +372,24 @@ export function resolveUsableCodexBinary(
       platform: options.platform,
       nodeExecPath: options.nodeExecPath,
     }));
+  let fallbackProbe: CodexBinaryProbeResult | undefined;
   for (const candidate of candidates) {
     const probe = runCommand(candidate.command, ["--version"]);
+    const storedProbe = {
+      status: probe.status,
+      stdout: probe.stdout,
+    };
+    fallbackProbe ??= storedProbe;
     if (probe.status === 0) {
       return {
         ...candidate,
-        probe: {
-          status: probe.status,
-          stdout: probe.stdout,
-        },
+        probe: storedProbe,
       };
     }
   }
-  return candidates[0] ?? null;
+  return candidates[0] && fallbackProbe
+    ? { ...candidates[0], probe: fallbackProbe }
+    : candidates[0] ?? null;
 }
 
 export function redactCodexDiagnosticText(value: string): string {
@@ -402,6 +422,9 @@ export function codexBinaryNotFoundMessage(
 ): string {
   const options = resolveOptions(resolveOptionsInput);
   const trimmed = requestedCodexBinary(options, requested);
+  if (!windowsShellCommandIsSafe(trimmed, options.platform)) {
+    return "Codex Windows shim path contains unsupported shell metacharacters. Choose a different install path or set HOMERAIL_CODEX_BIN.";
+  }
   if (isPathLike(trimmed, options.platform)) {
     return `Codex binary not found at: ${codexBinaryDisplayPath(trimmed, options)}. Install codex or set HOMERAIL_CODEX_BIN.`;
   }

--- a/homerail_manager/src/server/codex-binary.ts
+++ b/homerail_manager/src/server/codex-binary.ts
@@ -1,4 +1,8 @@
-import { spawnSync, type SpawnSyncReturns } from "node:child_process";
+import {
+  spawnSync,
+  type ChildProcess,
+  type SpawnSyncReturns,
+} from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -32,6 +36,11 @@ export interface CodexCommandEnvironmentOptions {
   nodeExecPath?: string;
 }
 
+export interface CodexProcessTerminateOptions {
+  platform?: NodeJS.Platform;
+  spawnSyncImpl?: typeof spawnSync;
+}
+
 export interface CodexUsableBinaryResolveOptions extends CodexBinaryResolveOptions {
   nodeExecPath?: string;
   runCommand?: (
@@ -62,6 +71,26 @@ export function codexCommandForSpawn(
 ): string {
   if (!windowsCommandNeedsShell(command, platform) || !/\s/.test(command)) return command;
   return `"${command}"`;
+}
+
+export function terminateCodexProcess(
+  child: ChildProcess,
+  needsShell: boolean,
+  options: CodexProcessTerminateOptions = {},
+): void {
+  const platform = options.platform ?? process.platform;
+  if (isWindows(platform) && needsShell && child.pid) {
+    const result = (options.spawnSyncImpl ?? spawnSync)(
+      "taskkill.exe",
+      ["/pid", String(child.pid), "/T", "/F"],
+      {
+        stdio: "ignore",
+        windowsHide: true,
+      },
+    );
+    if (result.status === 0) return;
+  }
+  if (!child.killed) child.kill("SIGTERM");
 }
 
 function windowsExecutableNames(command: string, platform: NodeJS.Platform): string[] {

--- a/homerail_manager/src/server/codex-binary.ts
+++ b/homerail_manager/src/server/codex-binary.ts
@@ -13,6 +13,12 @@ export interface CodexBinaryResolution {
   command: string;
   requested: string;
   needsShell: boolean;
+  probe?: CodexBinaryProbeResult;
+}
+
+export interface CodexBinaryProbeResult {
+  status: number | null;
+  stdout?: string;
 }
 
 export interface CodexBinaryResolveOptions {
@@ -46,7 +52,7 @@ export interface CodexUsableBinaryResolveOptions extends CodexBinaryResolveOptio
   runCommand?: (
     command: string,
     args: string[],
-  ) => Pick<SpawnSyncReturns<string>, "status">;
+  ) => CodexBinaryProbeResult;
 }
 
 function isWindows(platform: NodeJS.Platform): boolean {
@@ -138,12 +144,24 @@ function existingDirectoryEntries(
   }
 }
 
+function pathEnvironmentEntries(
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+): string[] {
+  const paths = pathApi(platform);
+  const values = isWindows(platform)
+    ? Object.entries(env)
+      .filter(([key, value]) => key.toLowerCase() === "path" && typeof value === "string")
+      .map(([, value]) => value as string)
+    : [env.PATH ?? env.Path ?? env.path ?? ""];
+  return values.flatMap((value) => value.split(paths.delimiter));
+}
+
 function findExecutablesOnPath(command: string, options: Required<CodexBinaryResolveOptions>): string[] {
-  const pathEnv = options.env.PATH ?? options.env.Path ?? options.env.path ?? "";
   const paths = pathApi(options.platform);
   const names = windowsExecutableNames(command, options.platform);
   const found: string[] = [];
-  for (const rawDir of pathEnv.split(paths.delimiter)) {
+  for (const rawDir of pathEnvironmentEntries(options.env, options.platform)) {
     const dir = rawDir.trim().replace(/^"(.*)"$/, "$1");
     if (!dir) continue;
     for (const name of names) {
@@ -340,7 +358,16 @@ export function resolveUsableCodexBinary(
       nodeExecPath: options.nodeExecPath,
     }));
   for (const candidate of candidates) {
-    if (runCommand(candidate.command, ["--version"]).status === 0) return candidate;
+    const probe = runCommand(candidate.command, ["--version"]);
+    if (probe.status === 0) {
+      return {
+        ...candidate,
+        probe: {
+          status: probe.status,
+          stdout: probe.stdout,
+        },
+      };
+    }
   }
   return candidates[0] ?? null;
 }
@@ -388,11 +415,10 @@ export function codexCommandEnvironment(
 ): NodeJS.ProcessEnv {
   const platform = options.platform ?? process.platform;
   const paths = pathApi(platform);
-  const existingPath = source.PATH ?? source.Path ?? source.path ?? "";
   const directories = [
     isPathLike(command, platform) ? paths.dirname(command) : undefined,
     paths.dirname(options.nodeExecPath ?? process.execPath),
-    ...existingPath.split(paths.delimiter),
+    ...pathEnvironmentEntries(source, platform),
   ].filter((directory): directory is string => Boolean(directory));
   const seen = new Set<string>();
   const normalized = directories.filter((directory) => {

--- a/homerail_manager/src/server/codex-binary.ts
+++ b/homerail_manager/src/server/codex-binary.ts
@@ -32,6 +32,14 @@ export interface CodexCommandEnvironmentOptions {
   nodeExecPath?: string;
 }
 
+export interface CodexUsableBinaryResolveOptions extends CodexBinaryResolveOptions {
+  nodeExecPath?: string;
+  runCommand?: (
+    command: string,
+    args: string[],
+  ) => Pick<SpawnSyncReturns<string>, "status">;
+}
+
 function isWindows(platform: NodeJS.Platform): boolean {
   return platform === "win32";
 }
@@ -93,20 +101,21 @@ function existingDirectoryEntries(
   }
 }
 
-function findExecutableOnPath(command: string, options: Required<CodexBinaryResolveOptions>): string | null {
+function findExecutablesOnPath(command: string, options: Required<CodexBinaryResolveOptions>): string[] {
   const pathEnv = options.env.PATH ?? options.env.Path ?? options.env.path ?? "";
   const paths = pathApi(options.platform);
   const names = windowsExecutableNames(command, options.platform);
+  const found: string[] = [];
   for (const rawDir of pathEnv.split(paths.delimiter)) {
     const dir = rawDir.trim().replace(/^"(.*)"$/, "$1");
     if (!dir) continue;
     for (const name of names) {
       const candidate = paths.join(dir, name);
-      const found = existingFile(candidate, options.fileExists);
-      if (found) return found;
+      const existing = existingFile(candidate, options.fileExists);
+      if (existing) found.push(existing);
     }
   }
-  return null;
+  return found;
 }
 
 function codexCandidatesInDirectory(
@@ -225,35 +234,78 @@ export function resolveCodexBinary(
   requested?: string,
   resolveOptionsInput: CodexBinaryResolveOptions = {},
 ): CodexBinaryResolution | null {
+  return resolveCodexBinaryCandidates(requested, resolveOptionsInput)[0] ?? null;
+}
+
+export function resolveCodexBinaryCandidates(
+  requested?: string,
+  resolveOptionsInput: CodexBinaryResolveOptions = {},
+): CodexBinaryResolution[] {
   const options = resolveOptions(resolveOptionsInput);
   const trimmed = requestedCodexBinary(options, requested);
+  const candidates: string[] = [];
 
   if (isPathLike(trimmed, options.platform)) {
     for (const candidate of pathCandidates(trimmed, options.platform)) {
       const found = existingFile(candidate, options.fileExists);
-      if (found) return { command: found, requested: trimmed, needsShell: windowsCommandNeedsShell(found, options.platform) };
+      if (found) candidates.push(found);
     }
-    return null;
+  } else {
+    candidates.push(...findExecutablesOnPath(trimmed, options));
+    if (trimmed === DEFAULT_CODEX_BIN) {
+      for (const candidate of commonCodexCandidates(options)) {
+        const found = existingFile(candidate, options.fileExists);
+        if (found) candidates.push(found);
+      }
+    }
   }
 
-  const fromPath = findExecutableOnPath(trimmed, options);
-  if (fromPath) {
-    return {
-      command: fromPath,
+  const seen = new Set<string>();
+  return candidates.flatMap((command) => {
+    const key = isWindows(options.platform) ? command.toLowerCase() : command;
+    if (seen.has(key)) return [];
+    seen.add(key);
+    return [{
+      command,
       requested: trimmed,
-      needsShell: windowsCommandNeedsShell(fromPath, options.platform),
-    };
+      needsShell: windowsCommandNeedsShell(command, options.platform),
+    }];
+  });
+}
+
+function hasExplicitCodexBinaryRequest(
+  requested: string | undefined,
+  env: NodeJS.ProcessEnv,
+): boolean {
+  if (typeof requested === "string" && requested.trim() && requested.trim() !== DEFAULT_CODEX_BIN) {
+    return true;
+  }
+  return [env.HOMERAIL_CODEX_BIN, env.CODEX_BIN_PATH]
+    .some((value) => typeof value === "string" && Boolean(value.trim()));
+}
+
+export function resolveUsableCodexBinary(
+  requested?: string,
+  options: CodexUsableBinaryResolveOptions = {},
+): CodexBinaryResolution | null {
+  const candidates = resolveCodexBinaryCandidates(requested, options);
+  if (candidates.length === 0) return null;
+
+  const env = options.env ?? process.env;
+  if (hasExplicitCodexBinaryRequest(requested, env)) {
+    return candidates[0] ?? null;
   }
 
-  if (trimmed !== DEFAULT_CODEX_BIN) {
-    return null;
+  const runCommand = options.runCommand
+    ?? ((command: string, args: string[]) => runCodexCommandSync(command, args, {
+      env,
+      platform: options.platform,
+      nodeExecPath: options.nodeExecPath,
+    }));
+  for (const candidate of candidates) {
+    if (runCommand(candidate.command, ["--version"]).status === 0) return candidate;
   }
-
-  for (const candidate of commonCodexCandidates(options)) {
-    const found = existingFile(candidate, options.fileExists);
-    if (found) return { command: found, requested: trimmed, needsShell: windowsCommandNeedsShell(found, options.platform) };
-  }
-  return null;
+  return candidates[0] ?? null;
 }
 
 export function redactCodexDiagnosticText(value: string): string {

--- a/homerail_manager/src/server/codex-binary.ts
+++ b/homerail_manager/src/server/codex-binary.ts
@@ -56,6 +56,14 @@ function windowsCommandNeedsShell(command: string, platform = process.platform):
   return isWindows(platform) && /\.(cmd|bat)$/i.test(command);
 }
 
+export function codexCommandForSpawn(
+  command: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (!windowsCommandNeedsShell(command, platform) || !/\s/.test(command)) return command;
+  return `"${command}"`;
+}
+
 function windowsExecutableNames(command: string, platform: NodeJS.Platform): string[] {
   if (!isWindows(platform)) return [command];
   if (/\.(exe|cmd|bat)$/i.test(command)) return [command];
@@ -396,7 +404,10 @@ export function runCodexCommandSync(
   const options: CodexCommandRunOptions =
     typeof optionsOrTimeout === "number" ? { timeoutMs: optionsOrTimeout } : optionsOrTimeout;
   try {
-    return (options.spawnSyncImpl ?? spawnSync)(command, args, {
+    return (options.spawnSyncImpl ?? spawnSync)(codexCommandForSpawn(
+      command,
+      options.platform ?? process.platform,
+    ), args, {
       timeout: options.timeoutMs ?? 5_000,
       encoding: "utf-8",
       env: codexCommandEnvironment(command, options.env ?? process.env, {

--- a/homerail_manager/src/server/codex-live-voice-capability.ts
+++ b/homerail_manager/src/server/codex-live-voice-capability.ts
@@ -224,7 +224,7 @@ export function inspectCodexInstallation(
     };
   }
 
-  const versionResult = runCommand(resolved.command, ["--version"]);
+  const versionResult = resolved.probe ?? runCommand(resolved.command, ["--version"]);
   const rawVersion = (versionResult.stdout || "").trim().split(/\r?\n/)[0]?.slice(0, 512) || "";
   const binary = codexBinaryDisplayPath(resolved.command, { homeDir });
   if (versionResult.status !== 0) {

--- a/homerail_manager/src/server/codex-live-voice-capability.ts
+++ b/homerail_manager/src/server/codex-live-voice-capability.ts
@@ -1,6 +1,10 @@
 import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import type { SpawnSyncReturns } from "node:child_process";
 import {
+  codexBinaryDisplayPath,
+  redactCodexDiagnosticText,
   resolveCodexBinary,
   runCodexCommandSync,
   type CodexBinaryResolution,
@@ -16,9 +20,23 @@ export const CODEX_LIVE_VOICE_FEATURE = "realtime_conversation";
 
 export type CodexLiveVoiceUnsupportedReason =
   | "missing"
+  | "unusable"
   | "unparseable"
   | "too_old"
   | "feature_missing";
+
+export type CodexInstallationDiagnosticCode =
+  | "codex_binary_not_found"
+  | "codex_binary_unusable"
+  | "codex_auth_missing"
+  | "codex_version_unparseable"
+  | "codex_version_too_old"
+  | "codex_live_voice_feature_missing";
+
+export interface CodexInstallationDiagnostic {
+  code: CodexInstallationDiagnosticCode;
+  message: string;
+}
 
 export interface CodexLiveVoiceCapability {
   supported: boolean;
@@ -34,20 +52,31 @@ export interface CodexLiveVoiceCapability {
 
 export interface CodexInstallationStatus {
   available: boolean;
+  logged_in: boolean;
   version?: string;
   semantic_version?: string;
   binary: string;
   live_voice: CodexLiveVoiceCapability;
+  diagnostics: CodexInstallationDiagnostic[];
 }
 
 export interface InspectCodexInstallationOptions {
   requested?: string;
+  env?: NodeJS.ProcessEnv;
+  homeDir?: string;
   resolveBinary?: (requested?: string) => CodexBinaryResolution | null;
   runCommand?: (
     command: string,
     args: string[],
   ) => SpawnSyncReturns<string>;
+  authPresent?: () => boolean;
   statMtimeMs?: (filePath: string) => number | undefined;
+}
+
+export interface CodexAuthenticationOptions {
+  env?: NodeJS.ProcessEnv;
+  homeDir?: string;
+  readAuthFile?: (authPath: string) => string;
 }
 
 interface SemanticVersion {
@@ -64,6 +93,20 @@ interface CachedFeatureProbe {
 }
 
 const featureCache = new Map<string, CachedFeatureProbe>();
+const SAFE_FEATURE_STAGES = new Set([
+  "stable",
+  "experimental",
+  "under development",
+  "deprecated",
+  "removed",
+]);
+
+function diagnostic(
+  code: CodexInstallationDiagnosticCode,
+  message: string,
+): CodexInstallationDiagnostic {
+  return { code, message };
+}
 
 function emptyCapability(reason: CodexLiveVoiceUnsupportedReason): CodexLiveVoiceCapability {
   return {
@@ -109,9 +152,13 @@ function parseFeatureProbe(stdout: string): CachedFeatureProbe {
     const stageParts = maybeEnabled === "true" || maybeEnabled === "false"
       ? parts.slice(1, -1)
       : parts.slice(1);
-    const stage = stageParts.join(" ").trim() || undefined;
+    const rawStage = redactCodexDiagnosticText(stageParts.join(" ").trim()).slice(0, 80);
+    const normalizedStage = rawStage.toLowerCase();
+    const stage = SAFE_FEATURE_STAGES.has(normalizedStage)
+      ? rawStage
+      : undefined;
     return {
-      present: stage?.toLowerCase() !== "removed",
+      present: normalizedStage !== "removed",
       stage,
     };
   }
@@ -126,53 +173,104 @@ function defaultStatMtimeMs(filePath: string): number | undefined {
   }
 }
 
+export function codexAuthenticationPresent(options: CodexAuthenticationOptions = {}): boolean {
+  const env = options.env ?? process.env;
+  if (env.OPENAI_API_KEY?.trim()) return true;
+  const homeDir = options.homeDir ?? os.homedir();
+  const configuredHome = env.CODEX_HOME?.trim();
+  const codexHome = configuredHome
+    ? path.resolve(configuredHome.replace(/^~(?=$|[/\\])/, homeDir))
+    : path.join(homeDir, ".codex");
+  try {
+    const content = (options.readAuthFile ?? ((authPath) => fs.readFileSync(authPath, "utf-8")))(
+      path.join(codexHome, "auth.json"),
+    ).trim();
+    return content.length > 0 && content !== "{}";
+  } catch {
+    return false;
+  }
+}
+
 export function inspectCodexInstallation(
   options: InspectCodexInstallationOptions = {},
 ): CodexInstallationStatus {
-  const requested = options.requested
-    ?? process.env.HOMERAIL_CODEX_BIN
-    ?? process.env.CODEX_BIN_PATH
-    ?? "codex";
-  const resolveBinary = options.resolveBinary ?? ((value?: string) => resolveCodexBinary(value));
-  const runCommand = options.runCommand ?? ((command, args) => runCodexCommandSync(command, args));
+  const env = options.env ?? process.env;
+  const homeDir = options.homeDir ?? os.homedir();
+  const requested = [
+    options.requested,
+    env.HOMERAIL_CODEX_BIN,
+    env.CODEX_BIN_PATH,
+  ].find((value) => typeof value === "string" && value.trim())?.trim() ?? "codex";
+  const resolveBinary = options.resolveBinary
+    ?? ((value?: string) => resolveCodexBinary(value, { env, homeDir }));
+  const runCommand = options.runCommand
+    ?? ((command, args) => runCodexCommandSync(command, args, { env }));
+  const loggedIn = (options.authPresent
+    ?? (() => codexAuthenticationPresent({ env, homeDir })))();
+  const authDiagnostics = loggedIn
+    ? []
+    : [diagnostic("codex_auth_missing", "Codex credentials were not found for this user.")];
   const resolved = resolveBinary(requested);
   if (!resolved) {
     return {
       available: false,
-      binary: requested,
+      logged_in: loggedIn,
+      binary: codexBinaryDisplayPath(requested, { homeDir }),
       live_voice: emptyCapability("missing"),
+      diagnostics: [
+        diagnostic("codex_binary_not_found", "Codex CLI was not found in the configured or standard install locations."),
+        ...authDiagnostics,
+      ],
     };
   }
 
   const versionResult = runCommand(resolved.command, ["--version"]);
-  const version = (versionResult.stdout || "").trim().split(/\r?\n/)[0] || undefined;
+  const rawVersion = (versionResult.stdout || "").trim().split(/\r?\n/)[0]?.slice(0, 512) || "";
+  const binary = codexBinaryDisplayPath(resolved.command, { homeDir });
   if (versionResult.status !== 0) {
     return {
       available: false,
-      version,
-      binary: resolved.command,
-      live_voice: emptyCapability("missing"),
+      logged_in: loggedIn,
+      binary,
+      live_voice: emptyCapability("unusable"),
+      diagnostics: [
+        diagnostic("codex_binary_unusable", "Codex CLI was found but could not be executed."),
+        ...authDiagnostics,
+      ],
     };
   }
 
-  const semantic = parseCodexVersion(version ?? "");
+  const semantic = parseCodexVersion(rawVersion);
   if (!semantic) {
     return {
       available: true,
-      version,
-      binary: resolved.command,
+      logged_in: loggedIn,
+      binary,
       live_voice: emptyCapability("unparseable"),
+      diagnostics: [
+        ...authDiagnostics,
+        diagnostic("codex_version_unparseable", "Codex CLI returned an unsupported version format."),
+      ],
     };
   }
 
+  const version = `codex-cli ${semantic.raw}`;
   const minimum = parseCodexVersion(`codex-cli ${CODEX_LIVE_VOICE_MINIMUM_VERSION}`)!;
   if (!versionAtLeast(semantic, minimum)) {
     return {
       available: true,
+      logged_in: loggedIn,
       version,
       semantic_version: semantic.raw,
-      binary: resolved.command,
+      binary,
       live_voice: emptyCapability("too_old"),
+      diagnostics: [
+        ...authDiagnostics,
+        diagnostic(
+          "codex_version_too_old",
+          `Codex ${semantic.raw} is older than the Live Voice minimum ${CODEX_LIVE_VOICE_MINIMUM_VERSION}.`,
+        ),
+      ],
     };
   }
 
@@ -191,21 +289,30 @@ export function inspectCodexInstallation(
   if (!feature.present) {
     return {
       available: true,
+      logged_in: loggedIn,
       version,
       semantic_version: semantic.raw,
-      binary: resolved.command,
+      binary,
       live_voice: {
         ...emptyCapability("feature_missing"),
         ...(feature.stage ? { stage: feature.stage } : {}),
       },
+      diagnostics: [
+        ...authDiagnostics,
+        diagnostic(
+          "codex_live_voice_feature_missing",
+          `Codex does not expose the required ${CODEX_LIVE_VOICE_FEATURE} feature.`,
+        ),
+      ],
     };
   }
 
   return {
     available: true,
+    logged_in: loggedIn,
     version,
     semantic_version: semantic.raw,
-    binary: resolved.command,
+    binary,
     live_voice: {
       supported: true,
       minimum_version: CODEX_LIVE_VOICE_MINIMUM_VERSION,
@@ -216,6 +323,7 @@ export function inspectCodexInstallation(
       default_voice: DEFAULT_CODEX_LIVE_VOICE_V3_VOICE,
       ...(feature.stage ? { stage: feature.stage } : {}),
     },
+    diagnostics: authDiagnostics,
   };
 }
 

--- a/homerail_manager/src/server/codex-live-voice-capability.ts
+++ b/homerail_manager/src/server/codex-live-voice-capability.ts
@@ -5,7 +5,7 @@ import type { SpawnSyncReturns } from "node:child_process";
 import {
   codexBinaryDisplayPath,
   redactCodexDiagnosticText,
-  resolveCodexBinary,
+  resolveUsableCodexBinary,
   runCodexCommandSync,
   type CodexBinaryResolution,
 } from "./codex-binary.js";
@@ -202,7 +202,7 @@ export function inspectCodexInstallation(
     env.CODEX_BIN_PATH,
   ].find((value) => typeof value === "string" && value.trim())?.trim() ?? "codex";
   const resolveBinary = options.resolveBinary
-    ?? ((value?: string) => resolveCodexBinary(value, { env, homeDir }));
+    ?? ((value?: string) => resolveUsableCodexBinary(value, { env, homeDir }));
   const runCommand = options.runCommand
     ?? ((command, args) => runCodexCommandSync(command, args, { env }));
   const loggedIn = (options.authPresent

--- a/homerail_manager/src/server/codex-models.ts
+++ b/homerail_manager/src/server/codex-models.ts
@@ -7,6 +7,7 @@ import {
 
 import {
   codexBinaryNotFoundMessage,
+  codexCommandForSpawn,
   codexCommandEnvironment,
   resolveUsableCodexBinary,
   type CodexBinaryResolution,
@@ -141,7 +142,9 @@ function queryCodexModels(
         shell: resolution.needsShell,
         windowsHide: true,
       };
-      child = (options.spawnImpl ?? spawn)(resolution.command, ["app-server"], {
+      child = (options.spawnImpl ?? spawn)(codexCommandForSpawn(
+        resolution.command,
+      ), ["app-server"], {
         ...spawnOptions,
         stdio: ["pipe", "pipe", "pipe"],
       }) as ChildProcessWithoutNullStreams;

--- a/homerail_manager/src/server/codex-models.ts
+++ b/homerail_manager/src/server/codex-models.ts
@@ -1,6 +1,5 @@
 import {
   spawn,
-  spawnSync,
   type ChildProcessWithoutNullStreams,
   type SpawnOptionsWithoutStdio,
 } from "node:child_process";
@@ -10,6 +9,7 @@ import {
   codexCommandForSpawn,
   codexCommandEnvironment,
   resolveUsableCodexBinary,
+  terminateCodexProcess,
   type CodexBinaryResolution,
 } from "./codex-binary.js";
 import { MANAGER_RUNTIME_VERSION } from "../runtime-version.js";
@@ -115,20 +115,6 @@ function errorMessage(value: unknown): string {
   return stringValue(raw?.message) || stringValue(value) || "Codex app-server request failed";
 }
 
-function terminateCodexProcess(
-  child: ChildProcessWithoutNullStreams,
-  resolution: CodexBinaryResolution,
-): void {
-  if (process.platform === "win32" && resolution.needsShell && child.pid) {
-    const result = spawnSync("taskkill.exe", ["/pid", String(child.pid), "/T", "/F"], {
-      stdio: "ignore",
-      windowsHide: true,
-    });
-    if (result.status === 0) return;
-  }
-  if (!child.killed) child.kill();
-}
-
 function queryCodexModels(
   resolution: CodexBinaryResolution,
   options: CodexModelListOptions,
@@ -169,7 +155,7 @@ function queryCodexModels(
       if (settled) return;
       settled = true;
       clearTimeout(timeout);
-      terminateCodexProcess(child, resolution);
+      terminateCodexProcess(child, resolution.needsShell);
       if (error) reject(error);
       else resolve(catalog ?? { binary: resolution.command, models: [] });
     }

--- a/homerail_manager/src/server/codex-models.ts
+++ b/homerail_manager/src/server/codex-models.ts
@@ -8,7 +8,7 @@ import {
 import {
   codexBinaryNotFoundMessage,
   codexCommandEnvironment,
-  resolveCodexBinary,
+  resolveUsableCodexBinary,
   type CodexBinaryResolution,
 } from "./codex-binary.js";
 import { MANAGER_RUNTIME_VERSION } from "../runtime-version.js";
@@ -273,7 +273,7 @@ export async function listCodexModels(
   options: CodexModelListOptions = {},
 ): Promise<CodexModelCatalog> {
   const resolution = options.resolution === undefined
-    ? resolveCodexBinary(undefined, { env: options.env ?? process.env })
+    ? resolveUsableCodexBinary(undefined, { env: options.env ?? process.env })
     : options.resolution;
   if (!resolution) throw new Error(codexBinaryNotFoundMessage(undefined, { env: options.env ?? process.env }));
   return queryCodexModels(resolution, options);

--- a/homerail_manager/src/server/codex-models.ts
+++ b/homerail_manager/src/server/codex-models.ts
@@ -7,6 +7,7 @@ import {
 
 import {
   codexBinaryNotFoundMessage,
+  codexCommandEnvironment,
   resolveCodexBinary,
   type CodexBinaryResolution,
 } from "./codex-binary.js";
@@ -136,7 +137,7 @@ function queryCodexModels(
     try {
       const spawnOptions: SpawnOptionsWithoutStdio = {
         cwd: options.cwd ?? process.cwd(),
-        env: options.env ?? process.env,
+        env: codexCommandEnvironment(resolution.command, options.env ?? process.env),
         shell: resolution.needsShell,
         windowsHide: true,
       };

--- a/homerail_manager/src/server/host-codex-manager-agent.ts
+++ b/homerail_manager/src/server/host-codex-manager-agent.ts
@@ -7,7 +7,11 @@ import { createInterface, type Interface as ReadlineInterface } from "node:readl
 import { ensureDefaultWorkspacePath, getHomerailHome } from "../config/env.js";
 import { repoRoot, resolveAssetDirectory } from "../assets/root.js";
 import { MANAGER_RUNTIME_VERSION } from "../runtime-version.js";
-import { codexBinaryNotFoundMessage, resolveCodexBinary } from "./codex-binary.js";
+import {
+  codexBinaryNotFoundMessage,
+  codexCommandEnvironment,
+  resolveCodexBinary,
+} from "./codex-binary.js";
 import {
   readWidgetFile,
   removeWidgetFile,
@@ -2810,7 +2814,7 @@ class HostCodexAppServerAdapter {
     Object.assign(env, context.environmentVariables ?? {});
     if (context.apiKey) env.OPENAI_API_KEY = context.apiKey;
     if (context.baseUrl) env.OPENAI_BASE_URL = context.baseUrl;
-    return env;
+    return codexCommandEnvironment(this.codexBin, env);
   }
 
   private async sendRequest(method: string, params: Record<string, unknown>): Promise<Record<string, unknown>> {

--- a/homerail_manager/src/server/host-codex-manager-agent.ts
+++ b/homerail_manager/src/server/host-codex-manager-agent.ts
@@ -9,6 +9,7 @@ import { repoRoot, resolveAssetDirectory } from "../assets/root.js";
 import { MANAGER_RUNTIME_VERSION } from "../runtime-version.js";
 import {
   codexBinaryNotFoundMessage,
+  codexCommandForSpawn,
   codexCommandEnvironment,
   resolveUsableCodexBinary,
 } from "./codex-binary.js";
@@ -2572,7 +2573,9 @@ class HostCodexAppServerAdapter {
       return;
     }
     try {
-      this.process = spawn(this.codexBin, _buildCodexAppServerArgsForTest(), {
+      this.process = spawn(codexCommandForSpawn(
+        this.codexBin,
+      ), _buildCodexAppServerArgsForTest(), {
         stdio: ["pipe", "pipe", "pipe"],
         env: this.buildEnv(context),
         cwd: context.workspace ?? process.cwd(),

--- a/homerail_manager/src/server/host-codex-manager-agent.ts
+++ b/homerail_manager/src/server/host-codex-manager-agent.ts
@@ -12,6 +12,7 @@ import {
   codexCommandForSpawn,
   codexCommandEnvironment,
   resolveUsableCodexBinary,
+  terminateCodexProcess,
 } from "./codex-binary.js";
 import {
   readWidgetFile,
@@ -2911,7 +2912,7 @@ class HostCodexAppServerAdapter {
     this.rl = null;
     try {
       this.process?.stdin?.end();
-      this.process?.kill("SIGTERM");
+      if (this.process) terminateCodexProcess(this.process, this.codexNeedsShell);
     } catch {
       // Ignore.
     }

--- a/homerail_manager/src/server/host-codex-manager-agent.ts
+++ b/homerail_manager/src/server/host-codex-manager-agent.ts
@@ -10,7 +10,7 @@ import { MANAGER_RUNTIME_VERSION } from "../runtime-version.js";
 import {
   codexBinaryNotFoundMessage,
   codexCommandEnvironment,
-  resolveCodexBinary,
+  resolveUsableCodexBinary,
 } from "./codex-binary.js";
 import {
   readWidgetFile,
@@ -3082,7 +3082,7 @@ class HostCodexAppServerAdapter {
   }
 
   private async validateBinary(): Promise<void> {
-    const resolved = resolveCodexBinary(this.codexBin);
+    const resolved = resolveUsableCodexBinary(this.codexBin);
     if (resolved) {
       this.codexBin = resolved.command;
       this.codexNeedsShell = resolved.needsShell;

--- a/homerail_manager/src/server/manager-agent-readiness.ts
+++ b/homerail_manager/src/server/manager-agent-readiness.ts
@@ -18,6 +18,7 @@ import { readDagResourceStatus, type DagResourceStatus } from "./dag-resource-st
 import {
   inspectCodexInstallation,
   type CodexLiveVoiceCapability,
+  type CodexInstallationDiagnostic,
 } from "./codex-live-voice-capability.js";
 import {
   ensurePreferredManagerAgentConfig,
@@ -37,6 +38,7 @@ export interface CodexCheck {
   semantic_version?: string;
   binary?: string;
   live_voice: CodexLiveVoiceCapability;
+  diagnostics: CodexInstallationDiagnostic[];
 }
 
 export interface ManagerAgentReadiness {
@@ -82,25 +84,7 @@ function methodNotAllowed(res: http.ServerResponse): void {
 }
 
 function codexStatus(): CodexCheck {
-  const installation = inspectCodexInstallation();
-  let loggedIn = false;
-  try {
-    const authPath = path.join(os.homedir(), ".codex", "auth.json");
-    if (fs.existsSync(authPath)) {
-      const content = fs.readFileSync(authPath, "utf-8").trim();
-      loggedIn = content.length > 0 && content !== "{}";
-    }
-  } catch {
-    loggedIn = false;
-  }
-  return {
-    available: installation.available,
-    logged_in: loggedIn,
-    version: installation.version,
-    semantic_version: installation.semantic_version,
-    binary: installation.binary,
-    live_voice: installation.live_voice,
-  };
+  return inspectCodexInstallation();
 }
 
 /** Claude Agent SDK 的主机侧凭证是否存在：ANTHROPIC_API_KEY 环境变量，
@@ -266,9 +250,14 @@ export function managerAgentReadiness(
       && config.harness === "codex_appserver"
       && codex.live_voice.supported;
     if (!codex.available) {
-      blockers.push({ code: "codex_unavailable", message: "Codex CLI is not available" });
-    }
-    if (!codex.logged_in) {
+      const binaryDiagnostic = codex.diagnostics.find((item) => (
+        item.code === "codex_binary_not_found" || item.code === "codex_binary_unusable"
+      ));
+      blockers.push({
+        code: binaryDiagnostic?.code ?? "codex_unavailable",
+        message: binaryDiagnostic?.message ?? "Codex CLI is not available",
+      });
+    } else if (!codex.logged_in) {
       blockers.push({ code: "codex_auth_missing", message: "Codex is not logged in" });
     }
   } else if (runtimeConfig.runtime_placement === "host_shell") {

--- a/homerail_manager/src/server/manager-agent-readiness.ts
+++ b/homerail_manager/src/server/manager-agent-readiness.ts
@@ -257,7 +257,8 @@ export function managerAgentReadiness(
         code: binaryDiagnostic?.code ?? "codex_unavailable",
         message: binaryDiagnostic?.message ?? "Codex CLI is not available",
       });
-    } else if (!codex.logged_in) {
+    }
+    if (!codex.logged_in) {
       blockers.push({ code: "codex_auth_missing", message: "Codex is not logged in" });
     }
   } else if (runtimeConfig.runtime_placement === "host_shell") {

--- a/homerail_manager/src/server/voice-agent-bootstrap.ts
+++ b/homerail_manager/src/server/voice-agent-bootstrap.ts
@@ -1,7 +1,6 @@
 import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as http from "node:http";
-import * as os from "node:os";
 import * as path from "node:path";
 import { getDataRoot, getHomerailHome } from "../config/env.js";
 import { repoRoot } from "../assets/root.js";
@@ -44,7 +43,6 @@ import {
   validateAndSaveManagerAgentConfig,
   type ManagerAgentConfigRoutesOptions,
 } from "./manager-agent-config.js";
-import { resolveCodexBinary, runCodexCommandSync } from "./codex-binary.js";
 import {
   managerAgentRuntimePlacementForHarness,
   managerAgentPluginOwnedLegacyWidgetType,
@@ -2262,29 +2260,7 @@ export function voiceAgentBootstrapHandler(
 
   // Codex 可用性检测：检查 CLI 是否安装 + 是否有登录态
   if (method === "GET" && pathname === "/api/voice-agent/codex-status") {
-    const requested = process.env.HOMERAIL_CODEX_BIN || process.env.CODEX_BIN_PATH || "codex";
-    const resolved = resolveCodexBinary(requested);
-    let available = false;
-    let version: string | undefined;
-    if (resolved) {
-      const result = runCodexCommandSync(resolved.command, ["--version"]);
-      if (result.status === 0) {
-        available = true;
-        version = (result.stdout || "").trim().split("\n")[0] || undefined;
-      }
-    }
-    // 检查登录态：~/.codex/auth.json 存在且非空
-    let loggedIn = false;
-    try {
-      const authPath = path.join(os.homedir(), ".codex", "auth.json");
-      if (fs.existsSync(authPath)) {
-        const content = fs.readFileSync(authPath, "utf-8").trim();
-        loggedIn = content.length > 0 && content !== "{}";
-      }
-    } catch {
-      loggedIn = false;
-    }
-    ok(res, "Codex status checked", { available, logged_in: loggedIn, version, binary: resolved?.command ?? requested });
+    ok(res, "Codex status checked", inspectCodexInstallation());
     return true;
   }
 

--- a/homerail_manager/tests/codex-appserver-client.test.ts
+++ b/homerail_manager/tests/codex-appserver-client.test.ts
@@ -1,0 +1,72 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { CodexAppServerClient } from "../src/server/codex-appserver-client.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function writeFakeCodexAppServer(): { command: string; cwd: string } {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "homerail codex appserver "));
+  temporaryDirectories.push(cwd);
+  const serverScript = path.join(cwd, "fake-codex-server.js");
+  fs.writeFileSync(serverScript, [
+    "let buffered = '';",
+    "process.stdin.setEncoding('utf8');",
+    "process.stdin.on('data', (chunk) => {",
+    "  buffered += chunk;",
+    "  for (;;) {",
+    "    const newline = buffered.indexOf('\\n');",
+    "    if (newline < 0) break;",
+    "    const line = buffered.slice(0, newline).trim();",
+    "    buffered = buffered.slice(newline + 1);",
+    "    if (!line) continue;",
+    "    const request = JSON.parse(line);",
+    "    if (request.method === 'initialize') {",
+    "      process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: request.id, result: { ready: true } }) + '\\n');",
+    "    }",
+    "  }",
+    "});",
+    "",
+  ].join("\n"));
+
+  if (process.platform === "win32") {
+    const command = path.join(cwd, "codex.cmd");
+    fs.writeFileSync(command, "@echo off\r\nnode \"%~dp0fake-codex-server.js\"\r\n");
+    return { command, cwd };
+  }
+
+  const command = path.join(cwd, "codex");
+  fs.writeFileSync(command, `#!/usr/bin/env node\nrequire(${JSON.stringify(serverScript)});\n`);
+  fs.chmodSync(command, 0o755);
+  return { command, cwd };
+}
+
+describe("CodexAppServerClient", () => {
+  it("starts a Node-backed Codex shim from a path with spaces under a GUI-style minimal PATH", async () => {
+    const fixture = writeFakeCodexAppServer();
+    const minimalPath = process.platform === "win32"
+      ? `${process.env.SystemRoot ?? "C:\\Windows"}\\System32`
+      : "/usr/bin:/bin";
+    const client = new CodexAppServerClient({
+      codexBin: fixture.command,
+      cwd: fixture.cwd,
+      env: { PATH: minimalPath },
+      requestTimeoutMs: 2_000,
+    });
+
+    try {
+      await client.start();
+      await expect(client.initialize()).resolves.toMatchObject({ ready: true });
+    } finally {
+      client.close();
+    }
+  });
+});

--- a/homerail_manager/tests/codex-binary.test.ts
+++ b/homerail_manager/tests/codex-binary.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   codexBinaryNotFoundMessage,
+  codexCommandForSpawn,
   codexCommandEnvironment,
   resolveCodexBinary,
   resolveUsableCodexBinary,
@@ -331,6 +332,16 @@ describe("resolveCodexBinary", () => {
         PATH: `${path.posix.dirname(command)}:/Applications/HomeRail.app/Contents/Resources/node-bin:/usr/bin:/bin`,
       }),
     });
+  });
+
+  it("quotes a shell-backed Windows shim path before spawning it", () => {
+    const command = "C:\\Users\\Alice Smith\\AppData\\Roaming\\npm\\codex.cmd";
+
+    expect(codexCommandForSpawn(command, "win32")).toBe(`"${command}"`);
+    expect(codexCommandForSpawn("C:\\Tools\\codex.cmd", "win32"))
+      .toBe("C:\\Tools\\codex.cmd");
+    expect(codexCommandForSpawn("/Users/Alice Smith/bin/codex", "darwin"))
+      .toBe("/Users/Alice Smith/bin/codex");
   });
 });
 

--- a/homerail_manager/tests/codex-binary.test.ts
+++ b/homerail_manager/tests/codex-binary.test.ts
@@ -7,6 +7,7 @@ import {
   codexBinaryNotFoundMessage,
   codexCommandEnvironment,
   resolveCodexBinary,
+  resolveUsableCodexBinary,
   runCodexCommandSync,
 } from "../src/server/codex-binary.js";
 
@@ -330,5 +331,51 @@ describe("resolveCodexBinary", () => {
         PATH: `${path.posix.dirname(command)}:/Applications/HomeRail.app/Contents/Resources/node-bin:/usr/bin:/bin`,
       }),
     });
+  });
+});
+
+describe("resolveUsableCodexBinary", () => {
+  it("skips an unusable default PATH candidate and selects a later working install", () => {
+    const stale = "/Users/alice/stale/codex";
+    const homebrew = "/opt/homebrew/bin/codex";
+    const attempted: string[] = [];
+
+    expect(resolveUsableCodexBinary("codex", {
+      platform: "darwin",
+      env: { PATH: "/Users/alice/stale:/usr/bin:/bin" },
+      homeDir: "/Users/alice",
+      fileExists: fakeExistingFiles([stale, homebrew], "posix"),
+      readDirNames: () => [],
+      runCommand: (command, args) => {
+        attempted.push(`${command} ${args.join(" ")}`);
+        return { status: command === homebrew ? 0 : 1 };
+      },
+    })?.command).toBe(homebrew);
+    expect(attempted).toEqual([
+      `${stale} --version`,
+      `${homebrew} --version`,
+    ]);
+  });
+
+  it("does not bypass an unusable explicit override", () => {
+    const explicit = "/Users/alice/custom/codex";
+    const homebrew = "/opt/homebrew/bin/codex";
+    const attempted: string[] = [];
+
+    expect(resolveUsableCodexBinary(undefined, {
+      platform: "darwin",
+      env: {
+        HOMERAIL_CODEX_BIN: explicit,
+        PATH: "/usr/bin:/bin",
+      },
+      homeDir: "/Users/alice",
+      fileExists: fakeExistingFiles([explicit, homebrew], "posix"),
+      readDirNames: () => [],
+      runCommand: (command) => {
+        attempted.push(command);
+        return { status: command === homebrew ? 0 : 1 };
+      },
+    })?.command).toBe(explicit);
+    expect(attempted).toEqual([]);
   });
 });

--- a/homerail_manager/tests/codex-binary.test.ts
+++ b/homerail_manager/tests/codex-binary.test.ts
@@ -282,6 +282,27 @@ describe("resolveCodexBinary", () => {
     expect(env.OPENAI_API_KEY).toBe("sk-do-not-log-this-value");
   });
 
+  it("merges every Windows PATH key before normalizing its casing", () => {
+    const env = codexCommandEnvironment(
+      "C:\\Users\\Alice\\AppData\\Roaming\\npm\\codex.cmd",
+      {
+        PATH: "C:\\Windows\\System32",
+        Path: "C:\\Users\\Alice\\bin;C:\\Windows\\System32",
+        PATHEXT: ".COM;.EXE;.BAT;.CMD",
+      },
+      {
+        platform: "win32",
+        nodeExecPath: "C:\\Program Files\\HomeRail\\node.exe",
+      },
+    );
+
+    expect(env.PATH).toBe(
+      "C:\\Users\\Alice\\AppData\\Roaming\\npm;C:\\Program Files\\HomeRail;C:\\Windows\\System32;C:\\Users\\Alice\\bin",
+    );
+    expect(env.Path).toBeUndefined();
+    expect(env.PATHEXT).toBe(".COM;.EXE;.BAT;.CMD");
+  });
+
   it("returns a failed result instead of throwing when spawnSync throws", () => {
     const error = new Error("spawn exploded");
     let spawnOptions: Record<string, unknown> | undefined;
@@ -387,7 +408,7 @@ describe("resolveUsableCodexBinary", () => {
     const homebrew = "/opt/homebrew/bin/codex";
     const attempted: string[] = [];
 
-    expect(resolveUsableCodexBinary("codex", {
+    const resolution = resolveUsableCodexBinary("codex", {
       platform: "darwin",
       env: { PATH: "/Users/alice/stale:/usr/bin:/bin" },
       homeDir: "/Users/alice",
@@ -395,9 +416,17 @@ describe("resolveUsableCodexBinary", () => {
       readDirNames: () => [],
       runCommand: (command, args) => {
         attempted.push(`${command} ${args.join(" ")}`);
-        return { status: command === homebrew ? 0 : 1 };
+        return {
+          status: command === homebrew ? 0 : 1,
+          stdout: command === homebrew ? "codex-cli 0.145.0\n" : "",
+        };
       },
-    })?.command).toBe(homebrew);
+    });
+    expect(resolution?.command).toBe(homebrew);
+    expect(resolution?.probe).toEqual({
+      status: 0,
+      stdout: "codex-cli 0.145.0\n",
+    });
     expect(attempted).toEqual([
       `${stale} --version`,
       `${homebrew} --version`,

--- a/homerail_manager/tests/codex-binary.test.ts
+++ b/homerail_manager/tests/codex-binary.test.ts
@@ -367,8 +367,33 @@ describe("resolveCodexBinary", () => {
       .toBe("/Users/Alice Smith/bin/codex");
   });
 
+  it("rejects shell-backed Windows shim paths with command metacharacters", () => {
+    const command = "C:\\Users\\Alice & Bob\\AppData\\Roaming\\npm\\codex.cmd";
+
+    expect(() => codexCommandForSpawn(command, "win32"))
+      .toThrowError("Codex Windows shim path contains unsupported shell metacharacters");
+    expect(resolveCodexBinary(command, {
+      platform: "win32",
+      env: {},
+      homeDir: "C:\\Users\\Alice & Bob",
+      fileExists: fakeExistingFiles([command], "win32"),
+      readDirNames: () => [],
+    })).toBeNull();
+    expect(codexBinaryNotFoundMessage(command, {
+      platform: "win32",
+      env: {},
+      homeDir: "C:\\Users\\Alice & Bob",
+    })).toBe(
+      "Codex Windows shim path contains unsupported shell metacharacters. Choose a different install path or set HOMERAIL_CODEX_BIN.",
+    );
+  });
+
   it("terminates the full process tree for a shell-backed Windows shim", () => {
-    const taskkillCalls: Array<{ command: string; args: string[] }> = [];
+    const taskkillCalls: Array<{
+      command: string;
+      args: string[];
+      options: Record<string, unknown> | undefined;
+    }> = [];
     let directKillCalled = false;
     const child = {
       pid: 321,
@@ -381,8 +406,12 @@ describe("resolveCodexBinary", () => {
 
     terminateCodexProcess(child, true, {
       platform: "win32",
-      spawnSyncImpl: ((command, args) => {
-        taskkillCalls.push({ command, args: args ?? [] });
+      spawnSyncImpl: ((command, args, options) => {
+        taskkillCalls.push({
+          command,
+          args: args ?? [],
+          options: options as Record<string, unknown> | undefined,
+        });
         return {
           pid: 1,
           output: [null, null, null],
@@ -397,8 +426,39 @@ describe("resolveCodexBinary", () => {
     expect(taskkillCalls).toEqual([{
       command: "taskkill.exe",
       args: ["/pid", "321", "/T", "/F"],
+      options: {
+        stdio: "ignore",
+        timeout: 5_000,
+        windowsHide: true,
+      },
     }]);
     expect(directKillCalled).toBe(false);
+  });
+
+  it("falls back to a direct signal when Windows tree termination fails", () => {
+    const directKillCalls: string[] = [];
+    const child = {
+      pid: 654,
+      killed: false,
+      kill: (signal: string) => {
+        directKillCalls.push(signal);
+        return true;
+      },
+    } as unknown as ChildProcess;
+
+    terminateCodexProcess(child, true, {
+      platform: "win32",
+      spawnSyncImpl: (() => ({
+        pid: 1,
+        output: [null, null, null],
+        stdout: null,
+        stderr: null,
+        status: null,
+        signal: null,
+      })) as typeof import("node:child_process").spawnSync,
+    });
+
+    expect(directKillCalls).toEqual(["SIGTERM"]);
   });
 });
 
@@ -453,5 +513,35 @@ describe("resolveUsableCodexBinary", () => {
       },
     })?.command).toBe(explicit);
     expect(attempted).toEqual([]);
+  });
+
+  it("retains the failed probe when every default candidate is unusable", () => {
+    const stale = "/Users/alice/stale/codex";
+    const homebrew = "/opt/homebrew/bin/codex";
+    const attempted: string[] = [];
+
+    const resolution = resolveUsableCodexBinary("codex", {
+      platform: "darwin",
+      env: { PATH: "/Users/alice/stale:/usr/bin:/bin" },
+      homeDir: "/Users/alice",
+      fileExists: fakeExistingFiles([stale, homebrew], "posix"),
+      readDirNames: () => [],
+      runCommand: (command) => {
+        attempted.push(command);
+        return {
+          status: 1,
+          stdout: command === stale ? "stale failure\n" : "brew failure\n",
+        };
+      },
+    });
+
+    expect(resolution).toMatchObject({
+      command: stale,
+      probe: {
+        status: 1,
+        stdout: "stale failure\n",
+      },
+    });
+    expect(attempted).toEqual([stale, homebrew]);
   });
 });

--- a/homerail_manager/tests/codex-binary.test.ts
+++ b/homerail_manager/tests/codex-binary.test.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import type { ChildProcess } from "node:child_process";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -10,6 +11,7 @@ import {
   resolveCodexBinary,
   resolveUsableCodexBinary,
   runCodexCommandSync,
+  terminateCodexProcess,
 } from "../src/server/codex-binary.js";
 
 function fakeExistingFiles(
@@ -342,6 +344,40 @@ describe("resolveCodexBinary", () => {
       .toBe("C:\\Tools\\codex.cmd");
     expect(codexCommandForSpawn("/Users/Alice Smith/bin/codex", "darwin"))
       .toBe("/Users/Alice Smith/bin/codex");
+  });
+
+  it("terminates the full process tree for a shell-backed Windows shim", () => {
+    const taskkillCalls: Array<{ command: string; args: string[] }> = [];
+    let directKillCalled = false;
+    const child = {
+      pid: 321,
+      killed: false,
+      kill: () => {
+        directKillCalled = true;
+        return true;
+      },
+    } as unknown as ChildProcess;
+
+    terminateCodexProcess(child, true, {
+      platform: "win32",
+      spawnSyncImpl: ((command, args) => {
+        taskkillCalls.push({ command, args: args ?? [] });
+        return {
+          pid: 1,
+          output: [null, null, null],
+          stdout: null,
+          stderr: null,
+          status: 0,
+          signal: null,
+        };
+      }) as typeof import("node:child_process").spawnSync,
+    });
+
+    expect(taskkillCalls).toEqual([{
+      command: "taskkill.exe",
+      args: ["/pid", "321", "/T", "/F"],
+    }]);
+    expect(directKillCalled).toBe(false);
   });
 });
 

--- a/homerail_manager/tests/codex-binary.test.ts
+++ b/homerail_manager/tests/codex-binary.test.ts
@@ -1,15 +1,22 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
   codexBinaryNotFoundMessage,
+  codexCommandEnvironment,
   resolveCodexBinary,
   runCodexCommandSync,
 } from "../src/server/codex-binary.js";
 
-function fakeExistingFiles(files: string[]): (filePath: string) => boolean {
-  const normalized = new Set(files.map((filePath) => path.win32.normalize(filePath)));
-  return (filePath: string) => normalized.has(path.win32.normalize(filePath));
+function fakeExistingFiles(
+  files: string[],
+  platform: "win32" | "posix" = "win32",
+): (filePath: string) => boolean {
+  const paths = platform === "win32" ? path.win32 : path.posix;
+  const normalized = new Set(files.map((filePath) => paths.normalize(filePath)));
+  return (filePath: string) => normalized.has(paths.normalize(filePath));
 }
 
 describe("resolveCodexBinary", () => {
@@ -31,7 +38,7 @@ describe("resolveCodexBinary", () => {
   });
 
   it("uses HOMERAIL_CODEX_BIN before CODEX_BIN_PATH", () => {
-    const preferred = "/custom/codex";
+    const preferred = "/Users/alice/Custom Tools/codex";
     const fallback = "/fallback/codex";
 
     expect(resolveCodexBinary(undefined, {
@@ -41,12 +48,133 @@ describe("resolveCodexBinary", () => {
         CODEX_BIN_PATH: fallback,
       },
       homeDir: "/Users/alice",
-      fileExists: fakeExistingFiles([preferred, fallback]),
+      fileExists: fakeExistingFiles([preferred, fallback], "posix"),
     })).toEqual({
       command: preferred,
       requested: preferred,
       needsShell: false,
     });
+  });
+
+  it("uses an explicit override before environment overrides and PATH", () => {
+    const explicit = "/Users/alice/Explicit Tools/codex";
+    const environment = "/Users/alice/Environment Tools/codex";
+    const inherited = "/Users/alice/bin/codex";
+
+    expect(resolveCodexBinary(explicit, {
+      platform: "darwin",
+      env: {
+        HOMERAIL_CODEX_BIN: environment,
+        CODEX_BIN_PATH: "/Users/alice/Fallback Tools/codex",
+        PATH: "/Users/alice/bin:/usr/bin:/bin",
+      },
+      homeDir: "/Users/alice",
+      fileExists: fakeExistingFiles([explicit, environment, inherited], "posix"),
+    })?.command).toBe(explicit);
+  });
+
+  it("skips blank higher-priority overrides", () => {
+    const fallback = "/Users/alice/Fallback Tools/codex";
+
+    expect(resolveCodexBinary(undefined, {
+      platform: "darwin",
+      env: {
+        HOMERAIL_CODEX_BIN: "   ",
+        CODEX_BIN_PATH: fallback,
+      },
+      homeDir: "/Users/alice",
+      fileExists: fakeExistingFiles([fallback], "posix"),
+    })?.command).toBe(fallback);
+  });
+
+  it("uses an inherited PATH command before fallback installations", () => {
+    const inherited = "/Users/alice/bin/codex";
+    const homebrew = "/opt/homebrew/bin/codex";
+
+    expect(resolveCodexBinary("codex", {
+      platform: "darwin",
+      env: { PATH: "/Users/alice/bin:/usr/bin:/bin" },
+      homeDir: "/Users/alice",
+      fileExists: fakeExistingFiles([inherited, homebrew], "posix"),
+      readDirNames: () => [],
+    })).toEqual({
+      command: inherited,
+      requested: "codex",
+      needsShell: false,
+    });
+  });
+
+  it("finds Homebrew Codex with a Finder-style minimal PATH", () => {
+    const homebrew = "/opt/homebrew/bin/codex";
+
+    expect(resolveCodexBinary("codex", {
+      platform: "darwin",
+      env: { PATH: "/usr/bin:/bin:/usr/sbin:/sbin" },
+      homeDir: "/Users/alice",
+      fileExists: fakeExistingFiles([homebrew], "posix"),
+      readDirNames: () => [],
+    })).toEqual({
+      command: homebrew,
+      requested: "codex",
+      needsShell: false,
+    });
+  });
+
+  it("finds the newest nvm Codex install with a Finder-style minimal PATH", () => {
+    const versionRoot = "/Users/Alice Smith/.nvm/versions/node";
+    const codex = `${versionRoot}/v22.16.0/bin/codex`;
+
+    expect(resolveCodexBinary("codex", {
+      platform: "darwin",
+      env: { PATH: "/usr/bin:/bin" },
+      homeDir: "/Users/Alice Smith",
+      fileExists: fakeExistingFiles([codex], "posix"),
+      readDirNames: (directoryPath) => directoryPath === versionRoot
+        ? ["v20.19.0", "v22.16.0"]
+        : [],
+    })).toEqual({
+      command: codex,
+      requested: "codex",
+      needsShell: false,
+    });
+  });
+
+  it("finds common user-local Codex installs outside the inherited PATH", () => {
+    const localCodex = "/home/alice/.local/bin/codex";
+
+    expect(resolveCodexBinary("codex", {
+      platform: "linux",
+      env: { PATH: "/usr/bin:/bin" },
+      homeDir: "/home/alice",
+      fileExists: fakeExistingFiles([localCodex], "posix"),
+      readDirNames: () => [],
+    })?.command).toBe(localCodex);
+  });
+
+  it("skips a non-executable POSIX PATH entry in favor of a later executable", () => {
+    if (process.platform === "win32") return;
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-codex-executable-"));
+    const staleDirectory = path.join(root, "stale");
+    const validDirectory = path.join(root, "valid with spaces");
+    fs.mkdirSync(staleDirectory);
+    fs.mkdirSync(validDirectory);
+    const stale = path.join(staleDirectory, "codex");
+    const valid = path.join(validDirectory, "codex");
+    fs.writeFileSync(stale, "#!/bin/sh\nexit 1\n");
+    fs.writeFileSync(valid, "#!/bin/sh\nexit 0\n");
+    fs.chmodSync(stale, 0o644);
+    fs.chmodSync(valid, 0o755);
+
+    try {
+      expect(resolveCodexBinary("codex", {
+        platform: process.platform,
+        env: { PATH: `${staleDirectory}${path.delimiter}${validDirectory}` },
+        homeDir: root,
+        readDirNames: () => [],
+      })?.command).toBe(valid);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("finds Windows PATH executables with supported extensions", () => {
@@ -63,6 +191,18 @@ describe("resolveCodexBinary", () => {
       requested: "codex",
       needsShell: false,
     });
+  });
+
+  it("honors the canonical Windows Path environment key", () => {
+    const binDir = "C:\\Program Files\\Codex Tools";
+    const exe = path.win32.join(binDir, "codex.exe");
+
+    expect(resolveCodexBinary("codex", {
+      platform: "win32",
+      env: { Path: `${binDir};C:\\Windows\\System32` },
+      homeDir: "C:\\Users\\alice",
+      fileExists: fakeExistingFiles([exe]),
+    })?.command).toBe(exe);
   });
 
   it("finds the Codex desktop app installation on Windows", () => {
@@ -101,6 +241,43 @@ describe("resolveCodexBinary", () => {
     })).toBe("Codex binary not found at: /wrong/path/codex. Install codex or set HOMERAIL_CODEX_BIN.");
   });
 
+  it("redacts credentials and the home directory from missing-path diagnostics", () => {
+    const message = codexBinaryNotFoundMessage(
+      "/Users/alice/Tools/sk-supersecret123/codex",
+      {
+        platform: "darwin",
+        env: {
+          OPENAI_API_KEY: "sk-environment-secret123",
+          HOMERAIL_CODEX_BIN: "/Users/alice/Tools/sk-supersecret123/codex",
+        },
+        homeDir: "/Users/alice",
+      },
+    );
+
+    expect(message).toContain("~/Tools/[REDACTED]/codex");
+    expect(message).not.toContain("supersecret");
+    expect(message).not.toContain("environment-secret");
+  });
+
+  it("prepends the Codex and current Node directories to a minimal child PATH", () => {
+    const env = codexCommandEnvironment(
+      "/opt/homebrew/bin/codex",
+      {
+        PATH: "/usr/bin:/bin",
+        OPENAI_API_KEY: "sk-do-not-log-this-value",
+      },
+      {
+        platform: "darwin",
+        nodeExecPath: "/Applications/HomeRail.app/Contents/Resources/node-bin/node",
+      },
+    );
+
+    expect(env.PATH).toBe(
+      "/opt/homebrew/bin:/Applications/HomeRail.app/Contents/Resources/node-bin:/usr/bin:/bin",
+    );
+    expect(env.OPENAI_API_KEY).toBe("sk-do-not-log-this-value");
+  });
+
   it("returns a failed result instead of throwing when spawnSync throws", () => {
     const error = new Error("spawn exploded");
     let spawnOptions: Record<string, unknown> | undefined;
@@ -120,6 +297,38 @@ describe("resolveCodexBinary", () => {
     expect(spawnOptions).toMatchObject({
       shell: true,
       windowsHide: true,
+    });
+  });
+
+  it("uses the enriched PATH when probing a Codex shim whose path contains spaces", () => {
+    const command = "/Users/Alice Smith/.nvm/versions/node/v22/bin/codex";
+    let spawnCommand = "";
+    let spawnOptions: Record<string, unknown> | undefined;
+    const result = runCodexCommandSync(command, ["--version"], {
+      platform: "darwin",
+      env: { PATH: "/usr/bin:/bin" },
+      nodeExecPath: "/Applications/HomeRail.app/Contents/Resources/node-bin/node",
+      spawnSyncImpl: ((actualCommand, _args, options) => {
+        spawnCommand = actualCommand;
+        spawnOptions = options as Record<string, unknown>;
+        return {
+          pid: 1,
+          output: [null, "codex-cli 0.145.0\n", ""],
+          stdout: "codex-cli 0.145.0\n",
+          stderr: "",
+          status: 0,
+          signal: null,
+        };
+      }) as typeof import("node:child_process").spawnSync,
+    });
+
+    expect(result.status).toBe(0);
+    expect(spawnCommand).toBe(command);
+    expect(spawnOptions).toMatchObject({
+      shell: false,
+      env: expect.objectContaining({
+        PATH: `${path.posix.dirname(command)}:/Applications/HomeRail.app/Contents/Resources/node-bin:/usr/bin:/bin`,
+      }),
     });
   });
 });

--- a/homerail_manager/tests/codex-live-voice-capability.test.ts
+++ b/homerail_manager/tests/codex-live-voice-capability.test.ts
@@ -2,6 +2,7 @@ import type { SpawnSyncReturns } from "node:child_process";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   _clearCodexLiveVoiceCapabilityCacheForTest,
+  codexAuthenticationPresent,
   inspectCodexInstallation,
 } from "../src/server/codex-live-voice-capability.js";
 
@@ -28,6 +29,7 @@ function inspect(version: string, features: string) {
       needsShell: false,
     }),
     runCommand,
+    authPresent: () => true,
     statMtimeMs: () => 42,
   });
   return { installation, runCommand };
@@ -42,16 +44,48 @@ describe("inspectCodexInstallation", () => {
     const installation = inspectCodexInstallation({
       requested: "codex",
       resolveBinary: () => null,
+      authPresent: () => false,
     });
 
     expect(installation).toMatchObject({
       available: false,
+      logged_in: false,
       binary: "codex",
       live_voice: {
         supported: false,
         minimum_version: "0.145.0",
         reason: "missing",
       },
+    });
+    expect(installation.diagnostics.map((item) => item.code)).toEqual([
+      "codex_binary_not_found",
+      "codex_auth_missing",
+    ]);
+  });
+
+  it("distinguishes a found but unusable binary from a missing binary", () => {
+    const installation = inspectCodexInstallation({
+      requested: "/Applications/Codex Tools/codex",
+      resolveBinary: () => ({
+        command: "/Applications/Codex Tools/codex",
+        requested: "/Applications/Codex Tools/codex",
+        needsShell: false,
+      }),
+      runCommand: () => result(127, "", "env: node: No such file or directory"),
+      authPresent: () => true,
+    });
+
+    expect(installation).toMatchObject({
+      available: false,
+      logged_in: true,
+      live_voice: {
+        supported: false,
+        reason: "unusable",
+      },
+      diagnostics: [{
+        code: "codex_binary_unusable",
+        message: "Codex CLI was found but could not be executed.",
+      }],
     });
   });
 
@@ -65,6 +99,9 @@ describe("inspectCodexInstallation", () => {
       supported: false,
       reason: "unparseable",
     });
+    expect(installation.diagnostics).toContainEqual(expect.objectContaining({
+      code: "codex_version_unparseable",
+    }));
     expect(runCommand).toHaveBeenCalledTimes(1);
   });
 
@@ -82,6 +119,9 @@ describe("inspectCodexInstallation", () => {
         reason: "too_old",
       },
     });
+    expect(installation.diagnostics).toContainEqual(expect.objectContaining({
+      code: "codex_version_too_old",
+    }));
     expect(runCommand).toHaveBeenCalledTimes(1);
   });
 
@@ -132,6 +172,9 @@ describe("inspectCodexInstallation", () => {
       stage: "removed",
       reason: "feature_missing",
     });
+    expect(installation.diagnostics).toContainEqual(expect.objectContaining({
+      code: "codex_live_voice_feature_missing",
+    }));
   });
 
   it("caches the feature probe for the same binary build", () => {
@@ -147,5 +190,93 @@ describe("inspectCodexInstallation", () => {
     expect(first.runCommand).toHaveBeenCalledTimes(2);
     expect(second.runCommand).toHaveBeenCalledTimes(1);
     expect(second.installation.live_voice.supported).toBe(true);
+  });
+
+  it("reports missing authentication separately from version and feature capability", () => {
+    const runCommand = vi.fn((_command: string, args: string[]) => (
+      args[0] === "--version"
+        ? result(0, "codex-cli 0.145.0\n")
+        : result(0, "realtime_conversation under development false\n")
+    ));
+    const installation = inspectCodexInstallation({
+      requested: "/test/codex",
+      resolveBinary: () => ({
+        command: "/test/codex",
+        requested: "/test/codex",
+        needsShell: false,
+      }),
+      runCommand,
+      authPresent: () => false,
+      statMtimeMs: () => 42,
+    });
+
+    expect(installation).toMatchObject({
+      available: true,
+      logged_in: false,
+      live_voice: { supported: true },
+      diagnostics: [{
+        code: "codex_auth_missing",
+        message: "Codex credentials were not found for this user.",
+      }],
+    });
+  });
+
+  it("accepts either an API key or a non-empty Codex auth file without exposing it", () => {
+    expect(codexAuthenticationPresent({
+      env: { OPENAI_API_KEY: "sk-private-test-token" },
+      homeDir: "/Users/alice",
+      readAuthFile: () => {
+        throw new Error("should not read auth file");
+      },
+    })).toBe(true);
+    expect(codexAuthenticationPresent({
+      env: {},
+      homeDir: "/Users/alice",
+      readAuthFile: () => "{\"tokens\":{\"access_token\":\"private\"}}",
+    })).toBe(true);
+  });
+
+  it("redacts token-like version output and never includes stderr or environment secrets", () => {
+    const installation = inspectCodexInstallation({
+      requested: "/Users/alice/sk-path-secret123/codex",
+      env: { OPENAI_API_KEY: "sk-environment-secret123" },
+      homeDir: "/Users/alice",
+      resolveBinary: () => ({
+        command: "/Users/alice/sk-path-secret123/codex",
+        requested: "/Users/alice/sk-path-secret123/codex",
+        needsShell: false,
+      }),
+      runCommand: () => result(
+        0,
+        "custom-codex sk-stdout-secret123\n",
+        "Bearer stderr-secret-token",
+      ),
+      authPresent: () => true,
+    });
+
+    const serialized = JSON.stringify(installation);
+    expect(installation.binary).toBe("~/[REDACTED]/codex");
+    expect(installation.version).toBeUndefined();
+    expect(serialized).not.toContain("path-secret");
+    expect(serialized).not.toContain("stdout-secret");
+    expect(serialized).not.toContain("stderr-secret");
+    expect(serialized).not.toContain("environment-secret");
+    expect(installation.diagnostics).toContainEqual(expect.objectContaining({
+      code: "codex_version_unparseable",
+    }));
+  });
+
+  it("does not expose unrecognized feature-stage output", () => {
+    const { installation } = inspect(
+      "codex-cli 0.145.0",
+      "realtime_conversation private-stage-value false\n",
+    );
+
+    expect(installation.live_voice).toMatchObject({
+      supported: true,
+      feature: "realtime_conversation",
+    });
+    expect(installation.live_voice.stage).toBeUndefined();
+    expect(JSON.stringify(installation)).not.toContain("private-stage-value");
   });
 });

--- a/homerail_manager/tests/codex-live-voice-capability.test.ts
+++ b/homerail_manager/tests/codex-live-voice-capability.test.ts
@@ -1,4 +1,5 @@
 import type { SpawnSyncReturns } from "node:child_process";
+import * as path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   _clearCodexLiveVoiceCapabilityCacheForTest,
@@ -255,7 +256,7 @@ describe("inspectCodexInstallation", () => {
     });
 
     const serialized = JSON.stringify(installation);
-    expect(installation.binary).toBe("~/[REDACTED]/codex");
+    expect(installation.binary).toBe(path.join("~", "[REDACTED]", "codex"));
     expect(installation.version).toBeUndefined();
     expect(serialized).not.toContain("path-secret");
     expect(serialized).not.toContain("stdout-secret");

--- a/homerail_manager/tests/codex-live-voice-capability.test.ts
+++ b/homerail_manager/tests/codex-live-voice-capability.test.ts
@@ -90,6 +90,36 @@ describe("inspectCodexInstallation", () => {
     });
   });
 
+  it("reuses the successful binary-resolution version probe", () => {
+    const runCommand = vi.fn(() => result(
+      0,
+      "realtime_conversation under development false\n",
+    ));
+    const installation = inspectCodexInstallation({
+      requested: "codex",
+      resolveBinary: () => ({
+        command: "/opt/homebrew/bin/codex",
+        requested: "codex",
+        needsShell: false,
+        probe: {
+          status: 0,
+          stdout: "codex-cli 0.145.0\n",
+        },
+      }),
+      runCommand,
+      authPresent: () => true,
+      statMtimeMs: () => 42,
+    });
+
+    expect(installation).toMatchObject({
+      available: true,
+      semantic_version: "0.145.0",
+      live_voice: { supported: true },
+    });
+    expect(runCommand).toHaveBeenCalledTimes(1);
+    expect(runCommand.mock.calls[0]?.[1]).not.toEqual(["--version"]);
+  });
+
   it("rejects an unparseable version", () => {
     const { installation, runCommand } = inspect(
       "custom-codex development",

--- a/homerail_manager/tests/codex-live-voice-capability.test.ts
+++ b/homerail_manager/tests/codex-live-voice-capability.test.ts
@@ -120,6 +120,31 @@ describe("inspectCodexInstallation", () => {
     expect(runCommand.mock.calls[0]?.[1]).not.toEqual(["--version"]);
   });
 
+  it("reuses an unsuccessful binary-resolution probe without spawning again", () => {
+    const runCommand = vi.fn();
+    const installation = inspectCodexInstallation({
+      requested: "codex",
+      resolveBinary: () => ({
+        command: "/Users/alice/stale/codex",
+        requested: "codex",
+        needsShell: false,
+        probe: {
+          status: 1,
+          stdout: "",
+        },
+      }),
+      runCommand,
+      authPresent: () => true,
+    });
+
+    expect(installation).toMatchObject({
+      available: false,
+      live_voice: { supported: false, reason: "unusable" },
+      diagnostics: [{ code: "codex_binary_unusable" }],
+    });
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
   it("rejects an unparseable version", () => {
     const { installation, runCommand } = inspect(
       "custom-codex development",

--- a/homerail_manager/tests/codex-models.test.ts
+++ b/homerail_manager/tests/codex-models.test.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "node:events";
 import * as http from "node:http";
+import * as path from "node:path";
 import { PassThrough } from "node:stream";
 import type { ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { afterEach, describe, expect, it } from "vitest";
@@ -147,6 +148,47 @@ describe("Codex model catalog", () => {
           service_tiers: [],
         },
       ],
+    });
+  });
+
+  it("enriches a GUI-style minimal PATH before loading models from a Node-backed shim", async () => {
+    const child = new FakeChildProcess();
+    const command = "/Users/Alice Smith/.nvm/versions/node/v22/bin/codex";
+    let spawnOptions: Record<string, unknown> | undefined;
+    child.stdin.on("data", (chunk) => {
+      const request = JSON.parse(chunk.toString().trim()) as Record<string, unknown>;
+      if (request.id === 1) {
+        child.stdout.write(`${JSON.stringify({ jsonrpc: "2.0", id: 1, result: {} })}\n`);
+      } else if (request.id === 2) {
+        child.stdout.write(`${JSON.stringify({
+          jsonrpc: "2.0",
+          id: 2,
+          result: { data: [] },
+        })}\n`);
+      }
+    });
+
+    await expect(listCodexModels({
+      resolution: {
+        command,
+        requested: "codex",
+        needsShell: false,
+      },
+      env: { PATH: "/usr/bin:/bin" },
+      spawnImpl: ((_command, _args, options) => {
+        spawnOptions = options as Record<string, unknown>;
+        return child as unknown as ChildProcessWithoutNullStreams;
+      }) as typeof spawn,
+      timeoutMs: 1_000,
+    })).resolves.toEqual({
+      binary: command,
+      models: [],
+    });
+
+    expect(spawnOptions).toMatchObject({
+      env: expect.objectContaining({
+        PATH: `${path.posix.dirname(command)}:${path.dirname(process.execPath)}:/usr/bin:/bin`,
+      }),
     });
   });
 

--- a/homerail_manager/tests/codex-models.test.ts
+++ b/homerail_manager/tests/codex-models.test.ts
@@ -187,7 +187,11 @@ describe("Codex model catalog", () => {
 
     expect(spawnOptions).toMatchObject({
       env: expect.objectContaining({
-        PATH: `${path.posix.dirname(command)}:${path.dirname(process.execPath)}:/usr/bin:/bin`,
+        PATH: [
+          path.dirname(command),
+          path.dirname(process.execPath),
+          "/usr/bin:/bin",
+        ].join(path.delimiter),
       }),
     });
   });

--- a/homerail_manager/tests/manager-agent-readiness.test.ts
+++ b/homerail_manager/tests/manager-agent-readiness.test.ts
@@ -6,9 +6,13 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { createServer } from "../src/server/http.js";
 import { _clearAllSettings, createSetting, upsertProvider } from "../src/persistence/llm-settings.js";
-import { clearManagerAgentConfig } from "../src/persistence/manager-agent-config.js";
+import {
+  clearManagerAgentConfig,
+  DEFAULT_MANAGER_AGENT_CONFIG,
+} from "../src/persistence/manager-agent-config.js";
 import { _clearNodes } from "../src/node/registry.js";
 import { registerFakeDockerNode } from "./helpers/fake-docker-node.js";
+import { managerAgentReadiness } from "../src/server/manager-agent-readiness.js";
 
 async function listen(server: http.Server): Promise<number> {
   await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
@@ -78,6 +82,9 @@ describe("/api/manager-agent/readiness", () => {
   let oldHostShell: string | undefined;
   let oldRepoRoot: string | undefined;
   let oldAnthropicKey: string | undefined;
+  let oldCodexHome: string | undefined;
+  let oldCodexBin: string | undefined;
+  let oldOpenAiKey: string | undefined;
 
   beforeEach(() => {
     oldHome = process.env.HOMERAIL_HOME;
@@ -86,12 +93,18 @@ describe("/api/manager-agent/readiness", () => {
     oldHostShell = process.env.HOMERAIL_MANAGER_AGENT_SHELL;
     oldRepoRoot = process.env.HOMERAIL_REPO_ROOT;
     oldAnthropicKey = process.env.ANTHROPIC_API_KEY;
+    oldCodexHome = process.env.CODEX_HOME;
+    oldCodexBin = process.env.HOMERAIL_CODEX_BIN;
+    oldOpenAiKey = process.env.OPENAI_API_KEY;
     tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-manager-agent-readiness-"));
     process.env.HOMERAIL_HOME = tmpHome;
     process.env.HOMERAIL_LOCAL_NODE_AUTOSTART = "0";
     delete process.env.HOMERAIL_MANAGER_AGENT_HOST_ENTRY;
     delete process.env.HOMERAIL_MANAGER_AGENT_SHELL;
     delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.CODEX_HOME;
+    delete process.env.HOMERAIL_CODEX_BIN;
+    delete process.env.OPENAI_API_KEY;
     clearManagerAgentConfig();
     _clearAllSettings();
     _clearNodes();
@@ -114,6 +127,12 @@ describe("/api/manager-agent/readiness", () => {
     else process.env.HOMERAIL_REPO_ROOT = oldRepoRoot;
     if (oldAnthropicKey === undefined) delete process.env.ANTHROPIC_API_KEY;
     else process.env.ANTHROPIC_API_KEY = oldAnthropicKey;
+    if (oldCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = oldCodexHome;
+    if (oldCodexBin === undefined) delete process.env.HOMERAIL_CODEX_BIN;
+    else process.env.HOMERAIL_CODEX_BIN = oldCodexBin;
+    if (oldOpenAiKey === undefined) delete process.env.OPENAI_API_KEY;
+    else process.env.OPENAI_API_KEY = oldOpenAiKey;
     await removeTempDir(tmpHome);
   });
 
@@ -133,6 +152,22 @@ describe("/api/manager-agent/readiness", () => {
     expect(body.data.blockers).toContainEqual(expect.objectContaining({
       code: "manager_config_invalid",
     }));
+  });
+
+  it("reports missing Codex binary and authentication as independent blockers", () => {
+    process.env.HOMERAIL_CODEX_BIN = path.join(tmpHome, "missing-codex");
+    process.env.CODEX_HOME = path.join(tmpHome, "missing-codex-home");
+
+    const readiness = managerAgentReadiness({
+      ...DEFAULT_MANAGER_AGENT_CONFIG,
+      harness: "codex_appserver",
+      model_name: "gpt-5.5",
+    });
+
+    expect(readiness.blockers.map((item) => item.code)).toEqual([
+      "codex_binary_not_found",
+      "codex_auth_missing",
+    ]);
   });
 
   it("reports missing host prerequisites without requiring a Docker node", async () => {


### PR DESCRIPTION
## What changed

- discover Codex across inherited PATH plus common Homebrew, npm, nvm, fnm, pnpm, Volta, asdf, mise, Bun, application, and Windows user install locations
- probe default discovery candidates with `codex --version`, skip stale shims, and reuse the successful or failed probe instead of spawning the same binary twice
- prepend the resolved Codex directory and HomeRail's current Node directory whenever probing or launching Codex, while preserving and merging Windows PATH key variants
- apply the enriched environment consistently to status checks, model discovery, the Host Codex Manager Agent, and Live Voice app-server sessions
- quote Windows `.cmd`/`.bat` shims installed under paths containing spaces and reject shell-metacharacter paths before `cmd.exe` execution
- terminate Windows shim process trees with bounded `taskkill /T /F` cleanup and a direct-signal fallback
- keep explicit `HOMERAIL_CODEX_BIN` and `CODEX_BIN_PATH` overrides strict instead of silently bypassing invalid user configuration
- return structured, redacted diagnostics for missing, unusable, unauthenticated, outdated, or feature-incomplete Codex installations
- continue reporting binary and authentication readiness blockers independently

## Root cause

A macOS app launched through Finder or LaunchServices does not inherit the interactive shell PATH. HomeRail could resolve `/opt/homebrew/bin/codex`, but the npm shim uses `#!/usr/bin/env node`; the subsequent probe and app-server processes could not locate Node and incorrectly reported Codex as unavailable.

The first implementation also stopped at the first executable-looking candidate. A stale shim earlier in PATH could therefore hide a later valid installation. Windows added two more constraints: npm uses shell-backed `.cmd` shims, and terminating only the shell process can leave the Node app-server child alive.

## User impact

Desktop launches can use a terminal-installed Codex without requiring users to start HomeRail from a shell or manually configure `HOMERAIL_CODEX_BIN`. Windows installations under paths containing spaces are supported, and their app-server process trees are cleaned up reliably.

## Validation

Validated against immutable base `24cc867e1da4ddb0fa3cd320b7f9be920cddc41d` and head `1dec6cbc52a8a3daa9964f8e03cbe1c377c3ec0d`:

- Manager Node 24 typecheck — PASS
- Manager Node 24 build — PASS
- focused Codex binary, capability, app-server, model catalog, and readiness suites — 5 files, 65/65 PASS
- [final GitHub CI](https://github.com/xiaotianfotos/homerail/actions/runs/30204887823) — PASS, including Windows Node 24, Linux Node 20/24, Docker smoke, and Agent UI coverage
- [final HomeRail PR Review](https://github.com/xiaotianfotos/homerail/actions/runs/30204887089) — PASS, high confidence, 0 actionable findings, 3/3 verifier quorum
- bundled-Node Finder-style `PATH=/usr/bin:/bin:/usr/sbin:/sbin` probe resolved `/opt/homebrew/bin/codex` and returned `codex-cli 0.145.0`

This PR does not change versions, release metadata, or the private Desktop repository.
