### PR TITLE
Accept independently cross-reviewed files in PR Review

### DIFF
--- a/assets/orchestrations/pr-review.yaml.template
+++ b/assets/orchestrations/pr-review.yaml.template
@@ -869,9 +869,11 @@ spec:
         URL prefixes as out of scope.
         Every retained finding
         must have a precise line.
-        Treat a reviewer with evidence_truncated=true or a non-empty
-        unreviewed_files list as failed coverage even if its status says
-        complete. Set status=findings when
+        Treat a reviewer with evidence_truncated=true as failed coverage even
+        if its status says complete. A specialized reviewer may list an
+        out-of-scope path in unreviewed_files only when at least two other
+        completed reviewers list that exact path in reviewed_files; otherwise
+        coverage failed. Set status=findings when
         actionable_count is positive, pass when it is zero, and inconclusive
         if any reviewer failed. Never edit the repository or end with prose.
         Your final action MUST call handoff on drafted with exactly these
@@ -939,9 +941,10 @@ spec:
         hosts. A rejected finding is a successful verifier correction, not a
         reason to reject the whole report. Vote accept when every retained
         finding has a grounded confirmed or rejected verdict, all four
-        reviewer_results have status complete, evidence_truncated=false and
-        empty unreviewed_files, report identity matches input.context, and
-        diff_truncated is false. Vote reject when any
+        reviewer_results have status complete, evidence_truncated=false, and
+        every unreviewed_files entry is covered by reviewed_files from at least
+        two other completed reviewers; report identity must match input.context
+        and diff_truncated must be false. Vote reject when any
         reviewer failed or reported incomplete coverage, the report is inconclusive, evidence is insufficient
         to adjudicate every finding, identity differs, or diff_truncated is
         true. An empty report is acceptable only when the reviewer evidence
@@ -988,8 +991,9 @@ spec:
         finding receives verdict rejected; that correction does not reject the
         whole report. Vote accept when every finding has a grounded confirmed or
         rejected verdict, all four reviewer_results have status complete,
-        evidence_truncated=false and empty unreviewed_files, report identity
-        matches input.context, and diff_truncated is false.
+        evidence_truncated=false, every unreviewed_files entry is covered by
+        reviewed_files from at least two other completed reviewers, report
+        identity matches input.context, and diff_truncated is false.
         Vote reject when any reviewer failed or reported incomplete coverage,
         the report is inconclusive,
         evidence is insufficient to adjudicate every finding, identity differs,
@@ -1004,10 +1008,12 @@ spec:
         Verify that runtime, security, tests, and frontend scopes all produced
         explicit ReviewerResult records and that the synthesis did not silently
         discard stronger evidence. Vote accept only when all four distinct
-        reviewer records are present with status complete,
-        evidence_truncated=false, and empty unreviewed_files. Vote reject when
-        any reviewer is missing, has status failed, reports truncated evidence,
-        leaves files unreviewed, or when report.status is inconclusive.
+        reviewer records are present with status complete and
+        evidence_truncated=false. A specialized reviewer may leave a path in
+        unreviewed_files only when at least two other completed reviewers list
+        that exact path in reviewed_files. Vote reject when any reviewer is
+        missing, has status failed, reports truncated evidence, leaves a path
+        without two independent reviews, or when report.status is inconclusive.
         Findings do not make coverage incomplete.
         Coverage does not adjudicate individual findings. Never include
         finding_verdicts or any other extra field. Do not end with prose. Your

--- a/homerail_manager/tests/pr-review-scenario.test.ts
+++ b/homerail_manager/tests/pr-review-scenario.test.ts
@@ -923,17 +923,42 @@ describe("PR Review scenario assets", () => {
       { ...passingReviewReport(), status: "inconclusive" },
       { passed: false, successes: 1, total: 3, threshold: 2 },
     ).status).toBe(0);
+
+    const specializedCoverage = passingReviewReport();
+    const specializedReviewers = specializedCoverage.reviewer_results as Array<Record<string, unknown>>;
+    specializedReviewers[3].reviewed_files = ["agent-ui/src/App.vue"];
+    specializedReviewers[3].unreviewed_files = ["homerail_manager/src/index.ts"];
+    for (const reviewer of specializedReviewers.slice(0, 3)) {
+      reviewer.reviewed_files = ["agent-ui/src/App.vue", "homerail_manager/src/index.ts"];
+    }
+    expect(runValidator(
+      "completed",
+      specializedCoverage,
+      { passed: true, successes: 2, total: 3, threshold: 2 },
+    ).status).toBe(0);
+
     const incompleteCoverage = passingReviewReport();
