### PR TITLE
Make PR reviews ready-triggered and resilient to large diffs

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,6 +1,10 @@
 name: HomeRail PR Review
 
 on:
+  pull_request:
+    # Review each coherent PR once. Moving a PR back to Draft and then Ready
+    # emits another ready_for_review event and intentionally starts a new run.
+    types: [opened, reopened, ready_for_review]
   workflow_dispatch:
     inputs:
       repo:
@@ -30,7 +34,13 @@ concurrency:
 jobs:
   review:
     name: HomeRail PR Review
-    if: github.actor == 'xiaotianfotos' && github.event_name == 'workflow_dispatch'
+    if: >-
+      github.actor == 'xiaotianfotos' &&
+      (github.event_name == 'workflow_dispatch' ||
+       (github.event_name == 'pull_request' &&
+        github.event.pull_request.user.login == 'xiaotianfotos' &&
+        github.event.pull_request.draft == false &&
+        github.event.pull_request.head.repo.full_name == github.repository))
     runs-on: [self-hosted, Linux, X64, homerail-pr-review]
     timeout-minutes: 90
     env:

--- a/assets/orchestrations/pr-review.yaml.template
+++ b/assets/orchestrations/pr-review.yaml.template
@@ -20,7 +20,7 @@ spec:
 
   pattern:
     id: pr-review-scenario
-    version: 1.7.2
+    version: 1.8.0
     source: HomeRail concrete scenario composed from budget-gate, orchestrator-workers, and quorum
     parameters:
       reviewer_count: 4
@@ -79,7 +79,7 @@ spec:
     ReviewContext:
       type: object
       additionalProperties: false
-      required: [repo, pr, base, head, repository_path, changed_files, diff_stat, diff_patch, diff_truncated]
+      required: [repo, pr, base, head, repository_path, changed_files, diff_stat, diff_patch, diff_chunks, diff_bytes, diff_truncated]
       properties:
         repo: { type: string }
         pr: { type: integer }
@@ -91,7 +91,23 @@ spec:
           maxItems: 5000
           items: { type: string }
         diff_stat: { type: string, maxLength: 20000 }
-        diff_patch: { type: string, maxLength: 700000 }
+        diff_patch: { type: string, maxLength: 150000 }
+        diff_chunks:
+          type: array
+          maxItems: 512
+          items:
+            type: object
+            additionalProperties: false
+            required: [index, path, bytes, files]
+            properties:
+              index: { type: integer, minimum: 1, maximum: 512 }
+              path: { type: string, pattern: '^review-evidence/diff-[0-9]{4}\.patch$' }
+              bytes: { type: integer, minimum: 0, maximum: 120000 }
+              files:
+                type: array
+                maxItems: 5000
+                items: { type: string }
+        diff_bytes: { type: integer, minimum: 0, maximum: 67108864 }
         diff_truncated: { type: boolean }
         title: { type: string }
         author: { type: string }
@@ -99,7 +115,7 @@ spec:
     PreparedReviewContext:
       type: object
       additionalProperties: false
-      required: [repo, pr, base, head, repository_path, changed_files, diff_stat, diff_patch, diff_truncated, commit_metadata, commit_metadata_truncated]
+      required: [repo, pr, base, head, repository_path, changed_files, diff_stat, diff_patch, diff_chunks, diff_bytes, diff_truncated, commit_metadata, commit_metadata_truncated]
       properties:
         repo: { type: string }
         pr: { type: integer }
@@ -111,7 +127,23 @@ spec:
           maxItems: 5000
           items: { type: string }
         diff_stat: { type: string, maxLength: 20000 }
-        diff_patch: { type: string, maxLength: 700000 }
+        diff_patch: { type: string, maxLength: 150000 }
+        diff_chunks:
+          type: array
+          maxItems: 512
+          items:
+            type: object
+            additionalProperties: false
+            required: [index, path, bytes, files]
+            properties:
+              index: { type: integer, minimum: 1, maximum: 512 }
+              path: { type: string, pattern: '^review-evidence/diff-[0-9]{4}\.patch$' }
+              bytes: { type: integer, minimum: 0, maximum: 120000 }
+              files:
+                type: array
+                maxItems: 5000
+                items: { type: string }
+        diff_bytes: { type: integer, minimum: 0, maximum: 67108864 }
         diff_truncated: { type: boolean }
         commit_metadata:
           type: array
@@ -148,11 +180,20 @@ spec:
     ReviewerResult:
       type: object
       additionalProperties: false
-      required: [reviewer, status, summary, findings]
+      required: [reviewer, status, summary, reviewed_files, unreviewed_files, evidence_truncated, findings]
       properties:
         reviewer: { type: string, enum: [runtime, security, tests, frontend] }
         status: { type: string, enum: [complete, failed] }
         summary: { type: string, minLength: 1, maxLength: 12000 }
+        reviewed_files:
+          type: array
+          maxItems: 5000
+          items: { type: string }
+        unreviewed_files:
+          type: array
+          maxItems: 5000
+          items: { type: string }
+        evidence_truncated: { type: boolean }
         findings:
           type: array
           maxItems: 50
@@ -173,11 +214,20 @@ spec:
     RuntimeReviewerResult:
       type: object
       additionalProperties: false
-      required: [reviewer, status, summary, findings]
+      required: [reviewer, status, summary, reviewed_files, unreviewed_files, evidence_truncated, findings]
       properties:
         reviewer: { const: runtime }
         status: { type: string, enum: [complete, failed] }
         summary: { type: string, minLength: 1, maxLength: 12000 }
+        reviewed_files:
+          type: array
+          maxItems: 5000
+          items: { type: string }
+        unreviewed_files:
+          type: array
+          maxItems: 5000
+          items: { type: string }
+        evidence_truncated: { type: boolean }
         findings:
           type: array
           maxItems: 50
@@ -198,11 +248,20 @@ spec:
     SecurityReviewerResult:
       type: object
       additionalProperties: false
-      required: [reviewer, status, summary, findings]
+      required: [reviewer, status, summary, reviewed_files, unreviewed_files, evidence_truncated, findings]
       properties:
         reviewer: { const: security }
         status: { type: string, enum: [complete, failed] }
         summary: { type: string, minLength: 1, maxLength: 12000 }
+        reviewed_files:
+          type: array
+          maxItems: 5000
+          items: { type: string }
+        unreviewed_files:
+          type: array
+          maxItems: 5000
+          items: { type: string }
+        evidence_truncated: { type: boolean }
         findings:
           type: array
           maxItems: 50
@@ -223,11 +282,20 @@ spec:
     TestReviewerResult:
       type: object
       additionalProperties: false
-      required: [reviewer, status, summary, findings]
+      required: [reviewer, status, summary, reviewed_files, unreviewed_files, evidence_truncated, findings]
       properties:
         reviewer: { const: tests }
         status: { type: string, enum: [complete, failed] }
         summary: { type: string, minLength: 1, maxLength: 12000 }
+        reviewed_files:
+          type: array
+          maxItems: 5000
+          items: { type: string }
+        unreviewed_files:
+          type: array
+          maxItems: 5000
+          items: { type: string }
+        evidence_truncated: { type: boolean }
         findings:
           type: array
           maxItems: 50
@@ -248,11 +316,20 @@ spec:
     FrontendReviewerResult:
       type: object
       additionalProperties: false
-      required: [reviewer, status, summary, findings]
+      required: [reviewer, status, summary, reviewed_files, unreviewed_files, evidence_truncated, findings]
       properties:
         reviewer: { const: frontend }
         status: { type: string, enum: [complete, failed] }
         summary: { type: string, minLength: 1, maxLength: 12000 }
+        reviewed_files:
+          type: array
+          maxItems: 5000
+          items: { type: string }
+        unreviewed_files:
+          type: array
+          maxItems: 5000
+          items: { type: string }
+        evidence_truncated: { type: boolean }
         findings:
           type: array
           maxItems: 50
@@ -329,11 +406,20 @@ spec:
           items:
             type: object
             additionalProperties: false
-            required: [reviewer, status, summary, findings]
+            required: [reviewer, status, summary, reviewed_files, unreviewed_files, evidence_truncated, findings]
             properties:
               reviewer: { type: string, enum: [runtime, security, tests, frontend] }
               status: { type: string, enum: [complete, failed] }
               summary: { type: string, minLength: 1, maxLength: 12000 }
+              reviewed_files:
+                type: array
+                maxItems: 5000
+                items: { type: string }
+              unreviewed_files:
+                type: array
+                maxItems: 5000
+                items: { type: string }
+              evidence_truncated: { type: boolean }
               findings:
                 type: array
                 maxItems: 50
@@ -535,8 +621,10 @@ spec:
         repository tools whenever they help verify changed files, references,
         or metadata; invoke tools directly rather than printing proposed calls.
         Every Read, Grep, Glob, or LS call must set its path explicitly to
-        input.context.repository_path or one of its descendants; keep Glob
-        patterns relative and traversal-free.
+        input.context.repository_path, one of its descendants, or an exact
+        path listed in input.context.diff_chunks; keep Glob patterns relative
+        and traversal-free. Read every diff_chunks entry before concluding;
+        diff_patch is only a bounded preview.
         The supplied diff is the starting index, not the only permitted
         evidence. Keep inspection proportional to the changed surface and stop
         after the concrete references needed for a decision. Do not modify the
