### PR TITLE
Stabilize plugin signing test on Windows runners

### DIFF
--- a/homerail_cli/tests/plugin-commands.test.ts
+++ b/homerail_cli/tests/plugin-commands.test.ts
@@ -183,7 +183,7 @@ describe("plugin PDK workflow", () => {
       archive_digest: packed.archive_digest,
     }));
     expect(process.exitCode).toBeUndefined();
-  });
+  }, 15_000);
 
   it("runs empty directory -> scaffold -> codegen -> validate -> dev/test matrix -> pack -> verify", async () => {
     const root = path.join(temporaryRoot, "release-notes");


### PR DESCRIPTION
## Summary
- give the publisher key generation and deterministic HRP signing test a focused 15-second timeout
- keep the rest of the suite on its existing timeout

## Root cause
The test completed in 6.153 seconds on the candidate Windows runner but inherited Vitest's 5-second default, so 253 other tests passed and packaging was skipped.

## Verification
- `npm --prefix homerail_cli run typecheck`
- targeted `plugin-commands.test.ts` signing test passed