### PR TITLE
fix(static-ui): proxy Codex Live Voice WebSocket upgrades

### DIFF
--- a/homerail_cli/src/static-ui-server.ts
+++ b/homerail_cli/src/static-ui-server.ts
@@ -35,6 +35,16 @@ const DAG_MUTATION_TOKEN = process.env.HOMERAIL_DAG_MUTATION_TOKEN?.trim();
 const USE_HTTPS = process.env.HOMERAIL_UI_HTTPS === "1";
 const BUILD_MANIFEST = "homerail-build.json";
 
+// WebSocket upgrade allowlist. Manager-published routes that the Agent UI must
+// reach same-origin are listed here; everything else is destroyed. Keep these in
+// sync with the Manager's own upgrade handlers.
+//
+//   /ws, /ws/events                       general event stream
+//   /api/voice/asr/realtime               same-origin ASR realtime
+//   /api/voice-agent/sessions/<id>/live   Codex Live Voice (dynamic sessionId)
+const CODEX_LIVE_VOICE_WS_PATH = /^\/api\/voice-agent\/sessions\/[^/]+\/live$/;
+const ALLOWED_WS_PATHS = new Set(["/ws", "/ws/events", "/api/voice/asr/realtime"]);
+
 const MIME: Record<string, string> = {
   ".html": "text/html; charset=utf-8",
   ".js": "text/javascript; charset=utf-8",
@@ -292,7 +302,7 @@ function onRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
 
 server.on("upgrade", (req, socket, head) => {
   const pathname = new URL(req.url || "/", "http://localhost").pathname;
-  if (pathname === "/ws" || pathname === "/ws/events" || pathname === "/api/voice/asr/realtime") {
+  if (ALLOWED_WS_PATHS.has(pathname) || CODEX_LIVE_VOICE_WS_PATH.test(pathname)) {
     handleWebSocket(req, socket as unknown as net.Socket, head);
     return;
   }

--- a/homerail_cli/tests/static-ui-admin-proxy.integration.test.ts
+++ b/homerail_cli/tests/static-ui-admin-proxy.integration.test.ts
@@ -192,6 +192,76 @@ describe("static Agent UI mutation proxy", () => {
     await waitUntil(async () => (await fetch(uiOrigin)).status === 200);
   }, 15_000);
 
+  it("proxies the dynamic Codex Live Voice WebSocket to the Manager unchanged", async () => {
+    let upgradedPath = "";
+    const manager = http.createServer();
+    manager.on("upgrade", (req, socket) => {
+      trackSocket(socket);
+      upgradedPath = req.url || "";
+      socket.write(
+        "HTTP/1.1 101 Switching Protocols\r\n" +
+        "Connection: Upgrade\r\n" +
+        "Upgrade: websocket\r\n" +
+        "\r\n",
+      );
+      socket.end();
+    });
+    servers.push(manager);
+    const managerUrl = await listen(manager, "127.0.0.1");
+    const uiPort = await reservePort();
+    const uiOrigin = `http://127.0.0.1:${uiPort}`;
+    await startStaticUi({
+      port: uiPort,
+      host: "127.0.0.1",
+      origin: uiOrigin,
+      managerUrl,
+    });
+
+    // Dynamic sessionId path: the matcher must accept any non-empty id segment
+    // and forward the path verbatim so Manager's Codex Live Voice handler keeps
+    // ownership of the route.
+    const sessionId = "01HK5CWD6YZ7EV1XBWG3V8N9P0";
+    const livePath = `/api/voice-agent/sessions/${sessionId}/live`;
+    const response = await websocketUpgrade(uiPort, livePath, uiOrigin);
+    expect(response).toContain("HTTP/1.1 101 Switching Protocols");
+    expect(upgradedPath).toBe(livePath);
+  }, 15_000);
+
+  it("destroys WebSocket upgrades on voice-agent routes outside the live allowlist", async () => {
+    let managerUpgrades = 0;
+    const manager = http.createServer();
+    manager.on("upgrade", (_req, socket) => {
+      // These paths must never reach Manager. If one does, track the socket so
+      // afterEach tears it down instead of leaking it into the next test.
+      trackSocket(socket);
+      managerUpgrades++;
+    });
+    servers.push(manager);
+    const managerUrl = await listen(manager, "127.0.0.1");
+    const uiPort = await reservePort();
+    const uiOrigin = `http://127.0.0.1:${uiPort}`;
+    await startStaticUi({
+      port: uiPort,
+      host: "127.0.0.1",
+      origin: uiOrigin,
+      managerUrl,
+    });
+
+    // Look-alike paths that must NOT be forwarded: an extra trailing segment, an
+    // empty id, and a different voice-agent endpoint. The matcher is anchored, so
+    // each of these should fall through to socket.destroy() and never reach Manager.
+    // A destroyed upgrade closes the socket without a 101 Switching Protocols line.
+    for (const badPath of [
+      "/api/voice-agent/sessions/01HK5CWD6YZ7EV1XBWG3V8N9P0/live/extra",
+      "/api/voice-agent/sessions//live",
+      "/api/voice-agent/sessions/01HK5CWD6YZ7EV1XBWG3V8N9P0/ticket",
+    ]) {
+      const response = await websocketUpgrade(uiPort, badPath, uiOrigin).catch((reason) => String(reason));
+      expect(response).not.toContain("HTTP/1.1 101 Switching Protocols");
+    }
+    expect(managerUpgrades).toBe(0);
+  }, 15_000);
+
   it("rejects no-Origin/cross-origin requests and proxies exact self-Origin without credentials", async () => {
     const received: Array<{ authorization?: string; origin?: string; method?: string; mutationToken?: string }> = [];
     const manager = http.createServer((req, res) => {


### PR DESCRIPTION
## Implements

Fixes #115.

## Problem

Codex Live Voice fails in the packaged desktop client with `Live Voice WebSocket connection failed`. Manager and Codex readiness are healthy, but the WebSocket never reaches Manager through the static Agent UI server.

The static UI server (`homerail_cli/src/static-ui-server.ts`) proxies HTTP API requests to Manager, but its WebSocket `upgrade` allowlist only accepts exact paths:

```
/ws
/ws/events
/api/voice/asr/realtime
```

The desktop UI requests a live ticket via `POST /api/voice-agent/sessions/{sessionId}/live-ticket` and then connects to the dynamic route:

```
ws://localhost:19193/api/voice-agent/sessions/{sessionId}/live
```

That path is not on the allowlist, so the static UI server calls `socket.destroy()` instead of forwarding the upgrade to Manager (`http://localhost:19191`). A direct connection to Manager's Live Voice endpoint succeeds, which confirms the bug is in the proxy layer.

## Fix

Add an anchored regex matcher for the Codex Live Voice route alongside the existing exact-path allowlist:

```ts
const CODEX_LIVE_VOICE_WS_PATH = /^\/api\/voice-agent\/sessions\/[^/]+\/live$/;
const ALLOWED_WS_PATHS = new Set(["/ws", "/ws/events", "/api/voice/asr/realtime"]);
```

```ts
server.on("upgrade", (req, socket, head) => {
  const pathname = new URL(req.url || "/", "http://localhost").pathname;
  if (ALLOWED_WS_PATHS.has(pathname) || CODEX_LIVE_VOICE_WS_PATH.test(pathname)) {
    handleWebSocket(req, socket as unknown as net.Socket, head);
    return;
  }
  socket.destroy();
});
```

The matcher accepts any non-empty sessionId segment and forwards the path unchanged to Manager, preserving the existing same-origin and Manager trust boundaries. The matched path is identical to Manager's own route at `homerail_manager/src/server/codex-live-voice-server.ts` (`/^\/api\/voice-agent\/sessions\/([^/]+)\/live$/`), so Manager keeps full ownership of the Live Voice handler. Look-alike paths (trailing segment, empty id, sibling endpoints like `/ticket`) still fall through to `socket.destroy()`.

No change to `homerail_desktop` is needed.

## Evidence

- `npm run typecheck` — passes
- `npm test` — 249/249 tests pass, including the static UI proxy integration suite
- New integration tests in `static-ui-admin-proxy.integration.test.ts`:
  - `proxies the dynamic Codex Live Voice WebSocket to the Manager unchanged` — verifies a dynamic sessionId path returns `101 Switching Protocols` and is forwarded verbatim to Manager.
  - `destroys WebSocket upgrades on voice-agent routes outside the live allowlist` — verifies `/live/extra`, `/sessions//live`, and `/sessions/<id>/ticket` are rejected and never reach Manager.

The positive case mirrors the existing ASR realtime test; the negative case locks down the matcher anchoring.

## Verification (from issue #115)

With this route enabled, 10 consecutive desktop same-origin flows succeeded: ticket request → WS connect through port 19193 → `authenticate` → `ready`.

## Out of scope

- No change to Manager's Live Voice server or the ticket flow.
- No change to the desktop shell or preload bridge.
- ASR realtime, `/ws`, and `/ws/events` behavior unchanged.

## Residual risk

- Future Manager-side WebSocket routes added to the Agent UI will need to be added to this allowlist. The allowlist is intentionally explicit (exact paths plus one anchored dynamic route) rather than a broad prefix, to keep the proxy's trust surface narrow.