### PR TITLE
Enable microphone input in macOS Alpha 2.3

### DIFF
--- a/.github/workflows/desktop-release-candidate.yml
+++ b/.github/workflows/desktop-release-candidate.yml
@@ -456,6 +456,44 @@ jobs:
             exit 1
           fi
           codesign --verify --deep --strict --verbose=2 "$app_path"
+          helper_apps=()
+          while IFS= read -r helper_app; do
+            helper_apps+=("$helper_app")
+          done < <(
+            find "$app_path/Contents/Frameworks" \
+              -maxdepth 1 \
+              -type d \
+              -name 'HomeRail Helper*.app' \
+              -print \
+              | sort
+          )
+          if [[ "${#helper_apps[@]}" -ne 4 ]]; then
+            echo "Expected four signed HomeRail Helper apps, found ${#helper_apps[@]}" >&2
+            exit 1
+          fi
+          for signed_bundle in "$app_path" "${helper_apps[@]}"; do
+            entitlements="$(codesign -d --entitlements - "$signed_bundle" 2>&1)"
+            if ! printf '%s\n' "$entitlements" | awk '
+              /\[Key\] com\.apple\.security\.device\.audio-input$/ {
+                saw_key = 1
+                next
+              }
+              saw_key && /\[Key\]/ {
+                exit 1
+              }
+              saw_key && /\[Bool\] true$/ {
+                found = 1
+                exit 0
+              }
+              END {
+                exit found ? 0 : 1
+              }
+            '; then
+              printf '%s\n' "$entitlements" >&2
+              echo "Missing enabled microphone entitlement on $signed_bundle" >&2
+              exit 1
+            fi
+          done
           xcrun stapler validate "$app_path"
           spctl --assess --type execute --verbose=2 "$app_path"
 