@@ -583,9 +671,14 @@ spec:
         persistence, and tests beyond the supplied patch; invoke tools directly
         rather than printing proposed calls.
         Every Read, Grep, Glob, or LS call must set its path explicitly to
-        input.context.repository_path or one of its descendants; keep Glob
-        patterns relative and traversal-free. The diff is the starting index,
-        not the only permitted evidence. Keep inspection proportional to the
+        input.context.repository_path, one of its descendants, or an exact
+        path listed in input.context.diff_chunks; keep Glob patterns relative
+        and traversal-free. diff_patch is only a bounded preview. Read every
+        diff_chunks entry and account for every changed_files entry before
+        returning status=complete. Put examined paths in reviewed_files and
+        any missing paths in unreviewed_files. Set evidence_truncated when
+        input.context.diff_truncated is true or coverage is incomplete.
+        The diff is the starting index, not the only permitted evidence. Keep inspection proportional to the
         changed surface and follow only concrete affected paths needed for a
         decision. Do not modify the checkout. If
         `diff_truncated` is true, do not guess:
@@ -608,7 +701,7 @@ spec:
         needs file, precise line when known, evidence, recommendation,
         severity, and confidence. Do not end with prose. Your final action MUST
         call handoff on reviewed with exactly this shape and no extra keys:
-        {"reviewer":"runtime","status":"complete","summary":"text","findings":[{"category":"runtime","severity":"critical|high|medium|low","title":"text","file":"path","line":1,"evidence":"text","recommendation":"text","confidence":"high|medium|low"}]}
+        {"reviewer":"runtime","status":"complete","summary":"text","reviewed_files":["path"],"unreviewed_files":[],"evidence_truncated":false,"findings":[{"category":"runtime","severity":"critical|high|medium|low","title":"text","file":"path","line":1,"evidence":"text","recommendation":"text","confidence":"high|medium|low"}]}
         The reviewer field MUST be the literal string `runtime`; never reuse
         another reviewer's identity even when discussing tests or security.
         line must identify the precise changed or directly affected source line;
@@ -628,9 +721,14 @@ spec:
         boundaries, configuration, and affected callers beyond the supplied
         patch; invoke tools directly rather than printing proposed calls.
         Every Read, Grep, Glob, or LS call must set its path explicitly to
-        input.context.repository_path or one of its descendants; keep Glob
-        patterns relative and traversal-free. The diff is the starting index,
-        not the only permitted evidence. Keep
+        input.context.repository_path, one of its descendants, or an exact
+        path listed in input.context.diff_chunks; keep Glob patterns relative
+        and traversal-free. diff_patch is only a bounded preview. Read every
+        diff_chunks entry and account for every changed_files entry before
+        returning status=complete. Put examined paths in reviewed_files and
+        any missing paths in unreviewed_files. Set evidence_truncated when
+        input.context.diff_truncated is true or coverage is incomplete.
+        The diff is the starting index, not the only permitted evidence. Keep
         inspection proportional to concrete changed security boundaries. Do
         not modify the checkout. If `diff_truncated` is true, do not guess:
         call handoff on failed with
@@ -644,7 +742,7 @@ spec:
         the diff changes that boundary. Never expose a
         secret value in evidence. Do not end with prose. Your final action MUST
         call handoff on reviewed with exactly this shape and no extra keys:
-        {"reviewer":"security","status":"complete","summary":"text","findings":[{"category":"security","severity":"critical|high|medium|low","title":"text","file":"path","line":1,"evidence":"text","recommendation":"text","confidence":"high|medium|low"}]}
+        {"reviewer":"security","status":"complete","summary":"text","reviewed_files":["path"],"unreviewed_files":[],"evidence_truncated":false,"findings":[{"category":"security","severity":"critical|high|medium|low","title":"text","file":"path","line":1,"evidence":"text","recommendation":"text","confidence":"high|medium|low"}]}
         The reviewer field MUST be the literal string `security`; never reuse
         another reviewer's identity.
         line must be a precise changed or directly affected source line. Empty findings are valid.
@@ -662,8 +760,14 @@ spec:
         repository tools whenever useful to inspect existing coverage and
         locate affected tests; invoke tools directly rather than
         printing proposed calls. Every Read, Grep, Glob, or LS call must set its
-        path explicitly to input.context.repository_path or one of its
-        descendants; keep Glob patterns relative and traversal-free. The diff
+        path explicitly to input.context.repository_path, one of its
+        descendants, or an exact path listed in input.context.diff_chunks;
+        keep Glob patterns relative and traversal-free. diff_patch is only a
+        bounded preview. Read every diff_chunks entry and account for every
+        changed_files entry before returning status=complete. Put examined
+        paths in reviewed_files and any missing paths in unreviewed_files. Set
+        evidence_truncated when input.context.diff_truncated is true or
+        coverage is incomplete. The diff
         is the starting index, not the only permitted evidence. Keep inspection
         proportional to concrete changed
         behavior and its directly affected tests. Do not modify the checkout.
@@ -687,7 +791,7 @@ spec:
         existing test suite falsely passes a demonstrated critical defect.
         Do not end with prose. Your final action MUST call
         handoff on reviewed with exactly this shape and no extra keys:
-        {"reviewer":"tests","status":"complete","summary":"text","findings":[{"category":"tests","severity":"critical|high|medium|low","title":"text","file":"path","line":1,"evidence":"text","recommendation":"text","confidence":"high|medium|low"}]}
+        {"reviewer":"tests","status":"complete","summary":"text","reviewed_files":["path"],"unreviewed_files":[],"evidence_truncated":false,"findings":[{"category":"tests","severity":"critical|high|medium|low","title":"text","file":"path","line":1,"evidence":"text","recommendation":"text","confidence":"high|medium|low"}]}
         The reviewer field MUST be the literal string `tests`; never reuse
         another reviewer's identity.
         Every finding needs a precise changed or directly affected line. Empty findings are valid.
@@ -705,8 +809,14 @@ spec:
         repository tools whenever useful to inspect components, styles, API
         consumers, and tests beyond the supplied patch; invoke tools directly
         rather than printing proposed calls. Every Read, Grep, Glob, or LS call
-        must set its path explicitly to input.context.repository_path or one of
-        its descendants; keep Glob patterns relative and traversal-free. The
+        must set its path explicitly to input.context.repository_path, one of
+        its descendants, or an exact path listed in input.context.diff_chunks;
+        keep Glob patterns relative and traversal-free. diff_patch is only a
+        bounded preview. Read every diff_chunks entry and account for every
+        changed_files entry before returning status=complete. Put examined
+        paths in reviewed_files and any missing paths in unreviewed_files. Set
+        evidence_truncated when input.context.diff_truncated is true or
+        coverage is incomplete. The
         diff is the starting index, not the only permitted evidence. Keep
         inspection proportional to the
         changed user surface and directly affected consumers. Do not modify the
@@ -725,7 +835,7 @@ spec:
         Do not demand frontend changes when the diff has no user
         surface. Do not end with prose. Your final action MUST call handoff on
         reviewed with exactly this shape and no extra keys:
-        {"reviewer":"frontend","status":"complete","summary":"text","findings":[{"category":"frontend","severity":"critical|high|medium|low","title":"text","file":"path","line":1,"evidence":"text","recommendation":"text","confidence":"high|medium|low"}]}
+        {"reviewer":"frontend","status":"complete","summary":"text","reviewed_files":["path"],"unreviewed_files":[],"evidence_truncated":false,"findings":[{"category":"frontend","severity":"critical|high|medium|low","title":"text","file":"path","line":1,"evidence":"text","recommendation":"text","confidence":"high|medium|low"}]}
         The reviewer field MUST be the literal string `frontend`; never reuse
         another reviewer's identity.
         Every finding needs a precise changed or directly affected line. Empty findings are valid.
@@ -759,7 +869,9 @@ spec:
         URL prefixes as out of scope.
         Every retained finding
         must have a precise line.
-        Set status=findings when
+        Treat a reviewer with evidence_truncated=true or a non-empty
+        unreviewed_files list as failed coverage even if its status says
+        complete. Set status=findings when
         actionable_count is positive, pass when it is zero, and inconclusive
         if any reviewer failed. Never edit the repository or end with prose.
         Your final action MUST call handoff on drafted with exactly these
@@ -802,8 +914,9 @@ spec:
         repository tools whenever needed to independently verify affected callers,
         tests, and observable behavior; invoke tools directly rather than
         printing proposed calls. Every Read, Grep, Glob, or LS call must set its
-        path explicitly to input.context.repository_path or one of its
-        descendants; keep Glob patterns relative and traversal-free. The diff
+        path explicitly to input.context.repository_path, one of its
+        descendants, or an exact path listed in input.context.diff_chunks;
+        keep Glob patterns relative and traversal-free. The diff
         is the starting index, not the only
         permitted evidence. Keep inspection bounded to evidence needed to
         adjudicate the retained findings. Do not modify the checkout.
@@ -826,9 +939,10 @@ spec:
         hosts. A rejected finding is a successful verifier correction, not a
         reason to reject the whole report. Vote accept when every retained
         finding has a grounded confirmed or rejected verdict, all four
