### PR TITLE
fix: add cold recovery failure details and SDK ABI guard

### DIFF
--- a/homerail_manager/src/index.ts
+++ b/homerail_manager/src/index.ts
@@ -11,6 +11,17 @@ import {
   recoverDagLiveSurfaceProjections,
 } from "./generative-ui/dag-live-surface-projector.js";
 import { getDagEnvironmentController } from "./server/dag-environment.js";
+import { HOMERAIL_PLUGIN_SDK_ABI_VERSION } from "homerail-plugin-sdk";
+
+const EXPECTED_PLUGIN_SDK_ABI_VERSION = 1;
+if (HOMERAIL_PLUGIN_SDK_ABI_VERSION !== EXPECTED_PLUGIN_SDK_ABI_VERSION) {
+  console.error(
+    `[homerail_manager] FATAL: homerail-plugin-sdk ABI version mismatch — ` +
+    `Manager expects ${EXPECTED_PLUGIN_SDK_ABI_VERSION}, runtime SDK reports ${HOMERAIL_PLUGIN_SDK_ABI_VERSION}. ` +
+    `Rebuild homerail_plugin_sdk (npm run build) and restart.`,
+  );
+  process.exit(1);
+}
 
 initEventLogging();
 
@@ -46,6 +57,11 @@ server.listen(port, host, () => {
   console.error(
     `cold recovery: recovered=${recovery.recovered.length} failed=${recovery.failed.length} skipped=${recovery.skipped.length}`,
   );
+  for (const failure of recovery.failed) {
+    console.error(
+      `cold recovery failed: run=${failure.runId} reason="${failure.reason}" demoted_nodes=[${failure.demotedNodes.join(", ")}]`,
+    );
+  }
   console.error(
     `live surface recovery: projected=${surfaceRecovery.projected_events} failed=${surfaceRecovery.failed.length}`,
   );

--- a/homerail_manager/src/index.ts
+++ b/homerail_manager/src/index.ts
@@ -13,6 +13,9 @@ import {
 import { getDagEnvironmentController } from "./server/dag-environment.js";
 import { HOMERAIL_PLUGIN_SDK_ABI_VERSION } from "homerail-plugin-sdk";
 
+// Precondition: this check itself only runs when the Manager dist is current.
+// A stale Manager dist would not contain this guard at all. The check targets
+// the more common failure mode: Manager rebuilt but SDK dist left stale.
 const EXPECTED_PLUGIN_SDK_ABI_VERSION = 1;
 if (HOMERAIL_PLUGIN_SDK_ABI_VERSION !== EXPECTED_PLUGIN_SDK_ABI_VERSION) {
   console.error(

--- a/homerail_manager/src/plugins/manifest-loader.ts
+++ b/homerail_manager/src/plugins/manifest-loader.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import {
   validatePluginCustomRendererSource,
   validatePluginSkill,
+  HOMERAIL_PLUGIN_SDK_ABI_VERSION,
 } from "homerail-plugin-sdk";
 import {
   GENERATIVE_UI_IR_VERSION,
@@ -328,6 +329,13 @@ export function loadPluginPackage(
     }
     const content = decodeHomerailPluginUtf8(buffer, declaration.path);
     const metadata = validatePluginSkill(declaration.id, content);
+    if (!metadata || typeof metadata.description !== "string") {
+      throw new Error(
+        `homerail-plugin-sdk ABI mismatch (expected ABI version ${HOMERAIL_PLUGIN_SDK_ABI_VERSION}): ` +
+        `validatePluginSkill() did not return { name, description } for skill "${declaration.id}". ` +
+        `The runtime SDK dist is likely stale — rebuild homerail_plugin_sdk and ensure the Manager loads the updated artifact.`,
+      );
+    }
     if (declaration.visual_profile) {
       parseDagWorkerSkillVisualProfileV1(parseJsonObject(
         buffers.get(declaration.visual_profile)!,

--- a/homerail_manager/src/plugins/manifest-loader.ts
+++ b/homerail_manager/src/plugins/manifest-loader.ts
@@ -335,7 +335,8 @@ export function loadPluginPackage(
     // guarded here because its return value is never dereferenced (void call).
     if (!metadata || typeof metadata.description !== "string") {
       throw new Error(
-        `homerail-plugin-sdk ABI mismatch (expected ABI version ${HOMERAIL_PLUGIN_SDK_ABI_VERSION}): ` +
+        `homerail-plugin-sdk ABI mismatch (Manager expects ABI version 1, ` +
+        `runtime SDK reports ${HOMERAIL_PLUGIN_SDK_ABI_VERSION}): ` +
         `validatePluginSkill() did not return { name, description } for skill "${declaration.id}". ` +
         `The runtime SDK dist is likely stale — rebuild homerail_plugin_sdk and ensure the Manager loads the updated artifact.`,
       );

--- a/homerail_manager/src/plugins/manifest-loader.ts
+++ b/homerail_manager/src/plugins/manifest-loader.ts
@@ -329,6 +329,10 @@ export function loadPluginPackage(
     }
     const content = decodeHomerailPluginUtf8(buffer, declaration.path);
     const metadata = validatePluginSkill(declaration.id, content);
+    // ABI guard: validatePluginSkill changed from void to { name, description }
+    // in ABI v1. A stale SDK dist still returns undefined, which would crash on
+    // .description access below. validatePluginCustomRendererSource is not
+    // guarded here because its return value is never dereferenced (void call).
     if (!metadata || typeof metadata.description !== "string") {
       throw new Error(
         `homerail-plugin-sdk ABI mismatch (expected ABI version ${HOMERAIL_PLUGIN_SDK_ABI_VERSION}): ` +

--- a/homerail_manager/src/runtime/active-runs.ts
+++ b/homerail_manager/src/runtime/active-runs.ts
@@ -1186,9 +1186,15 @@ export function restoreActiveRun(
   return { status: "restored", run, demotedFromRunning };
 }
 
+export interface ColdRecoveryFailure {
+  runId: string;
+  reason: string;
+  demotedNodes: string[];
+}
+
 export interface ColdRecoverySummary {
   recovered: string[];
-  failed: string[];
+  failed: ColdRecoveryFailure[];
   skipped: string[];
 }
 
@@ -1206,7 +1212,13 @@ export function recoverAllActiveRuns(): ColdRecoverySummary {
       const result = restoreActiveRun(metadata);
       if (result.status === "restored") {
         if (result.run.status === "failed") {
-          summary.failed.push(runId);
+          summary.failed.push({
+            runId,
+            reason: result.demotedFromRunning.length > 0
+              ? `orphaned running nodes demoted to failed: ${result.demotedFromRunning.join(", ")}`
+              : "run terminal after recovery (blocked by failed dependency)",
+            demotedNodes: result.demotedFromRunning,
+          });
         } else {
           summary.recovered.push(runId);
         }

--- a/homerail_manager/tests/cold-recovery.test.ts
+++ b/homerail_manager/tests/cold-recovery.test.ts
@@ -221,8 +221,9 @@ describe("manager cold recovery", () => {
 
     const run = getActiveRun("run-blocked-after-restart")!;
     expect(summary.failed.map((f) => f.runId)).toContain("run-blocked-after-restart");
-    expect(summary.failed[0].demotedNodes).toContain("root");
-    expect(summary.failed[0].reason).toContain("orphaned running nodes");
+    const failure = summary.failed.find((f) => f.runId === "run-blocked-after-restart")!;
+    expect(failure.demotedNodes).toContain("root");
+    expect(failure.reason).toContain("orphaned running nodes");
     expect(run.status).toBe("failed");
     expect(run.dagRun.nodeStates.get("root")).toBe("FAILED");
     expect(run.dagRun.nodeStates.get("observer")).toBe("SKIPPED");

--- a/homerail_manager/tests/cold-recovery.test.ts
+++ b/homerail_manager/tests/cold-recovery.test.ts
@@ -220,7 +220,9 @@ describe("manager cold recovery", () => {
     const summary = recoverAllActiveRuns();
 
     const run = getActiveRun("run-blocked-after-restart")!;
-    expect(summary.failed).toContain("run-blocked-after-restart");
+    expect(summary.failed.map((f) => f.runId)).toContain("run-blocked-after-restart");
+    expect(summary.failed[0].demotedNodes).toContain("root");
+    expect(summary.failed[0].reason).toContain("orphaned running nodes");
     expect(run.status).toBe("failed");
     expect(run.dagRun.nodeStates.get("root")).toBe("FAILED");
     expect(run.dagRun.nodeStates.get("observer")).toBe("SKIPPED");
@@ -238,7 +240,10 @@ describe("manager cold recovery", () => {
     const summary = recoverAllActiveRuns();
 
     const recovered = getActiveRun("run-legacy-recovery-state")!;
-    expect(summary.failed).toContain("run-legacy-recovery-state");
+    expect(summary.failed.map((f) => f.runId)).toContain("run-legacy-recovery-state");
+    const failure = summary.failed.find((f) => f.runId === "run-legacy-recovery-state")!;
+    expect(failure.demotedNodes).toEqual([]);
+    expect(failure.reason).toContain("blocked by failed dependency");
     expect(recovered.status).toBe("failed");
     expect(recovered.dagRun.nodeStates.get("observer")).toBe("SKIPPED");
   });

--- a/homerail_manager/tests/plugin-sdk-abi.test.ts
+++ b/homerail_manager/tests/plugin-sdk-abi.test.ts
@@ -79,6 +79,9 @@ describe("plugin SDK ABI guard", () => {
       /ABI mismatch/,
     );
     expect(() => loadPluginPackage(packageRoot, { source: "development" })).toThrow(
+      /Manager expects ABI version 1/,
+    );
+    expect(() => loadPluginPackage(packageRoot, { source: "development" })).toThrow(
       /rebuild homerail_plugin_sdk/i,
     );
   });

--- a/homerail_manager/tests/plugin-sdk-abi.test.ts
+++ b/homerail_manager/tests/plugin-sdk-abi.test.ts
@@ -1,0 +1,85 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { HomerailPluginManifestV1 } from "homerail-protocol";
+
+vi.mock("homerail-plugin-sdk", async (importOriginal) => {
+  const original = await importOriginal<typeof import("homerail-plugin-sdk")>();
+  return {
+    ...original,
+    validatePluginSkill: vi.fn().mockReturnValue(undefined),
+  };
+});
+
+import { loadPluginPackage } from "../src/plugins/manifest-loader.js";
+import { HOMERAIL_PLUGIN_SDK_ABI_VERSION } from "homerail-plugin-sdk";
+
+function writeMinimalPlugin(root: string, id = "com.example.abi", version = "1.0.0"): string {
+  const packageRoot = path.join(root, `${id}-${version}`);
+  fs.mkdirSync(path.join(packageRoot, "skills", "abi"), { recursive: true });
+  fs.mkdirSync(path.join(packageRoot, "schemas"), { recursive: true });
+  const manifest: HomerailPluginManifestV1 = {
+    manifest_version: 1,
+    id,
+    version,
+    name: "ABI Test",
+    publisher: { id: "com.example", name: "Example" },
+    license: "MIT",
+    compatibility: {
+      homerail: { min: "0.1.0", max_exclusive: "0.2.0" },
+      plugin_api: [1], ui_ir: [1], renderer_api: [1],
+    },
+    capabilities: [{
+      id: "abi", summary: "ABI test.", intents: ["test abi"],
+      modalities: ["text"], required_inputs: [], skill: "abi",
+      tools: [], workflows: [], actions: [],
+    }],
+    skills: [{ id: "abi", path: "skills/abi/SKILL.md", description: "ABI test skill." }],
+    schemas: [{ id: "abi-v1", file: "schemas/abi.v1.schema.json" }],
+    kinds: [], tools: [], workflows: [], renderers: [], actions: [],
+    runtime: { trust: "data_only", plugin_api: 1 },
+    permissions: { required: [], optional: [] },
+    state: { schema_version: 1, migrations: [] },
+  };
+  fs.writeFileSync(path.join(packageRoot, "homerail.plugin.json"), JSON.stringify(manifest, null, 2));
+  fs.writeFileSync(path.join(packageRoot, "skills", "abi", "SKILL.md"), [
+    "---", "name: abi", "description: ABI test skill.", "---", "", "# ABI Test", "", "Test body.", "",
+  ].join("\n"));
+  fs.writeFileSync(path.join(packageRoot, "schemas", "abi.v1.schema.json"), JSON.stringify({
+    type: "object", properties: { ok: { type: "boolean" } }, required: ["ok"], additionalProperties: false,
+  }, null, 2));
+  return packageRoot;
+}
+
+describe("plugin SDK ABI guard", () => {
+  let tmpHome: string;
+  let previousHome: string | undefined;
+
+  beforeEach(() => {
+    previousHome = process.env.HOMERAIL_HOME;
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-sdk-abi-"));
+    process.env.HOMERAIL_HOME = tmpHome;
+  });
+
+  afterEach(() => {
+    if (previousHome === undefined) delete process.env.HOMERAIL_HOME;
+    else process.env.HOMERAIL_HOME = previousHome;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("exports HOMERAIL_PLUGIN_SDK_ABI_VERSION from the SDK", () => {
+    expect(HOMERAIL_PLUGIN_SDK_ABI_VERSION).toBe(1);
+  });
+
+  it("throws a clear ABI mismatch error when validatePluginSkill returns undefined (stale dist)", () => {
+    const packageRoot = writeMinimalPlugin(tmpHome);
+    expect(() => loadPluginPackage(packageRoot, { source: "development" })).toThrow(
+      /ABI mismatch/,
+    );
+    expect(() => loadPluginPackage(packageRoot, { source: "development" })).toThrow(
+      /rebuild homerail_plugin_sdk/i,
+    );
+  });
+});

--- a/homerail_plugin_sdk/src/project.ts
+++ b/homerail_plugin_sdk/src/project.ts
@@ -132,6 +132,14 @@ function expectedPayloadPaths(manifest: HomerailPluginManifestV1): string[] {
     .sort((left, right) => Buffer.compare(Buffer.from(left), Buffer.from(right)));
 }
 
+/**
+ * Bumped when a compiled SDK export changes its runtime return type or
+ * signature in a way that is invisible to TypeScript (types resolve from
+ * `src/`, runtime loads `dist/`). The Manager asserts this at startup so a
+ * stale `dist/` fails fast instead of rejecting activities mid-run.
+ */
+export const HOMERAIL_PLUGIN_SDK_ABI_VERSION = 1 as const;
+
 export function validatePluginSkill(
   skillId: string,
   contentValue: Buffer | string,


### PR DESCRIPTION
Closes #93

## Summary

Addresses both symptoms reported in #93:

### Symptom 1 — Cold recovery `failed=N` without details

`ColdRecoverySummary.failed` was `string[]` (run IDs only). The startup log printed only aggregate counts, making it impossible to diagnose which run failed or why.

**Fix:** Changed `failed` to `ColdRecoveryFailure[]` carrying `runId`, `reason`, and `demotedNodes`. The Manager now logs a per-entity line for each failed run:

```
cold recovery failed: run=<runId> reason="orphaned running nodes demoted to failed: work" demoted_nodes=[work]
```

### Symptom 2 — `Cannot read properties of undefined (reading 'description')`

Commit 71015a8 changed `validatePluginSkill()` from returning `void` to returning `{ name, description }`. Because the SDK's `types` field points to `src/` while Node loads `dist/`, a stale `dist/` passes TypeScript compilation but returns `undefined` at runtime — causing sporadic mid-run activity rejections.

**Fix (three layers):**
1. **SDK ABI version constant** — `HOMERAIL_PLUGIN_SDK_ABI_VERSION = 1` exported from `homerail-plugin-sdk`. Bump this whenever a compiled export changes its runtime signature.
2. **Startup assertion** — The Manager checks the ABI version at boot and exits with a clear FATAL message on mismatch, before accepting any traffic.
3. **Defensive guard in `manifest-loader.ts`** — If `validatePluginSkill()` returns a non-conforming value at runtime, throw an explicit "ABI mismatch — rebuild homerail_plugin_sdk" error instead of a cryptic TypeError.

## Changes

| File | Change |
|------|--------|
| `homerail_plugin_sdk/src/project.ts` | Add `HOMERAIL_PLUGIN_SDK_ABI_VERSION` export |
| `homerail_manager/src/index.ts` | Startup ABI assertion + per-entity cold recovery failure logging |
| `homerail_manager/src/runtime/active-runs.ts` | `ColdRecoveryFailure` interface; structured failure details in `recoverAllActiveRuns()` |
| `homerail_manager/src/plugins/manifest-loader.ts` | Defensive ABI guard after `validatePluginSkill()` call |
| `homerail_manager/tests/cold-recovery.test.ts` | Updated assertions for structured `failed` array |
| `homerail_manager/tests/plugin-sdk-abi.test.ts` | New: ABI version export + stale-dist guard tests |

## Verification

- `tsc --noEmit` passes (manager + SDK)
- `vitest run` — 1144 manager tests pass, 35 SDK tests pass
- New `plugin-sdk-abi.test.ts` — 2 tests pass (ABI export, stale-dist error message)
- Updated `cold-recovery.test.ts` — 15 tests pass (structured failure details verified)
