### PR TITLE
Remove PR review budget gate and restore Alpha 2.2 baseline

### DIFF
--- a/agent-ui/package-lock.json
+++ b/agent-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homerail-agent-ui",
-  "version": "0.1.0-alpha.2.3",
+  "version": "0.1.0-alpha.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homerail-agent-ui",
-      "version": "0.1.0-alpha.2.3",
+      "version": "0.1.0-alpha.2.2",
       "dependencies": {
         "@dagrejs/dagre": "^1.1.4",
         "@headlessui/vue": "^1.7.23",
@@ -85,7 +85,7 @@
     },
     "../homerail_protocol": {
       "name": "homerail-protocol",
-      "version": "0.1.0-alpha.2.3",
+      "version": "0.1.0-alpha.2.2",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/agent-ui/package.json
+++ b/agent-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homerail-agent-ui",
   "private": true,
-  "version": "0.1.0-alpha.2.3",
+  "version": "0.1.0-alpha.2.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/assets/orchestrations/pr-review.yaml.template
+++ b/assets/orchestrations/pr-review.yaml.template
@@ -20,8 +20,8 @@ spec:
 
   pattern:
     id: pr-review-scenario
-    version: 1.8.0
-    source: HomeRail concrete scenario composed from budget-gate, orchestrator-workers, and quorum
+    version: 1.9.0
+    source: HomeRail concrete scenario composed from orchestrator-workers and quorum
     parameters:
       reviewer_count: 4
       privacy_advisories: 1
@@ -39,7 +39,7 @@ spec:
     PRReviewInput:
       type: object
       additionalProperties: false
-      required: [repo, pr, base, head, base_clone_url, head_clone_url, expected_usage, budget_key]
+      required: [repo, pr, base, head, base_clone_url, head_clone_url]
       properties:
         repo: { type: string, pattern: "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$" }
         pr: { type: integer, minimum: 1 }
@@ -47,8 +47,6 @@ spec:
         head: { type: string, pattern: '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$' }
         base_clone_url: { type: string, pattern: '^https://[A-Za-z0-9.-]+(?::[0-9]{1,5})?/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+\.git$' }
         head_clone_url: { type: string, pattern: '^https://[A-Za-z0-9.-]+(?::[0-9]{1,5})?/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+\.git$' }
-        expected_usage: { type: number, minimum: 0, maximum: 100 }
-        budget_key: { type: string, minLength: 1, maxLength: 200 }
         title: { type: string, maxLength: 500 }
         author: { type: string, maxLength: 200 }
 
@@ -63,7 +61,7 @@ spec:
         payload:
           type: object
           additionalProperties: false
-          required: [repo, pr, base, head, base_clone_url, head_clone_url, expected_usage, budget_key]
+          required: [repo, pr, base, head, base_clone_url, head_clone_url]
           properties:
             repo: { type: string, pattern: "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$" }
             pr: { type: integer, minimum: 1 }
@@ -71,8 +69,6 @@ spec:
             head: { type: string, pattern: '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$' }
             base_clone_url: { type: string, pattern: '^https://[A-Za-z0-9.-]+(?::[0-9]{1,5})?/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+\.git$' }
             head_clone_url: { type: string, pattern: '^https://[A-Za-z0-9.-]+(?::[0-9]{1,5})?/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+\.git$' }
-            expected_usage: { type: number, minimum: 0, maximum: 100 }
-            budget_key: { type: string, minLength: 1, maxLength: 200 }
             title: { type: string, maxLength: 500 }
             author: { type: string, maxLength: 200 }
 
@@ -1049,23 +1045,9 @@ spec:
         handoff; immediately resubmit the existing publication in the exact shape.
 
   nodes:
-    budget:
-      kind: state
-      inputs: { request: { contract: RunEnvelope } }
-      outputs: { admitted: {}, blocked: {} }
-      config:
-        namespace: pr-review-budget
-        key: default
-        key_field: payload.budget_key
-        operation: budget_admit
-        value_field: payload.expected_usage
-        budget_limit: 100
-        success_port: admitted
-        conflict_port: blocked
-
     prepare:
       kind: command
-      inputs: { request: {} }
+      inputs: { request: { contract: RunEnvelope } }
       outputs: { ready: { contract: PreparedReviewContext }, failed: {} }
       config:
         command:
@@ -1127,8 +1109,8 @@ spec:
             process.stdin.on('data', (chunk) => { stdin += chunk; }).on('end', () => {
               const inputs = JSON.parse(stdin);
               const request = Array.isArray(inputs.request) ? inputs.request.at(-1) : undefined;
-              const payload = request?.input?.payload;
-              if (!payload || typeof payload !== 'object') fail('budget input payload is missing');
+              const payload = request?.payload;
+              if (!payload || typeof payload !== 'object') fail('review input payload is missing');
               const { repo, pr, base, head, title, author } = payload;
               if (
                 typeof repo !== 'string' || !Number.isInteger(pr) ||
@@ -1628,11 +1610,6 @@ spec:
       outcome: cancelled
       inputs: { result: { contract: PublishedReview } }
 
-    budget_blocked:
-      kind: terminal
-      outcome: cancelled
-      inputs: { result: {} }
-
     preparation_failed:
       kind: terminal
       outcome: failure
@@ -1684,9 +1661,7 @@ spec:
       inputs: { result: {} }
 
   edges:
-    - { from: $run.input, to: budget.request }
-    - { from: budget.admitted, to: prepare.request }
-    - { from: budget.blocked, to: budget_blocked.result }
+    - { from: $run.input, to: prepare.request }
     - { from: prepare.ready, to: privacy_review.context }
     - { from: prepare.ready, to: strip_privacy_context.prepared }
     - { from: prepare.failed, to: preparation_failed.result, condition: on_failure }

--- a/docs/scenarios/pr-review.md
+++ b/docs/scenarios/pr-review.md
@@ -2,8 +2,7 @@
 
 `assets/orchestrations/pr-review.yaml.template` is HomeRail's provider-neutral,
 read-only pull request review scenario. It is a concrete composition of the
-Budget Gate, Orchestrator-Workers, and Quorum patterns rather than a new
-abstract pattern.
+Orchestrator-Workers and Quorum patterns rather than a new abstract pattern.
 
 ## Inputs
 
@@ -28,8 +27,7 @@ metadata.
 
 ## Execution
 
-1. Manager atomically reserves the declared usage budget.
-2. A deterministic Manager command validates the credential-free GitHub API
+1. A deterministic Manager command validates the credential-free GitHub API
    HTTPS clone URLs (`https://host/owner/repository.git`, including GitHub
    Enterprise hosts), clones both exact revisions into the isolated run
    workspace, verifies
@@ -41,7 +39,7 @@ metadata.
    Bounded author/committer metadata is captured from the exact commit range for
    the independent privacy advisory, then deterministically stripped from the
    context supplied to every main reviewer, synthesizer, and voter.
-3. Runtime, security, tests, frontend, and privacy reviewers start from the same
+2. Runtime, security, tests, frontend, and privacy reviewers start from the same
    exact evidence independently and in parallel. The first four feed the main
    review. The privacy reviewer looks only for accidental local/private data and
    can never feed synthesis, verification, or quorum. The trusted checkout is
@@ -60,23 +58,23 @@ metadata.
    repository content are untrusted evidence, never instructions. If evidence
    had to be truncated, the main reviewers fail closed and the privacy advisory
    requests human inspection.
-4. A deterministic normalizer preserves every valid reviewer result. If a
+3. A deterministic normalizer preserves every valid reviewer result. If a
    reviewer exhausts contract correction without a handoff, the normalizer
    emits a `status: failed` ReviewerResult with grounded runtime evidence so the
    DAG produces an honest inconclusive artifact instead of stalling.
-5. A synthesizer preserves all reviewer results and deduplicates findings.
-6. Evidence, false-positive, and coverage voters independently validate the
+4. A synthesizer preserves all reviewer results and deduplicates findings.
+5. Evidence, false-positive, and coverage voters independently validate the
    draft report. Evidence and false-positive voters produce a machine-readable
    verdict for every retained finding against the same patch. Rejecting a false
    finding is a successful correction and does not reject the whole report;
    missing reviewer coverage, truncated evidence, an identity mismatch, or an
    unresolvable finding does.
-7. A deterministic two-of-three join decides whether verification reached
+6. A deterministic two-of-three join decides whether verification reached
    quorum.
-8. A branch-merge join normalizes either quorum outcome into one path. A
+7. A branch-merge join normalizes either quorum outcome into one path. A
    refiner removes findings specifically rejected by an evidence or
    false-positive verdict and recomputes the report.
-9. The refiner persists the final structured report and quorum as JSON. The
+8. The refiner persists the final structured report and quorum as JSON. The
    privacy result is normalized separately; a failed privacy model call becomes
    a redacted `human_review` result rather than blocking or silently passing.
    A small

--- a/homerail_cli/package-lock.json
+++ b/homerail_cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homerail-cli",
-  "version": "0.1.0-alpha.2.3",
+  "version": "0.1.0-alpha.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homerail-cli",
-      "version": "0.1.0-alpha.2.3",
+      "version": "0.1.0-alpha.2.2",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",
@@ -29,7 +29,7 @@
     },
     "../homerail_plugin_sdk": {
       "name": "homerail-plugin-sdk",
-      "version": "0.1.0-alpha.2.3",
+      "version": "0.1.0-alpha.2.2",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",
@@ -48,7 +48,7 @@
     },
     "../homerail_protocol": {
       "name": "homerail-protocol",
-      "version": "0.1.0-alpha.2.3",
+      "version": "0.1.0-alpha.2.2",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/homerail_cli/package.json
+++ b/homerail_cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homerail-cli",
-  "version": "0.1.0-alpha.2.3",
+  "version": "0.1.0-alpha.2.2",
   "private": true,
   "description": "HomeRail TypeScript CLI for configuring, running, and inspecting DAG workflows.",
   "license": "MIT",

--- a/homerail_cli/src/commands/dag-run-template.ts
+++ b/homerail_cli/src/commands/dag-run-template.ts
@@ -2,8 +2,6 @@ import type { Command } from "commander";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import {
-  DEFAULT_PR_REVIEW_EXPECTED_USAGE,
-  defaultPrReviewBudgetKey,
   isFullGitRevision,
 } from "homerail-protocol";
 
@@ -39,8 +37,6 @@ export interface ResolvedPrReviewInput {
   head: string;
   base_clone_url: string;
   head_clone_url: string;
-  expected_usage: number;
-  budget_key: string;
   title?: string;
   author?: string;
 }
@@ -163,7 +159,6 @@ export async function resolvePrReviewInput(
   options: {
     fetchImpl?: typeof fetch;
     env?: NodeJS.ProcessEnv;
-    now?: Date;
     apiBaseUrl?: string;
   } = {},
 ): Promise<ResolvedPrReviewInput> {
@@ -196,12 +191,6 @@ export async function resolvePrReviewInput(
   if (!isFullGitRevision(base)) throw new Error("pr-review base must be a full commit SHA");
   if (!isFullGitRevision(head)) throw new Error("pr-review head must be a full commit SHA");
 
-  const expectedUsage = input.expected_usage === undefined
-    ? DEFAULT_PR_REVIEW_EXPECTED_USAGE
-    : Number(input.expected_usage);
-  if (!Number.isFinite(expectedUsage) || expectedUsage < 0 || expectedUsage > 100) {
-    throw new Error("pr-review expected_usage must be between 0 and 100");
-  }
   return {
     repo,
     pr,
@@ -209,8 +198,6 @@ export async function resolvePrReviewInput(
     head,
     base_clone_url: baseRepository.cloneUrl,
     head_clone_url: headRepository.cloneUrl,
-    expected_usage: expectedUsage,
-    budget_key: optionalString(input.budget_key) ?? defaultPrReviewBudgetKey(repo, options.now),
     ...(title ? { title } : {}),
     ...(author ? { author } : {}),
   };

--- a/homerail_cli/tests/dag-run-template.test.ts
+++ b/homerail_cli/tests/dag-run-template.test.ts
@@ -67,7 +67,7 @@ describe("PR Review run-template", () => {
 
     const input = await resolvePrReviewInput(
       { repo: "xiaotianfotos/homerail", pr: 25 },
-      { fetchImpl: fetchImpl as typeof fetch, now: new Date("2026-07-12T00:00:00Z"), env: {} },
+      { fetchImpl: fetchImpl as typeof fetch, env: {} },
     );
 
     expect(fetchImpl).toHaveBeenCalledWith(
@@ -81,8 +81,6 @@ describe("PR Review run-template", () => {
       head: "b".repeat(40),
       base_clone_url: "https://github.com/xiaotianfotos/homerail.git",
       head_clone_url: "https://github.com/xiaotianfotos/homerail.git",
-      expected_usage: 8,
-      budget_key: "pr-review:xiaotianfotos/homerail:2026-07-12",
     });
     expect(manualRunEnvelope(input)).toMatchObject({
       trigger_id: "manual",

--- a/homerail_manager/package-lock.json
+++ b/homerail_manager/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homerail-manager",
-  "version": "0.1.0-alpha.2.3",
+  "version": "0.1.0-alpha.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homerail-manager",
-      "version": "0.1.0-alpha.2.3",
+      "version": "0.1.0-alpha.2.2",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.34.51",
@@ -33,7 +33,7 @@
     },
     "../homerail_plugin_sdk": {
       "name": "homerail-plugin-sdk",
-      "version": "0.1.0-alpha.2.3",
+      "version": "0.1.0-alpha.2.2",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",
@@ -52,7 +52,7 @@
     },
     "../homerail_protocol": {
       "name": "homerail-protocol",
-      "version": "0.1.0-alpha.2.3",
+      "version": "0.1.0-alpha.2.2",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/homerail_manager/package.json
+++ b/homerail_manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homerail-manager",
-  "version": "0.1.0-alpha.2.3",
+  "version": "0.1.0-alpha.2.2",
   "private": true,
   "description": "HomeRail TypeScript Manager service and DAG coordinator.",
   "license": "MIT",

--- a/homerail_manager/src/server/host-codex-manager-agent.ts
+++ b/homerail_manager/src/server/host-codex-manager-agent.ts
@@ -30,8 +30,6 @@ import {
   compactManagerAgentSkillSupervisedDagResult,
   compactManagerAgentSkillViewPresentResult,
   createManagerAgentWidgetFileTools,
-  DEFAULT_PR_REVIEW_EXPECTED_USAGE,
-  defaultPrReviewBudgetKey,
   isFullGitRevision,
   managerAgentDagCommandResult,
   managerAgentDagContextPrompt,
@@ -1200,10 +1198,6 @@ export function createManagerTools(
         const pr = Number(args.pr);
         try {
           const metadata = await resolveGitHubPullRequest(repo, pr);
-          const requestedUsage = Number(args.expected_usage);
-          const expectedUsage = Number.isInteger(requestedUsage) && requestedUsage >= 0 && requestedUsage <= 100
-            ? requestedUsage
-            : DEFAULT_PR_REVIEW_EXPECTED_USAGE;
           const envelope = {
             trigger_id: "manager-agent",
             trigger_type: "manual",
@@ -1217,8 +1211,6 @@ export function createManagerTools(
               head_clone_url: metadata.headCloneUrl,
               title: metadata.title,
               author: metadata.author,
-              expected_usage: expectedUsage,
-              budget_key: defaultPrReviewBudgetKey(repo),
             },
           };
           const body = await requestManager(state.restUrl, "/runs/create-and-run", {

--- a/homerail_manager/tests/pr-review-scenario.test.ts
+++ b/homerail_manager/tests/pr-review-scenario.test.ts
@@ -63,7 +63,7 @@ function installPrepareCommandStub(
   prepare.gateway_config.command = [
     "node",
     "-e",
-    "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const i=JSON.parse(s),r=Array.isArray(i.request)?i.request.at(-1):undefined,p=r?.input?.payload;if(!p)throw new Error('missing request');process.stdout.write(JSON.stringify({repo:p.repo,pr:p.pr,base:p.base,head:p.head,repository_path:'/workspace/repository',changed_files:['src/run.ts'],diff_stat:'1 file changed',diff_patch:'diff --git a/src/run.ts b/src/run.ts',diff_chunks:[{index:1,path:'review-evidence/diff-0001.patch',bytes:39,files:['src/run.ts']}],diff_bytes:39,diff_truncated:" + JSON.stringify(diffTruncated) + ",commit_metadata:[],commit_metadata_truncated:false}))})",
+    "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const i=JSON.parse(s),r=Array.isArray(i.request)?i.request.at(-1):undefined,p=r?.payload;if(!p)throw new Error('missing request');process.stdout.write(JSON.stringify({repo:p.repo,pr:p.pr,base:p.base,head:p.head,repository_path:'/workspace/repository',changed_files:['src/run.ts'],diff_stat:'1 file changed',diff_patch:'diff --git a/src/run.ts b/src/run.ts',diff_chunks:[{index:1,path:'review-evidence/diff-0001.patch',bytes:39,files:['src/run.ts']}],diff_bytes:39,diff_truncated:" + JSON.stringify(diffTruncated) + ",commit_metadata:[],commit_metadata_truncated:false}))})",
   ];
 }
 
@@ -83,18 +83,14 @@ function productionPrepareCommand(): string {
 function prepareCommandInput(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
     request: [{
-      input: {
-        payload: {
-          repo: "enterprise/homerail",
-          pr: 8,
-          base: "a".repeat(40),
-          head: "b".repeat(40),
-          base_clone_url: "https://github.example/enterprise/homerail.git",
-          head_clone_url: "https://github.example/enterprise/homerail.git",
-          expected_usage: 8,
-          budget_key: "pr-review:enterprise/homerail:prepare-command",
-          ...overrides,
-        },
+      payload: {
+        repo: "enterprise/homerail",
+        pr: 8,
+        base: "a".repeat(40),
+        head: "b".repeat(40),
+        base_clone_url: "https://github.example/enterprise/homerail.git",
+        head_clone_url: "https://github.example/enterprise/homerail.git",
+        ...overrides,
       },
     }],
   };
@@ -170,6 +166,12 @@ describe("PR Review scenario assets", () => {
       }),
     ]);
     const nodes = result.canonical?.nodes ?? [];
+    expect(nodes.find((node) => node.id === "budget")).toBeUndefined();
+    expect(nodes.find((node) => node.id === "budget_blocked")).toBeUndefined();
+    expect(nodes.find((node) => node.id === "prepare")).toMatchObject({
+      inputs: [expect.objectContaining({ name: "request", contract: "RunEnvelope" })],
+      depends_on: [],
+    });
     expect(nodes.filter((node) => node.id.endsWith("_review") && !node.id.startsWith("normalize_"))
       .map((node) => node.id).sort()).toEqual([
       "frontend_review",
@@ -514,8 +516,6 @@ describe("PR Review scenario assets", () => {
       head: "b".repeat(40),
       base_clone_url: "https://github.example/enterprise/homerail.git",
       head_clone_url: "https://github.example/contributor/homerail.git",
-      expected_usage: 8,
-      budget_key: "pr-review:enterprise/homerail:2026-07-13",
     };
     expect(validateJsonContract(inputContract, reviewInput)).toMatchObject({ valid: true });
     expect(validateJsonContract(inputContract, {
@@ -683,7 +683,7 @@ describe("PR Review scenario assets", () => {
     try {
       const invoked = await _invokeHostCodexVoiceToolForTest(
         "run_pr_review",
-        { repo: "xiaotianfotos/homerail", pr: 25, expected_usage: 8 },
+        { repo: "xiaotianfotos/homerail", pr: 25 },
         { managerRestUrl: `${baseUrl}/api` },
       );
       expect(JSON.parse(invoked.result.content[0].text)).toMatchObject({
@@ -703,7 +703,6 @@ describe("PR Review scenario assets", () => {
           head: "b".repeat(40),
           base_clone_url: "https://github.com/xiaotianfotos/homerail.git",
           head_clone_url: "https://github.com/contributor/homerail.git",
-          expected_usage: 8,
         },
       });
     } finally {
@@ -1007,8 +1006,6 @@ describe("PR Review scenario assets", () => {
         head: "b".repeat(40),
         base_clone_url: "https://github.com/xiaotianfotos/homerail.git",
         head_clone_url: "https://github.com/xiaotianfotos/homerail.git",
-        expected_usage: 8,
-        budget_key: "pr-review:xiaotianfotos/homerail:2026-07-12",
       },
     };
     executor.createRun("pr-review-runtime", parsed, JSON.stringify(input));
@@ -1121,8 +1118,6 @@ describe("PR Review scenario assets", () => {
         head: "b".repeat(40),
         base_clone_url: "https://github.com/xiaotianfotos/homerail.git",
         head_clone_url: "https://github.com/xiaotianfotos/homerail.git",
-        expected_usage: 8,
-        budget_key: "pr-review:xiaotianfotos/homerail:truncated",
       },
     };
     executor.createRun(runId, parsed, JSON.stringify(input));
@@ -1215,8 +1210,6 @@ describe("PR Review scenario assets", () => {
         head: "b".repeat(40),
         base_clone_url: "https://github.com/xiaotianfotos/homerail.git",
         head_clone_url: "https://github.com/xiaotianfotos/homerail.git",
-        expected_usage: 8,
-        budget_key: "pr-review:xiaotianfotos/homerail:reviewer-failure",
       },
     };
     executor.createRun("pr-review-reviewer-failure", parsed, JSON.stringify(input));

--- a/homerail_node/package-lock.json
+++ b/homerail_node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homerail-node",
-  "version": "0.1.0-alpha.2.3",
+  "version": "0.1.0-alpha.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homerail-node",
-      "version": "0.1.0-alpha.2.3",
+      "version": "0.1.0-alpha.2.2",
       "license": "MIT",
       "dependencies": {
         "dockerode": "^5.0.0",
@@ -30,7 +30,7 @@
     },
     "../homerail_protocol": {
       "name": "homerail-protocol",
-      "version": "0.1.0-alpha.2.3",
+      "version": "0.1.0-alpha.2.2",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/homerail_node/package.json
+++ b/homerail_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homerail-node",
-  "version": "0.1.0-alpha.2.3",
+  "version": "0.1.0-alpha.2.2",
   "private": true,
   "description": "HomeRail TypeScript Node service for Docker-backed Worker provisioning.",
   "license": "MIT",

--- a/homerail_plugin_sdk/package-lock.json
+++ b/homerail_plugin_sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homerail-plugin-sdk",
-  "version": "0.1.0-alpha.2.3",
+  "version": "0.1.0-alpha.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homerail-plugin-sdk",
-      "version": "0.1.0-alpha.2.3",
+      "version": "0.1.0-alpha.2.2",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",
@@ -25,7 +25,7 @@
     },
     "../homerail_protocol": {
       "name": "homerail-protocol",
-      "version": "0.1.0-alpha.2.3",
+      "version": "0.1.0-alpha.2.2",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/homerail_plugin_sdk/package.json
+++ b/homerail_plugin_sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homerail-plugin-sdk",
-  "version": "0.1.0-alpha.2.3",
+  "version": "0.1.0-alpha.2.2",
   "description": "HomeRail declarative plugin development kit and deterministic HRP package codec.",
   "license": "MIT",
   "type": "module",

--- a/homerail_protocol/package-lock.json
+++ b/homerail_protocol/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homerail-protocol",
-  "version": "0.1.0-alpha.2.3",
+  "version": "0.1.0-alpha.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homerail-protocol",
-      "version": "0.1.0-alpha.2.3",
+      "version": "0.1.0-alpha.2.2",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/homerail_protocol/package.json
+++ b/homerail_protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homerail-protocol",
-  "version": "0.1.0-alpha.2.3",
+  "version": "0.1.0-alpha.2.2",
   "description": "HomeRail protocol contract package \u2014 single source of truth for runtime communication between homerail_worker, homerail_node, and homerail_manager",
   "license": "MIT",
   "type": "module",

--- a/homerail_protocol/src/index.ts
+++ b/homerail_protocol/src/index.ts
@@ -1,12 +1,12 @@
 /**
- * HomeRail Protocol — v0.1.0-alpha.2.3
+ * HomeRail Protocol — v0.1.0-alpha.2.2
  *
  * Single source of truth for all runtime communication between
  * homerail_worker, homerail_node, and homerail_manager.
- * @version 0.1.0-alpha.2.3
+ * @version 0.1.0-alpha.2.2
  */
 
-export const PROTOCOL_VERSION = "0.1.0-alpha.2.3";
+export const PROTOCOL_VERSION = "0.1.0-alpha.2.2";
 
 export * from "./types.js";
 export * from "./dag-activity.js";

--- a/homerail_protocol/src/manager-agent-tools.ts
+++ b/homerail_protocol/src/manager-agent-tools.ts
@@ -963,7 +963,6 @@ export const MANAGER_AGENT_TOOL_SPECS: Record<ManagerAgentToolName, AgentToolDef
       properties: {
         repo: { type: "string", description: "GitHub repository in owner/name form" },
         pr: { type: "integer", minimum: 1 },
-        expected_usage: { type: "integer", minimum: 0, maximum: 100 },
       },
       required: ["repo", "pr"],
       additionalProperties: false,

--- a/homerail_protocol/src/pr-review.ts
+++ b/homerail_protocol/src/pr-review.ts
@@ -3,18 +3,9 @@
  * @version 0.1.0
  */
 
-/** One standard PR Review reserves eight scenario budget units: four primary
- * reviews, one synthesis pass, and three independent quorum votes. */
-export const DEFAULT_PR_REVIEW_EXPECTED_USAGE = 8;
-
 const FULL_GIT_REVISION = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i;
 
 /** Accept only complete SHA-1 or SHA-256 Git object identifiers. */
 export function isFullGitRevision(value: unknown): value is string {
   return typeof value === "string" && FULL_GIT_REVISION.test(value);
-}
-
-/** Keep repeated PR reviews under one repository-scoped daily budget. */
-export function defaultPrReviewBudgetKey(repo: string, now = new Date()): string {
-  return `pr-review:${repo}:${now.toISOString().slice(0, 10)}`;
 }

--- a/homerail_protocol/tests/cross-version.test.ts
+++ b/homerail_protocol/tests/cross-version.test.ts
@@ -1,6 +1,6 @@
 /**
  * Cross-version compatibility tests.
- * @version 0.1.0-alpha.2.3
+ * @version 0.1.0-alpha.2.2
  */
 
 import { describe, it, expect } from "vitest";

--- a/homerail_protocol/tests/pr-review.test.ts
+++ b/homerail_protocol/tests/pr-review.test.ts
@@ -1,20 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  DEFAULT_PR_REVIEW_EXPECTED_USAGE,
-  defaultPrReviewBudgetKey,
-  isFullGitRevision,
-} from "../src/pr-review.js";
-
-describe("PR Review scenario defaults", () => {
-  it("shares one documented admission estimate and daily budget key", () => {
-    expect(DEFAULT_PR_REVIEW_EXPECTED_USAGE).toBe(8);
-    expect(defaultPrReviewBudgetKey(
-      "xiaotianfotos/homerail",
-      new Date("2026-07-12T23:59:59.000Z"),
-    )).toBe("pr-review:xiaotianfotos/homerail:2026-07-12");
-  });
-});
+import { isFullGitRevision } from "../src/pr-review.js";
 
 describe("isFullGitRevision", () => {
   it("accepts full SHA-1 and SHA-256 revisions only", () => {

--- a/homerail_worker/package-lock.json
+++ b/homerail_worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homerail-worker",
-  "version": "0.1.0-alpha.2.3",
+  "version": "0.1.0-alpha.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homerail-worker",
-      "version": "0.1.0-alpha.2.3",
+      "version": "0.1.0-alpha.2.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -30,7 +30,7 @@
     },
     "../homerail_protocol": {
       "name": "homerail-protocol",
-      "version": "0.1.0-alpha.2.3",
+      "version": "0.1.0-alpha.2.2",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/homerail_worker/package.json
+++ b/homerail_worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homerail-worker",
-  "version": "0.1.0-alpha.2.3",
+  "version": "0.1.0-alpha.2.2",
   "private": true,
   "description": "HomeRail TypeScript Worker runtime for Claude Agent SDK and compatible agent backends.",
   "license": "MIT",

--- a/homerail_worker/src/__tests__/manager-agent-server.test.ts
+++ b/homerail_worker/src/__tests__/manager-agent-server.test.ts
@@ -383,7 +383,7 @@ class PrReviewToolAgent implements AgentClient {
   ): AsyncIterable<AgentEvent> {
     const tool = tools.find((item) => item.name === "run_pr_review");
     if (!tool) throw new Error("run_pr_review tool missing");
-    const input = { repo: "xiaotianfotos/homerail", pr: 25, expected_usage: 0 };
+    const input = { repo: "xiaotianfotos/homerail", pr: 25 };
     yield { type: "tool_use", id: "tool-pr-review", name: "run_pr_review", input };
     const result = await tool.handler(input);
     yield {
@@ -1007,8 +1007,6 @@ describe("manager-agent server", () => {
         head: "b".repeat(40),
         base_clone_url: "https://github.example/xiaotianfotos/homerail.git",
         head_clone_url: "https://github.example/contributor/homerail.git",
-        expected_usage: 0,
-        budget_key: expect.stringMatching(/^pr-review:xiaotianfotos\/homerail:\d{4}-\d{2}-\d{2}$/),
       });
     } finally {
       await close(server);

--- a/homerail_worker/src/manager-agent/server.ts
+++ b/homerail_worker/src/manager-agent/server.ts
@@ -20,9 +20,7 @@ import {
   compactManagerAgentSkillSupervisedDagResult,
   compactManagerAgentSkillViewPresentResult,
   createManagerAgentWidgetFileTools,
-  DEFAULT_PR_REVIEW_EXPECTED_USAGE,
   DEFAULT_MANAGER_AGENT_RUNTIME_AGENT_TYPE,
-  defaultPrReviewBudgetKey,
   isFullGitRevision,
   managerAgentDagCommandResult,
   managerAgentDagContextPrompt,
@@ -920,10 +918,6 @@ export function createManagerTools(state: {
         const pr = Number(args.pr);
         try {
           const metadata = await resolveGitHubPullRequest(repo, pr);
-          const requestedUsage = Number(args.expected_usage);
-          const expectedUsage = Number.isInteger(requestedUsage) && requestedUsage >= 0 && requestedUsage <= 100
-            ? requestedUsage
-            : DEFAULT_PR_REVIEW_EXPECTED_USAGE;
           const envelope = {
             trigger_id: "manager-agent",
             trigger_type: "manual",
@@ -937,8 +931,6 @@ export function createManagerTools(state: {
               head_clone_url: metadata.headCloneUrl,
               title: metadata.title,
               author: metadata.author,
-              expected_usage: expectedUsage,
-              budget_key: defaultPrReviewBudgetKey(repo),
             },
           };
           const body = await requestManager("/runs/create-and-run", {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homerail",
-  "version": "0.1.0-alpha.2.3",
+  "version": "0.1.0-alpha.2.2",
   "private": true,
   "description": "Voice-first local agent orchestration runtime for auditable DAG workflows.",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Change unified public package metadata from `0.1.0-alpha.2.3` to `0.1.0-alpha.2.2`.
- Remove the PR Review scenario's repository-scoped daily budget admission gate.
- Route the immutable PR review envelope directly into deterministic evidence preparation.
- Remove the obsolete `expected_usage` and `budget_key` fields from CLI and Manager Agent PR-review inputs.

The generic HomeRail Budget Gate pattern remains available for workflows that explicitly need bounded admission. This change removes it only from the automatic PR Review scenario.

## Why

Automatic PR review must run whenever a pull request becomes ready for review. Accumulated reviews previously consumed a hard-coded daily limit of 100 units; a normal review reserved eight units and was cancelled before any reviewer ran when fewer than eight remained.

## Desktop input

Future Alpha.2.2 candidates must pin private Desktop main commit `73817ad048ada95235251700fac5736a597ba7f1`.

That Desktop commit contains the updater cache-provenance and Electron inactivity-timeout fix and reports `0.1.0-alpha.2.2`.

## Verification

- Unified release validator returns `0.1.0-alpha.2.2`, tag `v0.1.0-alpha.2.2`, channel `alpha`.
- Public monorepo build passed for Protocol, Plugin SDK, Manager, Node, Worker, CLI, and Agent UI.
- Public monorepo typecheck passed.
- PR Review Manager scenario: 13/13 passed.
- Worker Manager Agent regression: 24/24 passed.
- CLI PR Review input regression: 7/7 passed.
- Protocol PR Review regression: 1/1 passed.
- Desktop baseline: typecheck passed; 105 tests passed, 3 skipped; Electron production build passed.

## Deployment note

This pull request's own automatic review still executes the currently deployed stable PR Review DAG. Until this change is merged and deployed, that old runtime can still stop at the previous daily budget gate. Code CI remains authoritative evidence for this bootstrap change.

## Release guard

This PR does not build or publish a release. After the corrected Alpha.2.2 baseline candidate is verified, Alpha.2.3 must be created from it with version metadata changes only in both repositories. The real Alpha.2.2 to Alpha.2.3 upgrade must pass before the test releases are exposed.