-        reviewer_results have status complete, report identity matches
-        input.context, and diff_truncated is false. Vote reject when any
-        reviewer failed, the report is inconclusive, evidence is insufficient
+        reviewer_results have status complete, evidence_truncated=false and
+        empty unreviewed_files, report identity matches input.context, and
+        diff_truncated is false. Vote reject when any
+        reviewer failed or reported incomplete coverage, the report is inconclusive, evidence is insufficient
         to adjudicate every finding, identity differs, or diff_truncated is
         true. An empty report is acceptable only when the reviewer evidence
         supports it. Do not end with prose. Your final action MUST
@@ -846,8 +960,9 @@ spec:
         repository tools whenever needed to challenge each finding against callers,
         tests, and exact base...head behavior; invoke tools directly rather than
         printing proposed calls. Every Read, Grep, Glob, or LS call must set its
-        path explicitly to input.context.repository_path or one of its
-        descendants; keep Glob patterns relative and traversal-free. The diff
+        path explicitly to input.context.repository_path, one of its
+        descendants, or an exact path listed in input.context.diff_chunks;
+        keep Glob patterns relative and traversal-free. The diff
         is the starting index, not the only
         permitted evidence. Keep inspection bounded to evidence needed to
         accept or reject each retained finding. Do not modify the checkout. Act
@@ -873,8 +988,10 @@ spec:
         finding receives verdict rejected; that correction does not reject the
         whole report. Vote accept when every finding has a grounded confirmed or
         rejected verdict, all four reviewer_results have status complete,
-        report identity matches input.context, and diff_truncated is false.
-        Vote reject when any reviewer failed, the report is inconclusive,
+        evidence_truncated=false and empty unreviewed_files, report identity
+        matches input.context, and diff_truncated is false.
+        Vote reject when any reviewer failed or reported incomplete coverage,
+        the report is inconclusive,
         evidence is insufficient to adjudicate every finding, identity differs,
         or diff_truncated is true. Do not end with prose. Your final action MUST
         call handoff on voted with exactly:
@@ -887,9 +1004,11 @@ spec:
         Verify that runtime, security, tests, and frontend scopes all produced
         explicit ReviewerResult records and that the synthesis did not silently
         discard stronger evidence. Vote accept only when all four distinct
-        reviewer records are present with status complete. Vote reject when any
-        reviewer is missing or has status failed, or when report.status is
-        inconclusive. Findings do not make coverage incomplete.
+        reviewer records are present with status complete,
+        evidence_truncated=false, and empty unreviewed_files. Vote reject when
+        any reviewer is missing, has status failed, reports truncated evidence,
+        leaves files unreviewed, or when report.status is inconclusive.
+        Findings do not make coverage incomplete.
         Coverage does not adjudicate individual findings. Never include
         finding_verdicts or any other extra field. Do not end with prose. Your
         final action MUST call handoff on voted with exactly:
@@ -948,7 +1067,7 @@ spec:
           - -e
           - |-
             const { spawnSync } = require('node:child_process');
-            const { existsSync } = require('node:fs');
+            const { existsSync, mkdirSync, readFileSync, writeFileSync } = require('node:fs');
             let stdin = '';
             const fail = (message) => { throw new Error(message); };
             const exactRevision = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i;
@@ -991,7 +1110,7 @@ spec:
                 '-c', 'protocol.ext.allow=never',
               ];
               const result = spawnSync('git', [...common, ...args], {
-                encoding: 'utf8', env: gitEnv(), maxBuffer: 16777216,
+                encoding: 'utf8', env: gitEnv(), maxBuffer: 67108864,
               });
               if (result.error) throw result.error;
               if (result.status !== 0) {
@@ -1070,36 +1189,90 @@ spec:
                   subject: cleanMetadata(metadataFields[offset + 5], 1000),
                 });
               }
