### PR TITLE
Show desktop update progress and install state

### DIFF
--- a/agent-ui/src/components/agent/AgentModeTopBar.test.ts
+++ b/agent-ui/src/components/agent/AgentModeTopBar.test.ts
@@ -4,6 +4,16 @@ import { http } from '@/api/clients/http-client'
 import { i18n } from '@/plugins/i18n'
 import AgentModeTopBar from './AgentModeTopBar.vue'
 
+function updateStatus(overrides: Partial<DesktopUpdateStatus> = {}): DesktopUpdateStatus {
+  return {
+    supported: true,
+    state: 'not-available',
+    currentVersion: '0.1.0-alpha.1',
+    channel: 'early-access',
+    ...overrides,
+  }
+}
+
 describe('AgentModeTopBar localization', () => {
   let app: App<Element> | null = null
   let root: HTMLElement | null = null
@@ -17,6 +27,7 @@ describe('AgentModeTopBar localization', () => {
     root?.remove()
     app = null
     root = null
+    Reflect.deleteProperty(window, 'homerailDesktop')
     vi.restoreAllMocks()
   })
 
@@ -66,6 +77,46 @@ describe('AgentModeTopBar localization', () => {
       expect(button?.title).toContain('1 个运行等待指令')
       expect(button?.textContent).toContain('1')
       expect(button?.querySelector('.animate-spin')).toBeNull()
+    })
+  })
+
+  it('shows the installing state immediately after restart-to-update is requested', async () => {
+    i18n.global.locale.value = 'en-US'
+    const installUpdate = vi.fn().mockResolvedValue(updateStatus({
+      state: 'installing',
+      installStartedAt: Date.now(),
+      update: { version: '0.1.0-alpha.2' },
+    }))
+    Object.defineProperty(window, 'homerailDesktop', {
+      configurable: true,
+      value: {
+        updateStatus: vi.fn().mockResolvedValue(updateStatus({
+          state: 'downloaded',
+          update: { version: '0.1.0-alpha.2' },
+        })),
+        installUpdate,
+      } satisfies HomeRailDesktopBridge,
+    })
+    root = document.createElement('div')
+    document.body.appendChild(root)
+    app = createApp(AgentModeTopBar, { activeMode: 'text' })
+    app.use(i18n)
+    app.mount(root)
+
+    await vi.waitFor(() => {
+      const button = root?.querySelector<HTMLButtonElement>('[data-testid="desktop-update-install"]')
+      expect(button?.textContent).toContain('Restart to update')
+      expect(button?.disabled).toBe(false)
+    })
+
+    root?.querySelector<HTMLButtonElement>('[data-testid="desktop-update-install"]')?.click()
+
+    await vi.waitFor(() => {
+      const button = root?.querySelector<HTMLButtonElement>('[data-testid="desktop-update-install"]')
+      expect(installUpdate).toHaveBeenCalledOnce()
+      expect(button?.textContent).toContain('Installing update')
+      expect(button?.disabled).toBe(true)
+      expect(button?.getAttribute('aria-busy')).toBe('true')
     })
   })
 })

--- a/agent-ui/src/components/agent/AgentModeTopBar.test.ts
+++ b/agent-ui/src/components/agent/AgentModeTopBar.test.ts
@@ -119,4 +119,55 @@ describe('AgentModeTopBar localization', () => {
       expect(button?.getAttribute('aria-busy')).toBe('true')
     })
   })
