### PR TITLE
fix(agent-ui): show platform-specific DAG guidance in resource status pill

### DIFF
--- a/agent-ui/src/components/agent/DagResourceStatusPill.test.ts
+++ b/agent-ui/src/components/agent/DagResourceStatusPill.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, type App } from 'vue'
+import { i18n } from '@/plugins/i18n'
+import type { DagEnvironmentStatus } from '@/api/services/dag-environment-api'
+import DagResourceStatusPill from './DagResourceStatusPill.vue'
+
+// Stub the DAG environment composable so tests drive the pill with a
+// controlled status snapshot and never touch the real WebSocket lifecycle.
+let mockStatus: DagEnvironmentStatus | null = null
+vi.mock('@/composables/useDagEnvironment', () => ({
+  useDagEnvironment: () => ({
+    status: { value: mockStatus },
+    loading: { value: false },
+    action: { value: null },
+    error: { value: '' },
+    refresh: () => Promise.resolve(),
+    check: () => Promise.resolve(),
+    build: () => Promise.resolve(),
+  }),
+}))
+
+vi.mock('@/stores/agent-store', () => ({
+  useAgentStore: () => ({ settingsRequestedTab: null, settingsPageOpen: false }),
+}))
+
+function baseStatus(overrides: Partial<DagEnvironmentStatus> = {}): DagEnvironmentStatus {
+  return {
+    revision: 1,
+    updated_at: Date.now(),
+    platform: 'linux',
+    docker: { status: 'ready', message: '' },
+    source: {
+      available: true,
+      repo_root: '/repo',
+      protocol_version: '1',
+    },
+    worker_image: { status: 'ready', image: 'homerail-worker:latest', message: '' },
+    images: [],
+    workers: [],
+    ...overrides,
+  } as DagEnvironmentStatus
+}
+
+describe('DagResourceStatusPill', () => {
+  let app: App<Element> | null = null
+  let root: HTMLElement | null = null
+
+  beforeEach(() => {
+    mockStatus = null
+    i18n.global.locale.value = 'en-US'
+  })
+
+  afterEach(() => {
+    app?.unmount()
+    root?.remove()
+    app = null
+    root = null
+  })
+
+  function mount(): HTMLElement {
+    root = document.createElement('div')
+    document.body.appendChild(root)
+    app = createApp(DagResourceStatusPill)
+    app.use(i18n)
+    app.mount(root)
+    return root
+  }
+
+  it('is hidden when the environment is fully ready', () => {
+    mockStatus = baseStatus()
+    const root = mount()
+    expect(root.querySelector('.dag-resource-status')).toBeNull()
+  })
+
+  it('is hidden on the initial not-yet-probed state to stay quiet on a fresh install', () => {
+    mockStatus = baseStatus({
+      docker: { status: 'unknown', message: '' },
+      worker_image: { status: 'unknown', image: '', message: '' },
+    })
+    const root = mount()
+    expect(root.querySelector('.dag-resource-status')).toBeNull()
+  })
+
+  it('surfaces Docker daemon unavailability with the error style', () => {
+    mockStatus = baseStatus({
+      platform: 'linux',
+      docker: { status: 'error', reason_code: 'docker_daemon_unavailable', message: '' },
+      worker_image: { status: 'unknown', image: '', message: '' },
+    })
+    const root = mount()
+    const button = root.querySelector<HTMLButtonElement>('.dag-resource-status__button')
+    expect(button).not.toBeNull()
+    expect(button!.textContent).toContain('Docker unavailable')
+    expect(button!.className).toContain('dag-resource-status__button--error')
+  })
+
+  it('renders platform-specific recovery guidance in the tooltip for Windows', () => {
+    mockStatus = baseStatus({
+      platform: 'win32',
+      docker: { status: 'error', reason_code: 'docker_daemon_unavailable', message: '' },
+      worker_image: { status: 'unknown', image: '', message: '' },
+    })
+    const root = mount()
+    const button = root.querySelector<HTMLButtonElement>('.dag-resource-status__button')
+    expect(button).not.toBeNull()
+    // Windows guidance points the user at Docker Desktop, not the Linux daemon.
+    expect(button!.title).toContain('Docker Desktop')
+  })
+
+  it('renders platform-specific recovery guidance in the tooltip for Linux', () => {
+    mockStatus = baseStatus({
+      platform: 'linux',
+      docker: { status: 'error', reason_code: 'docker_daemon_unavailable', message: '' },
+      worker_image: { status: 'unknown', image: '', message: '' },
+    })
+    const root = mount()
+    const button = root.querySelector<HTMLButtonElement>('.dag-resource-status__button')
+    expect(button).not.toBeNull()
+    // Linux guidance references the daemon / systemctl, not Docker Desktop.
+    expect(button!.title.toLowerCase()).toContain('docker')
+  })
+
+  it('shows a build-failed label when the worker image build fails', () => {
+    mockStatus = baseStatus({
+      docker: { status: 'ready', message: '' },
+      worker_image: {
+        status: 'error',
+        image: 'homerail-worker:latest',
+        message: '',
+        reason_code: 'worker_image_build_failed',
+      },
+    })
+    const root = mount()
+    const button = root.querySelector<HTMLButtonElement>('.dag-resource-status__button')
+    expect(button).not.toBeNull()
+    expect(button!.textContent).toContain('Image build failed')
+    expect(button!.className).toContain('dag-resource-status__button--error')
+  })
+
+  it('shows a preparing label and spinner while the worker image is building', () => {
+    mockStatus = baseStatus({
+      docker: { status: 'ready', message: '' },
+      worker_image: { status: 'building', image: 'homerail-worker:latest', message: '' },
+    })
+    const root = mount()
+    const button = root.querySelector<HTMLButtonElement>('.dag-resource-status__button')
+    expect(button).not.toBeNull()
+    expect(button!.textContent).toContain('Preparing DAG')
+    // Spinner (Loader2) renders as an svg; error icon must not be present.
+    expect(button!.querySelector('svg.animate-spin')).not.toBeNull()
+    expect(button!.className).not.toContain('dag-resource-status__button--error')
+  })
+
+  it('opens environment settings on click', async () => {
+    mockStatus = baseStatus({
+      docker: { status: 'ready', message: '' },
+      worker_image: {
+        status: 'error',
+        image: 'homerail-worker:latest',
+        message: '',
+        reason_code: 'worker_image_build_failed',
+      },
+    })
+    const root = mount()
+    const button = root.querySelector<HTMLButtonElement>('.dag-resource-status__button')
+    expect(button).not.toBeNull()
+    button!.click()
+    // The stubbed store records the requested tab; clicking must not throw and
+    // must target the nodes/environment settings page.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(button).not.toBeNull()
+  })
+})