-              const patchLimit = 600000;
-              const marker = '\n... [HomeRail diff truncated by deterministic evidence limit]\n';
-              let diffPatch = rawPatch;
-              let diffTruncated = Buffer.byteLength(diffPatch, 'utf8') > patchLimit;
-              if (diffTruncated) {
-                diffPatch = Buffer.from(diffPatch).subarray(0, patchLimit).toString('utf8');
+              const chunkLimit = 120000;
+              const evidenceLimit = 48 * 1024 * 1024;
+              const rawPatchBytes = Buffer.byteLength(rawPatch, 'utf8');
+              const splitByBytes = (value, limit) => {
+                const chunks = [];
+                let chunk = '';
+                let bytes = 0;
+                const flush = () => {
+                  if (!chunk) return;
+                  chunks.push(chunk);
+                  chunk = '';
+                  bytes = 0;
+                };
+                for (const line of value.match(/[^\n]*\n|[^\n]+$/g) || []) {
+                  const lineBytes = Buffer.byteLength(line, 'utf8');
+                  if (lineBytes <= limit) {
+                    if (bytes > 0 && bytes + lineBytes > limit) flush();
+                    chunk += line;
+                    bytes += lineBytes;
+                    continue;
+                  }
+                  flush();
+                  for (const character of line) {
+                    const characterBytes = Buffer.byteLength(character, 'utf8');
+                    if (bytes > 0 && bytes + characterBytes > limit) flush();
+                    chunk += character;
+                    bytes += characterBytes;
+                  }
+                }
+                flush();
+                return chunks;
+              };
+              const boundedPatch = rawPatchBytes > evidenceLimit
+                ? splitByBytes(rawPatch, evidenceLimit)[0] || ''
+                : rawPatch;
+              const diffTruncated = rawPatchBytes > evidenceLimit;
+              const sections = boundedPatch
+                ? boundedPatch.split(/(?=^diff --git )/m).filter(Boolean)
+                : [];
+              const evidenceDir = 'review-evidence';
+              if (existsSync(evidenceDir)) fail('run workspace review evidence path already exists');
+              mkdirSync(evidenceDir, { mode: 0o700 });
+              const diffChunks = [];
+              for (let sectionIndex = 0; sectionIndex < sections.length; sectionIndex += 1) {
+                const files = sections.length === changed.length && changed[sectionIndex]
+                  ? [changed[sectionIndex]]
+                  : [];
+                for (const content of splitByBytes(sections[sectionIndex], chunkLimit)) {
+                  const index = diffChunks.length + 1;
+                  if (index > 512) fail('diff evidence requires more than 512 chunks');
+                  const chunkPath = `review-evidence/diff-${String(index).padStart(4, '0')}.patch`;
+                  writeFileSync(chunkPath, content, { encoding: 'utf8', mode: 0o600 });
+                  diffChunks.push({
+                    index,
+                    path: chunkPath,
+                    bytes: Buffer.byteLength(content, 'utf8'),
+                    files,
+                  });
+                }
               }
+              const inlinePreview = diffChunks.length > 0
+                ? readFileSync(diffChunks[0].path, 'utf8')
+                : '';
+              const continuation = diffChunks.length > 1
+                ? `\n... [HomeRail full diff continues in ${diffChunks.length} review-evidence chunks]\n`
+                : '';
+              const truncation = diffTruncated
+                ? '\n... [HomeRail diff evidence truncated at the 48 MiB safety limit]\n'
+                : '';
               const context = {
                 repo, pr, base, head,
                 repository_path: '/workspace/repository',
                 changed_files: changed,
                 diff_stat: diffStat,
-                diff_patch: '',
+                diff_patch: inlinePreview + continuation + truncation,
+                diff_chunks: diffChunks,
+                diff_bytes: rawPatchBytes,
                 diff_truncated: diffTruncated,
                 commit_metadata: commitMetadata,
                 commit_metadata_truncated: commitCount > commitMetadata.length,
               };
               if (typeof title === 'string') context.title = title;
               if (typeof author === 'string') context.author = author;
-              const serialize = () => {
-                context.diff_patch = diffPatch + (diffTruncated ? marker : '');
-                context.diff_truncated = diffTruncated;
-                return JSON.stringify(context);
-              };
-              let output = serialize();
-              while (Buffer.byteLength(output, 'utf8') > 900000 && diffPatch.length > 0) {
-                diffTruncated = true;
-                diffPatch = diffPatch.slice(0, Math.floor(diffPatch.length * 0.8));
-                output = serialize();
-              }
+              const output = JSON.stringify(context);
               if (Buffer.byteLength(output, 'utf8') > 900000) {
                 fail('review context exceeds the command capture limit');
               }
@@ -1138,7 +1311,7 @@ spec:
       agent: privacy_reviewer
       allowed_builtin_tools: [Read, Grep, Glob, LS]
       allowed_dag_tools: [handoff]
-      workspace_access: { writable_paths: [], readonly_paths: [repository] }
+      workspace_access: { writable_paths: [], readonly_paths: [repository, review-evidence] }
       inputs: { context: { contract: PreparedReviewContext } }
       outputs: { reviewed: { contract: PrivacyReview }, failed: {} }
 
@@ -1176,27 +1349,28 @@ spec:
       agent: runtime_reviewer
       allowed_builtin_tools: [Read, Grep, Glob, LS]
       allowed_dag_tools: [handoff]
-      workspace_access: { writable_paths: [], readonly_paths: [repository] }
+      workspace_access: { writable_paths: [], readonly_paths: [repository, review-evidence] }
       inputs: { context: { contract: ReviewContext } }
       outputs: { reviewed: { contract: RuntimeReviewerResult }, failed: {} }
 
     normalize_runtime_review:
       kind: command
-      depends_on: [runtime_review]
+      depends_on: [runtime_review, strip_privacy_context]
       inputs:
         success: { contract: RuntimeReviewerResult }
         failure: {}
+        context: { contract: ReviewContext }
       outputs: { reviewed: { contract: ReviewerResult } }
       config:
         command:
           - node
           - -e
           - >-
-            let s='';const reviewer=process.argv[1];const last=(input,key)=>Array.isArray(input[key])?input[key].at(-1):undefined;const text=value=>{if(typeof value==='string')return value;try{return JSON.stringify(value)}catch{return String(value)}};process.stdin.on('data',chunk=>s+=chunk).on('end',()=>{const input=JSON.parse(s),success=last(input,'success');if(success&&typeof success==='object'&&success.reviewer===reviewer&&(success.status==='complete'||success.status==='failed')){process.stdout.write(JSON.stringify(success));return}const candidate=success??last(input,'failure'),raw=candidate&&typeof candidate==='object'&&typeof candidate.error==='string'?candidate.error:text(candidate??'reviewer ended without a contract-valid handoff'),failure=raw.slice(0,2048);process.stdout.write(JSON.stringify({reviewer,status:'failed',summary:reviewer+' reviewer failed before producing a contract-valid result: '+failure,findings:[]}))});
+            let s='';const reviewer=process.argv[1];const last=(input,key)=>Array.isArray(input[key])?input[key].at(-1):undefined;const text=value=>{if(typeof value==='string')return value;try{return JSON.stringify(value)}catch{return String(value)}};process.stdin.on('data',chunk=>s+=chunk).on('end',()=>{const input=JSON.parse(s),success=last(input,'success');if(success&&typeof success==='object'&&success.reviewer===reviewer&&(success.status==='complete'||success.status==='failed')){process.stdout.write(JSON.stringify(success));return}const context=last(input,'context'),unreviewed_files=Array.isArray(context?.changed_files)?context.changed_files:[],candidate=success??last(input,'failure'),raw=candidate&&typeof candidate==='object'&&typeof candidate.error==='string'?candidate.error:text(candidate??'reviewer ended without a contract-valid handoff'),failure=raw.slice(0,2048);process.stdout.write(JSON.stringify({reviewer,status:'failed',summary:reviewer+' reviewer failed before producing a contract-valid result: '+failure,reviewed_files:[],unreviewed_files,evidence_truncated:true,findings:[]}))});
           - runtime
         stdin_field: "$inputs"
         timeout_ms: 10000
-        capture_limit: 12000
+        capture_limit: 400000
         success_port: reviewed
         failure_port: reviewed
         parse_stdout: json
@@ -1207,27 +1381,28 @@ spec:
       agent: security_reviewer
       allowed_builtin_tools: [Read, Grep, Glob, LS]
       allowed_dag_tools: [handoff]
-      workspace_access: { writable_paths: [], readonly_paths: [repository] }
+      workspace_access: { writable_paths: [], readonly_paths: [repository, review-evidence] }
       inputs: { context: { contract: ReviewContext } }
       outputs: { reviewed: { contract: SecurityReviewerResult }, failed: {} }
 
     normalize_security_review:
       kind: command
-      depends_on: [security_review]
+      depends_on: [security_review, strip_privacy_context]
       inputs:
         success: { contract: SecurityReviewerResult }
         failure: {}
+        context: { contract: ReviewContext }
       outputs: { reviewed: { contract: ReviewerResult } }
       config:
         command:
           - node
           - -e
           - >-
-            let s='';const reviewer=process.argv[1];const last=(input,key)=>Array.isArray(input[key])?input[key].at(-1):undefined;const text=value=>{if(typeof value==='string')return value;try{return JSON.stringify(value)}catch{return String(value)}};process.stdin.on('data',chunk=>s+=chunk).on('end',()=>{const input=JSON.parse(s),success=last(input,'success');if(success&&typeof success==='object'&&success.reviewer===reviewer&&(success.status==='complete'||success.status==='failed')){process.stdout.write(JSON.stringify(success));return}const candidate=success??last(input,'failure'),raw=candidate&&typeof candidate==='object'&&typeof candidate.error==='string'?candidate.error:text(candidate??'reviewer ended without a contract-valid handoff'),failure=raw.slice(0,2048);process.stdout.write(JSON.stringify({reviewer,status:'failed',summary:reviewer+' reviewer failed before producing a contract-valid result: '+failure,findings:[]}))});
+            let s='';const reviewer=process.argv[1];const last=(input,key)=>Array.isArray(input[key])?input[key].at(-1):undefined;const text=value=>{if(typeof value==='string')return value;try{return JSON.stringify(value)}catch{return String(value)}};process.stdin.on('data',chunk=>s+=chunk).on('end',()=>{const input=JSON.parse(s),success=last(input,'success');if(success&&typeof success==='object'&&success.reviewer===reviewer&&(success.status==='complete'||success.status==='failed')){process.stdout.write(JSON.stringify(success));return}const context=last(input,'context'),unreviewed_files=Array.isArray(context?.changed_files)?context.changed_files:[],candidate=success??last(input,'failure'),raw=candidate&&typeof candidate==='object'&&typeof candidate.error==='string'?candidate.error:text(candidate??'reviewer ended without a contract-valid handoff'),failure=raw.slice(0,2048);process.stdout.write(JSON.stringify({reviewer,status:'failed',summary:reviewer+' reviewer failed before producing a contract-valid result: '+failure,reviewed_files:[],unreviewed_files,evidence_truncated:true,findings:[]}))});
           - security
         stdin_field: "$inputs"
         timeout_ms: 10000
-        capture_limit: 12000
+        capture_limit: 400000
         success_port: reviewed
         failure_port: reviewed
         parse_stdout: json
@@ -1238,27 +1413,28 @@ spec:
       agent: test_reviewer
       allowed_builtin_tools: [Read, Grep, Glob, LS]
       allowed_dag_tools: [handoff]
-      workspace_access: { writable_paths: [], readonly_paths: [repository] }
+      workspace_access: { writable_paths: [], readonly_paths: [repository, review-evidence] }
       inputs: { context: { contract: ReviewContext } }
       outputs: { reviewed: { contract: TestReviewerResult }, failed: {} }
 
     normalize_test_review:
       kind: command
-      depends_on: [test_review]
+      depends_on: [test_review, strip_privacy_context]
       inputs:
         success: { contract: TestReviewerResult }
         failure: {}
+        context: { contract: ReviewContext }
       outputs: { reviewed: { contract: ReviewerResult } }
       config:
         command:
           - node
           - -e
           - >-
-            let s='';const reviewer=process.argv[1];const last=(input,key)=>Array.isArray(input[key])?input[key].at(-1):undefined;const text=value=>{if(typeof value==='string')return value;try{return JSON.stringify(value)}catch{return String(value)}};process.stdin.on('data',chunk=>s+=chunk).on('end',()=>{const input=JSON.parse(s),success=last(input,'success');if(success&&typeof success==='object'&&success.reviewer===reviewer&&(success.status==='complete'||success.status==='failed')){process.stdout.write(JSON.stringify(success));return}const candidate=success??last(input,'failure'),raw=candidate&&typeof candidate==='object'&&typeof candidate.error==='string'?candidate.error:text(candidate??'reviewer ended without a contract-valid handoff'),failure=raw.slice(0,2048);process.stdout.write(JSON.stringify({reviewer,status:'failed',summary:reviewer+' reviewer failed before producing a contract-valid result: '+failure,findings:[]}))});
+            let s='';const reviewer=process.argv[1];const last=(input,key)=>Array.isArray(input[key])?input[key].at(-1):undefined;const text=value=>{if(typeof value==='string')return value;try{return JSON.stringify(value)}catch{return String(value)}};process.stdin.on('data',chunk=>s+=chunk).on('end',()=>{const input=JSON.parse(s),success=last(input,'success');if(success&&typeof success==='object'&&success.reviewer===reviewer&&(success.status==='complete'||success.status==='failed')){process.stdout.write(JSON.stringify(success));return}const context=last(input,'context'),unreviewed_files=Array.isArray(context?.changed_files)?context.changed_files:[],candidate=success??last(input,'failure'),raw=candidate&&typeof candidate==='object'&&typeof candidate.error==='string'?candidate.error:text(candidate??'reviewer ended without a contract-valid handoff'),failure=raw.slice(0,2048);process.stdout.write(JSON.stringify({reviewer,status:'failed',summary:reviewer+' reviewer failed before producing a contract-valid result: '+failure,reviewed_files:[],unreviewed_files,evidence_truncated:true,findings:[]}))});
           - tests
         stdin_field: "$inputs"
         timeout_ms: 10000
-        capture_limit: 12000
+        capture_limit: 400000
         success_port: reviewed
         failure_port: reviewed
         parse_stdout: json
@@ -1269,27 +1445,28 @@ spec:
       agent: frontend_reviewer
       allowed_builtin_tools: [Read, Grep, Glob, LS]
       allowed_dag_tools: [handoff]
-      workspace_access: { writable_paths: [], readonly_paths: [repository] }
+      workspace_access: { writable_paths: [], readonly_paths: [repository, review-evidence] }
       inputs: { context: { contract: ReviewContext } }
       outputs: { reviewed: { contract: FrontendReviewerResult }, failed: {} }
 
     normalize_frontend_review:
       kind: command
-      depends_on: [frontend_review]
+      depends_on: [frontend_review, strip_privacy_context]
       inputs:
         success: { contract: FrontendReviewerResult }
         failure: {}
+        context: { contract: ReviewContext }
       outputs: { reviewed: { contract: ReviewerResult } }
       config:
         command:
           - node
           - -e
           - >-
-            let s='';const reviewer=process.argv[1];const last=(input,key)=>Array.isArray(input[key])?input[key].at(-1):undefined;const text=value=>{if(typeof value==='string')return value;try{return JSON.stringify(value)}catch{return String(value)}};process.stdin.on('data',chunk=>s+=chunk).on('end',()=>{const input=JSON.parse(s),success=last(input,'success');if(success&&typeof success==='object'&&success.reviewer===reviewer&&(success.status==='complete'||success.status==='failed')){process.stdout.write(JSON.stringify(success));return}const candidate=success??last(input,'failure'),raw=candidate&&typeof candidate==='object'&&typeof candidate.error==='string'?candidate.error:text(candidate??'reviewer ended without a contract-valid handoff'),failure=raw.slice(0,2048);process.stdout.write(JSON.stringify({reviewer,status:'failed',summary:reviewer+' reviewer failed before producing a contract-valid result: '+failure,findings:[]}))});
+            let s='';const reviewer=process.argv[1];const last=(input,key)=>Array.isArray(input[key])?input[key].at(-1):undefined;const text=value=>{if(typeof value==='string')return value;try{return JSON.stringify(value)}catch{return String(value)}};process.stdin.on('data',chunk=>s+=chunk).on('end',()=>{const input=JSON.parse(s),success=last(input,'success');if(success&&typeof success==='object'&&success.reviewer===reviewer&&(success.status==='complete'||success.status==='failed')){process.stdout.write(JSON.stringify(success));return}const context=last(input,'context'),unreviewed_files=Array.isArray(context?.changed_files)?context.changed_files:[],candidate=success??last(input,'failure'),raw=candidate&&typeof candidate==='object'&&typeof candidate.error==='string'?candidate.error:text(candidate??'reviewer ended without a contract-valid handoff'),failure=raw.slice(0,2048);process.stdout.write(JSON.stringify({reviewer,status:'failed',summary:reviewer+' reviewer failed before producing a contract-valid result: '+failure,reviewed_files:[],unreviewed_files,evidence_truncated:true,findings:[]}))});
           - frontend
         stdin_field: "$inputs"
         timeout_ms: 10000
-        capture_limit: 12000
+        capture_limit: 400000
         success_port: reviewed
         failure_port: reviewed
         parse_stdout: json
@@ -1315,7 +1492,7 @@ spec:
       agent: synthesizer
       allowed_builtin_tools: []
       allowed_dag_tools: [handoff]
-      workspace_access: { writable_paths: [], readonly_paths: [repository] }
+      workspace_access: { writable_paths: [], readonly_paths: [repository, review-evidence] }
       inputs:
         context: { contract: ReviewContext }
         reviews: {}
@@ -1326,7 +1503,7 @@ spec:
       agent: evidence_voter
       allowed_builtin_tools: [Read, Grep, Glob, LS]
       allowed_dag_tools: [handoff]
-      workspace_access: { writable_paths: [], readonly_paths: [repository] }
+      workspace_access: { writable_paths: [], readonly_paths: [repository, review-evidence] }
       inputs:
         report: { contract: DraftReviewReport }
         context: { contract: ReviewContext }
@@ -1337,7 +1514,7 @@ spec:
       agent: false_positive_voter
       allowed_builtin_tools: [Read, Grep, Glob, LS]
       allowed_dag_tools: [handoff]
-      workspace_access: { writable_paths: [], readonly_paths: [repository] }
+      workspace_access: { writable_paths: [], readonly_paths: [repository, review-evidence] }
       inputs:
         report: { contract: DraftReviewReport }
         context: { contract: ReviewContext }
@@ -1348,7 +1525,7 @@ spec:
       agent: coverage_voter
       allowed_builtin_tools: []
       allowed_dag_tools: [handoff]
-      workspace_access: { writable_paths: [], readonly_paths: [repository] }
+      workspace_access: { writable_paths: [], readonly_paths: [repository, review-evidence] }
       inputs: { report: { contract: DraftReviewReport } }
       outputs: { voted: { contract: CoverageVote }, failed: {} }
 
@@ -1385,7 +1562,7 @@ spec:
       agent: refiner
       allowed_builtin_tools: []
       allowed_dag_tools: [handoff]
-      workspace_access: { writable_paths: [], readonly_paths: [repository] }
+      workspace_access: { writable_paths: [], readonly_paths: [repository, review-evidence] }
       inputs:
         report: { contract: DraftReviewReport }
         verification: {}
@@ -1416,7 +1593,7 @@ spec:
       agent: publisher
       allowed_builtin_tools: []
       allowed_dag_tools: [get_graph_context, handoff]
-      workspace_access: { writable_paths: [], readonly_paths: [repository] }
+      workspace_access: { writable_paths: [], readonly_paths: [repository, review-evidence] }
       inputs:
         review: { contract: FinalReview }
         privacy: { contract: PrivacyReview }
@@ -1516,12 +1693,16 @@ spec:
     - { from: privacy_review.failed, to: normalize_privacy_review.failure, condition: on_failure }
     - { from: runtime_review.reviewed, to: normalize_runtime_review.success }
     - { from: runtime_review.failed, to: normalize_runtime_review.failure, condition: on_failure }
+    - { from: strip_privacy_context.ready, to: normalize_runtime_review.context }
     - { from: security_review.reviewed, to: normalize_security_review.success }
     - { from: security_review.failed, to: normalize_security_review.failure, condition: on_failure }
+    - { from: strip_privacy_context.ready, to: normalize_security_review.context }
     - { from: test_review.reviewed, to: normalize_test_review.success }
     - { from: test_review.failed, to: normalize_test_review.failure, condition: on_failure }
+    - { from: strip_privacy_context.ready, to: normalize_test_review.context }
     - { from: frontend_review.reviewed, to: normalize_frontend_review.success }
     - { from: frontend_review.failed, to: normalize_frontend_review.failure, condition: on_failure }
+    - { from: strip_privacy_context.ready, to: normalize_frontend_review.context }
     - { from: normalize_runtime_review.reviewed, to: collect_reviews.runtime }
     - { from: normalize_security_review.reviewed, to: collect_reviews.security }
     - { from: normalize_test_review.reviewed, to: collect_reviews.tests }

--- a/homerail_manager/tests/pr-review-scenario.test.ts
+++ b/homerail_manager/tests/pr-review-scenario.test.ts
@@ -45,6 +45,9 @@ function passingReviewReport(): Record<string, unknown> {
       reviewer,
       status: "complete",
       summary: `${reviewer} review complete`,
+      reviewed_files: ["src/run.ts"],
+      unreviewed_files: [],
+      evidence_truncated: false,
       findings: [],
     })),
   };
