### PR TITLE
Add automatic-upgrade test warning to Alpha release notes

### DIFF
--- a/scripts/desktop-release-contracts.test.mjs
+++ b/scripts/desktop-release-contracts.test.mjs
@@ -643,6 +643,11 @@ test("candidate manifest is reproducibly verified and detects artifact tampering
     assert.match(releaseNotes, /Windows: explicitly unsigned Alpha installer/);
     assert.match(releaseNotes, /macOS: Developer ID signed and Apple-notarized/);
     assert.match(releaseNotes, /platform-specific release gates/);
+    assert.match(
+      releaseNotes,
+      /unstable build intended only for automatic upgrade testing/,
+    );
+    assert.match(releaseNotes, /Do not install it for general use/);
     assert.doesNotMatch(releaseNotes, /This is a signed HomeRail Desktop/);
     assert.doesNotMatch(
       releaseNotes,

--- a/scripts/desktop-release/release-candidate.mjs
+++ b/scripts/desktop-release/release-candidate.mjs
@@ -279,12 +279,20 @@ function writeCandidate(args) {
     args.channel === "alpha"
       ? "- Windows: explicitly unsigned Alpha installer, verified as unsigned under the Alpha release policy."
       : `- Windows: trusted Authenticode signing is required for this ${phase}.`;
+  const prereleaseWarning =
+    args.channel === "alpha"
+      ? [
+          "",
+          "> **Warning:** This is an unstable build intended only for automatic upgrade testing. Do not install it for general use.",
+        ]
+      : [];
   fs.writeFileSync(
     path.join(candidateDir, "release-notes.md"),
     [
       `# HomeRail ${args.version}`,
       "",
       `This HomeRail Desktop ${phase} passed its platform-specific release gates.`,
+      ...prereleaseWarning,
       "",
       `- HomeRail commit: \`${args["source-commit"]}\``,
       `- Desktop commit: \`${args["desktop-commit"]}\``,


### PR DESCRIPTION
## What changed

- Add a prominent English warning to generated Alpha Desktop release notes.
- State that the build is unstable, intended only for automatic-upgrade testing, and not for general installation.
- Add release-contract assertions so future Alpha candidates cannot silently lose the warning.

## Why

Alpha 2.2 and Alpha 2.3 are technical prereleases used to validate the real updater chain. Their GitHub releases must communicate that boundary before any user downloads them.

## Validation

- `node --test scripts/desktop-release-contracts.test.mjs` — 18 passed
- `npm run test:live-validator` — 84 passed, 2 skipped
- `git diff --check`
