### PR TITLE
Increase runtime Action workflow test timeout

### DIFF
--- a/homerail_cli/tests/plugin-commands.test.ts
+++ b/homerail_cli/tests/plugin-commands.test.ts
@@ -345,7 +345,7 @@ describe("plugin PDK workflow", () => {
     await runJson("install", archive, "--staging");
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(process.exitCode).toBeUndefined();
-  });
+  }, 15_000);
 
   it("produces byte-for-byte deterministic archives and refuses accidental overwrite", () => {
     const root = path.join(temporaryRoot, "deterministic");


### PR DESCRIPTION
## Summary
- give the multi-step runtime Action validate/pack/verify/upload test a 15-second timeout
- keep the default timeout for all other CLI tests
- change no production code

## Root cause
Desktop candidate run 30321402265 failed on Windows because this test completed in 5.835 seconds, just beyond Vitest's default 5-second timeout. The preceding candidate run passed the same public Windows suite, confirming timing variance rather than a deterministic functional failure.

## Validation
- targeted test passed 5 consecutive local runs
- full CLI suite reached 256/257 tests locally; the remaining unrelated packaged-UI integration test could not build because this isolated worktree does not have Agent UI dependencies installed
- PR CI and automatic review remain required