--- a/agent-ui/src/components/agent/DagResourceStatusPill.vue
+++ b/agent-ui/src/components/agent/DagResourceStatusPill.vue
@@ -3,6 +3,10 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { AlertTriangle, Hammer, Loader2 } from 'lucide-vue-next'
 import { useDagEnvironment } from '@/composables/useDagEnvironment'
+import {
+  dagEnvironmentGuidanceKey,
+  dagEnvironmentReasonCode,
+} from '@/composables/useDagEnvironmentGuidance'
 import { useAgentStore } from '@/stores/agent-store'
 import { cn } from '@/lib/utils'
 
@@ -11,29 +15,66 @@ const store = useAgentStore()
 const { status } = useDagEnvironment()
 const workerImage = computed(() => status.value?.worker_image ?? null)
 
-const visible = computed(() => {
-  const status = workerImage.value?.status
-  return status !== 'ready'
-})
+// Docker unavailability is the most common DAG failure mode and is what users
+// need an actionable hint for. The pill must surface it even when the worker
+// image itself has not been probed yet (status unknown/skipped).
+const dockerUnavailable = computed(() => status.value?.docker.status === 'error')
 
 const preparing = computed(() => {
-  const status = workerImage.value?.status
-  return status === 'checking' || status === 'building'
+  const worker = workerImage.value?.status
+  return worker === 'checking' || worker === 'building'
+})
+
+const reasonCode = computed(() => dagEnvironmentReasonCode(status.value))
+
+const visible = computed(() => {
+  // While Docker or the worker image is actively being prepared, always show.
+  if (preparing.value) return true
+  // Docker daemon problems always surface, regardless of worker-image state.
+  if (dockerUnavailable.value) return true
+  const worker = workerImage.value?.status
+  if (worker === 'error' || worker === 'skipped') return true
+  // Suppress the initial, not-yet-probed state so a fresh install is quiet.
+  if (worker === 'unknown' && !reasonCode.value) return false
+  return worker !== 'ready'
 })
 
 const label = computed(() => {
   if (preparing.value) return t('dag.resources.preparingShort')
-  if (workerImage.value?.status === 'error') return t('dag.resources.resources')
-  return t('dag.resources.preparation')
+  switch (reasonCode.value) {
+    case 'docker_cli_missing':
+    case 'docker_daemon_unavailable':
+    case 'docker_permission_denied':
+    case 'docker_linux_engine_required':
+    case 'docker_check_failed':
+      return t('dag.resources.dockerUnavailable')
+    case 'worker_image_missing':
+      return t('dag.resources.imageMissing')
+    case 'worker_image_stale':
+    case 'worker_image_incompatible':
+      return t('dag.resources.imageStale')
+    case 'worker_image_build_failed':
+      return t('dag.resources.buildFailed')
+    case 'worker_source_unavailable':
+      return t('dag.resources.sourceUnavailable')
+    default:
+      if (workerImage.value?.status === 'skipped') return t('dag.resources.preparation')
+      return t('dag.resources.resources')
+  }
 })
 
 const title = computed(() => {
-  if (!workerImage.value) return t('dag.resources.manage')
+  // Prefer platform-specific recovery guidance so the tooltip alone is enough
+  // to tell the user what to do (start Docker on Windows, etc.).
+  const guidanceKey = dagEnvironmentGuidanceKey(status.value, reasonCode.value)
+  if (guidanceKey) return t(guidanceKey)
+  if (!status.value) return t('dag.resources.manage')
   if (preparing.value) return t('dag.resources.preparingDescription')
-  if (workerImage.value.status === 'error') return t('dag.resources.manageDescription')
-  if (workerImage.value.status === 'skipped') return t('dag.resources.skipped')
+  if (workerImage.value?.status === 'skipped') return t('dag.resources.skipped')
   return t('dag.resources.manageDescription')
 })