--- a/agent-ui/package-lock.json
+++ b/agent-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homerail-agent-ui",
-  "version": "0.1.0-alpha.2.2",
+  "version": "0.1.0-alpha.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homerail-agent-ui",
-      "version": "0.1.0-alpha.2.2",
+      "version": "0.1.0-alpha.2.3",
       "dependencies": {
         "@dagrejs/dagre": "^1.1.4",
         "@headlessui/vue": "^1.7.23",
@@ -85,7 +85,7 @@
     },
     "../homerail_protocol": {
       "name": "homerail-protocol",
-      "version": "0.1.0-alpha.2.2",
+      "version": "0.1.0-alpha.2.3",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/agent-ui/package.json
+++ b/agent-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homerail-agent-ui",
   "private": true,
-  "version": "0.1.0-alpha.2.2",
+  "version": "0.1.0-alpha.2.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/homerail_cli/package-lock.json
+++ b/homerail_cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homerail-cli",
-  "version": "0.1.0-alpha.2.2",
+  "version": "0.1.0-alpha.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homerail-cli",
-      "version": "0.1.0-alpha.2.2",
+      "version": "0.1.0-alpha.2.3",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",
@@ -29,7 +29,7 @@
     },
     "../homerail_plugin_sdk": {
       "name": "homerail-plugin-sdk",
-      "version": "0.1.0-alpha.2.2",
+      "version": "0.1.0-alpha.2.3",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",
@@ -48,7 +48,7 @@
     },
     "../homerail_protocol": {
       "name": "homerail-protocol",
-      "version": "0.1.0-alpha.2.2",
+      "version": "0.1.0-alpha.2.3",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/homerail_cli/package.json
+++ b/homerail_cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homerail-cli",
-  "version": "0.1.0-alpha.2.2",
+  "version": "0.1.0-alpha.2.3",
   "private": true,
   "description": "HomeRail TypeScript CLI for configuring, running, and inspecting DAG workflows.",
   "license": "MIT",

--- a/homerail_manager/package-lock.json
+++ b/homerail_manager/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homerail-manager",
-  "version": "0.1.0-alpha.2.2",
+  "version": "0.1.0-alpha.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homerail-manager",
-      "version": "0.1.0-alpha.2.2",
+      "version": "0.1.0-alpha.2.3",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.34.51",
@@ -33,7 +33,7 @@
     },
     "../homerail_plugin_sdk": {
       "name": "homerail-plugin-sdk",
-      "version": "0.1.0-alpha.2.2",
+      "version": "0.1.0-alpha.2.3",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",
@@ -52,7 +52,7 @@
     },
     "../homerail_protocol": {
       "name": "homerail-protocol",
-      "version": "0.1.0-alpha.2.2",
+      "version": "0.1.0-alpha.2.3",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/homerail_manager/package.json
+++ b/homerail_manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homerail-manager",
-  "version": "0.1.0-alpha.2.2",
+  "version": "0.1.0-alpha.2.3",
   "private": true,
   "description": "HomeRail TypeScript Manager service and DAG coordinator.",
   "license": "MIT",

--- a/homerail_node/package-lock.json
+++ b/homerail_node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homerail-node",
-  "version": "0.1.0-alpha.2.2",
+  "version": "0.1.0-alpha.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homerail-node",
-      "version": "0.1.0-alpha.2.2",
+      "version": "0.1.0-alpha.2.3",
       "license": "MIT",
       "dependencies": {
         "dockerode": "^5.0.0",
@@ -30,7 +30,7 @@
     },
     "../homerail_protocol": {
       "name": "homerail-protocol",
-      "version": "0.1.0-alpha.2.2",
+      "version": "0.1.0-alpha.2.3",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/homerail_node/package.json
+++ b/homerail_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homerail-node",
-  "version": "0.1.0-alpha.2.2",
+  "version": "0.1.0-alpha.2.3",
   "private": true,
   "description": "HomeRail TypeScript Node service for Docker-backed Worker provisioning.",
   "license": "MIT",

--- a/homerail_plugin_sdk/package-lock.json
+++ b/homerail_plugin_sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homerail-plugin-sdk",
-  "version": "0.1.0-alpha.2.2",
+  "version": "0.1.0-alpha.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homerail-plugin-sdk",
-      "version": "0.1.0-alpha.2.2",
+      "version": "0.1.0-alpha.2.3",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",
@@ -25,7 +25,7 @@
     },
     "../homerail_protocol": {
       "name": "homerail-protocol",
-      "version": "0.1.0-alpha.2.2",
+      "version": "0.1.0-alpha.2.3",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/homerail_plugin_sdk/package.json
+++ b/homerail_plugin_sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homerail-plugin-sdk",
-  "version": "0.1.0-alpha.2.2",
+  "version": "0.1.0-alpha.2.3",
   "description": "HomeRail declarative plugin development kit and deterministic HRP package codec.",
   "license": "MIT",
   "type": "module",

--- a/homerail_protocol/package-lock.json
+++ b/homerail_protocol/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homerail-protocol",
-  "version": "0.1.0-alpha.2.2",
+  "version": "0.1.0-alpha.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homerail-protocol",
-      "version": "0.1.0-alpha.2.2",
+      "version": "0.1.0-alpha.2.3",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/homerail_protocol/package.json
+++ b/homerail_protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homerail-protocol",
-  "version": "0.1.0-alpha.2.2",
+  "version": "0.1.0-alpha.2.3",
   "description": "HomeRail protocol contract package \u2014 single source of truth for runtime communication between homerail_worker, homerail_node, and homerail_manager",
   "license": "MIT",
   "type": "module",

--- a/homerail_protocol/src/index.ts
+++ b/homerail_protocol/src/index.ts
@@ -1,12 +1,12 @@
 /**
- * HomeRail Protocol — v0.1.0-alpha.2.2
+ * HomeRail Protocol — v0.1.0-alpha.2.3
  *
  * Single source of truth for all runtime communication between
  * homerail_worker, homerail_node, and homerail_manager.
- * @version 0.1.0-alpha.2.2
+ * @version 0.1.0-alpha.2.3
  */
 
-export const PROTOCOL_VERSION = "0.1.0-alpha.2.2";
+export const PROTOCOL_VERSION = "0.1.0-alpha.2.3";
 
 export * from "./types.js";
 export * from "./dag-activity.js";

--- a/homerail_protocol/tests/cross-version.test.ts
+++ b/homerail_protocol/tests/cross-version.test.ts
@@ -1,6 +1,6 @@
 /**
  * Cross-version compatibility tests.
- * @version 0.1.0-alpha.2.2
+ * @version 0.1.0-alpha.2.3
  */
 
 import { describe, it, expect } from "vitest";

--- a/homerail_worker/package-lock.json
+++ b/homerail_worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homerail-worker",
-  "version": "0.1.0-alpha.2.2",
+  "version": "0.1.0-alpha.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homerail-worker",
-      "version": "0.1.0-alpha.2.2",
+      "version": "0.1.0-alpha.2.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -30,7 +30,7 @@
     },
     "../homerail_protocol": {
       "name": "homerail-protocol",
-      "version": "0.1.0-alpha.2.2",
+      "version": "0.1.0-alpha.2.3",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/homerail_worker/package.json
+++ b/homerail_worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homerail-worker",
-  "version": "0.1.0-alpha.2.2",
+  "version": "0.1.0-alpha.2.3",
   "private": true,
   "description": "HomeRail TypeScript Worker runtime for Claude Agent SDK and compatible agent backends.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homerail",
-  "version": "0.1.0-alpha.2.2",
+  "version": "0.1.0-alpha.2.3",
   "private": true,
   "description": "Voice-first local agent orchestration runtime for auditable DAG workflows.",
   "license": "MIT",

--- a/scripts/desktop-release-contracts.test.mjs
+++ b/scripts/desktop-release-contracts.test.mjs
@@ -34,6 +34,10 @@ const releaseDocs = fs.readFileSync(
   path.join(repoRoot, "docs", "desktop-release.md"),
   "utf8",
 );
+const macEntitlements = fs.readFileSync(
+  path.join(repoRoot, "scripts", "desktop-release", "entitlements.mac.plist"),
+  "utf8",
+);
 const currentPublicVersion = JSON.parse(
   fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"),
 ).version;
@@ -294,6 +298,8 @@ test("candidate signs macOS, explicitly leaves Windows Alpha unsigned, and creat
   const macBuild = candidateStep("Build, sign, and notarize macOS app");
   assert.match(macBuild, /--config\.forceCodeSigning=true/);
   assert.match(macBuild, /--config\.mac\.notarize=true/);
+  assert.match(macBuild, /--config\.mac\.entitlements=/);
+  assert.match(macBuild, /--config\.mac\.entitlementsInherit=/);
   assert.equal((candidateWorkflow.match(/--config\.forceCodeSigning=true/g) ?? []).length, 1);
   assert.equal((candidateWorkflow.match(/--config\.publish\.channel=/g) ?? []).length, 2);
   assert.match(candidateWorkflow, /verify:update-metadata/);
@@ -303,6 +309,11 @@ test("candidate signs macOS, explicitly leaves Windows Alpha unsigned, and creat
   assert.match(candidateWorkflow, /asset_name="\$\{asset#\.\/\}"/);
   const macVerification = candidateStep("Verify macOS package, signature, and notarization");
   assert.match(macVerification, /codesign --verify --deep --strict/);
+  assert.match(macVerification, /HomeRail Helper\*\.app/);
+  assert.match(macVerification, /Expected four signed HomeRail Helper apps/);
+  assert.match(macVerification, /codesign -d --entitlements -/);
+  assert.match(macVerification, /com\\\.apple\\\.security\\\.device\\\.audio-input/);
+  assert.match(macVerification, /Missing enabled microphone entitlement/);
   assert.match(macVerification, /xcrun stapler validate/);
   assert.match(macVerification, /spctl --assess/);
   const macUpload = candidateStep("Upload macOS candidate assets");
@@ -311,6 +322,13 @@ test("candidate signs macOS, explicitly leaves Windows Alpha unsigned, and creat
   }
   assert.doesNotMatch(macUpload, /desktop\/dist-electron\/\*\.yml/);
   assert.match(candidateWorkflow, /release-candidate\.mjs create/);
+});
+
+test("macOS release entitlements enable microphone input for the app and helpers", () => {
+  assert.match(
+    macEntitlements,
+    /<key>com\.apple\.security\.device\.audio-input<\/key>\s*<true\/>/,
+  );
 });
 
 test("Windows candidate runs Node 24 CI before building and smoke-testing unsigned Alpha", () => {

--- a/scripts/desktop-release/entitlements.mac.plist
+++ b/scripts/desktop-release/entitlements.mac.plist
@@ -8,5 +8,7 @@
   <true/>
   <key>com.apple.security.cs.disable-library-validation</key>
   <true/>
+  <key>com.apple.security.device.audio-input</key>
+  <true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

- advance all public HomeRail packages and protocol metadata from 0.1.0-alpha.2.2 to 0.1.0-alpha.2.3
- add the macOS audio-input entitlement used for both the main app and inherited Helper signatures
- fail the release candidate if the signed main app or any of the four HomeRail Helper apps lacks an enabled microphone entitlement
- retain the explicit unstable automatic-upgrade test warning in generated Alpha release notes

## Validation

- node --test scripts/desktop-release-contracts.test.mjs (19 passed)
- npm run test:live-validator (85 passed, 2 skipped)
- plutil -lint scripts/desktop-release/entitlements.mac.plist
- Bash 3.2 helper enumeration and entitlement parser checks with positive and negative signed-app samples
- git diff --check

## Release boundary

This remains a Draft PR. It does not publish, tag, or replace any release asset. Alpha 2.3 will be built only after the corrected Alpha 2.2 baseline is independently verified and published for the real upgrade test.