+
+  it('offers an explicit update check retry after installation handoff fails', async () => {
+    i18n.global.locale.value = 'en-US'
+    let finishCheck: ((status: DesktopUpdateStatus) => void) | null = null
+    const checkForUpdates = vi.fn(() => new Promise<DesktopUpdateStatus>((resolve) => {
+      finishCheck = resolve
+    }))
+    Object.defineProperty(window, 'homerailDesktop', {
+      configurable: true,
+      value: {
+        updateStatus: vi.fn().mockResolvedValue(updateStatus({
+          state: 'downloaded',
+          update: { version: '0.1.0-alpha.2' },
+        })),
+        installUpdate: vi.fn().mockRejectedValue(new Error('installer handoff timed out')),
+        checkForUpdates,
+      } satisfies HomeRailDesktopBridge,
+    })
+    root = document.createElement('div')
+    document.body.appendChild(root)
+    app = createApp(AgentModeTopBar, { activeMode: 'text' })
+    app.use(i18n)
+    app.mount(root)
+
+    await vi.waitFor(() => {
+      expect(root?.querySelector<HTMLButtonElement>('[data-testid="desktop-update-install"]')?.textContent)
+        .toContain('Restart to update')
+    })
+    root?.querySelector<HTMLButtonElement>('[data-testid="desktop-update-install"]')?.click()
+
+    await vi.waitFor(() => {
+      const button = root?.querySelector<HTMLButtonElement>('[data-testid="desktop-update-install"]')
+      expect(button?.textContent).toContain('Retry update check')
+      expect(button?.disabled).toBe(false)
+      expect(button?.title).toContain('installer handoff timed out')
+    })
+    root?.querySelector<HTMLButtonElement>('[data-testid="desktop-update-install"]')?.click()
+
+    await vi.waitFor(() => {
+      const button = root?.querySelector<HTMLButtonElement>('[data-testid="desktop-update-install"]')
+      expect(checkForUpdates).toHaveBeenCalledOnce()
+      expect(button?.textContent).toContain('Checking for updates')
+      expect(button?.disabled).toBe(true)
+      expect(button?.getAttribute('aria-busy')).toBe('true')
+    })
+
+    finishCheck?.(updateStatus({ state: 'checking' }))
+    await vi.waitFor(() => {
+      expect(root?.querySelector('[data-testid="desktop-update-install"]')).toBeNull()
+    })
+  })
 })

--- a/agent-ui/src/components/agent/AgentModeTopBar.vue
+++ b/agent-ui/src/components/agent/AgentModeTopBar.vue
@@ -43,6 +43,7 @@ const hasWaitingRuns = computed(() => waitingRunCount.value > 0)
 const runtimeRunCount = computed(() => activeRunCount.value + waitingRunCount.value)
 const desktopUpdateStatus = ref<DesktopUpdateStatus | null>(null)
 const installRequestPending = ref(false)
