### PR TITLE
Update release metadata for Alpha 3

### DIFF
--- a/agent-ui/package-lock.json
+++ b/agent-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homerail-agent-ui",
-  "version": "0.1.0-alpha.2.2",
+  "version": "0.1.0-alpha.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homerail-agent-ui",
-      "version": "0.1.0-alpha.2.2",
+      "version": "0.1.0-alpha.3",
       "dependencies": {
         "@dagrejs/dagre": "^1.1.4",
         "@headlessui/vue": "^1.7.23",
@@ -85,7 +85,7 @@
     },
     "../homerail_protocol": {
       "name": "homerail-protocol",
-      "version": "0.1.0-alpha.2.2",
+      "version": "0.1.0-alpha.3",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/agent-ui/package.json
+++ b/agent-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homerail-agent-ui",
   "private": true,
-  "version": "0.1.0-alpha.2.2",
+  "version": "0.1.0-alpha.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/homerail_cli/package-lock.json
+++ b/homerail_cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homerail-cli",
-  "version": "0.1.0-alpha.2.2",
+  "version": "0.1.0-alpha.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homerail-cli",
-      "version": "0.1.0-alpha.2.2",
+      "version": "0.1.0-alpha.3",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",
@@ -29,7 +29,7 @@
     },
     "../homerail_plugin_sdk": {
       "name": "homerail-plugin-sdk",
-      "version": "0.1.0-alpha.2.2",
+      "version": "0.1.0-alpha.3",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",
@@ -48,7 +48,7 @@
     },
     "../homerail_protocol": {
       "name": "homerail-protocol",
-      "version": "0.1.0-alpha.2.2",
+      "version": "0.1.0-alpha.3",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/homerail_cli/package.json
+++ b/homerail_cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homerail-cli",
-  "version": "0.1.0-alpha.2.2",
+  "version": "0.1.0-alpha.3",
   "private": true,
   "description": "HomeRail TypeScript CLI for configuring, running, and inspecting DAG workflows.",
   "license": "MIT",

--- a/homerail_manager/package-lock.json
+++ b/homerail_manager/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homerail-manager",
-  "version": "0.1.0-alpha.2.2",
+  "version": "0.1.0-alpha.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homerail-manager",
-      "version": "0.1.0-alpha.2.2",
+      "version": "0.1.0-alpha.3",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.34.51",
@@ -33,7 +33,7 @@
     },
     "../homerail_plugin_sdk": {
       "name": "homerail-plugin-sdk",
-      "version": "0.1.0-alpha.2.2",
+      "version": "0.1.0-alpha.3",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",
@@ -52,7 +52,7 @@
     },
     "../homerail_protocol": {
       "name": "homerail-protocol",
-      "version": "0.1.0-alpha.2.2",
+      "version": "0.1.0-alpha.3",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/homerail_manager/package.json
+++ b/homerail_manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homerail-manager",
-  "version": "0.1.0-alpha.2.2",
+  "version": "0.1.0-alpha.3",
   "private": true,
   "description": "HomeRail TypeScript Manager service and DAG coordinator.",
   "license": "MIT",

--- a/homerail_node/package-lock.json
+++ b/homerail_node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homerail-node",
-  "version": "0.1.0-alpha.2.2",
+  "version": "0.1.0-alpha.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homerail-node",
-      "version": "0.1.0-alpha.2.2",
+      "version": "0.1.0-alpha.3",
       "license": "MIT",
       "dependencies": {
         "dockerode": "^5.0.0",
@@ -30,7 +30,7 @@
     },
     "../homerail_protocol": {
       "name": "homerail-protocol",
-      "version": "0.1.0-alpha.2.2",
+      "version": "0.1.0-alpha.3",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/homerail_node/package.json
+++ b/homerail_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homerail-node",
-  "version": "0.1.0-alpha.2.2",
+  "version": "0.1.0-alpha.3",
   "private": true,
   "description": "HomeRail TypeScript Node service for Docker-backed Worker provisioning.",
   "license": "MIT",

--- a/homerail_plugin_sdk/package-lock.json
+++ b/homerail_plugin_sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homerail-plugin-sdk",
-  "version": "0.1.0-alpha.2.2",
+  "version": "0.1.0-alpha.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homerail-plugin-sdk",
-      "version": "0.1.0-alpha.2.2",
+      "version": "0.1.0-alpha.3",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",
@@ -25,7 +25,7 @@
     },
     "../homerail_protocol": {
       "name": "homerail-protocol",
-      "version": "0.1.0-alpha.2.2",
+      "version": "0.1.0-alpha.3",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/homerail_plugin_sdk/package.json
+++ b/homerail_plugin_sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homerail-plugin-sdk",
-  "version": "0.1.0-alpha.2.2",
+  "version": "0.1.0-alpha.3",
   "description": "HomeRail declarative plugin development kit and deterministic HRP package codec.",
   "license": "MIT",
   "type": "module",

--- a/homerail_protocol/package-lock.json
+++ b/homerail_protocol/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homerail-protocol",
-  "version": "0.1.0-alpha.2.2",
+  "version": "0.1.0-alpha.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homerail-protocol",
-      "version": "0.1.0-alpha.2.2",
+      "version": "0.1.0-alpha.3",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/homerail_protocol/package.json
+++ b/homerail_protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homerail-protocol",
-  "version": "0.1.0-alpha.2.2",
+  "version": "0.1.0-alpha.3",
   "description": "HomeRail protocol contract package \u2014 single source of truth for runtime communication between homerail_worker, homerail_node, and homerail_manager",
   "license": "MIT",
   "type": "module",

--- a/homerail_protocol/src/index.ts
+++ b/homerail_protocol/src/index.ts
@@ -1,12 +1,12 @@
 /**
- * HomeRail Protocol — v0.1.0-alpha.2.2
+ * HomeRail Protocol — v0.1.0-alpha.3
  *
  * Single source of truth for all runtime communication between
  * homerail_worker, homerail_node, and homerail_manager.
- * @version 0.1.0-alpha.2.2
+ * @version 0.1.0-alpha.3
  */
 
-export const PROTOCOL_VERSION = "0.1.0-alpha.2.2";
+export const PROTOCOL_VERSION = "0.1.0-alpha.3";
 
 export * from "./types.js";
 export * from "./dag-activity.js";

--- a/homerail_protocol/tests/cross-version.test.ts
+++ b/homerail_protocol/tests/cross-version.test.ts
@@ -1,6 +1,6 @@
 /**
  * Cross-version compatibility tests.
- * @version 0.1.0-alpha.2.2
+ * @version 0.1.0-alpha.3
  */
 
 import { describe, it, expect } from "vitest";

--- a/homerail_worker/package-lock.json
+++ b/homerail_worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homerail-worker",
-  "version": "0.1.0-alpha.2.2",
+  "version": "0.1.0-alpha.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homerail-worker",
-      "version": "0.1.0-alpha.2.2",
+      "version": "0.1.0-alpha.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -30,7 +30,7 @@
     },
     "../homerail_protocol": {
       "name": "homerail-protocol",
-      "version": "0.1.0-alpha.2.2",
+      "version": "0.1.0-alpha.3",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/homerail_worker/package.json
+++ b/homerail_worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homerail-worker",
-  "version": "0.1.0-alpha.2.2",
+  "version": "0.1.0-alpha.3",
   "private": true,
   "description": "HomeRail TypeScript Worker runtime for Claude Agent SDK and compatible agent backends.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homerail",
-  "version": "0.1.0-alpha.2.2",
+  "version": "0.1.0-alpha.3",
   "private": true,
   "description": "Voice-first local agent orchestration runtime for auditable DAG workflows.",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- advance all unified public package and lockfile versions from `0.1.0-alpha.2.2` to `0.1.0-alpha.3`
- update the protocol runtime identity and version fixtures
- keep the change version-only for the Alpha.2.2 to Alpha.3 automatic-upgrade validation

## Validation
- `node scripts/desktop-release/validate-unified-version.mjs --public-root ... --desktop-root ... --version 0.1.0-alpha.3`
- `node --test scripts/desktop-release-contracts.test.mjs` (19 passed)
- Desktop companion tests: 111 passed, 3 skipped

No tag, release, or build is created by this PR.