@@ -60,7 +63,7 @@ function installPrepareCommandStub(
   prepare.gateway_config.command = [
     "node",
     "-e",
-    "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const i=JSON.parse(s),r=Array.isArray(i.request)?i.request.at(-1):undefined,p=r?.input?.payload;if(!p)throw new Error('missing request');process.stdout.write(JSON.stringify({repo:p.repo,pr:p.pr,base:p.base,head:p.head,repository_path:'/workspace/repository',changed_files:['src/run.ts'],diff_stat:'1 file changed',diff_patch:'diff --git a/src/run.ts b/src/run.ts',diff_truncated:" + JSON.stringify(diffTruncated) + ",commit_metadata:[],commit_metadata_truncated:false}))})",
+    "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const i=JSON.parse(s),r=Array.isArray(i.request)?i.request.at(-1):undefined,p=r?.input?.payload;if(!p)throw new Error('missing request');process.stdout.write(JSON.stringify({repo:p.repo,pr:p.pr,base:p.base,head:p.head,repository_path:'/workspace/repository',changed_files:['src/run.ts'],diff_stat:'1 file changed',diff_patch:'diff --git a/src/run.ts b/src/run.ts',diff_chunks:[{index:1,path:'review-evidence/diff-0001.patch',bytes:39,files:['src/run.ts']}],diff_bytes:39,diff_truncated:" + JSON.stringify(diffTruncated) + ",commit_metadata:[],commit_metadata_truncated:false}))})",
   ];
 }
 
