### PR TITLE
fix(agent-ui): prevent duplicate Live Voice playback and remove redundant controls

### DIFF
--- a/agent-ui/src/agent/codex-live-voice-client.test.ts
+++ b/agent-ui/src/agent/codex-live-voice-client.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   CodexLiveVoiceClient,
+  codexLiveVoiceOwnsAudio,
   type CodexLiveVoiceEvent,
   type CodexLiveVoiceState,
 } from './codex-live-voice-client'
@@ -59,6 +60,27 @@ class FakeDataChannel extends EventTarget {
     this.dispatchEvent(new Event('close'))
   }
 }
+
+describe('Codex Live Voice audio ownership', () => {
+  it.each<CodexLiveVoiceState>([
+    'connecting',
+    'listening',
+    'user-speaking',
+    'manager-working',
+    'assistant-speaking',
+    'muted',
+    'reconnecting',
+  ])('owns audio while the session state is %s', state => {
+    expect(codexLiveVoiceOwnsAudio(state)).toBe(true)
+  })
+
+  it.each<CodexLiveVoiceState>(['idle', 'error', 'closed'])(
+    'releases audio ownership when the session state is %s',
+    state => {
+      expect(codexLiveVoiceOwnsAudio(state)).toBe(false)
+    },
+  )
+})
 
 class FakePeer extends EventTarget {
   iceGatheringState: RTCIceGatheringState = 'complete'

--- a/agent-ui/src/agent/codex-live-voice-client.test.ts
+++ b/agent-ui/src/agent/codex-live-voice-client.test.ts
@@ -267,6 +267,31 @@ describe('CodexLiveVoiceClient', () => {
     await client.stop()
   })
 
+  it('allows a pending microphone request to be superseded by an explicit stop', async () => {
+    let resolveMedia: ((stream: MediaStream) => void) | undefined
+    const { stream, track } = fakeMedia()
+    const states: CodexLiveVoiceState[] = []
+    const client = new CodexLiveVoiceClient({
+      sessionId: 'voice-stop-while-connecting',
+      getUserMedia: () => new Promise<MediaStream>(resolve => {
+        resolveMedia = resolve
+      }),
+      audioFactory: fakeAudio,
+      onState: state => states.push(state),
+    })
+
+    const startPromise = client.start()
+    await vi.waitFor(() => expect(client.currentState).toBe('connecting'))
+    await client.stop()
+
+    expect(client.currentState).toBe('closed')
+    resolveMedia?.(stream)
+    await expect(startPromise).rejects.toThrow(/superseded/i)
+
+    expect(track.stop).toHaveBeenCalledTimes(1)
+    expect(states.at(-1)).toBe('closed')
+  })
+
   it('rejects text instead of silently dropping it while the WebSocket is unavailable', async () => {
     const socket = new FakeSocket()
     const peer = new FakePeer()

--- a/agent-ui/src/agent/codex-live-voice-client.ts
+++ b/agent-ui/src/agent/codex-live-voice-client.ts
@@ -15,6 +15,16 @@ export type CodexLiveVoiceState =
   | 'error'
   | 'closed'
 
+const CODEX_LIVE_VOICE_INACTIVE_STATES = new Set<CodexLiveVoiceState>([
+  'idle',
+  'error',
+  'closed',
+])
+
+export function codexLiveVoiceOwnsAudio(state: CodexLiveVoiceState): boolean {
+  return !CODEX_LIVE_VOICE_INACTIVE_STATES.has(state)
+}
+
 type CodexLiveVoiceActivityState =
   | 'listening'
   | 'user-speaking'

--- a/agent-ui/src/components/agent/AgentVoiceCockpit.vue
+++ b/agent-ui/src/components/agent/AgentVoiceCockpit.vue
@@ -695,6 +695,11 @@ const voiceInputLocked = computed(() => {
     onboardingStatus.value.needsOnboarding
   )
 })
+const voiceInputActionLocked = computed(
+  () =>
+    voiceInputLocked.value &&
+    !(codexLiveVoiceEffective.value && codexLiveVoiceSessionActive.value)
+)
 const voiceState = computed(() => {
   if (codexLiveVoiceEffective.value) {
     if (codexLiveVoiceState.value === 'assistant-speaking') return 'speaking'
@@ -1173,7 +1178,6 @@ const composerPlaceholder = computed(() => {
 })
 const voiceInputButtonLabel = computed(() => {
   if (!codexLiveVoiceEffective.value) return t('voice.composer.toggleVoice')
-  if (codexLiveVoiceConnecting.value) return voiceStateText.value
   if (codexLiveVoiceSessionActive.value) return t('voice.liveVoice.end')
   return t('voice.liveVoice.tapToStart')
 })
@@ -3893,7 +3897,7 @@ async function startCodexLiveVoice(): Promise<void> {
     selectedNodeId: selectedGenerativeUiNodeId.value || null,
     getUserMedia: async () => {
       const stream = await createVoiceMediaStream()
-      startCodexLiveVoiceMeter(stream)
+      if (codexLiveVoiceClient === client) startCodexLiveVoiceMeter(stream)
       return stream
     },
     onState: applyCodexLiveVoiceState,
@@ -3903,7 +3907,8 @@ async function startCodexLiveVoice(): Promise<void> {
   try {
     await client.start()
   } catch (err: any) {
-    if (codexLiveVoiceClient === client) codexLiveVoiceClient = null
+    if (codexLiveVoiceClient !== client) return
+    codexLiveVoiceClient = null
     stopCodexLiveVoiceMeter()
     applyCodexLiveVoiceState('error')
     error.value = err?.message || t('voice.liveVoice.error')
@@ -3976,14 +3981,14 @@ function stopCodexLiveVoiceMeter(): void {
 }
 
 async function toggleListening(): Promise<void> {
-  if (voiceInputLocked.value) return
+  if (codexLiveVoiceEffective.value && codexLiveVoiceSessionActive.value) {
+    await stopCodexLiveVoice()
+    return
+  }
+  if (voiceInputActionLocked.value) return
   if (codexLiveVoiceEffective.value) {
     activateNoSleepPlayer()
-    if (codexLiveVoiceSessionActive.value) {
-      await stopCodexLiveVoice()
-    } else {
-      await startCodexLiveVoice()
-    }
+    await startCodexLiveVoice()
     return
   }
   if (!tabCanUseVoiceOutput()) return
@@ -6018,16 +6023,16 @@ function summarizeTask(value: string): string {
               <button
                 class="voice-input-zone"
                 :class="{
-                  'voice-input-zone--active': listening && !voiceInputLocked,
+                  'voice-input-zone--active': listening && !voiceInputActionLocked,
                   'voice-input-zone--speaking': speaking,
-                  'voice-input-zone--locked': voiceInputLocked,
+                  'voice-input-zone--locked': voiceInputActionLocked,
                   'voice-input-zone--agent-running': agentActivityActive && !listening,
                   'voice-input-zone--live': codexLiveVoiceEffective,
                   'voice-input-zone--live-connected':
                     codexLiveVoiceSessionActive && !codexLiveVoiceConnecting
                 }"
                 :title="voiceInputButtonLabel"
-                :disabled="voiceInputLocked"
+                :disabled="voiceInputActionLocked"
                 @click="toggleListening"
               >
                 <span
@@ -6036,11 +6041,7 @@ function summarizeTask(value: string): string {
                   aria-hidden="true"
                 >
                   <X
-                    v-if="
-                      codexLiveVoiceEffective &&
-                      codexLiveVoiceSessionActive &&
-                      !codexLiveVoiceConnecting
-                    "
+                    v-if="codexLiveVoiceEffective && codexLiveVoiceSessionActive"
                     class="h-6 w-6"
                   />
                   <span
@@ -6113,25 +6114,21 @@ function summarizeTask(value: string): string {
                 <button
                   class="voice-composer__mic"
                   :class="{
-                    'voice-composer__mic--active': listening && !voiceInputLocked,
+                    'voice-composer__mic--active': listening && !voiceInputActionLocked,
                     'voice-composer__mic--speaking': speaking,
-                    'voice-composer__mic--locked': voiceInputLocked,
+                    'voice-composer__mic--locked': voiceInputActionLocked,
                     'voice-composer__mic--live': codexLiveVoiceEffective,
                     'voice-composer__mic--live-connected':
                       codexLiveVoiceSessionActive && !codexLiveVoiceConnecting
                   }"
                   type="button"
                   :title="voiceInputButtonLabel"
-                  :disabled="voiceInputLocked"
+                  :disabled="voiceInputActionLocked"
                   :aria-label="voiceInputButtonLabel"
                   @click="toggleListening"
                 >
                   <X
-                    v-if="
-                      codexLiveVoiceEffective &&
-                      codexLiveVoiceSessionActive &&
-                      !codexLiveVoiceConnecting
-                    "
+                    v-if="codexLiveVoiceEffective && codexLiveVoiceSessionActive"
                     class="h-6 w-6"
                   />
                   <span

--- a/agent-ui/src/components/agent/AgentVoiceCockpit.vue
+++ b/agent-ui/src/components/agent/AgentVoiceCockpit.vue
@@ -39,6 +39,7 @@ import {
 } from '@/agent/voice-session-restore'
 import {
   CodexLiveVoiceClient,
+  codexLiveVoiceOwnsAudio,
   type CodexLiveVoiceEvent,
   type CodexLiveVoiceState
 } from '@/agent/codex-live-voice-client'
@@ -424,6 +425,7 @@ let speechQueueRunning = false
 let ttsBroadcastChannel: BroadcastChannel | null = null
 let currentTtsSource: AudioBufferSourceNode | null = null
 let currentTtsAudioReject: ((error: Error) => void) | null = null
+let ttsSpeechAbort: AbortController | null = null
 let ttsPlaybackGeneration = 0
 let screenWakeLock: { release: () => Promise<void> } | null = null
 let noSleepPlayerActive = false
@@ -533,8 +535,7 @@ const codexLiveVoiceEffective = computed(
     onboardingStatus.value.liveVoiceEffective
 )
 const codexLiveVoiceSessionActive = computed(
-  () =>
-    !['idle', 'error', 'closed'].includes(codexLiveVoiceState.value)
+  () => codexLiveVoiceOwnsAudio(codexLiveVoiceState.value)
 )
 const codexLiveVoiceConnecting = computed(
   () =>
@@ -3383,6 +3384,13 @@ async function submitDraft(force = false): Promise<void> {
 async function speak(text: string): Promise<void> {
   const clean = text.trim()
   if (!clean) return
+  if (codexLiveVoiceSessionActive.value) {
+    recordTtsDebug(
+      'tts_speak_skipped',
+      `reason=codex_live_voice_active text="${previewSpeechText(clean)}"`
+    )
+    return
+  }
   if (!voiceOutputEnabled.value) {
     recordTtsDebug('tts_output_disabled', `跳过已关闭的语音输出：${previewSpeechText(clean)}`)
     return
@@ -3397,12 +3405,14 @@ async function speak(text: string): Promise<void> {
   pcmChunks = []
   spokenText.value = clean
   speaking.value = true
+  const requestAbort = new AbortController()
+  ttsSpeechAbort = requestAbort
   try {
     recordTtsDebug(
       'tts_speech_request',
       `generation=${playbackToken} text="${previewSpeechText(clean)}"`
     )
-    const response = await speechStream(clean, undefined, false)
+    const response = await speechStream(clean, undefined, false, requestAbort.signal)
     recordTtsDebug(
       'tts_speech_response',
       `generation=${playbackToken} status=${response.status} content-type=${response.headers.get('content-type') || ''}`
@@ -3427,7 +3437,12 @@ async function speak(text: string): Promise<void> {
     await playTtsBlob(blob)
     recordTtsDebug('tts_playback_complete', `generation=${playbackToken}`)
   } catch (err: any) {
-    if (err?.message === 'TTS playback cancelled') {
+    if (
+      err?.name === 'AbortError' ||
+      err?.message === 'TTS playback cancelled' ||
+      playbackToken !== ttsPlaybackGeneration ||
+      codexLiveVoiceSessionActive.value
+    ) {
       recordTtsDebug('tts_speak_cancelled', `generation=${playbackToken}`, 'warning')
       return
     }
@@ -3439,6 +3454,7 @@ async function speak(text: string): Promise<void> {
     voiceConfigError.value = `${t('voice.errors.tts')}: ${err?.message || t('voice.errors.unknown')}`
     throw err
   } finally {
+    if (ttsSpeechAbort === requestAbort) ttsSpeechAbort = null
     if (playbackToken === ttsPlaybackGeneration) speaking.value = false
   }
 }
@@ -3450,6 +3466,13 @@ async function speakText(text: string): Promise<void> {
 function enqueueSpeechEvent(event: VoiceSpeechEvent, source = 'stream'): boolean {
   const text = event.text?.trim()
   if (!text) return false
+  if (codexLiveVoiceSessionActive.value) {
+    recordTtsDebug(
+      'tts_enqueue_skipped',
+      `source=${source} reason=codex_live_voice_active channel=${event.channel} text="${previewSpeechText(text)}"`
+    )
+    return false
+  }
   if (!voiceOutputEnabled.value) {
     recordTtsDebug(
       'tts_enqueue_skipped',
@@ -3649,6 +3672,8 @@ function cancelLocalSpeech(reason: string): void {
     `reason=${reason} generation=${previousGeneration}->${ttsPlaybackGeneration} dropped=${dropped} running=${speechQueueRunning}`,
     reason === 'unmount' ? 'debug' : 'warning'
   )
+  ttsSpeechAbort?.abort()
+  ttsSpeechAbort = null
   stopNativeTtsPlayback()
   try {
     currentTtsSource?.stop(0)
@@ -3768,8 +3793,13 @@ async function playTtsBlob(blob: Blob): Promise<void> {
 }
 
 function applyCodexLiveVoiceState(state: CodexLiveVoiceState): void {
+  const wasActive = codexLiveVoiceSessionActive.value
   codexLiveVoiceState.value = state
-  const active = !['idle', 'error', 'closed'].includes(state)
+  const active = codexLiveVoiceOwnsAudio(state)
+  if (active && !wasActive) {
+    cancelLocalSpeech('codex_live_voice_audio_owner')
+    broadcastVoiceActivity('listening')
+  }
   const microphoneActive = [
     'listening',
     'user-speaking',
@@ -3849,7 +3879,6 @@ async function startCodexLiveVoice(): Promise<void> {
   const sessionId = workspace.value?.session_id
   if (!sessionId || !codexLiveVoiceEffective.value) return
   if (codexLiveVoiceClient) await stopCodexLiveVoice(false)
-  cancelLocalSpeech('codex_live_voice_started')
   closeVoiceInputAfterSubmit()
   voiceTurnAbort?.abort()
   voiceTurnAbort = null
@@ -5827,22 +5856,6 @@ function summarizeTask(value: string): string {
 
           <div class="voice-control mt-5 border-t border-[var(--hr-border)] pt-4">
             <div class="voice-control__deck">
-              <div
-                v-if="codexLiveVoiceEffective"
-                class="flex items-center gap-2 rounded-full border border-[var(--hr-info-border)] bg-[var(--hr-info-soft)] px-3 py-1.5 text-xs text-[var(--hr-info)]"
-                data-testid="codex-live-voice-managed"
-              >
-                <span>{{ t('voice.liveVoice.managed') }}</span>
-                <button
-                  v-if="codexLiveVoiceSessionActive"
-                  type="button"
-                  class="rounded-full border border-[var(--hr-info-border)] px-2 py-0.5 font-medium hover:bg-[var(--hr-surface-2)]"
-                  data-testid="codex-live-voice-end"
-                  @click="stopCodexLiveVoice()"
-                >
-                  {{ t('voice.liveVoice.end') }}
-                </button>
-              </div>
               <div
                 v-if="codexLiveVoiceEffective"
                 class="codex-live-voice-meter"

--- a/agent-ui/src/components/agent/AgentVoiceCockpitLayout.test.ts
+++ b/agent-ui/src/components/agent/AgentVoiceCockpitLayout.test.ts
@@ -63,8 +63,13 @@ describe('AgentVoiceCockpit responsive layout', () => {
       cockpitSource.indexOf('async function toggleListening(): Promise<void>'),
       cockpitSource.indexOf('async function setupVoiceHidControl()'),
     )
-    expect(toggleListening).toContain('if (codexLiveVoiceSessionActive.value)')
+    const activeStopGuard =
+      'if (codexLiveVoiceEffective.value && codexLiveVoiceSessionActive.value)'
+    expect(toggleListening).toContain(activeStopGuard)
     expect(toggleListening).toContain('await stopCodexLiveVoice()')
+    expect(toggleListening.indexOf(activeStopGuard)).toBeLessThan(
+      toggleListening.indexOf('if (voiceInputActionLocked.value)')
+    )
     expect(toggleListening).not.toContain('toggleMuted()')
     expect(cockpitSource).toContain(
       'v-if="!codexLiveVoiceEffective && !isTvCompactViewport && (listening || speaking)"'
@@ -116,9 +121,17 @@ describe('AgentVoiceCockpit responsive layout', () => {
     expect(cockpitSource).not.toContain('data-testid="codex-live-voice-end"')
     expect(cockpitSource).toContain(':aria-label="voiceInputButtonLabel"')
     expect(cockpitSource).toContain('@click="toggleListening"')
+    expect(cockpitSource.match(/:disabled="voiceInputActionLocked"/g)).toHaveLength(2)
+    expect(cockpitSource.match(
+      /v-if="codexLiveVoiceEffective && codexLiveVoiceSessionActive"/g
+    )).toHaveLength(2)
     expect(cockpitSource).toContain(
       "if (codexLiveVoiceSessionActive.value) return t('voice.liveVoice.end')"
     )
+    expect(cockpitSource).toContain(
+      'if (codexLiveVoiceClient === client) startCodexLiveVoiceMeter(stream)'
+    )
+    expect(cockpitSource).toContain('if (codexLiveVoiceClient !== client) return')
   })
 
   it('uses a dense glass model popover with an opaque fallback', () => {

--- a/agent-ui/src/components/agent/AgentVoiceCockpitLayout.test.ts
+++ b/agent-ui/src/components/agent/AgentVoiceCockpitLayout.test.ts
@@ -72,6 +72,55 @@ describe('AgentVoiceCockpit responsive layout', () => {
     expect(cockpitSource).toContain('await refreshOnboarding()')
   })
 
+  it('gives active Live Voice exclusive ownership of audio output', () => {
+    expect(cockpitSource).toContain(
+      '() => codexLiveVoiceOwnsAudio(codexLiveVoiceState.value)'
+    )
+
+    const speak = cockpitSource.slice(
+      cockpitSource.indexOf('async function speak(text: string)'),
+      cockpitSource.indexOf('async function speakText(text: string)'),
+    )
+    expect(speak).toContain('if (codexLiveVoiceSessionActive.value)')
+    expect(speak).toContain('reason=codex_live_voice_active')
+    expect(speak.indexOf('if (codexLiveVoiceSessionActive.value)')).toBeLessThan(
+      speak.indexOf('speechStream(clean'),
+    )
+    expect(speak).toContain('requestAbort.signal')
+
+    const enqueue = cockpitSource.slice(
+      cockpitSource.indexOf('function enqueueSpeechEvent('),
+      cockpitSource.indexOf('async function drainSpeechQueue()'),
+    )
+    expect(enqueue).toContain('if (codexLiveVoiceSessionActive.value)')
+    expect(enqueue).toContain('reason=codex_live_voice_active')
+
+    const cancel = cockpitSource.slice(
+      cockpitSource.indexOf('function cancelLocalSpeech('),
+      cockpitSource.indexOf('async function unlockTtsDomPlayback()'),
+    )
+    expect(cancel).toContain('ttsSpeechAbort?.abort()')
+    expect(cancel).toContain('speechEventQueue = []')
+
+    const applyState = cockpitSource.slice(
+      cockpitSource.indexOf('function applyCodexLiveVoiceState('),
+      cockpitSource.indexOf('function handleCodexLiveVoiceEvent('),
+    )
+    expect(applyState).toContain('if (active && !wasActive)')
+    expect(applyState).toContain("cancelLocalSpeech('codex_live_voice_audio_owner')")
+    expect(applyState).toContain("broadcastVoiceActivity('listening')")
+  })
+
+  it('uses the main voice button as the only Live Voice start and stop control', () => {
+    expect(cockpitSource).not.toContain('data-testid="codex-live-voice-managed"')
+    expect(cockpitSource).not.toContain('data-testid="codex-live-voice-end"')
+    expect(cockpitSource).toContain(':aria-label="voiceInputButtonLabel"')
+    expect(cockpitSource).toContain('@click="toggleListening"')
+    expect(cockpitSource).toContain(
+      "if (codexLiveVoiceSessionActive.value) return t('voice.liveVoice.end')"
+    )
+  })
+
   it('uses a dense glass model popover with an opaque fallback', () => {
     expect(cockpitSource).toContain('background: var(--hr-bg-raised);')
     expect(cockpitSource).toContain(


### PR DESCRIPTION
## Summary

- Give an active Codex Live Voice session exclusive ownership of audio output.
- Reject local TTS enqueue and playback while Live Voice is connecting, connected, muted, speaking, or reconnecting.
- Abort an in-flight `/api/voice/speech` request, stop current playback, clear queued speech, and broadcast ownership to other tabs when Live Voice becomes active.
- Release ownership in `idle`, `error`, and `closed` states so ordinary TTS can resume after Live Voice stops or fails.
- Remove the `codex-live-voice-managed` status strip and its duplicate end-session button; keep the primary voice button as the single start/stop control.

## Root cause

`enqueueSpeechEvent()` and `speak()` did not account for a Live Voice WebRTC session already providing assistant audio. Background speech events could therefore still reach the ordinary TTS endpoint and play the same response a second time. The existing cancellation path also did not abort an in-flight speech fetch.

## Validation

- `npm --prefix agent-ui run typecheck`
- `npm --prefix agent-ui run build`
- Agent UI full suite: 88 test files, 484 tests passed
- Targeted Live Voice/TTS/API suite: 3 test files, 36 tests passed
- Browser smoke against the local Manager: redundant managed strip = 0, duplicate end buttons = 0, primary “Start Live Voice” button and input meter remain available, no page errors

## Manual follow-up

A real microphone/audio acceptance pass should still be performed on the next packaged desktop candidate to confirm that a Live Voice response is heard exactly once and ordinary TTS resumes after ending the session.
