### PR TITLE
Stabilize custom renderer browser wait on Windows

### DIFF
--- a/agent-ui/src/generative-ui/custom-renderer-browser.test.ts
+++ b/agent-ui/src/generative-ui/custom-renderer-browser.test.ts
@@ -159,8 +159,14 @@ describe('Custom Renderer real Chromium isolation', () => {
     }, { frameSource: srcdoc, envelope: init })
 
     try {
+      // Playwright defaults to requestAnimationFrame polling here. Hosted
+      // Windows browsers may throttle rAF even though postMessage delivery
+      // continues, so poll on a wall-clock interval instead.
       await page.waitForFunction(() => (window as any).__customRendererMessages
-        .some((message: any) => message?.type === 'homerail.custom-renderer.a2ui'), undefined, { timeout: 10_000 })
+        .some((message: any) => message?.type === 'homerail.custom-renderer.a2ui'), undefined, {
+        polling: 100,
+        timeout: 10_000,
+      })
     } catch (cause) {
       const messages = await page.evaluate(() => (window as any).__customRendererMessages)
       throw new Error(`Renderer did not return A2UI: messages=${JSON.stringify(messages)} console=${JSON.stringify(consoleMessages)}`, { cause })


### PR DESCRIPTION
## Summary

- make the real Chromium custom-renderer test poll on a wall-clock interval
- retain the existing 10-second timeout and all isolation assertions

## Root cause

The Windows release-candidate run received both the renderer `ready` and valid
`homerail.custom-renderer.a2ui` messages, but the assertion still timed out.
Playwright's default `waitForFunction` polling uses `requestAnimationFrame`.
Hosted Windows headless browsers can throttle rAF while `postMessage` delivery
continues, leaving the page state correct but the predicate unevaluated.

This changes only the polling scheduler. It does not relax the product
behavior, timeout, message validation, navigation checks, or data-leak checks.

## Validation

- real Chromium isolation test: 1/1 passed
- Agent UI production typecheck: passed
- `git diff --check`: passed

## Release impact

This unblocks the public Windows CI gate used by Desktop Release Candidate
builds. It does not publish, build, or change a release version.