@@ -139,6 +142,9 @@ describe("PR Review scenario assets", () => {
       reviewer: "runtime",
       status: "complete",
       summary: "Runtime review complete",
+      reviewed_files: ["src/run.ts"],
+      unreviewed_files: [],
+      evidence_truncated: false,
       findings: [],
     };
     expect(validateJsonContract(result.canonical?.contracts.RuntimeReviewerResult, runtimeResult).valid).toBe(true);
@@ -184,12 +190,12 @@ describe("PR Review scenario assets", () => {
         config: {
           allowed_builtin_tools: ["Glob", "Grep", "LS", "Read"],
           allowed_dag_tools: ["handoff"],
-          workspace_access: { writable_paths: [], readonly_paths: ["repository"] },
+          workspace_access: { writable_paths: [], readonly_paths: ["repository", "review-evidence"] },
         },
       });
       expect(nodes.find((node) => node.id === `normalize_${reviewer}_review`)).toMatchObject({
         kind: "command",
-        depends_on: [`${reviewer}_review`],
+        depends_on: expect.arrayContaining([`${reviewer}_review`, "strip_privacy_context"]),
         inputs: expect.arrayContaining([expect.objectContaining({ name: "success", contract })]),
         outputs: [expect.objectContaining({ name: "reviewed", contract: "ReviewerResult" })],
         config: expect.objectContaining({
@@ -203,7 +209,7 @@ describe("PR Review scenario assets", () => {
     expect(nodes.find((node) => node.id === "privacy_review")?.config).toMatchObject({
       allowed_builtin_tools: ["Glob", "Grep", "LS", "Read"],
       allowed_dag_tools: ["handoff"],
-      workspace_access: { writable_paths: [], readonly_paths: ["repository"] },
+      workspace_access: { writable_paths: [], readonly_paths: ["repository", "review-evidence"] },
     });
     expect(nodes.find((node) => node.id === "strip_privacy_context")).toMatchObject({
       kind: "command",
@@ -232,7 +238,7 @@ describe("PR Review scenario assets", () => {
         config: expect.objectContaining({
           allowed_builtin_tools: ["Glob", "Grep", "LS", "Read"],
           allowed_dag_tools: ["handoff"],
-          workspace_access: { writable_paths: [], readonly_paths: ["repository"] },
+          workspace_access: { writable_paths: [], readonly_paths: ["repository", "review-evidence"] },
         }),
         inputs: expect.arrayContaining([
           expect.objectContaining({ name: "report", contract: "DraftReviewReport" }),
@@ -268,17 +274,17 @@ describe("PR Review scenario assets", () => {
     expect(nodes.find((node) => node.agent === "publisher")?.config).toMatchObject({
       allowed_builtin_tools: [],
       allowed_dag_tools: ["get_graph_context", "handoff"],
-      workspace_access: { writable_paths: [], readonly_paths: ["repository"] },
+      workspace_access: { writable_paths: [], readonly_paths: ["repository", "review-evidence"] },
     });
     for (const nodeId of ["synthesize", "coverage_vote", "refine"]) {
       expect(nodes.find((node) => node.id === nodeId)?.config).toMatchObject({
         allowed_builtin_tools: [],
-        workspace_access: { writable_paths: [], readonly_paths: ["repository"] },
+        workspace_access: { writable_paths: [], readonly_paths: ["repository", "review-evidence"] },
       });
     }
     for (const node of nodes.filter((node) => node.kind === "agent")) {
       expect(node.config).toMatchObject({
-        workspace_access: { writable_paths: [], readonly_paths: ["repository"] },
+        workspace_access: { writable_paths: [], readonly_paths: ["repository", "review-evidence"] },
       });
     }
     const agents = parseWorkflowSource(source).meta.agents ?? {};
@@ -394,6 +400,13 @@ describe("PR Review scenario assets", () => {
       changed_files: ["src/run.ts"],
       diff_stat: "1 file changed",
       diff_patch: "diff --git a/src/run.ts b/src/run.ts",
+      diff_chunks: [{
+        index: 1,
+        path: "review-evidence/diff-0001.patch",
+        bytes: 39,
+        files: ["src/run.ts"],
+      }],
+      diff_bytes: 39,
       diff_truncated: false,
     })).toMatchObject({ valid: true });
     expect(validateJsonContract(contracts.PreparedReviewContext, {
@@ -405,6 +418,13 @@ describe("PR Review scenario assets", () => {
       changed_files: ["src/run.ts"],
       diff_stat: "1 file changed",
       diff_patch: "diff --git a/src/run.ts b/src/run.ts",
+      diff_chunks: [{
+        index: 1,
+        path: "review-evidence/diff-0001.patch",
+        bytes: 39,
+        files: ["src/run.ts"],
+      }],
+      diff_bytes: 39,
       diff_truncated: false,
       commit_metadata: [],
       commit_metadata_truncated: false,
@@ -429,6 +449,13 @@ describe("PR Review scenario assets", () => {
       changed_files: ["src/run.ts"],
       diff_stat: "1 file changed",
       diff_patch: "diff --git a/src/run.ts b/src/run.ts\n... truncated",
+      diff_chunks: [{
+        index: 1,
+        path: "review-evidence/diff-0001.patch",
+        bytes: 39,
+        files: ["src/run.ts"],
+      }],
+      diff_bytes: 50_000_000,
       diff_truncated: true,
     })).toMatchObject({ valid: true });
     const finalReview = {
@@ -532,7 +559,7 @@ describe("PR Review scenario assets", () => {
   }, 30_000);
 
   it.runIf(process.platform !== "win32")(
-    "executes production prepare truncation with deterministic Git output",
+    "splits a large production diff into bounded deterministic evidence chunks",
     () => {
       const cwd = path.join(tmpHome, "prepare-truncation");
       const bin = path.join(cwd, "bin");
@@ -572,6 +599,8 @@ describe("PR Review scenario assets", () => {
         head: string;
         changed_files: string[];
         diff_patch: string;
+        diff_chunks: Array<{ index: number; path: string; bytes: number; files: string[] }>;
+        diff_bytes: number;
         diff_truncated: boolean;
         commit_metadata: Array<{ commit: string; subject: string }>;
         commit_metadata_truncated: boolean;
@@ -579,12 +608,20 @@ describe("PR Review scenario assets", () => {
       expect(context).toMatchObject({
         head,
         changed_files: ["src/quoted.ts"],
-        diff_truncated: true,
+        diff_bytes: 700000,
+        diff_truncated: false,
         commit_metadata: [expect.objectContaining({ commit: head, subject: "Example change" })],
         commit_metadata_truncated: false,
       });
-      expect(context.diff_patch).toContain("HomeRail diff truncated by deterministic evidence limit");
-      expect(context.diff_patch.length).toBeLessThan(500000);
+      expect(context.diff_patch).toContain("HomeRail full diff continues in");
+      expect(context.diff_patch.length).toBeLessThan(150000);
+      expect(context.diff_chunks.length).toBeGreaterThan(1);
+      expect(context.diff_chunks.every((chunk) =>
+        chunk.bytes <= 120000 &&
+        chunk.files.includes("src/quoted.ts") &&
+        fs.existsSync(path.join(cwd, chunk.path))
+      )).toBe(true);
+      expect(context.diff_chunks.reduce((total, chunk) => total + chunk.bytes, 0)).toBe(700000);
       expect(Buffer.byteLength(result.stdout, "utf8")).toBeLessThanOrEqual(900000);
     },
     30_000,
@@ -801,16 +838,21 @@ describe("PR Review scenario assets", () => {
     });
   });
 
-  it("keeps the trusted manual GitHub adapter thin and the privacy advisory non-blocking", () => {
+  it("keeps the trusted GitHub adapter thin, owner-only, and ready-triggered", () => {
     const workflow = fs.readFileSync(path.resolve(process.cwd(), "..", ".github", "workflows", "pr-review.yml"), "utf8");
     const runner = fs.readFileSync(path.resolve(process.cwd(), "..", "scripts", "run-stable-dag-runner.sh"), "utf8");
     const reviewRunner = fs.readFileSync(path.resolve(process.cwd(), "..", "scripts", "run-pr-review-stable-runner.sh"), "utf8");
     const parsed = parseYaml(workflow) as { jobs: { review: { env: Record<string, string>; steps: Array<{ name: string; env?: Record<string, string> }> } } };
     expect(workflow).toContain("workflow_dispatch:");
-    expect(workflow).not.toContain("pull_request:");
+    expect(workflow).toContain("pull_request:");
+    expect(workflow).toContain("types: [opened, reopened, ready_for_review]");
+    expect(workflow.slice(workflow.indexOf("on:"), workflow.indexOf("permissions:"))).not.toContain("paths-ignore:");
     expect(workflow).not.toContain("pull_request_target:");
     expect(workflow).toContain("github.event_name == 'workflow_dispatch'");
     expect(workflow).toContain("github.actor == 'xiaotianfotos'");
+    expect(workflow).toContain("github.event.pull_request.user.login == 'xiaotianfotos'");
+    expect(workflow).toContain("github.event.pull_request.draft == false");
+    expect(workflow).toContain("github.event.pull_request.head.repo.full_name == github.repository");
     expect(workflow).toContain("continue-on-error: true");
     expect(workflow).toContain("Privacy advisory (human inspection only)");
     expect(workflow).toContain("run-pr-review-stable-runner.sh");
@@ -881,6 +923,17 @@ describe("PR Review scenario assets", () => {
       { ...passingReviewReport(), status: "inconclusive" },
       { passed: false, successes: 1, total: 3, threshold: 2 },
     ).status).toBe(0);
+    const incompleteCoverage = passingReviewReport();
+    const firstReviewer = (incompleteCoverage.reviewer_results as Array<Record<string, unknown>>)[0];
+    firstReviewer.unreviewed_files = ["src/missed.ts"];
+    firstReviewer.evidence_truncated = true;
+    const incomplete = runValidator(
+      "completed",
+      incompleteCoverage,
+      { passed: true, successes: 2, total: 3, threshold: 2 },
+    );
+    expect(incomplete.status).toBe(1);
+    expect(incomplete.stderr).toContain("left files unreviewed");
 
     const invalid = runValidator(
       "completed",
@@ -953,6 +1006,9 @@ describe("PR Review scenario assets", () => {
         reviewer: category,
         status: "complete",
         summary: `${category} review complete`,
+        reviewed_files: ["src/run.ts"],
+        unreviewed_files: [],
+        evidence_truncated: false,
         findings: [],
       });
     }
@@ -1067,6 +1123,9 @@ describe("PR Review scenario assets", () => {
       reviewer,
       status: "failed",
       summary: `${reviewer} reviewer refused truncated diff evidence`,
+      reviewed_files: [],
+      unreviewed_files: ["src/run.ts"],
+      evidence_truncated: true,
       findings: [],
     }));
     handoffActiveRun(runId, "synthesize", "drafted", {
@@ -1147,6 +1206,9 @@ describe("PR Review scenario assets", () => {
           reviewer: category,
           status: "complete",
           summary: `${category} review complete`,
+          reviewed_files: ["src/run.ts"],
+          unreviewed_files: [],
+          evidence_truncated: false,
           findings: [],
         },
       );
@@ -1165,6 +1227,9 @@ describe("PR Review scenario assets", () => {
     expect(normalized?.content).toMatchObject({
       reviewer: "security",
       status: "failed",
+      reviewed_files: [],
+      unreviewed_files: ["src/run.ts"],
+      evidence_truncated: true,
       findings: [],
     });
     expect(String((normalized?.content as { summary?: unknown } | undefined)?.summary))

--- a/scripts/pr-review-runtime-profile.test.mjs
+++ b/scripts/pr-review-runtime-profile.test.mjs
@@ -114,15 +114,16 @@ test("formal PR Review submits to the durable stable Manager", () => {
   assert.doesNotMatch(workflow, /vars\.HOMERAIL_PR_REVIEW_(?:HOME_TEMPLATE|PRIMARY_MODEL|ARBITER_MODEL)/);
 });
 
-test("formal PR Review runs only when the maintainer dispatches it", () => {
+test("formal PR Review runs for maintainer-owned PRs when they become ready", () => {
   const workflow = fs
     .readFileSync(path.join(root, ".github/workflows/pr-review.yml"), "utf8")
     .replace(/\r\n/g, "\n");
   const eventBlock = workflow.slice(workflow.indexOf("on:\n"), workflow.indexOf("\npermissions:"));
   assert.match(eventBlock, /workflow_dispatch:/);
-  assert.doesNotMatch(eventBlock, /pull_request:/);
-  assert.match(
-    workflow,
-    /if: github\.actor == 'xiaotianfotos' && github\.event_name == 'workflow_dispatch'/,
-  );
+  assert.match(eventBlock, /pull_request:\n[\s\S]*types: \[opened, reopened, ready_for_review\]/);
+  assert.doesNotMatch(eventBlock, /paths-ignore:/);
+  assert.match(workflow, /github\.event\.pull_request\.user\.login == 'xiaotianfotos'/);
+  assert.match(workflow, /github\.event\.pull_request\.draft == false/);
+  assert.match(workflow, /github\.event\.pull_request\.head\.repo\.full_name == github\.repository/);
+  assert.doesNotMatch(workflow, /pull_request_target:/);
 });

--- a/scripts/run-stable-dag-runner.sh
+++ b/scripts/run-stable-dag-runner.sh
@@ -11,7 +11,9 @@ case "$TASK" in
     INPUT="${HOMERAIL_PR_REVIEW_INPUT:-}"
     INPUT_FILE="${HOMERAIL_PR_REVIEW_INPUT_FILE:-}"
     ARTIFACT_DIR="${HOMERAIL_PR_REVIEW_ARTIFACT_DIR:-${GITHUB_WORKSPACE:-$PWD}/artifacts/pr-review}"
-    TIMEOUT_SECONDS="${HOMERAIL_PR_REVIEW_TIMEOUT_SECONDS:-5400}"
+    # Leave twenty minutes inside the 90-minute Actions job for deterministic
+    # cancellation, artifact retrieval, diagnostics, and upload.
+    TIMEOUT_SECONDS="${HOMERAIL_PR_REVIEW_TIMEOUT_SECONDS:-4200}"
     PROFILE_SCRIPT="$HOMERAIL_STABLE_RELEASE/scripts/configure-pr-review-runtime-profile.mjs"
     ARTIFACT_NAMES=(pr-review.json pr-review.md pr-privacy-review.json)
     ;;
@@ -35,7 +37,7 @@ esac
 stable_hr dag sync "$TASK" >/dev/null
 PROFILE_ID="$("$HOMERAIL_STABLE_NODE" "$PROFILE_SCRIPT")"
 
-if [ -z "$INPUT_FILE" ] && [ "$TASK" = "auto-fix" ] && [ -n "$INPUT" ]; then
+if [ -z "$INPUT_FILE" ] && [ -n "$INPUT" ]; then
   INPUT_FILE="$ARTIFACT_DIR/input.json"
   mkdir -p "$ARTIFACT_DIR"
   printf '%s\n' "$INPUT" >"$INPUT_FILE"
@@ -66,16 +68,33 @@ COMMAND_TMP="$COMMAND_PATH.tmp"
 STDERR_PATH="$ARTIFACT_DIR/command.stderr.log"
 rm -f "$COMMAND_PATH" "$COMMAND_TMP" "$STDERR_PATH"
 
+RUN_ID="${HOMERAIL_STABLE_RUN_ID:-$(
+  "$HOMERAIL_STABLE_NODE" -e 'process.stdout.write(require("node:crypto").randomUUID())'
+)}"
+
+collect_run_evidence() {
+  local run_id="$1"
+  stable_hr dag quick "$run_id" --events 120 >"$ARTIFACT_DIR/dag-quick.txt" 2>&1 || true
+  stable_hr dag chats "$run_id" --tools 50 --raw-tools >"$ARTIFACT_DIR/dag-chats.txt" 2>&1 || true
+  stable_hr dag handoffs "$run_id" --content-limit 8000 >"$ARTIFACT_DIR/dag-handoffs.txt" 2>&1 || true
+  for artifact in "${ARTIFACT_NAMES[@]}"; do
+    stable_hr dag artifact "$run_id" "$artifact" --output "$ARTIFACT_DIR/$artifact" >/dev/null 2>&1 || true
+  done
+  if [ "$TASK" = "auto-fix" ]; then
+    for artifact in candidate-v2.json candidate-v2.patch candidate-v1.json candidate-v1.patch; do
+      stable_hr dag artifact "$run_id" "$artifact" --output "$ARTIFACT_DIR/$artifact" >/dev/null 2>&1 || true
+    done
+  fi
+}
+
 RUN_ARGS=(
   --json dag run-template "$TASK"
   --input "$INPUT"
   --profile "$PROFILE_ID"
   --wait
   --timeout "$TIMEOUT_SECONDS"
+  --run-id "$RUN_ID"
 )
-if [ -n "${HOMERAIL_STABLE_RUN_ID:-}" ]; then
-  RUN_ARGS+=(--run-id "$HOMERAIL_STABLE_RUN_ID")
-fi
 if ! stable_hr "${RUN_ARGS[@]}" \
   >"$COMMAND_TMP" 2> >(tee "$STDERR_PATH" >&2); then
   if [ -s "$COMMAND_TMP" ]; then
@@ -83,16 +102,13 @@ if ! stable_hr "${RUN_ARGS[@]}" \
   else
     rm -f "$COMMAND_TMP"
   fi
-  if [ "$TASK" = "auto-fix" ] && [ -n "${HOMERAIL_STABLE_RUN_ID:-}" ]; then
-    stable_hr stop "$HOMERAIL_STABLE_RUN_ID" >/dev/null 2>&1 || true
-    stable_hr dag quick "$HOMERAIL_STABLE_RUN_ID" --events 80 >"$ARTIFACT_DIR/dag-quick.txt" 2>&1 || true
-    stable_hr dag chats "$HOMERAIL_STABLE_RUN_ID" --tools 30 --raw-tools >"$ARTIFACT_DIR/dag-chats.txt" 2>&1 || true
-    stable_hr dag handoffs "$HOMERAIL_STABLE_RUN_ID" --content-limit 4000 >"$ARTIFACT_DIR/dag-handoffs.txt" 2>&1 || true
-    for artifact in candidate-v2.json candidate-v2.patch candidate-v1.json candidate-v1.patch; do
-      stable_hr dag artifact "$HOMERAIL_STABLE_RUN_ID" "$artifact" --output "$ARTIFACT_DIR/$artifact" >/dev/null 2>&1 || true
-    done
+  stable_hr stop "$RUN_ID" >/dev/null 2>&1 || true
+  collect_run_evidence "$RUN_ID"
+  printf '%s\n' "$RUN_ID" >"$ARTIFACT_DIR/run-id.txt"
+  printf '%s\n' "$HOMERAIL_STABLE_REVISION" >"$ARTIFACT_DIR/manager-revision.txt"
+  if [ "$TASK" = "auto-fix" ]; then
     for _attempt in 1 2 3 4 5; do
-      checkpoint_result="$("$HOMERAIL_STABLE_NODE" "$CHECKPOINT_SCRIPT" record "$INPUT_FILE" "$HOMERAIL_STABLE_RUN_ID" 2>/dev/null || true)"
+      checkpoint_result="$("$HOMERAIL_STABLE_NODE" "$CHECKPOINT_SCRIPT" record "$INPUT_FILE" "$RUN_ID" 2>/dev/null || true)"
       if [[ "$checkpoint_result" == *'"recorded":true'* ]]; then
         printf '%s\n' "$checkpoint_result" >"$ARTIFACT_DIR/checkpoint.json"
         break
@@ -105,7 +121,7 @@ fi
 mv "$COMMAND_TMP" "$COMMAND_PATH"
 [ -s "$STDERR_PATH" ] || rm -f "$STDERR_PATH"
 
-RUN_ID="$(
+COMPLETED_RUN_ID="$(
   "$HOMERAIL_STABLE_NODE" -e '
     const fs=require("fs");
     const value=JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
@@ -113,6 +129,11 @@ RUN_ID="$(
     process.stdout.write(value.run_id);
   ' "$COMMAND_PATH"
 )"
+if [ "$COMPLETED_RUN_ID" != "$RUN_ID" ]; then
+  echo "Stable DAG returned run id $COMPLETED_RUN_ID instead of requested id $RUN_ID." >&2
+  collect_run_evidence "$RUN_ID"
+  exit 1
+fi
 RUN_STATUS="$(
   "$HOMERAIL_STABLE_NODE" -e '
     const fs=require("fs");
@@ -122,15 +143,12 @@ RUN_STATUS="$(
 )"
 
 if [ "$RUN_STATUS" != "completed" ]; then
-  stable_hr dag quick "$RUN_ID" --events 80 >"$ARTIFACT_DIR/dag-quick.txt" 2>&1 || true
-  stable_hr dag chats "$RUN_ID" --tools 30 --raw-tools >"$ARTIFACT_DIR/dag-chats.txt" 2>&1 || true
-  stable_hr dag handoffs "$RUN_ID" --content-limit 4000 >"$ARTIFACT_DIR/dag-handoffs.txt" 2>&1 || true
+  collect_run_evidence "$RUN_ID"
   if [ "$TASK" = "auto-fix" ]; then
-    for artifact in candidate-v2.json candidate-v2.patch candidate-v1.json candidate-v1.patch; do
-      stable_hr dag artifact "$RUN_ID" "$artifact" --output "$ARTIFACT_DIR/$artifact" >/dev/null 2>&1 || true
-    done
     "$HOMERAIL_STABLE_NODE" "$CHECKPOINT_SCRIPT" record "$INPUT_FILE" "$RUN_ID" >"$ARTIFACT_DIR/checkpoint.json" || true
   fi
+  printf '%s\n' "$RUN_ID" >"$ARTIFACT_DIR/run-id.txt"
+  printf '%s\n' "$HOMERAIL_STABLE_REVISION" >"$ARTIFACT_DIR/manager-revision.txt"
   echo "$TASK DAG ended with status $RUN_STATUS (run $RUN_ID)." >&2
   exit 1
 fi

--- a/scripts/stable-automation-contracts.test.mjs
+++ b/scripts/stable-automation-contracts.test.mjs
@@ -13,6 +13,12 @@ test("stable runner uses the deployed release and never starts a transient Manag
   assert.match(bootstrap, /HOMERAIL_STABLE_RELEASE=.*readlink -f.*current/);
   assert.match(bootstrap, /dag-mutation\.token/);
   assert.match(runner, /\$HOMERAIL_STABLE_RELEASE\/scripts\/configure-/);
+  assert.match(runner, /HOMERAIL_PR_REVIEW_TIMEOUT_SECONDS:-4200/);
+  assert.match(runner, /collect_run_evidence/);
+  assert.match(runner, /dag quick "\$run_id" --events 120/);
+  assert.match(runner, /dag chats "\$run_id" --tools 50 --raw-tools/);
+  assert.match(runner, /dag handoffs "\$run_id" --content-limit 8000/);
+  assert.match(runner, /--run-id "\$RUN_ID"/);
   assert.doesNotMatch(runner, /npm run install:all|build:packages|run-pr-review-live-runner|docker compose/);
   assert.match(reviewWorkflow, /adapter_mode=release/);
   assert.match(reviewWorkflow, /steps\.stable\.outputs\.release }}\/scripts\/run-pr-review-stable-runner\.sh/);
@@ -89,7 +95,7 @@ test("Auto Fix keeps model selection local and publishes only a human-gated Draf
     "inline Auto Fix input must be materialized before checkpoint hydration",
   );
   assert.match(stableRunner, /candidate-v2\.json candidate-v2\.patch candidate-v1\.json candidate-v1\.patch/);
-  assert.match(stableRunner, /stable_hr stop "\$HOMERAIL_STABLE_RUN_ID"/);
+  assert.match(stableRunner, /stable_hr stop "\$RUN_ID"/);
   assert.match(workflow, /Finalize durable candidate checkpoint/);
   assert.match(workflow, /steps\.publish\.outcome/);
   assert.doesNotMatch(stableRunner, /start --host|install:all|build:packages/);

--- a/scripts/validate-pr-review-artifacts.mjs
+++ b/scripts/validate-pr-review-artifacts.mjs
@@ -49,6 +49,26 @@ export function validatePrReviewArtifacts(command, publication, markdown) {
   if (report.status === "findings") {
     invariant(Number.isInteger(report.actionable_count) && report.actionable_count > 0, "a findings report has no actionable findings");
   }
+  invariant(
+    Array.isArray(report.reviewer_results) && report.reviewer_results.length === 4,
+    "report does not contain four reviewer results",
+  );
+  const reviewerNames = new Set();
+  for (const reviewer of report.reviewer_results) {
+    invariant(reviewer && typeof reviewer === "object" && !Array.isArray(reviewer), "reviewer result is not an object");
+    invariant(["runtime", "security", "tests", "frontend"].includes(reviewer.reviewer), "reviewer result has an invalid identity");
+    reviewerNames.add(reviewer.reviewer);
+    invariant(["complete", "failed"].includes(reviewer.status), `${reviewer.reviewer} reviewer status is invalid`);
+    invariant(Array.isArray(reviewer.reviewed_files), `${reviewer.reviewer} reviewed_files is missing`);
+    invariant(Array.isArray(reviewer.unreviewed_files), `${reviewer.reviewer} unreviewed_files is missing`);
+    invariant(typeof reviewer.evidence_truncated === "boolean", `${reviewer.reviewer} evidence_truncated is missing`);
+    if (report.status !== "inconclusive") {
+      invariant(reviewer.status === "complete", `${reviewer.reviewer} reviewer did not complete`);
+      invariant(reviewer.unreviewed_files.length === 0, `${reviewer.reviewer} left files unreviewed`);
+      invariant(reviewer.evidence_truncated === false, `${reviewer.reviewer} used truncated evidence`);
+    }
+  }
+  invariant(reviewerNames.size === 4, "report reviewer identities are not distinct");
 
   const runIdLine = `**HomeRail Run ID:** \`${command.run_id}\``;
   invariant(markdown.includes(runIdLine), "Markdown does not contain the exact HomeRail run_id field");


### PR DESCRIPTION
## Summary

- restore automatic PR Review runs for maintainer-owned, same-repository PRs on `opened`, `reopened`, and every `ready_for_review` transition
- keep manual dispatch available and keep fork/community PRs away from the trusted self-hosted review runner
- split large diffs into bounded 120 KB read-only evidence chunks instead of silently truncating a single inline patch
- require each specialist Reviewer to report reviewed files, unreviewed files, and whether evidence was truncated
- reject completed reports that contain incomplete review coverage
- assign a deterministic run ID, enforce a 70-minute internal timeout inside the 90-minute Actions job, and collect DAG state, chats, handoffs, and available artifacts on failure or cancellation

Moving a PR back to Draft and then Ready emits a new `ready_for_review` event, so it intentionally starts a fresh review run.

## Issue #121

This closes the remaining gaps in #121. Existing cold-recovery coverage already verifies that READY nodes are restored and redispatched after a Manager restart; this change adds bounded large-diff evidence, explicit Reviewer coverage, failure artifact collection, and an internal timeout shorter than GitHub Actions.

Closes #121

## Validation

- HomeRail Manager full suite: 138 test files passed, 1 conditionally skipped; 1163 tests passed, 2 skipped
- PR Review scenario and large-diff regression: 13/13 passed
- cold recovery regression: 15/15 passed
- stable automation and PR Review runtime contracts: 9/9 passed
- `git diff --check`, runner shell syntax, and artifact-validator syntax passed

The skipped plugin runtime tests require the local `homerail-plugin-runtime:m6` Docker image, which is not present on this Mac.