-    const firstReviewer = (incompleteCoverage.reviewer_results as Array<Record<string, unknown>>)[0];
-    firstReviewer.unreviewed_files = ["src/missed.ts"];
-    firstReviewer.evidence_truncated = true;
+    const incompleteReviewers = incompleteCoverage.reviewer_results as Array<Record<string, unknown>>;
+    incompleteReviewers[0].unreviewed_files = ["src/missed.ts"];
+    incompleteReviewers[1].reviewed_files = ["src/run.ts", "src/missed.ts"];
     const incomplete = runValidator(
       "completed",
       incompleteCoverage,
       { passed: true, successes: 2, total: 3, threshold: 2 },
     );
     expect(incomplete.status).toBe(1);
-    expect(incomplete.stderr).toContain("left files unreviewed");
+    expect(incomplete.stderr).toContain("without two independent reviews");
+
+    const truncatedCoverage = passingReviewReport();
+    const firstReviewer = (truncatedCoverage.reviewer_results as Array<Record<string, unknown>>)[0];
+    firstReviewer.evidence_truncated = true;
+    const truncated = runValidator(
+      "completed",
+      truncatedCoverage,
+      { passed: true, successes: 2, total: 3, threshold: 2 },
+    );
+    expect(truncated.status).toBe(1);
+    expect(truncated.stderr).toContain("used truncated evidence");
 
     const invalid = runValidator(
       "completed",

--- a/scripts/validate-pr-review-artifacts.mjs
+++ b/scripts/validate-pr-review-artifacts.mjs
@@ -54,6 +54,7 @@ export function validatePrReviewArtifacts(command, publication, markdown) {
     "report does not contain four reviewer results",
   );
   const reviewerNames = new Set();
+  const reviewedByFile = new Map();
   for (const reviewer of report.reviewer_results) {
     invariant(reviewer && typeof reviewer === "object" && !Array.isArray(reviewer), "reviewer result is not an object");
     invariant(["runtime", "security", "tests", "frontend"].includes(reviewer.reviewer), "reviewer result has an invalid identity");
@@ -62,13 +63,35 @@ export function validatePrReviewArtifacts(command, publication, markdown) {
     invariant(Array.isArray(reviewer.reviewed_files), `${reviewer.reviewer} reviewed_files is missing`);
     invariant(Array.isArray(reviewer.unreviewed_files), `${reviewer.reviewer} unreviewed_files is missing`);
     invariant(typeof reviewer.evidence_truncated === "boolean", `${reviewer.reviewer} evidence_truncated is missing`);
+    const reviewedFiles = new Set(reviewer.reviewed_files);
+    for (const file of reviewer.reviewed_files) {
+      invariant(typeof file === "string" && file.length > 0, `${reviewer.reviewer} reviewed_files contains an invalid path`);
+      const reviewers = reviewedByFile.get(file) ?? new Set();
+      reviewers.add(reviewer.reviewer);
+      reviewedByFile.set(file, reviewers);
+    }
+    for (const file of reviewer.unreviewed_files) {
+      invariant(typeof file === "string" && file.length > 0, `${reviewer.reviewer} unreviewed_files contains an invalid path`);
+      invariant(!reviewedFiles.has(file), `${reviewer.reviewer} both reviewed and skipped ${file}`);
+    }
     if (report.status !== "inconclusive") {
       invariant(reviewer.status === "complete", `${reviewer.reviewer} reviewer did not complete`);
-      invariant(reviewer.unreviewed_files.length === 0, `${reviewer.reviewer} left files unreviewed`);
       invariant(reviewer.evidence_truncated === false, `${reviewer.reviewer} used truncated evidence`);
     }
   }
   invariant(reviewerNames.size === 4, "report reviewer identities are not distinct");
+  if (report.status !== "inconclusive") {
+    for (const reviewer of report.reviewer_results) {
+      for (const file of reviewer.unreviewed_files) {
+        const independentReviewers = new Set(reviewedByFile.get(file) ?? []);
+        independentReviewers.delete(reviewer.reviewer);
+        invariant(
+          independentReviewers.size >= 2,
+          `${reviewer.reviewer} left ${file} without two independent reviews`,
+        );
+      }
+    }
+  }
 
   const runIdLine = `**HomeRail Run ID:** \`${command.run_id}\``;
   invariant(markdown.includes(runIdLine), "Markdown does not contain the exact HomeRail run_id field");


### PR DESCRIPTION
## Summary

- allow a specialized reviewer to skip an out-of-scope path only when at least two other completed reviewers independently reviewed that exact path
- keep incomplete and truncated review evidence fail-closed
- align the synthesizer and quorum voters with the validator semantics

## Validation

- PR Review scenario tests: 13 passed
- validator accepts the actual PR #151 review artifacts
- coverage with fewer than two independent reviewers still fails
- truncated evidence still fails
- diff check and JavaScript syntax check pass