+
+const isError = computed(() => dockerUnavailable.value || workerImage.value?.status === 'error')
 
 function openEnvironmentSettings(): void {
   store.settingsRequestedTab = 'nodes'
@@ -46,12 +87,12 @@ function openEnvironmentSettings(): void {
     <button
       type="button"
       class="dag-resource-status__button"
-      :class="cn(workerImage?.status === 'error' && 'dag-resource-status__button--error')"
+      :class="cn(isError && 'dag-resource-status__button--error')"
       :title="title"
       @click="openEnvironmentSettings"
     >
       <Loader2 v-if="preparing" class="h-4 w-4 animate-spin" />
-      <AlertTriangle v-else-if="workerImage?.status === 'error'" class="h-4 w-4" />
+      <AlertTriangle v-else-if="isError" class="h-4 w-4" />
       <Hammer v-else class="h-4 w-4" />
       <span>{{ label }}</span>
     </button>

--- a/agent-ui/src/components/agent/settings/DagEnvironmentSettings.vue
+++ b/agent-ui/src/components/agent/settings/DagEnvironmentSettings.vue
@@ -12,10 +12,11 @@ import {
   Server,
 } from 'lucide-vue-next'
 import { useDagEnvironment } from '@/composables/useDagEnvironment'
-import type {
-  DagEnvironmentCompatibility,
-  DagEnvironmentReasonCode,
-} from '@/api/services/dag-environment-api'
+import {
+  dagEnvironmentGuidanceKey,
+  dagEnvironmentReasonCode,
+} from '@/composables/useDagEnvironmentGuidance'
+import type { DagEnvironmentCompatibility } from '@/api/services/dag-environment-api'
 
 const { t, locale } = useI18n()
 const { status, loading, action, error, check, build } = useDagEnvironment()
@@ -83,40 +84,8 @@ function compatibilityClass(value: DagEnvironmentCompatibility): string {
   return 'text-[var(--hr-text-3)] border-[var(--hr-border)] bg-[var(--hr-surface-2)]'
 }
 
-function guidanceKey(reason: DagEnvironmentReasonCode | undefined): string | null {
-  if (!reason) return null
-  if (reason === 'docker_cli_missing') {
-    if (status.value?.platform === 'win32') return 'settings.environment.guidance.installWindows'
-    if (status.value?.platform === 'darwin') return 'settings.environment.guidance.installMac'
-    return 'settings.environment.guidance.installLinux'
-  }
-  if (reason === 'docker_daemon_unavailable') {
-    if (status.value?.platform === 'win32') return 'settings.environment.guidance.startWindows'
-    if (status.value?.platform === 'darwin') return 'settings.environment.guidance.startMac'
-    return 'settings.environment.guidance.startLinux'
-  }
-  if (reason === 'docker_permission_denied') return 'settings.environment.guidance.permissionLinux'
-  if (reason === 'docker_linux_engine_required') return 'settings.environment.guidance.linuxEngineWindows'
-  if (reason === 'worker_source_unavailable') return 'settings.environment.guidance.sourceUnavailable'
-  if (
-    reason === 'worker_image_missing'
-    || reason === 'worker_image_stale'
-    || reason === 'worker_image_incompatible'
-    || reason === 'worker_image_build_failed'
-  ) return `settings.environment.guidance.${reason}`
-  return 'settings.environment.guidance.checkFailed'
-}
-
 const guidance = computed(() => {
-  const reason = status.value?.docker.reason_code
-    ?? status.value?.worker_image.reason_code
-    ?? (
-      status.value?.worker_image.reason === 'stale'
-      || status.value?.worker_image.compatibility === 'stale'
-        ? 'worker_image_stale'
-        : undefined
-    )
-  const key = guidanceKey(reason)
+  const key = dagEnvironmentGuidanceKey(status.value, dagEnvironmentReasonCode(status.value))
   if (key) return t(key)
   if (
     status.value?.docker.status === 'unknown'

--- a/agent-ui/src/composables/useDagEnvironmentGuidance.ts
+++ b/agent-ui/src/composables/useDagEnvironmentGuidance.ts
@@ -1,0 +1,70 @@
+import type {
+  DagEnvironmentReasonCode,
+  DagEnvironmentStatus,
+} from '@/api/services/dag-environment-api'
+
+/**
+ * Resolve the structured reason code that should drive guidance for a DAG
+ * environment status snapshot.
+ *
+ * Docker availability wins over worker-image state: when the daemon itself is
+ * unavailable there is no point describing an image problem, and the recovery
+ * action is platform-specific (start Docker) rather than rebuilding an image.
+ * Worker-image staleness expressed only via `reason`/`compatibility` (no
+ * explicit `reason_code`) is normalized to `worker_image_stale` so callers share
+ * one enum.
+ */
+export function dagEnvironmentReasonCode(
+  status: DagEnvironmentStatus | null | undefined,
+): DagEnvironmentReasonCode | undefined {
+  if (!status) return undefined
+  return (
+    status.docker?.reason_code
+    ?? status.worker_image?.reason_code
+    ?? (
+      status.worker_image?.reason === 'stale'
+      || status.worker_image?.compatibility === 'stale'
+        ? 'worker_image_stale'
+        : undefined
+    )
+  )
+}
+
+/**
+ * Map a DAG environment status to the i18n key for platform-specific recovery
+ * guidance, or `null` when no dedicated guidance applies. The returned key is
+ * always under `settings.environment.guidance.*` so the pill and the settings
+ * panel render identical copy for the same failure.
+ */
+export function dagEnvironmentGuidanceKey(
+  status: DagEnvironmentStatus | null | undefined,
+  reason?: DagEnvironmentReasonCode,
+): string | null {
+  if (!status) return null
+  const resolved = reason ?? dagEnvironmentReasonCode(status)
+  if (!resolved) return null
+  const platform = status.platform
+  switch (resolved) {
+    case 'docker_cli_missing':
+      if (platform === 'win32') return 'settings.environment.guidance.installWindows'
+      if (platform === 'darwin') return 'settings.environment.guidance.installMac'
+      return 'settings.environment.guidance.installLinux'
+    case 'docker_daemon_unavailable':
+      if (platform === 'win32') return 'settings.environment.guidance.startWindows'
+      if (platform === 'darwin') return 'settings.environment.guidance.startMac'
+      return 'settings.environment.guidance.startLinux'
+    case 'docker_permission_denied':
+      return 'settings.environment.guidance.permissionLinux'
+    case 'docker_linux_engine_required':
+      return 'settings.environment.guidance.linuxEngineWindows'
+    case 'worker_source_unavailable':
+      return 'settings.environment.guidance.sourceUnavailable'
+    case 'worker_image_missing':
+    case 'worker_image_stale':
+    case 'worker_image_incompatible':
+    case 'worker_image_build_failed':
+      return `settings.environment.guidance.${resolved}`
+    default:
+      return 'settings.environment.guidance.checkFailed'
+  }
+}

--- a/agent-ui/src/locales/en-US/dag.json
+++ b/agent-ui/src/locales/en-US/dag.json
@@ -76,6 +76,11 @@
     "skipped": "Worker image build was skipped, so Docker DAG runs may be temporarily unavailable.",
     "status": "DAG resource status",
     "manage": "Manage DAG runtime",
-    "manageDescription": "Open Settings to check Docker or build the Worker image."
+    "manageDescription": "Open Settings to check Docker or build the Worker image.",
+    "dockerUnavailable": "Docker unavailable",
+    "imageMissing": "Worker image missing",
+    "imageStale": "Worker image needs rebuild",
+    "buildFailed": "Image build failed",
+    "sourceUnavailable": "Worker source unavailable"
   }
 }

--- a/agent-ui/src/locales/zh-Hans/dag.json
+++ b/agent-ui/src/locales/zh-Hans/dag.json
@@ -76,6 +76,11 @@
     "skipped": "本次启动跳过了 worker 镜像构建，Docker DAG 可能暂时不可用。",
     "status": "DAG 资源状态",
     "manage": "管理 DAG 运行环境",
-    "manageDescription": "打开设置，检查 Docker 或构建 Worker 镜像。"
+    "manageDescription": "打开设置，检查 Docker 或构建 Worker 镜像。",
+    "dockerUnavailable": "Docker 不可用",
+    "imageMissing": "缺少 Worker 镜像",
+    "imageStale": "Worker 镜像需重建",
+    "buildFailed": "镜像构建失败",
+    "sourceUnavailable": "Worker 源不可用"
   }
 }

--- a/agent-ui/src/locales/zh-Hant/dag.json
+++ b/agent-ui/src/locales/zh-Hant/dag.json
@@ -76,6 +76,11 @@
     "skipped": "本次啓動跳過了 worker 鏡像構建，Docker DAG 可能暫時不可用。",
     "status": "DAG 資源狀態",
     "manage": "管理 DAG 執行環境",
-    "manageDescription": "開啟設定，檢查 Docker 或建置 Worker 映像。"
+    "manageDescription": "開啟設定，檢查 Docker 或建置 Worker 映像。",
+    "dockerUnavailable": "Docker 不可用",
+    "imageMissing": "缺少 Worker 映像",
+    "imageStale": "Worker 映像需重建",
+    "buildFailed": "映像建置失敗",
+    "sourceUnavailable": "Worker 原始碼不可用"
   }
 }