+const retryRequestPending = ref(false)
 let removeUpdateListener: (() => void) | null = null
 
 const runtimeTitle = computed(() => {
@@ -66,6 +67,12 @@ const installFailure = computed(() =>
 const updateInstalling = computed(() =>
   installRequestPending.value || desktopUpdateStatus.value?.state === 'installing',
 )
+const updateActionPending = computed(() =>
+  updateInstalling.value || retryRequestPending.value,
+)
+const updateRetrySupported = computed(() =>
+  Boolean(desktopBridge()?.checkForUpdates),
+)
 const updateActionVisible = computed(() =>
   Boolean(
     desktopUpdateStatus.value?.supported
@@ -77,6 +84,7 @@ const updateActionVisible = computed(() =>
   ),
 )
 const updateButtonTitle = computed(() => {
+  if (retryRequestPending.value) return t('shell.updates.checking')
   if (installFailure.value) {
     return desktopUpdateStatus.value?.error || t('shell.updates.failed')
   }
@@ -85,7 +93,8 @@ const updateButtonTitle = computed(() => {
   return version ? t('shell.updates.downloadedVersion', { version }) : t('shell.updates.downloaded')
 })
 const updateButtonText = computed(() => {
-  if (installFailure.value) return t('shell.updates.failed')
+  if (retryRequestPending.value) return t('shell.updates.checking')
+  if (installFailure.value) return t('shell.updates.retry')
   if (updateInstalling.value) return t('shell.updates.installing')
   return t('shell.updates.restart')
 })
@@ -139,6 +148,7 @@ function startDesktopUpdateWatcher(): void {
     if (status.state === 'installing' || status.state === 'error') {
       installRequestPending.value = false
     }
+    retryRequestPending.value = false
   }) ?? null
 
   void bridge.updateStatus()
@@ -163,17 +173,18 @@ function stopDesktopUpdateWatcher(): void {
 
 async function installDesktopUpdate(): Promise<void> {
   const bridge = desktopBridge()
+  const downloadedStatus = desktopUpdateStatus.value
   if (
     !bridge?.installUpdate
     || updateInstalling.value
-    || desktopUpdateStatus.value?.state !== 'downloaded'
+    || downloadedStatus?.state !== 'downloaded'
   ) return
   installRequestPending.value = true
   try {
     desktopUpdateStatus.value = await bridge.installUpdate()
   } catch (error) {
     desktopUpdateStatus.value = {
-      ...(desktopUpdateStatus.value as DesktopUpdateStatus),
+      ...downloadedStatus,
       state: 'error',
       error: error instanceof Error ? error.message : String(error),
       installStartedAt: Date.now(),
@@ -181,6 +192,36 @@ async function installDesktopUpdate(): Promise<void> {
   } finally {
     installRequestPending.value = false
   }
+}
+
+async function retryDesktopUpdateCheck(): Promise<void> {
+  const bridge = desktopBridge()
+  const failedStatus = desktopUpdateStatus.value
+  if (
+    !bridge?.checkForUpdates
+    || retryRequestPending.value
+    || failedStatus?.state !== 'error'
+    || !failedStatus.installStartedAt
+  ) return
+  retryRequestPending.value = true
+  try {
+    desktopUpdateStatus.value = await bridge.checkForUpdates()
+  } catch (error) {
+    desktopUpdateStatus.value = {
+      ...failedStatus,
+      error: error instanceof Error ? error.message : String(error),
+    }
+  } finally {
+    retryRequestPending.value = false
+  }
+}
+
+function handleDesktopUpdateAction(): void {
+  if (installFailure.value) {
+    void retryDesktopUpdateCheck()
+    return
+  }
+  void installDesktopUpdate()
 }
 
 onMounted(() => {
@@ -239,11 +280,11 @@ onBeforeUnmount(() => {
         :title="updateButtonTitle"
         type="button"
         data-testid="desktop-update-install"
-        :aria-busy="updateInstalling"
-        :disabled="updateInstalling || installFailure"
-        @click="installDesktopUpdate"
+        :aria-busy="updateActionPending"
+        :disabled="updateActionPending || (installFailure && !updateRetrySupported)"
+        @click="handleDesktopUpdateAction"
       >
-        <RotateCcw class="h-4 w-4" :class="updateInstalling ? 'animate-spin' : ''" />
+        <RotateCcw class="h-4 w-4" :class="updateActionPending ? 'animate-spin' : ''" />
         {{ updateButtonText }}
       </button>
       <button

--- a/agent-ui/src/components/agent/AgentModeTopBar.vue
+++ b/agent-ui/src/components/agent/AgentModeTopBar.vue
@@ -42,7 +42,7 @@ const hasActiveRuns = computed(() => activeRunCount.value > 0)
 const hasWaitingRuns = computed(() => waitingRunCount.value > 0)
 const runtimeRunCount = computed(() => activeRunCount.value + waitingRunCount.value)
 const desktopUpdateStatus = ref<DesktopUpdateStatus | null>(null)
-const updateInstalling = ref(false)
+const installRequestPending = ref(false)
 let removeUpdateListener: (() => void) | null = null
 
 const runtimeTitle = computed(() => {
@@ -56,12 +56,38 @@ const runtimeTitle = computed(() => {
   if (hasWaitingRuns.value) return t('shell.dashboard.waiting', { count: waitingRunCount.value })
   return t('shell.dashboard.title')
 })
-const downloadedUpdate = computed(() =>
-  Boolean(desktopUpdateStatus.value?.supported && desktopUpdateStatus.value.state === 'downloaded'),
+const installFailure = computed(() =>
+  Boolean(
+    desktopUpdateStatus.value?.supported
+    && desktopUpdateStatus.value.state === 'error'
+    && desktopUpdateStatus.value.installStartedAt,
+  ),
+)
+const updateInstalling = computed(() =>
+  installRequestPending.value || desktopUpdateStatus.value?.state === 'installing',
+)
+const updateActionVisible = computed(() =>
+  Boolean(
+    desktopUpdateStatus.value?.supported
+    && (
+      desktopUpdateStatus.value.state === 'downloaded'
+      || desktopUpdateStatus.value.state === 'installing'
+      || installFailure.value
+    ),
+  ),
 )
 const updateButtonTitle = computed(() => {
+  if (installFailure.value) {
+    return desktopUpdateStatus.value?.error || t('shell.updates.failed')
+  }
+  if (updateInstalling.value) return t('shell.updates.installing')
   const version = desktopUpdateStatus.value?.update?.version
   return version ? t('shell.updates.downloadedVersion', { version }) : t('shell.updates.downloaded')
+})
+const updateButtonText = computed(() => {
+  if (installFailure.value) return t('shell.updates.failed')
+  if (updateInstalling.value) return t('shell.updates.installing')
+  return t('shell.updates.restart')
 })
 
 async function refreshActiveRuns(): Promise<void> {
@@ -110,12 +136,15 @@ function startDesktopUpdateWatcher(): void {
 
   removeUpdateListener = bridge.onUpdateStatus?.((status) => {
     desktopUpdateStatus.value = status
+    if (status.state === 'installing' || status.state === 'error') {
+      installRequestPending.value = false
+    }
   }) ?? null
 
   void bridge.updateStatus()
     .then((status) => {
       desktopUpdateStatus.value = status
-      if (status.state === 'downloaded' || !bridge.checkForUpdates) return
+      if (status.state === 'downloaded' || status.state === 'installing' || !bridge.checkForUpdates) return
       void bridge.checkForUpdates()
         .then((nextStatus) => {
           desktopUpdateStatus.value = nextStatus
@@ -134,15 +163,23 @@ function stopDesktopUpdateWatcher(): void {
 
 async function installDesktopUpdate(): Promise<void> {
   const bridge = desktopBridge()
-  if (!bridge?.installUpdate || updateInstalling.value) return
-  updateInstalling.value = true
+  if (
+    !bridge?.installUpdate
+    || updateInstalling.value
+    || desktopUpdateStatus.value?.state !== 'downloaded'
+  ) return
+  installRequestPending.value = true
   try {
-    const status = await bridge.installUpdate()
-    if (status.state !== 'downloaded') {
-      updateInstalling.value = false
+    desktopUpdateStatus.value = await bridge.installUpdate()
+  } catch (error) {
+    desktopUpdateStatus.value = {
+      ...(desktopUpdateStatus.value as DesktopUpdateStatus),
+      state: 'error',
+      error: error instanceof Error ? error.message : String(error),
+      installStartedAt: Date.now(),
     }
-  } catch {
-    updateInstalling.value = false
+  } finally {
+    installRequestPending.value = false
   }
 }
 
@@ -197,14 +234,17 @@ onBeforeUnmount(() => {
     <div class="agent-mode-topbar__right flex flex-shrink-0 items-center gap-2">
       <slot name="right" />
       <button
-        v-if="downloadedUpdate"
+        v-if="updateActionVisible"
         class="flex h-9 items-center gap-2 rounded-full border border-[var(--hr-accent-border)] bg-[var(--hr-accent-soft)] px-3 text-sm font-medium text-[var(--hr-accent)] transition-colors hover:opacity-85"
         :title="updateButtonTitle"
         type="button"
+        data-testid="desktop-update-install"
+        :aria-busy="updateInstalling"
+        :disabled="updateInstalling || installFailure"
         @click="installDesktopUpdate"
       >
         <RotateCcw class="h-4 w-4" :class="updateInstalling ? 'animate-spin' : ''" />
-        {{ t('shell.updates.restart') }}
+        {{ updateButtonText }}
       </button>
       <button
         v-if="showRuntime"

--- a/agent-ui/src/components/agent/settings/DesktopUpdateSettings.test.ts
+++ b/agent-ui/src/components/agent/settings/DesktopUpdateSettings.test.ts
@@ -96,6 +96,41 @@ describe('DesktopUpdateSettings', () => {
     expect(setUpdateChannel).not.toHaveBeenCalled()
   })
 
+  it('shows download progress reported by the desktop updater', async () => {
+    mount({
+      updateStatus: vi.fn().mockResolvedValue(updateStatus({
+        state: 'downloading',
+        downloadProgress: {
+          percent: 37.4,
+          transferred: 374,
+          total: 1000,
+          bytesPerSecond: 128,
+        },
+      })),
+      setUpdateChannel: vi.fn(),
+    })
+    await flushUi()
+
+    expect(root?.querySelector('[data-testid="desktop-update-state"]')?.textContent)
+      .toContain('Downloading update… 37%')
+    const progress = root?.querySelector('[data-testid="desktop-update-progress"]')
+    expect(progress?.getAttribute('aria-valuenow')).toBe('37')
+  })
+
+  it('keeps channel switching disabled while the installer takes control', async () => {
+    const setUpdateChannel = vi.fn()
+    mount({
+      updateStatus: vi.fn().mockResolvedValue(updateStatus({ state: 'installing' })),
+      setUpdateChannel,
+    })
+    await flushUi()
+
+    const earlyAccess = root?.querySelector<HTMLButtonElement>('[data-testid="desktop-update-channel-early-access"]')
+    expect(earlyAccess?.disabled).toBe(true)
+    expect(root?.querySelector('[data-testid="desktop-update-state"]')?.textContent)
+      .toContain('Installing update')
+  })
+
   it('shows a channel switch failure instead of swallowing it', async () => {
     mount({
       updateStatus: vi.fn().mockResolvedValue(updateStatus()),

--- a/agent-ui/src/components/agent/settings/DesktopUpdateSettings.vue
+++ b/agent-ui/src/components/agent/settings/DesktopUpdateSettings.vue
@@ -12,11 +12,16 @@ let removeListener: (() => void) | null = null
 
 const channelBusy = computed(() => {
   if (switching.value) return true
-  return ['checking', 'available', 'downloading', 'downloaded'].includes(status.value?.state ?? '')
+  return ['checking', 'available', 'downloading', 'downloaded', 'installing'].includes(status.value?.state ?? '')
 })
 
 const statusText = computed(() => {
   if (!status.value) return ''
+  if (status.value.state === 'downloading' && status.value.downloadProgress) {
+    return t('settings.general.updates.state.downloadingProgress', {
+      percent: Math.round(status.value.downloadProgress.percent),
+    })
+  }
   return t(`settings.general.updates.state.${status.value.state}`)
 })
 
@@ -110,6 +115,21 @@ onBeforeUnmount(() => {
           {{ t('settings.general.updates.currentVersion', { version: status.currentVersion }) }}
           · {{ statusText }}
         </p>
+        <div
+          v-if="status?.state === 'downloading' && status.downloadProgress"
+          class="mt-2 h-1.5 max-w-2xl overflow-hidden rounded-full bg-[var(--hr-surface-2)]"
+          role="progressbar"
+          :aria-label="statusText"
+          aria-valuemin="0"
+          aria-valuemax="100"
+          :aria-valuenow="Math.round(status.downloadProgress.percent)"
+          data-testid="desktop-update-progress"
+        >
+          <div
+            class="h-full rounded-full bg-[var(--hr-accent)] transition-[width]"
+            :style="{ width: `${Math.max(0, Math.min(100, status.downloadProgress.percent))}%` }"
+          />
+        </div>
         <p
           v-if="status?.channelNotice === 'waiting-for-newer-stable'"
           class="mt-2 text-xs leading-5 text-[var(--hr-warning)]"

--- a/agent-ui/src/locales/en-US/settings.json
+++ b/agent-ui/src/locales/en-US/settings.json
@@ -66,13 +66,15 @@
       },
       "currentVersion": "Installed version: {version}",
       "waitingForStable": "This prerelease will stay installed until a newer Stable version is available. HomeRail will not downgrade it.",
-      "error": "Update channel change failed: {message}",
+      "error": "Desktop update failed: {message}",
       "state": {
         "idle": "Ready to check",
         "checking": "Checking for updates…",
         "available": "Update found",
         "downloading": "Downloading update…",
+        "downloadingProgress": "Downloading update… {percent}%",
         "downloaded": "Update downloaded; restart to install",
+        "installing": "Installing update…",
         "not-available": "No newer update on this channel",
         "error": "Update check failed"
       }

--- a/agent-ui/src/locales/en-US/shell.json
+++ b/agent-ui/src/locales/en-US/shell.json
@@ -6,7 +6,9 @@
   "updates": {
     "downloadedVersion": "HomeRail {version} is ready. Restart to install.",
     "downloaded": "An update is ready. Restart to install.",
-    "restart": "Restart to update"
+    "restart": "Restart to update",
+    "installing": "Installing update…",
+    "failed": "Update failed"
   },
   "dashboard": {
     "title": "DAG dashboard",

--- a/agent-ui/src/locales/en-US/shell.json
+++ b/agent-ui/src/locales/en-US/shell.json
@@ -8,7 +8,9 @@
     "downloaded": "An update is ready. Restart to install.",
     "restart": "Restart to update",
     "installing": "Installing update…",
-    "failed": "Update failed"
+    "failed": "Update failed",
+    "retry": "Retry update check",
+    "checking": "Checking for updates…"
   },
   "dashboard": {
     "title": "DAG dashboard",

--- a/agent-ui/src/locales/zh-Hans/settings.json
+++ b/agent-ui/src/locales/zh-Hans/settings.json
@@ -66,13 +66,15 @@
       },
       "currentVersion": "当前安装版本：{version}",
       "waitingForStable": "当前预发布版本会继续保留，直到出现版本号更高的稳定版；HomeRail 不会自动降级。",
-      "error": "更新通道切换失败：{message}",
+      "error": "桌面更新失败：{message}",
       "state": {
         "idle": "可以检查更新",
         "checking": "正在检查更新…",
         "available": "发现新版本",
         "downloading": "正在下载更新…",
+        "downloadingProgress": "正在下载更新… {percent}%",
         "downloaded": "更新已下载，重启后安装",
+        "installing": "正在安装更新…",
         "not-available": "此通道暂无更高版本",
         "error": "更新检查失败"
       }

--- a/agent-ui/src/locales/zh-Hans/shell.json
+++ b/agent-ui/src/locales/zh-Hans/shell.json
@@ -6,7 +6,9 @@
   "updates": {
     "downloadedVersion": "HomeRail {version} 已下载，重启后安装",
     "downloaded": "新版本已下载，重启后安装",
-    "restart": "重启更新"
+    "restart": "重启更新",
+    "installing": "正在安装更新…",
+    "failed": "更新失败"
   },
   "dashboard": {
     "title": "DAG 仪表盘",

--- a/agent-ui/src/locales/zh-Hans/shell.json
+++ b/agent-ui/src/locales/zh-Hans/shell.json
@@ -8,7 +8,9 @@
     "downloaded": "新版本已下载，重启后安装",
     "restart": "重启更新",
     "installing": "正在安装更新…",
-    "failed": "更新失败"
+    "failed": "更新失败",
+    "retry": "重新检查更新",
+    "checking": "正在检查更新…"
   },
   "dashboard": {
     "title": "DAG 仪表盘",

--- a/agent-ui/src/locales/zh-Hant/settings.json
+++ b/agent-ui/src/locales/zh-Hant/settings.json
@@ -66,13 +66,15 @@
       },
       "currentVersion": "目前安裝版本：{version}",
       "waitingForStable": "目前預發佈版本會繼續保留，直到出現版本號更高的穩定版；HomeRail 不會自動降級。",
-      "error": "更新通道切換失敗：{message}",
+      "error": "桌面更新失敗：{message}",
       "state": {
         "idle": "可以檢查更新",
         "checking": "正在檢查更新…",
         "available": "找到新版本",
         "downloading": "正在下載更新…",
+        "downloadingProgress": "正在下載更新… {percent}%",
         "downloaded": "更新已下載，重新啟動後安裝",
+        "installing": "正在安裝更新…",
         "not-available": "此通道暫無更高版本",
         "error": "更新檢查失敗"
       }

--- a/agent-ui/src/locales/zh-Hant/shell.json
+++ b/agent-ui/src/locales/zh-Hant/shell.json
@@ -6,7 +6,9 @@
   "updates": {
     "downloadedVersion": "HomeRail {version} 已下載，重啓後安裝",
     "downloaded": "新版本已下載，重啓後安裝",
-    "restart": "重啓更新"
+    "restart": "重啓更新",
+    "installing": "正在安裝更新…",
+    "failed": "更新失敗"
   },
   "dashboard": {
     "title": "DAG 儀表盤",

--- a/agent-ui/src/locales/zh-Hant/shell.json
+++ b/agent-ui/src/locales/zh-Hant/shell.json
@@ -8,7 +8,9 @@
     "downloaded": "新版本已下載，重啓後安裝",
     "restart": "重啓更新",
     "installing": "正在安裝更新…",
-    "failed": "更新失敗"
+    "failed": "更新失敗",
+    "retry": "重新檢查更新",
+    "checking": "正在檢查更新…"
   },
   "dashboard": {
     "title": "DAG 儀表盤",

--- a/agent-ui/src/types/homerail-desktop.d.ts
+++ b/agent-ui/src/types/homerail-desktop.d.ts
@@ -7,6 +7,7 @@ declare global {
     | 'available'
     | 'downloading'
     | 'downloaded'
+    | 'installing'
     | 'not-available'
     | 'error'
 
@@ -26,6 +27,13 @@ declare global {
     error?: string
     checkedAt?: number
     downloadedAt?: number
+    installStartedAt?: number
+    downloadProgress?: {
+      percent: number
+      transferred: number
+      total: number
+      bytesPerSecond?: number
+    }
   }
 
   interface HomeRailDesktopBridge {


### PR DESCRIPTION
## What changed

- show download percentage and an accessible progress bar in Desktop update settings
- keep update-channel controls locked while installation is in progress
- replace the ambiguous restart spinner with explicit installing and failure states
- let users explicitly recheck for an update after an installation handoff failure
- add localized English, Simplified Chinese, and Traditional Chinese copy
- add component coverage for progress, installing state, and the restart-to-update action

## Why

The current UI does not distinguish a download in progress from a completed download, and clicking **Restart to update** can leave an indefinite spinner with no evidence that the installer has taken control.

## Impact

Users can see when an update is still downloading, are only offered the restart action after download, and receive an explicit installing or recoverable failure state during the Desktop handoff.

## Validation

- targeted updater UI tests: 11 passed
- full Agent UI suite: 87 test files / 464 tests passed
- `npm run typecheck`
- `npm run build`