### PR DESCRIPTION
Fixes #92.

## Summary

The DAG resource status pill in the agent top bar is the most visible surface for DAG readiness, but it rendered only generic labels (\"DAG resources\" / \"DAG preparation\") and never read the structured `reason_code` the Manager already publishes. Worse, its visibility check looked only at `worker_image.status`, so the exact scenario #92 reports — **Docker CLI installed but daemon not running** — was either hidden or shown with an unhelpful label and no recovery hint.

## The backend for #92 already shipped

Investigation confirmed the substantive work for #92 landed in #122 (\"Manage DAG runtime readiness from Settings\"):
- Structured reason codes (`docker_daemon_unavailable`, `docker_cli_missing`, `docker_permission_denied`, `docker_linux_engine_required`, `worker_image_*`) — ✅ in `dag-environment.ts`
- Daemon-before-build probing (`docker version` → `docker info` before any image work) — ✅
- Persisted status with `reason_code` — ✅
- Retry/recheck API (`POST /api/dag/environment/check`) — ✅
- Platform-specific guidance copy (`settings.environment.guidance.startWindows`/`startMac`/`startLinux`/…) — ✅ already rendered by `DagEnvironmentSettings.vue`

**Only the pill lagged behind, surfacing none of it.** This PR closes that gap. (Note: the exact error string quoted in the issue, \"failed to build homerail-worker:latest (exit code 1)\", no longer appears in the codebase; the current build-failure message is \"Docker build exited with code N\". The issue predates the #122 rework.)

## Changes

- **New shared composable `useDagEnvironmentGuidance.ts`**: extracts the reason-code resolution (`docker.reason_code ?? worker_image.reason_code`, with `worker_image_stale` normalization) and the platform-specific guidance-key mapping out of `DagEnvironmentSettings.vue`. The pill and the settings panel now share one mapping and cannot drift.
- **`DagEnvironmentSettings.vue`**: delegates to the shared composable. Behavior unchanged; existing settings tests (5) still pass.
- **`DagResourceStatusPill.vue`** rewrite:
  - Surfaces Docker unavailability (`docker.status === 'error'`) even when the worker image has not been probed — this is the #92 scenario that was previously hidden.
  - Picks a short reason-specific label from new `dag.resources.*` keys (\"Docker unavailable\" / \"Worker image missing\" / \"Image build failed\" / …).
  - Sets the tooltip to the platform-specific recovery guidance, reusing the existing `settings.environment.guidance.*` copy: Windows users see \"Start Docker Desktop…\", Linux users see the `systemctl` command, etc.
  - Stays quiet on a fresh install (`worker_image` unknown, no reason code) so it doesn't nag before the first probe completes.
- **i18n**: added 5 short pill labels to `dag.json` for zh-Hans, zh-Hant, en-US. Platform guidance copy is reused as-is.
- **New test `DagResourceStatusPill.test.ts`**: covers ready/hidden, Docker daemon unavailable with platform-specific tooltip (Windows vs Linux), worker image build failed, building/preparing state, and the initial-quiet state. Follows the existing `DagRunList.test.ts` pattern (`createApp` + manual mount; no `@vue/test-utils` dependency).

## Scope boundary (intentionally not done)

- **No server / protocol / type changes.** The structured codes, persistence, and API all exist.
- **Legacy cleanup investigated and declined.** An earlier reading suggested `dag-resource-status.ts` and the `dag_resources` field on `/api/manager-agent/readiness` were vestigial. On verification this is **not** safe: `dagResourcesUnavailableForRun()` is live in `mutations.ts` (gates `create-and-run` and `invoke` when DAG resources are unavailable), and the modern `DagEnvironmentController` imports `dagResourceStatusPath()` from the same file. Removing the readiness `dag_resources` field would also regress the agent-ui single-request fast path. Leaving all of it untouched — noted here so reviewers don't re-flag it.
- **No browser-build-trap exposure**: the protocol barrel is untouched; all fingerprint/hashing stays server-side.

## Verification

- `vue-tsc` typecheck: the only errors are pre-existing `Cannot find module 'ajv'` in `../homerail_protocol/src/*` (unrelated; the protocol package's own deps aren't installed in this worktree's tree). No errors in any file I touched.
- `vitest`: the new `DagResourceStatusPill.test.ts` (8 tests) plus the full settings + `useDagEnvironment` suites (52 tests total) pass.
- Note on local env: component tests that import the i18n plugin need a localStorage shim under the local Node/jsdom combo (jsdom 27 throws `SecurityError` for the opaque-origin `about:blank` test URL); CI runs on Node 24 where this is not an issue. The shim was used only for local validation and is **not** part of this PR.

## Out of scope / follow-ups

- Unifying the Manager's async Docker readiness path (`dag-environment.ts`) with the CLI `doctor --docker` path (`dockerReadiness`). The issue suggested reusing the doctor logic, but the Manager already has its own async equivalent wired to the UI; literal unification would expand scope without user benefit.
- A repo-level vitest `setupFiles` polyfill for jsdom's opaque-origin localStorage, if the team wants component tests to run cleanly on more environments.

## Residual risk

- The pill's `visible` logic now treats `worker_image.status === 'skipped'` as visible (preparing/preparation label). This matches the prior behavior for skipped, just now consistently reachable.
- The shared composable changes the Settings panel's guidance path mechanically (same mapping, relocated). The 5 existing `DagEnvironmentSettings` tests guard against regression.