### PR TITLE
Show DAG node model identity and detailed token usage

### DIFF
--- a/agent-ui/src/api/types/dag.types.ts
+++ b/agent-ui/src/api/types/dag.types.ts
@@ -215,7 +215,19 @@ export interface DAGNodeMetrics {
     output: number
     cache_read: number
     cache_creation: number
+    total: number
   } | null
+  execution: {
+    provider_id?: string
+    provider_display_name?: string
+    model_name?: string
+    model_display_name?: string
+    agent_backend?: string
+    protocol?: string
+    context_limit?: number
+    context_usage_pct?: number
+  } | null
+  usage_scope: 'node_cumulative'
   usage_available: boolean
   duration_ms: number | null
   num_turns: number | null
@@ -235,6 +247,7 @@ export interface DAGRunMetrics {
       output: number
       cache_read: number
       cache_creation: number
+      total: number
     }
     usage_available: boolean
     cost_usd: number | null

--- a/agent-ui/src/components/agent/dag-runtime/DagNodeDetailDrawer.test.ts
+++ b/agent-ui/src/components/agent/dag-runtime/DagNodeDetailDrawer.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, h, nextTick, ref, type App } from 'vue'
+import type { DAGRunMetrics } from '@/api/types/dag.types'
 import { i18n } from '@/plugins/i18n'
 import DagNodeDetailDrawer from './DagNodeDetailDrawer.vue'
 
@@ -177,6 +178,8 @@ describe('DagNodeDetailDrawer', () => {
             tool_calls: 0,
             tool_failures: 0,
             tokens: null,
+            execution: null,
+            usage_scope: 'node_cumulative',
             usage_available: false,
             duration_ms: null,
             num_turns: null,
@@ -187,7 +190,7 @@ describe('DagNodeDetailDrawer', () => {
         totals: {
           tool_calls: 0,
           tool_failures: 0,
-          tokens: { input: 0, output: 0, cache_read: 0, cache_creation: 0 },
+          tokens: { input: 0, output: 0, cache_read: 0, cache_creation: 0, total: 0 },
           usage_available: false,
           cost_usd: null,
         },
@@ -204,5 +207,147 @@ describe('DagNodeDetailDrawer', () => {
       .toContain('Manager logic · QUORUM')
     expect(root.textContent).toContain('no worker or model is dispatched')
     expect(root.querySelector('.dag-detail-drawer')?.textContent).not.toContain('tokens')
+  })
+
+  it('shows persisted execution identity and updates cumulative token categories live', async () => {
+    const metrics = ref<DAGRunMetrics>({
+      run_id: 'run-1',
+      status: 'completed',
+      nodes: {
+        prepare_repository: {
+          node_id: 'prepare_repository',
+          node_name: 'prepare_repository',
+          agent_name: 'prepare_repository',
+          status: 'completed',
+          tool_calls: 3,
+          tool_failures: 0,
+          tokens: {
+            input: 12_000,
+            output: 3_000,
+            cache_read: 4_000,
+            cache_creation: 1_000,
+            total: 20_000,
+          },
+          execution: {
+            provider_id: 'anthropic',
+            provider_display_name: 'Anthropic',
+            model_name: 'claude-sonnet-4-20250514',
+            model_display_name: 'Claude Sonnet 4',
+            agent_backend: 'claude-sdk',
+            protocol: 'anthropic_compatible',
+            context_limit: 200_000,
+            context_usage_pct: 10,
+          },
+          usage_scope: 'node_cumulative',
+          usage_available: true,
+          duration_ms: 2_500,
+          num_turns: 2,
+          started_at: null,
+          completed_at: null,
+        },
+      },
+      totals: {
+        tool_calls: 3,
+        tool_failures: 0,
+        tokens: {
+          input: 12_000,
+          output: 3_000,
+          cache_read: 4_000,
+          cache_creation: 1_000,
+          total: 20_000,
+        },
+        usage_available: true,
+        cost_usd: null,
+      },
+    })
+    const Harness = defineComponent({
+      setup() {
+        return () => h(DagNodeDetailDrawer, {
+          metrics: metrics.value,
+          selectedNodeId: 'prepare_repository',
+          open: true,
+          panelFocus: 'logs',
+          expandedPanels: new Set(['logs']),
+        })
+      },
+    })
+
+    root = document.createElement('div')
+    document.body.appendChild(root)
+    app = createApp(Harness)
+    app.use(i18n)
+    app.mount(root)
+
+    expect(root.querySelector('[data-testid="dag-execution-model"]')?.textContent).toContain('Claude Sonnet 4')
+    expect(root.textContent).toContain('claude-sonnet-4-20250514')
+    expect(root.querySelector('[data-testid="dag-execution-provider"]')?.textContent).toContain('Anthropic')
+    expect(root.querySelector('[data-testid="dag-execution-backend"]')?.textContent).toContain('claude-sdk')
+    expect(root.querySelector('[data-testid="dag-execution-protocol"]')?.textContent).toContain('anthropic_compatible')
+    expect(root.querySelector('[data-testid="dag-execution-total-tokens"]')?.textContent).toContain('20.0K')
+    expect(root.textContent).toContain('12.0K')
+    expect(root.textContent).toContain('3.0K')
+    expect(root.textContent).toContain('4.0K')
+    expect(root.textContent).toContain('1.0K')
+    expect(root.textContent).toContain('10.0%')
+    expect(root.textContent).toContain('200.0K')
+    expect(root.textContent).toContain('Cumulative for this node')
+
+    metrics.value.nodes.prepare_repository.tokens = {
+      input: 13_000,
+      output: 4_000,
+      cache_read: 4_000,
+      cache_creation: 1_000,
+      total: 22_000,
+    }
+    await nextTick()
+
+    expect(root.querySelector('[data-testid="dag-execution-total-tokens"]')?.textContent).toContain('22.0K')
+    expect(root.querySelector('.dag-detail-drawer')).not.toBeNull()
+  })
+
+  it('renders unavailable worker identity and usage as dashes instead of zeroes', () => {
+    root = document.createElement('div')
+    document.body.appendChild(root)
+    app = createApp(DagNodeDetailDrawer, {
+      metrics: {
+        run_id: 'run-1',
+        status: 'running',
+        nodes: {
+          prepare_repository: {
+            node_id: 'prepare_repository',
+            node_name: 'prepare_repository',
+            agent_name: 'prepare_repository',
+            status: 'running',
+            tool_calls: 0,
+            tool_failures: 0,
+            tokens: null,
+            execution: null,
+            usage_scope: 'node_cumulative',
+            usage_available: false,
+            duration_ms: null,
+            num_turns: null,
+            started_at: null,
+            completed_at: null,
+          },
+        },
+        totals: {
+          tool_calls: 0,
+          tool_failures: 0,
+          tokens: { input: 0, output: 0, cache_read: 0, cache_creation: 0, total: 0 },
+          usage_available: false,
+          cost_usd: null,
+        },
+      },
+      selectedNodeId: 'prepare_repository',
+      open: true,
+      panelFocus: 'logs',
+      expandedPanels: new Set(['logs']),
+    })
+    app.use(i18n)
+    app.mount(root)
+
+    expect(root.querySelector('[data-testid="dag-execution-model"]')?.textContent?.trim()).toBe('—')
+    expect(root.querySelector('[data-testid="dag-execution-total-tokens"]')?.textContent?.trim()).toBe('—')
+    expect(root.querySelector('[data-testid="dag-node-execution"]')?.textContent).not.toContain('0 tokens')
   })
 })

--- a/agent-ui/src/components/agent/dag-runtime/DagNodeDetailDrawer.vue
+++ b/agent-ui/src/components/agent/dag-runtime/DagNodeDetailDrawer.vue
@@ -65,6 +65,26 @@ const nodeMetrics = computed(() => {
   return props.metrics.nodes[props.selectedNodeId] ?? null
 })
 
+const execution = computed(() => nodeMetrics.value?.execution ?? null)
+
+const modelDisplayName = computed(() => (
+  execution.value?.model_display_name
+  || execution.value?.model_name
+  || t('dag.detail.unknown')
+))
+
+const exactModelName = computed(() => {
+  const exact = execution.value?.model_name
+  if (!exact || exact === execution.value?.model_display_name) return null
+  return exact
+})
+
+const providerDisplayName = computed(() => (
+  execution.value?.provider_display_name
+  || execution.value?.provider_id
+  || t('dag.detail.unknown')
+))
+
 const persona = computed(() => {
   return node.value ? getAgentPersona(node.value.agent_name) : null
 })
@@ -235,16 +255,89 @@ defineExpose({ scrollBy })
           <span class="font-mono font-semibold text-[var(--hr-danger)]">{{ nodeMetrics.tool_failures }}</span>
         </span>
         <span class="flex items-center gap-1.5">
-          <Coins class="h-3.5 w-3.5 text-[var(--hr-success)]" />
-          <span class="font-mono font-semibold text-[var(--hr-text-1)]">
-            {{ nodeMetrics.tokens ? fmtTokens(nodeMetrics.tokens.input + nodeMetrics.tokens.output + nodeMetrics.tokens.cache_read) : '—' }}
-          </span>
-        </span>
-        <span class="flex items-center gap-1.5">
           <Clock class="h-3.5 w-3.5 text-[var(--hr-text-3)]" />
           <span class="font-mono text-[var(--hr-text-2)]">{{ fmtDuration(nodeMetrics.duration_ms) }}</span>
         </span>
       </div>
+      <section
+        v-if="nodeSemantic.isWorker"
+        data-testid="dag-node-execution"
+        class="flex-shrink-0 border-b border-[var(--hr-border)] bg-[var(--hr-surface-1)] px-6 py-4"
+      >
+        <div class="flex items-center justify-between gap-3">
+          <div class="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-[var(--hr-text-3)]">
+            <Coins class="h-3.5 w-3.5 text-[var(--hr-success)]" />
+            {{ t('dag.detail.execution') }}
+          </div>
+          <span class="text-[10px] text-[var(--hr-text-4)]">{{ t('dag.detail.nodeCumulative') }}</span>
+        </div>
+
+        <div class="mt-3 grid grid-cols-2 gap-x-5 gap-y-3">
+          <div class="min-w-0">
+            <div class="text-[10px] uppercase tracking-wide text-[var(--hr-text-4)]">{{ t('dag.detail.model') }}</div>
+            <div data-testid="dag-execution-model" class="mt-0.5 truncate text-sm font-medium text-[var(--hr-text-1)]">
+              {{ modelDisplayName }}
+            </div>
+            <div v-if="exactModelName" class="truncate font-mono text-[10px] text-[var(--hr-text-4)]">{{ exactModelName }}</div>
+          </div>
+          <div class="min-w-0">
+            <div class="text-[10px] uppercase tracking-wide text-[var(--hr-text-4)]">{{ t('dag.detail.provider') }}</div>
+            <div data-testid="dag-execution-provider" class="mt-0.5 truncate text-sm text-[var(--hr-text-2)]">{{ providerDisplayName }}</div>
+          </div>
+          <div class="min-w-0">
+            <div class="text-[10px] uppercase tracking-wide text-[var(--hr-text-4)]">{{ t('dag.detail.backend') }}</div>
+            <div data-testid="dag-execution-backend" class="mt-0.5 truncate font-mono text-xs text-[var(--hr-text-2)]">
+              {{ execution?.agent_backend || t('dag.detail.unknown') }}
+            </div>
+          </div>
+          <div class="min-w-0">
+            <div class="text-[10px] uppercase tracking-wide text-[var(--hr-text-4)]">{{ t('dag.detail.protocol') }}</div>
+            <div data-testid="dag-execution-protocol" class="mt-0.5 truncate font-mono text-xs text-[var(--hr-text-2)]">
+              {{ execution?.protocol || t('dag.detail.unknown') }}
+            </div>
+          </div>
+        </div>
+
+        <div class="mt-4">
+          <div class="mb-2 text-[10px] uppercase tracking-wide text-[var(--hr-text-4)]">{{ t('dag.detail.tokenUsage') }}</div>
+          <div class="grid grid-cols-5 gap-1.5">
+            <div class="rounded-lg border border-[var(--hr-border)] bg-[var(--hr-panel)] px-2 py-2">
+              <div class="text-[9px] text-[var(--hr-text-4)]">{{ t('dag.detail.inputTokens') }}</div>
+              <div class="mt-0.5 font-mono text-xs text-[var(--hr-text-1)]">{{ nodeMetrics?.tokens ? fmtTokens(nodeMetrics.tokens.input) : t('dag.detail.unknown') }}</div>
+            </div>
+            <div class="rounded-lg border border-[var(--hr-border)] bg-[var(--hr-panel)] px-2 py-2">
+              <div class="text-[9px] text-[var(--hr-text-4)]">{{ t('dag.detail.outputTokens') }}</div>
+              <div class="mt-0.5 font-mono text-xs text-[var(--hr-text-1)]">{{ nodeMetrics?.tokens ? fmtTokens(nodeMetrics.tokens.output) : t('dag.detail.unknown') }}</div>
+            </div>
+            <div class="rounded-lg border border-[var(--hr-border)] bg-[var(--hr-panel)] px-2 py-2">
+              <div class="text-[9px] text-[var(--hr-text-4)]">{{ t('dag.detail.cacheReadTokens') }}</div>
+              <div class="mt-0.5 font-mono text-xs text-[var(--hr-text-1)]">{{ nodeMetrics?.tokens ? fmtTokens(nodeMetrics.tokens.cache_read) : t('dag.detail.unknown') }}</div>
+            </div>
+            <div class="rounded-lg border border-[var(--hr-border)] bg-[var(--hr-panel)] px-2 py-2">
+              <div class="text-[9px] text-[var(--hr-text-4)]">{{ t('dag.detail.cacheCreationTokens') }}</div>
+              <div class="mt-0.5 font-mono text-xs text-[var(--hr-text-1)]">{{ nodeMetrics?.tokens ? fmtTokens(nodeMetrics.tokens.cache_creation) : t('dag.detail.unknown') }}</div>
+            </div>
+            <div
+              class="rounded-lg border border-[var(--hr-success-border)] bg-[var(--hr-success-soft)] px-2 py-2"
+              :title="t('dag.detail.totalTokensHint')"
+            >
+              <div class="text-[9px] text-[var(--hr-success)]">{{ t('dag.detail.totalTokens') }}</div>
+              <div data-testid="dag-execution-total-tokens" class="mt-0.5 font-mono text-xs font-semibold text-[var(--hr-success)]">
+                {{ nodeMetrics?.tokens ? fmtTokens(nodeMetrics.tokens.total) : t('dag.detail.unknown') }}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="mt-3 flex items-center gap-2 text-[10px] text-[var(--hr-text-4)]">
+          <span>{{ t('dag.detail.context') }}</span>
+          <span class="font-mono text-[var(--hr-text-2)]">
+            <template v-if="execution?.context_usage_pct != null">{{ execution.context_usage_pct.toFixed(1) }}%</template>
+            <template v-else>{{ t('dag.detail.unknown') }}</template>
+            <template v-if="execution?.context_limit != null"> · {{ fmtTokens(execution.context_limit) }}</template>
+          </span>
+        </div>
+      </section>
       <div
         v-else-if="!nodeSemantic.isWorker"
         class="flex items-center gap-2 border-b border-[var(--hr-border)] bg-[var(--hr-accent-soft)] px-6 py-2.5 text-xs text-[var(--hr-text-2)]"

--- a/agent-ui/src/components/agent/dag-runtime/DagRuntimeCanvas.vue
+++ b/agent-ui/src/components/agent/dag-runtime/DagRuntimeCanvas.vue
@@ -113,7 +113,7 @@ function nodeRadius(metrics: DAGNodeMetrics | undefined, semantic: DagRuntimeNod
   // 基础半径 28（触摸目标 ≥44px 直径），按 token 消耗适度放大（对数缩放）
   const base = 28
   if (!metrics?.tokens) return base
-  const total = metrics.tokens.input + metrics.tokens.output + metrics.tokens.cache_read
+  const total = metrics.tokens.total
   if (total <= 0) return base
   return Math.min(38, base + Math.log2(total / 1000 + 1) * 2.5)
 }
@@ -124,7 +124,7 @@ function badgeTexts(metrics?: DAGNodeMetrics): string[] {
   if (metrics.tool_calls > 0) badges.push(`🔧${metrics.tool_calls}`)
   if (metrics.tool_failures > 0) badges.push(`✗${metrics.tool_failures}`)
   if (metrics.tokens) {
-    const total = metrics.tokens.input + metrics.tokens.output + metrics.tokens.cache_read
+    const total = metrics.tokens.total
     if (total > 0) badges.push(fmtTokens(total))
   }
   return badges
@@ -588,7 +588,7 @@ function drawBadges(ctx: CanvasRenderingContext2D, node: RuntimeNode): void {
     badges.push({ text: `✗${m.tool_failures}`, color: canvasPalette.danger })
   }
   if (m.tokens) {
-    const total = m.tokens.input + m.tokens.output + m.tokens.cache_read
+    const total = m.tokens.total
     if (total > 0) {
       badges.push({ text: fmtTokens(total), color: canvasPalette.success })
     }

--- a/agent-ui/src/components/agent/dag-runtime/DagRuntimeToolbar.vue
+++ b/agent-ui/src/components/agent/dag-runtime/DagRuntimeToolbar.vue
@@ -50,7 +50,7 @@ const executionStatusLabel = computed(() => {
 const totals = computed(() => {
   if (props.metrics) {
     return {
-      tokens: props.metrics.totals.tokens.input + props.metrics.totals.tokens.output + props.metrics.totals.tokens.cache_read,
+      tokens: props.metrics.totals.tokens.total,
       toolCalls: props.metrics.totals.tool_calls,
       failures: props.metrics.totals.tool_failures,
       available: props.metrics.totals.usage_available,
@@ -59,7 +59,12 @@ const totals = computed(() => {
   // 降级：从 store.nodes 本地累加（无 usage 时）
   let tokens = 0, calls = 0, fails = 0
   for (const n of store.nodes) {
-    if (n.token_usage) tokens += n.token_usage.input_tokens + n.token_usage.output_tokens + n.token_usage.cache_read_input_tokens
+    if (n.token_usage) {
+      tokens += n.token_usage.input_tokens
+        + n.token_usage.output_tokens
+        + n.token_usage.cache_read_input_tokens
+        + n.token_usage.cache_creation_input_tokens
+    }
   }
   return { tokens, toolCalls: calls, failures: fails, available: tokens > 0 }
 })

--- a/agent-ui/src/locales/en-US/dag.json
+++ b/agent-ui/src/locales/en-US/dag.json
@@ -50,7 +50,22 @@
     "noTask": "No task description",
     "logs": "Chat logs",
     "noLogs": "No logs for this node",
-    "managerExecuted": "Executed by Manager control logic; no worker or model is dispatched."
+    "managerExecuted": "Executed by Manager control logic; no worker or model is dispatched.",
+    "execution": "Execution",
+    "model": "Model",
+    "provider": "Provider",
+    "backend": "Agent backend",
+    "protocol": "Protocol",
+    "tokenUsage": "Token usage",
+    "inputTokens": "Input",
+    "outputTokens": "Output",
+    "cacheReadTokens": "Cache read",
+    "cacheCreationTokens": "Cache write",
+    "totalTokens": "Total",
+    "totalTokensHint": "Input + output + cache read + cache creation tokens",
+    "context": "Context usage",
+    "nodeCumulative": "Cumulative for this node",
+    "unknown": "—"
   },
   "nodeTypes": {
     "legend": "DAG execution node legend",

--- a/agent-ui/src/locales/zh-Hans/dag.json
+++ b/agent-ui/src/locales/zh-Hans/dag.json
@@ -50,7 +50,22 @@
     "noTask": "无任务描述",
     "logs": "聊天日志",
     "noLogs": "该节点暂无日志",
-    "managerExecuted": "由 Manager 控制逻辑执行，不会调度 Worker 或模型。"
+    "managerExecuted": "由 Manager 控制逻辑执行，不会调度 Worker 或模型。",
+    "execution": "执行信息",
+    "model": "模型",
+    "provider": "提供商",
+    "backend": "Agent 后端",
+    "protocol": "协议",
+    "tokenUsage": "Token 用量",
+    "inputTokens": "输入",
+    "outputTokens": "输出",
+    "cacheReadTokens": "缓存读取",
+    "cacheCreationTokens": "缓存写入",
+    "totalTokens": "合计",
+    "totalTokensHint": "输入 + 输出 + 缓存读取 + 缓存写入 Token",
+    "context": "上下文用量",
+    "nodeCumulative": "当前节点累计",
+    "unknown": "—"
   },
   "nodeTypes": {
     "legend": "DAG 执行节点图例",

--- a/agent-ui/src/locales/zh-Hant/dag.json
+++ b/agent-ui/src/locales/zh-Hant/dag.json
@@ -50,7 +50,22 @@
     "noTask": "無任務描述",
     "logs": "聊天日誌",
     "noLogs": "該節點暫無日誌",
-    "managerExecuted": "由 Manager 控制邏輯執行，不會調度 Worker 或模型。"
+    "managerExecuted": "由 Manager 控制邏輯執行，不會調度 Worker 或模型。",
+    "execution": "執行資訊",
+    "model": "模型",
+    "provider": "提供商",
+    "backend": "Agent 後端",
+    "protocol": "協議",
+    "tokenUsage": "Token 用量",
+    "inputTokens": "輸入",
+    "outputTokens": "輸出",
+    "cacheReadTokens": "快取讀取",
+    "cacheCreationTokens": "快取寫入",
+    "totalTokens": "合計",
+    "totalTokensHint": "輸入 + 輸出 + 快取讀取 + 快取寫入 Token",
+    "context": "上下文用量",
+    "nodeCumulative": "目前節點累計",
+    "unknown": "—"
   },
   "nodeTypes": {
     "legend": "DAG 執行節點圖例",

--- a/homerail_manager/src/node/websocket.ts
+++ b/homerail_manager/src/node/websocket.ts
@@ -625,6 +625,7 @@ export function setupNodeWebSocket(
                   ...(typeof msg.data.round_id === "string" ? { round_id: msg.data.round_id } : {}),
                   ...(typeof msg.data.generation === "number" ? { generation: msg.data.generation } : {}),
                   ...(typeof msg.data.command_id === "string" ? { command_id: msg.data.command_id } : {}),
+                  ...(typeof msg.data.execution_id === "string" ? { execution_id: msg.data.execution_id } : {}),
                 };
                 appendNodeUsage({
                   runId,

--- a/homerail_manager/src/node/websocket.ts
+++ b/homerail_manager/src/node/websocket.ts
@@ -21,7 +21,7 @@ import {
 import { handleDagMessageResponse } from "../orchestration/dag-message-router.js";
 import { clearByTargetId, isCurrentDispatchTarget } from "../orchestration/dispatch-tracker.js";
 import { emit } from "../events/bus.js";
-import { appendChatEntry } from "../persistence/store.js";
+import { appendChatEntry, appendNodeUsage } from "../persistence/store.js";
 import { appendSessionTranscriptEntry } from "../persistence/dag-session-files.js";
 import {
   autoHandoffAfterCorrectionExhausted,
@@ -612,6 +612,36 @@ export function setupNodeWebSocket(
               sessionId,
               msg.data,
             );
+            if (msg.data.event === "usage") {
+              const rawUsage = msg.data.usage as {
+                input_tokens?: number;
+                output_tokens?: number;
+                cache_read_input_tokens?: number;
+                cache_creation_input_tokens?: number;
+              } | undefined;
+              if (rawUsage) {
+                const scope = {
+                  ...(typeof msg.data.session_id === "string" ? { session_id: msg.data.session_id } : {}),
+                  ...(typeof msg.data.round_id === "string" ? { round_id: msg.data.round_id } : {}),
+                  ...(typeof msg.data.generation === "number" ? { generation: msg.data.generation } : {}),
+                  ...(typeof msg.data.command_id === "string" ? { command_id: msg.data.command_id } : {}),
+                };
+                appendNodeUsage({
+                  runId,
+                  nodeId,
+                  ...(Object.keys(scope).length > 0 ? { scope } : {}),
+                  usage: {
+                    input_tokens: Number(rawUsage.input_tokens ?? 0),
+                    output_tokens: Number(rawUsage.output_tokens ?? 0),
+                    cache_read_input_tokens: Number(rawUsage.cache_read_input_tokens ?? 0),
+                    cache_creation_input_tokens: Number(rawUsage.cache_creation_input_tokens ?? 0),
+                  },
+                  duration_ms: typeof msg.data.duration_ms === "number" ? msg.data.duration_ms : undefined,
+                  num_turns: typeof msg.data.num_turns === "number" ? msg.data.num_turns : undefined,
+                  timestamp: Date.now(),
+                });
+              }
+            }
           }
           return;
         }

--- a/homerail_manager/src/orchestration/graph.ts
+++ b/homerail_manager/src/orchestration/graph.ts
@@ -13,7 +13,9 @@ export interface DAGAgentConfig {
   llm_setting_id?: string;
   llm?: {
     provider?: string;
+    provider_display_name?: string;
     model?: string;
+    model_display_name?: string;
     api_key?: string;
     base_url?: string;
     protocol?: string;

--- a/homerail_manager/src/persistence/types.ts
+++ b/homerail_manager/src/persistence/types.ts
@@ -8,6 +8,7 @@ import type {
 } from "../orchestration/graph.js";
 import type { DAGRunCounters, DAGRunLimits } from "../runtime/active-runs.js";
 import type { DagRunStatus } from "./status.js";
+import type { DagNodeUsageScope } from "homerail-protocol";
 
 export interface PersistedGraphNode {
   node_id: string;
@@ -119,12 +120,15 @@ export interface ChatEntry {
   timestamp: number;
 }
 
-/** Token usage snapshot reported by a worker for a single node. The worker
- * emits cumulative totals once per node (on handoff, normal completion, or
- * error). Persisted to Manager SQLite; the last record per node wins. */
+/**
+ * Token usage snapshot reported by a Worker for one node turn. Snapshots from
+ * the same scope replace one another; final metrics sum the latest snapshot
+ * from every scope to produce a cumulative node total.
+ */
 export interface NodeUsageRecord {
   runId: string;
   nodeId: string;
+  scope?: DagNodeUsageScope;
   usage: {
     input_tokens: number;
     output_tokens: number;

--- a/homerail_manager/src/runtime/active-runs.ts
+++ b/homerail_manager/src/runtime/active-runs.ts
@@ -4266,7 +4266,9 @@ function _withDispatchCredentials(agentConfig: DAGAgentConfig): DispatchCredenti
         llm: {
           ...agentConfig.llm,
           provider: resolved.provider_name,
+          provider_display_name: resolved.provider_display_name,
           model: resolved.model,
+          model_display_name: resolved.model_display_name,
           api_key: resolved.api_key,
           base_url: resolved.base_url,
           protocol: resolved.protocol,

--- a/homerail_manager/src/runtime/agent-runtime-resolver.ts
+++ b/homerail_manager/src/runtime/agent-runtime-resolver.ts
@@ -11,6 +11,8 @@ import {
 } from "../persistence/llm-settings.js";
 import {
   canonicalModelNameForEndpoint,
+  findCatalogEndpoint,
+  findEndpointModel,
   isKimiProviderId,
   KIMI_CN_PROVIDER_ID,
   KIMI_PROVIDER_ID,
@@ -40,7 +42,9 @@ export interface AgentRuntimeResolutionInput {
 
 export interface AgentRuntimeResolution {
   provider_name: string;
+  provider_display_name?: string;
   model: string;
+  model_display_name?: string;
   api_key: string;
   base_url: string;
   protocol: string;
@@ -168,7 +172,9 @@ export function resolveAgentRuntimeConfig(input: AgentRuntimeResolutionInput): A
     }
     return {
       provider_name: "",
+      provider_display_name: "OpenAI",
       model,
+      model_display_name: model,
       api_key: "",
       base_url: "",
       protocol: "codex_appserver",
@@ -183,6 +189,11 @@ export function resolveAgentRuntimeConfig(input: AgentRuntimeResolutionInput): A
   const requestedModel = input.modelName
     ? canonicalModelNameForEndpoint(setting.provider_id, setting.endpoint_id, input.modelName)
     : undefined;
+  const model = input.settingId ? setting.model_name : requestedModel || setting.model_name;
+  const catalogModel = findEndpointModel(
+    findCatalogEndpoint(setting.provider_id, setting.endpoint_id),
+    model,
+  );
   if (!baseUrl) {
     if (agentType === "claude-sdk") {
       throw new Error(`Claude SDK requires an Anthropic-compatible endpoint for ${setting.provider_id}/${setting.model_name}; Chat Completions endpoints are not supported for harness execution. Configure an Anthropic base URL or use the Kimi Code harness for Kimi.`);
@@ -191,7 +202,11 @@ export function resolveAgentRuntimeConfig(input: AgentRuntimeResolutionInput): A
   }
   return {
     provider_name: setting.provider_id,
-    model: input.settingId ? setting.model_name : requestedModel || setting.model_name,
+    provider_display_name: getProvider(setting.provider_id)?.name ?? setting.provider_id,
+    model,
+    model_display_name: model === setting.model_name
+      ? setting.display_name ?? catalogModel?.display_name ?? catalogModel?.name ?? model
+      : catalogModel?.display_name ?? catalogModel?.name ?? model,
     api_key: setting.api_key,
     base_url: baseUrl,
     protocol: agentType === "claude-sdk" ? "anthropic_compatible" : setting.protocol,

--- a/homerail_manager/src/server/routes.ts
+++ b/homerail_manager/src/server/routes.ts
@@ -339,6 +339,7 @@ function _usageScopeKey(record: NodeUsageRecord): string {
     scope.round_id ?? "",
     scope.generation ?? null,
     scope.command_id ?? "",
+    scope.execution_id ?? "",
   ]);
 }
 

--- a/homerail_manager/src/server/routes.ts
+++ b/homerail_manager/src/server/routes.ts
@@ -6,6 +6,12 @@ import {
   loadNodeUsages,
 } from "../persistence/store.js";
 import type { PersistedEvent, PersistedRunMetadata, PersistedRunSnapshot, NodeUsageRecord } from "../persistence/types.js";
+import {
+  DAG_NODE_USAGE_AGGREGATION,
+  dagNodeTokenTotal,
+  normalizeDagNodeExecutionIdentity,
+  type DagNodeExecutionIdentity,
+} from "homerail-protocol";
 import { DAG_EVENT_TYPES, subscribe, type DAGEventPayload } from "../events/bus.js";
 import { getDiagnostics } from "../config/diagnostics.js";
 import { runtimeStatusHandler } from "../runtime/status.js";
@@ -314,7 +320,10 @@ interface NodeMetrics {
     output: number;
     cache_read: number;
     cache_creation: number;
+    total: number;
   } | null;
+  execution: DagNodeExecutionIdentity | null;
+  usage_scope: typeof DAG_NODE_USAGE_AGGREGATION;
   usage_available: boolean;
   duration_ms: number | null;
   num_turns: number | null;
@@ -322,26 +331,81 @@ interface NodeMetrics {
   completed_at: string | null;
 }
 
+function _usageScopeKey(record: NodeUsageRecord): string {
+  const scope = record.scope;
+  if (!scope || Object.keys(scope).length === 0) return "legacy";
+  return JSON.stringify([
+    scope.session_id ?? "",
+    scope.round_id ?? "",
+    scope.generation ?? null,
+    scope.command_id ?? "",
+  ]);
+}
+
+function _nonNegativeToken(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? Math.floor(value)
+    : 0;
+}
+
+function _nodeExecutionIdentity(
+  chats: PersistedRunSnapshot["chats"],
+  nodeId: string,
+): DagNodeExecutionIdentity | null {
+  const entries = chats[nodeId] ?? [];
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (entry?.role !== "manager" || entry.type !== "prompt") continue;
+    const content = entry.content && typeof entry.content === "object" && !Array.isArray(entry.content)
+      ? entry.content as Record<string, unknown>
+      : undefined;
+    const agentConfig = content?.agentConfig
+      && typeof content.agentConfig === "object"
+      && !Array.isArray(content.agentConfig)
+      ? content.agentConfig as Record<string, unknown>
+      : undefined;
+    if (!agentConfig) continue;
+    const llm = agentConfig.llm
+      && typeof agentConfig.llm === "object"
+      && !Array.isArray(agentConfig.llm)
+      ? agentConfig.llm as Record<string, unknown>
+      : {};
+    return normalizeDagNodeExecutionIdentity({
+      provider_id: llm.provider,
+      provider_display_name: llm.provider_display_name,
+      model_name: llm.model ?? agentConfig.model,
+      model_display_name: llm.model_display_name,
+      agent_backend: agentConfig.agent_type,
+      protocol: llm.protocol,
+      context_limit: llm.context_limit,
+      context_usage_pct: llm.context_usage_pct,
+    }) ?? null;
+  }
+  return null;
+}
+
 /** Aggregate per-node tool-call counts and token usage for the runtime
  * overlay. Tool calls are counted from persisted chat entries (each
  * tool_use / tool_result stream event is one entry); tool failures are
- * tool_result entries flagged is_error. Token usage comes from the
- * SQLite metrics records emitted by workers (last record per node wins). */
+ * tool_result entries flagged is_error. Token usage comes from persisted
+ * Worker snapshots: the last snapshot in each turn scope wins and scopes are
+ * summed into an authoritative cumulative node total. */
 function _buildMetricsSummary(snapshot: PersistedRunSnapshot) {
   const metadata = snapshot.metadata;
   const nodeIds = metadata.graph?.nodes.map((node) => node.node_id) ?? Object.keys(metadata.nodeStates);
 
-  // Last usage record per node wins (worker emits cumulative totals).
-  const usageByNode = new Map<string, NodeUsageRecord>();
+  const usageByNodeAndScope = new Map<string, Map<string, NodeUsageRecord>>();
   for (const record of snapshot.usages ?? loadNodeUsages(metadata.runId)) {
-    usageByNode.set(record.nodeId, record);
+    const scopes = usageByNodeAndScope.get(record.nodeId) ?? new Map<string, NodeUsageRecord>();
+    scopes.set(_usageScopeKey(record), record);
+    usageByNodeAndScope.set(record.nodeId, scopes);
   }
 
   const nodes: Record<string, NodeMetrics> = {};
   const totals = {
     tool_calls: 0,
     tool_failures: 0,
-    tokens: { input: 0, output: 0, cache_read: 0, cache_creation: 0 },
+    tokens: { input: 0, output: 0, cache_read: 0, cache_creation: 0, total: 0 },
     usage_available: false,
   };
 
@@ -358,14 +422,46 @@ function _buildMetricsSummary(snapshot: PersistedRunSnapshot) {
       }
     }
 
-    const usage = usageByNode.get(nodeId);
+    const usageScopes = Array.from(usageByNodeAndScope.get(nodeId)?.values() ?? []);
+    const usage = usageScopes.length > 0
+      ? usageScopes.reduce((summary, record) => {
+          summary.input += _nonNegativeToken(record.usage.input_tokens);
+          summary.output += _nonNegativeToken(record.usage.output_tokens);
+          summary.cache_read += _nonNegativeToken(record.usage.cache_read_input_tokens);
+          summary.cache_creation += _nonNegativeToken(record.usage.cache_creation_input_tokens);
+          if (typeof record.duration_ms === "number" && Number.isFinite(record.duration_ms) && record.duration_ms >= 0) {
+            summary.duration_ms += record.duration_ms;
+            summary.has_duration = true;
+          }
+          if (typeof record.num_turns === "number" && Number.isFinite(record.num_turns) && record.num_turns >= 0) {
+            summary.num_turns += record.num_turns;
+            summary.has_num_turns = true;
+          }
+          return summary;
+        }, {
+          input: 0,
+          output: 0,
+          cache_read: 0,
+          cache_creation: 0,
+          duration_ms: 0,
+          num_turns: 0,
+          has_duration: false,
+          has_num_turns: false,
+        })
+      : undefined;
     const status = (metadata.nodeStates[nodeId] || "PENDING").toLowerCase();
     const tokens = usage
       ? {
-          input: usage.usage.input_tokens,
-          output: usage.usage.output_tokens,
-          cache_read: usage.usage.cache_read_input_tokens,
-          cache_creation: usage.usage.cache_creation_input_tokens,
+          input: usage.input,
+          output: usage.output,
+          cache_read: usage.cache_read,
+          cache_creation: usage.cache_creation,
+          total: dagNodeTokenTotal({
+            input_tokens: usage.input,
+            output_tokens: usage.output,
+            cache_read_input_tokens: usage.cache_read,
+            cache_creation_input_tokens: usage.cache_creation,
+          }),
         }
       : null;
 
@@ -377,9 +473,11 @@ function _buildMetricsSummary(snapshot: PersistedRunSnapshot) {
       tool_calls: toolCalls,
       tool_failures: toolFailures,
       tokens,
-      usage_available: Boolean(usage),
-      duration_ms: usage?.duration_ms ?? null,
-      num_turns: usage?.num_turns ?? null,
+      execution: _nodeExecutionIdentity(snapshot.chats, nodeId),
+      usage_scope: DAG_NODE_USAGE_AGGREGATION,
+      usage_available: usage !== undefined,
+      duration_ms: usage?.has_duration ? usage.duration_ms : null,
+      num_turns: usage?.has_num_turns ? usage.num_turns : null,
       started_at: null,
       completed_at: _isTerminalNodeStatus(status)
         ? (metadata.completedAt ? new Date(metadata.completedAt).toISOString() : null)
@@ -393,6 +491,7 @@ function _buildMetricsSummary(snapshot: PersistedRunSnapshot) {
       totals.tokens.output += tokens.output;
       totals.tokens.cache_read += tokens.cache_read;
       totals.tokens.cache_creation += tokens.cache_creation;
+      totals.tokens.total += tokens.total;
       totals.usage_available = true;
     }
   }

--- a/homerail_manager/src/worker/websocket.ts
+++ b/homerail_manager/src/worker/websocket.ts
@@ -640,6 +640,7 @@ export function setupWorkerWebSocket(
                   ...(typeof msg.data.round_id === "string" ? { round_id: msg.data.round_id } : {}),
                   ...(typeof msg.data.generation === "number" ? { generation: msg.data.generation } : {}),
                   ...(typeof msg.data.command_id === "string" ? { command_id: msg.data.command_id } : {}),
+                  ...(typeof msg.data.execution_id === "string" ? { execution_id: msg.data.execution_id } : {}),
                 };
                 appendNodeUsage({
                   runId,

--- a/homerail_manager/src/worker/websocket.ts
+++ b/homerail_manager/src/worker/websocket.ts
@@ -629,15 +629,22 @@ export function setupWorkerWebSocket(
               msg.data,
             );
             // Persist per-node token usage when the worker reports a
-            // "usage" stream event. The worker emits cumulative totals,
-            // so we append a record; the metrics endpoint treats the last
-            // record per node as authoritative.
+            // "usage" stream event. Each execution scope is cumulative;
+            // the metrics endpoint keeps the latest snapshot per scope and
+            // then sums those scopes into the node lifetime total.
             if (msg.data.event === "usage") {
               const rawUsage = msg.data.usage as { input_tokens?: number; output_tokens?: number; cache_read_input_tokens?: number; cache_creation_input_tokens?: number } | undefined;
               if (rawUsage) {
+                const scope = {
+                  ...(typeof msg.data.session_id === "string" ? { session_id: msg.data.session_id } : {}),
+                  ...(typeof msg.data.round_id === "string" ? { round_id: msg.data.round_id } : {}),
+                  ...(typeof msg.data.generation === "number" ? { generation: msg.data.generation } : {}),
+                  ...(typeof msg.data.command_id === "string" ? { command_id: msg.data.command_id } : {}),
+                };
                 appendNodeUsage({
                   runId,
                   nodeId,
+                  ...(Object.keys(scope).length > 0 ? { scope } : {}),
                   usage: {
                     input_tokens: Number(rawUsage.input_tokens ?? 0),
                     output_tokens: Number(rawUsage.output_tokens ?? 0),

--- a/homerail_manager/tests/agent-runtime-resolver.test.ts
+++ b/homerail_manager/tests/agent-runtime-resolver.test.ts
@@ -40,7 +40,9 @@ describe("agent runtime resolver", () => {
 
     expect(resolved).toMatchObject({
       provider_name: "",
+      provider_display_name: "OpenAI",
       model: "codex-account-model",
+      model_display_name: "codex-account-model",
       api_key: "",
       base_url: "",
       protocol: "codex_appserver",
@@ -71,6 +73,7 @@ describe("agent runtime resolver", () => {
       provider_id: "kimi",
       endpoint_id: "kimi_coding_plan",
       model_name: "kimi-k2.7-code",
+      display_name: "Kimi Coding",
       api_key: "pk-test-kimi",
       protocol: "openai_compatible",
       plan_type: "coding_plan",
@@ -92,7 +95,9 @@ describe("agent runtime resolver", () => {
     for (const resolved of [manager, dag]) {
       expect(resolved).toMatchObject({
         provider_name: "kimi_cn",
+        provider_display_name: expect.any(String),
         model: "kimi-for-coding",
+        model_display_name: "Kimi Coding",
         api_key: "pk-test-kimi",
         base_url: "https://api.kimi.com/coding/v1",
         protocol: "openai_compatible",

--- a/homerail_manager/tests/dag-node-observability.test.ts
+++ b/homerail_manager/tests/dag-node-observability.test.ts
@@ -131,7 +131,13 @@ describe("DAG node observability", () => {
     appendNodeUsage({
       runId,
       nodeId: "work",
-      scope: { session_id: "session-1", round_id: "round-0002", generation: 1, command_id: "command-2" },
+      scope: {
+        session_id: "session-1",
+        round_id: "round-0002",
+        generation: 1,
+        command_id: "command-2",
+        execution_id: "execution-1",
+      },
       usage: {
         input_tokens: 7,
         output_tokens: 2,
@@ -185,7 +191,13 @@ describe("DAG node observability", () => {
     appendNodeUsage({
       runId,
       nodeId: "work",
-      scope: { session_id: "session-1", round_id: "round-0002", generation: 1, command_id: "command-2" },
+      scope: {
+        session_id: "session-1",
+        round_id: "round-0002",
+        generation: 1,
+        command_id: "command-2",
+        execution_id: "execution-1",
+      },
       usage: {
         input_tokens: 9,
         output_tokens: 4,
@@ -203,6 +215,35 @@ describe("DAG node observability", () => {
       cache_read: 5,
       cache_creation: 3,
       total: 39,
+    });
+
+    // A contract-correction prompt is a separate billed execution even when
+    // it reuses the same session, round, generation, and command fence.
+    appendNodeUsage({
+      runId,
+      nodeId: "work",
+      scope: {
+        session_id: "session-1",
+        round_id: "round-0002",
+        generation: 1,
+        command_id: "command-2",
+        execution_id: "execution-2",
+      },
+      usage: {
+        input_tokens: 3,
+        output_tokens: 2,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+      timestamp: 6,
+    });
+    const corrected = await metrics(port, runId);
+    expect(corrected.data.nodes.work.tokens).toEqual({
+      input: 24,
+      output: 12,
+      cache_read: 5,
+      cache_creation: 3,
+      total: 44,
     });
   });
 

--- a/homerail_manager/tests/dag-node-observability.test.ts
+++ b/homerail_manager/tests/dag-node-observability.test.ts
@@ -1,0 +1,222 @@
+import * as fs from "node:fs";
+import * as http from "node:http";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { parseDAGYaml } from "../src/orchestration/yaml-loader.js";
+import { closeDb } from "../src/persistence/db.js";
+import {
+  _clearAllPersistence,
+  appendChatEntry,
+  appendNodeUsage,
+} from "../src/persistence/store.js";
+import { _clearActiveRuns, createActiveRun } from "../src/runtime/active-runs.js";
+import { createServer } from "../src/server/http.js";
+
+async function listen(server: http.Server): Promise<number> {
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+  const address = server.address();
+  if (!address || typeof address !== "object") throw new Error("server did not bind");
+  return address.port;
+}
+
+async function close(server: http.Server): Promise<void> {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+function createTestRun(runId: string): void {
+  createActiveRun(runId, parseDAGYaml(`
+name: node-observability
+workflow_id: node-observability
+agents:
+  worker:
+    agent_type: deterministic
+    system: HANDOFF port=done content=ok
+nodes:
+  work:
+    agent: worker
+    after: []
+    outputs:
+      done:
+        to: ""
+`));
+}
+
+async function metrics(port: number, runId: string): Promise<Record<string, any>> {
+  const response = await fetch(`http://127.0.0.1:${port}/api/dag-status/${runId}/metrics`);
+  expect(response.status).toBe(200);
+  return await response.json() as Record<string, any>;
+}
+
+describe("DAG node observability", () => {
+  let server: http.Server;
+  let tmpHome: string;
+  let oldHome: string | undefined;
+
+  beforeEach(() => {
+    oldHome = process.env.HOMERAIL_HOME;
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-node-observability-"));
+    process.env.HOMERAIL_HOME = tmpHome;
+    _clearActiveRuns();
+    _clearAllPersistence();
+    server = createServer(0, undefined, undefined, false, { autoDetectCodex: false });
+  });
+
+  afterEach(async () => {
+    _clearActiveRuns();
+    _clearAllPersistence();
+    await close(server);
+    closeDb();
+    if (oldHome === undefined) delete process.env.HOMERAIL_HOME;
+    else process.env.HOMERAIL_HOME = oldHome;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("persists safe execution identity and cumulative multi-round token metrics", async () => {
+    const runId = "node-observability-history";
+    createTestRun(runId);
+    appendChatEntry(runId, "work", {
+      role: "manager",
+      type: "prompt",
+      targetId: "worker-1",
+      content: {
+        agentConfig: {
+          agent_type: "claude-sdk",
+          llm_setting_id: "private-setting-id",
+          llm: {
+            provider: "anthropic",
+            provider_display_name: "Anthropic",
+            model: "claude-sonnet",
+            model_display_name: "Claude Sonnet",
+            protocol: "anthropic_compatible",
+            context_limit: 200_000,
+            context_usage_pct: 12.5,
+            api_key: "sk-private-value-123456",
+            base_url: "https://private.example.test",
+          },
+        },
+      },
+      timestamp: 1,
+    });
+
+    appendNodeUsage({
+      runId,
+      nodeId: "work",
+      scope: { session_id: "session-1", round_id: "round-0001", generation: 1 },
+      usage: {
+        input_tokens: 10,
+        output_tokens: 5,
+        cache_read_input_tokens: 2,
+        cache_creation_input_tokens: 1,
+      },
+      duration_ms: 100,
+      num_turns: 1,
+      timestamp: 2,
+    });
+    appendNodeUsage({
+      runId,
+      nodeId: "work",
+      scope: { session_id: "session-1", round_id: "round-0001", generation: 1 },
+      usage: {
+        input_tokens: 12,
+        output_tokens: 6,
+        cache_read_input_tokens: 4,
+        cache_creation_input_tokens: 3,
+      },
+      duration_ms: 120,
+      num_turns: 1,
+      timestamp: 3,
+    });
+    appendNodeUsage({
+      runId,
+      nodeId: "work",
+      scope: { session_id: "session-1", round_id: "round-0002", generation: 1, command_id: "command-2" },
+      usage: {
+        input_tokens: 7,
+        output_tokens: 2,
+        cache_read_input_tokens: 1,
+        cache_creation_input_tokens: 0,
+      },
+      duration_ms: 80,
+      num_turns: 1,
+      timestamp: 4,
+    });
+
+    // Prove the endpoint reads historical SQLite metrics, not active-run memory.
+    _clearActiveRuns();
+    const port = await listen(server);
+    const historical = await metrics(port, runId);
+    expect(historical.data.nodes.work).toMatchObject({
+      execution: {
+        provider_id: "anthropic",
+        provider_display_name: "Anthropic",
+        model_name: "claude-sonnet",
+        model_display_name: "Claude Sonnet",
+        agent_backend: "claude-sdk",
+        protocol: "anthropic_compatible",
+        context_limit: 200_000,
+        context_usage_pct: 12.5,
+      },
+      tokens: {
+        input: 19,
+        output: 8,
+        cache_read: 5,
+        cache_creation: 3,
+        total: 35,
+      },
+      usage_scope: "node_cumulative",
+      usage_available: true,
+      duration_ms: 200,
+      num_turns: 2,
+    });
+    expect(historical.data.totals.tokens).toEqual({
+      input: 19,
+      output: 8,
+      cache_read: 5,
+      cache_creation: 3,
+      total: 35,
+    });
+    expect(JSON.stringify(historical.data)).not.toContain("private-setting-id");
+    expect(JSON.stringify(historical.data)).not.toContain("private.example.test");
+    expect(JSON.stringify(historical.data)).not.toContain("sk-private");
+
+    // A newer running-total snapshot replaces only its own round scope.
+    appendNodeUsage({
+      runId,
+      nodeId: "work",
+      scope: { session_id: "session-1", round_id: "round-0002", generation: 1, command_id: "command-2" },
+      usage: {
+        input_tokens: 9,
+        output_tokens: 4,
+        cache_read_input_tokens: 1,
+        cache_creation_input_tokens: 0,
+      },
+      duration_ms: 90,
+      num_turns: 1,
+      timestamp: 5,
+    });
+    const refreshed = await metrics(port, runId);
+    expect(refreshed.data.nodes.work.tokens).toEqual({
+      input: 21,
+      output: 10,
+      cache_read: 5,
+      cache_creation: 3,
+      total: 39,
+    });
+  });
+
+  it("uses null rather than fake zeroes when identity and usage are unavailable", async () => {
+    const runId = "node-observability-unknown";
+    createTestRun(runId);
+    const port = await listen(server);
+    const body = await metrics(port, runId);
+
+    expect(body.data.nodes.work).toMatchObject({
+      execution: null,
+      tokens: null,
+      usage_available: false,
+      usage_scope: "node_cumulative",
+    });
+  });
+});

--- a/homerail_manager/tests/dispatch-capabilities.test.ts
+++ b/homerail_manager/tests/dispatch-capabilities.test.ts
@@ -1161,6 +1161,7 @@ nodes:
     createSetting({
       provider_id: "dual-url-provider",
       model_name: "dual-model",
+      display_name: "Dual Model",
       api_key: "test-key",
       protocol: "openai_compatible",
       base_url: "https://dual.example/v1",
@@ -1194,7 +1195,9 @@ nodes:
     const envelope = dispatcher.dispatch.mock.calls[0]?.[0] as DispatchEnvelope;
     expect(envelope.agentConfig.llm).toMatchObject({
       provider: "dual-url-provider",
+      provider_display_name: "Dual URL Provider",
       model: "dual-model",
+      model_display_name: "Dual Model",
       base_url: "https://dual.example/anthropic",
       protocol: "anthropic_compatible",
     });

--- a/homerail_manager/tests/transport-fence-websocket.test.ts
+++ b/homerail_manager/tests/transport-fence-websocket.test.ts
@@ -611,6 +611,7 @@ describe("round-aware terminal websocket transport", () => {
             generation: 1,
             lease_generation: lease.lease_generation,
             command_id: commandId,
+            execution_id: "execution-1",
             usage: {
               input_tokens: 101,
               output_tokens: 23,
@@ -632,6 +633,7 @@ describe("round-aware terminal websocket transport", () => {
               round_id: "round-0002",
               generation: 1,
               command_id: commandId,
+              execution_id: "execution-1",
             },
             usage: {
               input_tokens: 101,

--- a/homerail_manager/tests/transport-fence-websocket.test.ts
+++ b/homerail_manager/tests/transport-fence-websocket.test.ts
@@ -584,6 +584,73 @@ describe("round-aware terminal websocket transport", () => {
   });
 
   it.each(["worker", "node"] as const)(
+    "persists current fenced %s usage with its cumulative execution scope",
+    async (sourceType) => {
+      const runId = `run-${sourceType}-usage-scope`;
+      const envelope = startRoundTwo(runId);
+      const sessionId = envelope.sessionId!;
+      const commandId = `${runId}-command-2`;
+      const { server, ws, sourceId } = await openTransport(sourceType, runId, () => undefined);
+      const lease = acquireDagActorLease({
+        run_id: runId,
+        actor_id: "researcher",
+        target_type: sourceType,
+        target_id: sourceId,
+      });
+
+      try {
+        ws.send(JSON.stringify({
+          type: "stream",
+          data: {
+            event: "usage",
+            run_id: runId,
+            node_id: "actor",
+            session_id: sessionId,
+            round_id: "round-0002",
+            actor_id: "researcher",
+            generation: 1,
+            lease_generation: lease.lease_generation,
+            command_id: commandId,
+            usage: {
+              input_tokens: 101,
+              output_tokens: 23,
+              cache_read_input_tokens: 17,
+              cache_creation_input_tokens: 5,
+            },
+            duration_ms: 1_250,
+            num_turns: 2,
+          },
+        }));
+        await delay(50);
+
+        expect(loadNodeUsages(runId)).toEqual([
+          expect.objectContaining({
+            runId,
+            nodeId: "actor",
+            scope: {
+              session_id: sessionId,
+              round_id: "round-0002",
+              generation: 1,
+              command_id: commandId,
+            },
+            usage: {
+              input_tokens: 101,
+              output_tokens: 23,
+              cache_read_input_tokens: 17,
+              cache_creation_input_tokens: 5,
+            },
+            duration_ms: 1_250,
+            num_turns: 2,
+          }),
+        ]);
+      } finally {
+        ws.terminate();
+        await closeServer(server);
+      }
+    },
+  );
+
+  it.each(["worker", "node"] as const)(
     "routes only current fenced %s Actor surface patches without mirroring raw body data",
     async (sourceType) => {
       const runId = `run-${sourceType}-actor-surface-patch`;

--- a/homerail_protocol/src/dag-observability.ts
+++ b/homerail_protocol/src/dag-observability.ts
@@ -1,0 +1,95 @@
+/**
+ * Safe DAG node execution identity and token observability contract.
+ * @version 0.1.0
+ */
+
+import { redactTelemetry } from "./telemetry-redaction.js";
+
+/** Token categories reported by a model-backed DAG node. */
+export interface DagNodeTokenUsage {
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_input_tokens: number;
+  cache_creation_input_tokens: number;
+}
+
+/**
+ * Trusted, non-secret identity of the runtime that executed a DAG node.
+ *
+ * Endpoint URLs, setting IDs, credentials, and transport headers are
+ * intentionally absent from this contract.
+ */
+export interface DagNodeExecutionIdentity {
+  provider_id?: string;
+  provider_display_name?: string;
+  model_name?: string;
+  model_display_name?: string;
+  agent_backend?: string;
+  protocol?: string;
+  context_limit?: number;
+  context_usage_pct?: number;
+}
+
+/** One authoritative Worker turn within a potentially multi-round node. */
+export interface DagNodeUsageScope {
+  session_id?: string;
+  round_id?: string;
+  generation?: number;
+  command_id?: string;
+}
+
+export const DAG_NODE_USAGE_AGGREGATION = "node_cumulative" as const;
+
+function boundedIdentityString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const redacted = String(redactTelemetry(value)).trim();
+  if (!redacted || redacted === "***REDACTED***") return undefined;
+  return redacted.slice(0, 256);
+}
+
+function nonNegativeNumber(value: unknown, integer = false): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return undefined;
+  return integer ? Math.floor(value) : value;
+}
+
+/**
+ * Whitelist and bound the only execution identity fields that may cross the
+ * Manager metrics boundary.
+ */
+export function normalizeDagNodeExecutionIdentity(
+  value: unknown,
+): DagNodeExecutionIdentity | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const source = value as Record<string, unknown>;
+  const normalized: DagNodeExecutionIdentity = {
+    provider_id: boundedIdentityString(source.provider_id),
+    provider_display_name: boundedIdentityString(source.provider_display_name),
+    model_name: boundedIdentityString(source.model_name),
+    model_display_name: boundedIdentityString(source.model_display_name),
+    agent_backend: boundedIdentityString(source.agent_backend),
+    protocol: boundedIdentityString(source.protocol),
+    context_limit: nonNegativeNumber(source.context_limit, true),
+    context_usage_pct: nonNegativeNumber(source.context_usage_pct),
+  };
+  for (const key of Object.keys(normalized) as Array<keyof DagNodeExecutionIdentity>) {
+    if (normalized[key] === undefined) delete normalized[key];
+  }
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+function tokenCount(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? Math.floor(value)
+    : 0;
+}
+
+/**
+ * Total processed tokens. Cache reads and cache creations are separate input
+ * categories, so the total is the sum of all four authoritative counters.
+ */
+export function dagNodeTokenTotal(usage: Partial<DagNodeTokenUsage>): number {
+  return tokenCount(usage.input_tokens)
+    + tokenCount(usage.output_tokens)
+    + tokenCount(usage.cache_read_input_tokens)
+    + tokenCount(usage.cache_creation_input_tokens);
+}

--- a/homerail_protocol/src/dag-observability.ts
+++ b/homerail_protocol/src/dag-observability.ts
@@ -36,6 +36,8 @@ export interface DagNodeUsageScope {
   round_id?: string;
   generation?: number;
   command_id?: string;
+  /** One Worker prompt execution, including contract-correction attempts. */
+  execution_id?: string;
 }
 
 export const DAG_NODE_USAGE_AGGREGATION = "node_cumulative" as const;

--- a/homerail_protocol/src/index.ts
+++ b/homerail_protocol/src/index.ts
@@ -16,6 +16,7 @@ export const WORKER_CONTRACT_VERSION = "1";
 
 export * from "./types.js";
 export * from "./dag-activity.js";
+export * from "./dag-observability.js";
 export * from "./dag-worker-skill-context.js";
 export * from "./dag-credentials.js";
 export * from "./dag-actor-surface-patch.js";

--- a/homerail_protocol/tests/dag-observability.test.ts
+++ b/homerail_protocol/tests/dag-observability.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  dagNodeTokenTotal,
+  normalizeDagNodeExecutionIdentity,
+} from "../src/dag-observability.js";
+
+describe("DAG node observability", () => {
+  it("uses one documented total across every token category", () => {
+    expect(dagNodeTokenTotal({
+      input_tokens: 10,
+      output_tokens: 4,
+      cache_read_input_tokens: 6,
+      cache_creation_input_tokens: 2,
+    })).toBe(22);
+  });
+
+  it("whitelists execution identity without leaking endpoint or credential fields", () => {
+    const identity = normalizeDagNodeExecutionIdentity({
+      provider_id: "anthropic",
+      provider_display_name: "Anthropic",
+      model_name: "claude-sonnet",
+      model_display_name: "Claude Sonnet",
+      agent_backend: "claude-sdk",
+      protocol: "anthropic_compatible",
+      context_limit: 200_000,
+      context_usage_pct: 12.5,
+      api_key: "sk-private-value-123456",
+      base_url: "https://private.example.test",
+      authorization: "Bearer private-value",
+    });
+
+    expect(identity).toEqual({
+      provider_id: "anthropic",
+      provider_display_name: "Anthropic",
+      model_name: "claude-sonnet",
+      model_display_name: "Claude Sonnet",
+      agent_backend: "claude-sdk",
+      protocol: "anthropic_compatible",
+      context_limit: 200_000,
+      context_usage_pct: 12.5,
+    });
+    expect(JSON.stringify(identity)).not.toContain("private");
+  });
+
+  it("treats missing or secret-looking identity as unavailable", () => {
+    expect(normalizeDagNodeExecutionIdentity({
+      model_name: "sk-secretvalue123456",
+      context_limit: -1,
+    })).toBeUndefined();
+  });
+});

--- a/homerail_worker/src/__tests__/claude-sdk.test.ts
+++ b/homerail_worker/src/__tests__/claude-sdk.test.ts
@@ -108,6 +108,97 @@ describe("ClaudeSdkAdapter", () => {
     ]);
   });
 
+  it("deduplicates repeated usage snapshots for the same assistant message id", async () => {
+    vi.doMock("@anthropic-ai/claude-agent-sdk", () =>
+      makeFakeSdk([
+        {
+          type: "assistant",
+          message: {
+            id: "msg-1",
+            content: [{ type: "thinking", thinking: "Reasoning..." }],
+            usage: { input_tokens: 100, output_tokens: 0 },
+          },
+        },
+        {
+          type: "assistant",
+          message: {
+            id: "msg-1",
+            content: [{ type: "tool_use", id: "call-1", name: "echo", input: {} }],
+            usage: { input_tokens: 100, output_tokens: 0 },
+          },
+        },
+        {
+          type: "assistant",
+          message: {
+            id: "msg-1",
+            content: [{ type: "tool_use", id: "call-1", name: "echo", input: {} }],
+            usage: { input_tokens: 110, output_tokens: 0 },
+          },
+        },
+        {
+          type: "assistant",
+          message: {
+            id: "msg-2",
+            content: [{ type: "text", text: "Done." }],
+            stop_reason: "end_turn",
+            usage: {
+              input_tokens: 20,
+              output_tokens: 0,
+              cache_read_input_tokens: 80,
+            },
+          },
+        },
+        {
+          type: "assistant",
+          message: {
+            id: "msg-2",
+            content: [{ type: "text", text: "Done." }],
+            stop_reason: "end_turn",
+            usage: {
+              input_tokens: 20,
+              output_tokens: 0,
+              cache_read_input_tokens: 80,
+            },
+          },
+        },
+        { type: "result", subtype: "success", is_error: false },
+      ]),
+    );
+
+    const { ClaudeSdkAdapter } = await import("../agent/claude-sdk.js");
+    const adapter = new ClaudeSdkAdapter();
+    const events: AgentEvent[] = [];
+    for await (const event of adapter.run("test", [], ctx)) events.push(event);
+
+    const usageEvents = events
+      .filter((event): event is Extract<AgentEvent, { type: "usage" }> => event.type === "usage")
+      .map((event) => event.usage);
+    expect(usageEvents).toEqual([
+      { input_tokens: 100, output_tokens: 0 },
+      { input_tokens: 110, output_tokens: 0 },
+      {
+        input_tokens: 130,
+        output_tokens: 0,
+        cache_read_input_tokens: 80,
+      },
+      {
+        input_tokens: 130,
+        output_tokens: 0,
+        cache_read_input_tokens: 80,
+      },
+    ]);
+    expect(events.at(-1)).toEqual({
+      type: "done",
+      usage: {
+        input_tokens: 130,
+        output_tokens: 0,
+        cache_read_input_tokens: 80,
+      },
+      duration_ms: undefined,
+      num_turns: undefined,
+    });
+  });
+
   it("suppresses per-token thinking diagnostics and reports one aggregate count", async () => {
     const thinkingTokenMessages = Array.from({ length: 10_000 }, () => ({
       type: "system",

--- a/homerail_worker/src/__tests__/prompt-runner.test.ts
+++ b/homerail_worker/src/__tests__/prompt-runner.test.ts
@@ -182,6 +182,8 @@ describe("prompt runner", () => {
       .filter((message) => message.type === "stream" && message.data?.event === "usage");
     expect(usageEvents).toHaveLength(3);
     expect(usageEvents.map((message) => message.data.usage.input_tokens)).toEqual([10, 20, 20]);
+    expect(new Set(usageEvents.map((message) => message.data.execution_id)).size).toBe(1);
+    expect(usageEvents[0]?.data.execution_id).toEqual(expect.any(String));
     expect(usageEvents.at(-1)?.data).toMatchObject({
       session_id: "session-live-usage",
       round_id: "round-0002",

--- a/homerail_worker/src/__tests__/prompt-runner.test.ts
+++ b/homerail_worker/src/__tests__/prompt-runner.test.ts
@@ -119,6 +119,79 @@ describe("prompt runner", () => {
     expect(parsed.map((msg) => msg.type)).toContain("SESSION_END");
   });
 
+  it("streams cumulative usage snapshots with the authoritative node-turn scope", async () => {
+    const mockAgent: AgentClient = {
+      run() {
+        return (async function* () {
+          yield {
+            type: "usage" as const,
+            usage: {
+              input_tokens: 10,
+              output_tokens: 2,
+              cache_read_input_tokens: 3,
+              cache_creation_input_tokens: 1,
+            },
+          };
+          yield {
+            type: "usage" as const,
+            usage: {
+              input_tokens: 20,
+              output_tokens: 4,
+              cache_read_input_tokens: 5,
+              cache_creation_input_tokens: 2,
+            },
+          };
+          yield {
+            type: "done" as const,
+            usage: {
+              input_tokens: 20,
+              output_tokens: 4,
+              cache_read_input_tokens: 5,
+              cache_creation_input_tokens: 2,
+            },
+            duration_ms: 1500,
+            num_turns: 2,
+          };
+        })();
+      },
+    };
+    registerAgentBackend("test-live-usage", () => mockAgent);
+
+    const sent: string[] = [];
+    await runPrompt(
+      {
+        task: "measure usage",
+        sender: "test",
+        runId: "run-live-usage",
+        dagConfig: makeConfigWith({
+          session_id: "session-live-usage",
+          round_id: "round-0002",
+          actor_id: "researcher",
+          generation: 3,
+          command_id: "command-2",
+        }),
+      },
+      {
+        wsSend: (message) => sent.push(message),
+        agentBackend: "test-live-usage",
+      },
+    );
+
+    const usageEvents = sent
+      .map((message) => JSON.parse(message))
+      .filter((message) => message.type === "stream" && message.data?.event === "usage");
+    expect(usageEvents).toHaveLength(3);
+    expect(usageEvents.map((message) => message.data.usage.input_tokens)).toEqual([10, 20, 20]);
+    expect(usageEvents.at(-1)?.data).toMatchObject({
+      session_id: "session-live-usage",
+      round_id: "round-0002",
+      generation: 3,
+      command_id: "command-2",
+      duration_ms: 1500,
+      num_turns: 2,
+    });
+  });
+
   it("restricts correction turns to the handoff tool and correction system prompt", async () => {
     let observedTools: string[] = [];
     let observedContext: AgentRunContext | undefined;

--- a/homerail_worker/src/agent/claude-sdk.ts
+++ b/homerail_worker/src/agent/claude-sdk.ts
@@ -33,6 +33,12 @@ import { createBuiltinToolBudgetHook } from "./builtin-tool-budget.js";
 const HANDOFF_ONLY_THINKING_BUDGET = 2048;
 const HANDOFF_STOP = Symbol("claude-sdk-handoff-stop");
 const DAG_TOOLS_MCP_SERVER_NAME = "dag-tools";
+const AGENT_USAGE_KEYS = [
+  "input_tokens",
+  "output_tokens",
+  "cache_read_input_tokens",
+  "cache_creation_input_tokens",
+] as const satisfies ReadonlyArray<keyof AgentUsage>;
 
 interface ClaudeSkillProjectionRuntime {
   configDir: string;
@@ -181,6 +187,7 @@ interface SdkModule {
 interface SdkMessage {
   type: string;
   message?: {
+    id?: string;
     content?: Array<{
       type: string;
       text?: string;
@@ -452,6 +459,7 @@ export class ClaudeSdkAdapter implements AgentClient {
     // Declared outside try so the final `done` yield (after finally) can
     // read them even when the query loop never ran (e.g. early SDK error).
     const accumulatedUsage: AgentUsage = {};
+    const assistantUsageByMessageId = new Map<string, AgentUsage>();
     let finalDurationMs: number | undefined;
     let finalNumTurns: number | undefined;
     let messageCount = 0;
@@ -725,27 +733,51 @@ export class ClaudeSdkAdapter implements AgentClient {
             };
             stderrTail = "";
           }
-          // Extract usage from this message. Per-message usage on assistant
-          // turns is additive (each turn's input/output); the result message
-          // carries an aggregate we prefer when present.
+          // Extract usage from this message. Claude-compatible providers can
+          // repeat one assistant message id for thinking, text, and tool-use
+          // snapshots. Treat those as replacements for the same turn rather
+          // than independent deltas. The result message carries an aggregate
+          // we prefer when present.
           const msgUsage = msg.message?.usage ?? msg.usage;
           let usageChanged = false;
           if (msgUsage) {
-            usageChanged = true;
             if (msg.type === "result") {
               // Result message carries the authoritative aggregate — replace.
-              accumulatedUsage.input_tokens = msgUsage.input_tokens ?? accumulatedUsage.input_tokens;
-              accumulatedUsage.output_tokens = msgUsage.output_tokens ?? accumulatedUsage.output_tokens;
-              accumulatedUsage.cache_read_input_tokens = msgUsage.cache_read_input_tokens ?? accumulatedUsage.cache_read_input_tokens;
-              accumulatedUsage.cache_creation_input_tokens = msgUsage.cache_creation_input_tokens ?? accumulatedUsage.cache_creation_input_tokens;
+              for (const key of AGENT_USAGE_KEYS) {
+                const value = msgUsage[key];
+                if (value !== undefined && value !== accumulatedUsage[key]) {
+                  accumulatedUsage[key] = value;
+                  usageChanged = true;
+                }
+              }
               finalDurationMs = msg.duration_ms;
               finalNumTurns = msg.num_turns;
             } else {
-              // Per-turn delta — accumulate.
-              accumulatedUsage.input_tokens = (accumulatedUsage.input_tokens ?? 0) + (msgUsage.input_tokens ?? 0);
-              accumulatedUsage.output_tokens = (accumulatedUsage.output_tokens ?? 0) + (msgUsage.output_tokens ?? 0);
-              accumulatedUsage.cache_read_input_tokens = (accumulatedUsage.cache_read_input_tokens ?? 0) + (msgUsage.cache_read_input_tokens ?? 0);
-              accumulatedUsage.cache_creation_input_tokens = (accumulatedUsage.cache_creation_input_tokens ?? 0) + (msgUsage.cache_creation_input_tokens ?? 0);
+              const messageId = msg.message?.id?.trim();
+              if (messageId) {
+                const previous = assistantUsageByMessageId.get(messageId);
+                const next: AgentUsage = { ...previous };
+                for (const key of AGENT_USAGE_KEYS) {
+                  if (msgUsage[key] !== undefined) next[key] = msgUsage[key];
+                }
+                for (const key of AGENT_USAGE_KEYS) {
+                  if (previous?.[key] === next[key]) continue;
+                  accumulatedUsage[key] = (accumulatedUsage[key] ?? 0)
+                    - (previous?.[key] ?? 0)
+                    + (next[key] ?? 0);
+                  usageChanged = true;
+                }
+                assistantUsageByMessageId.set(messageId, next);
+              } else {
+                // Providers without stable message ids still expose per-turn
+                // deltas, so preserve the existing additive fallback.
+                for (const key of AGENT_USAGE_KEYS) {
+                  const value = msgUsage[key];
+                  if (value === undefined) continue;
+                  accumulatedUsage[key] = (accumulatedUsage[key] ?? 0) + value;
+                  usageChanged = true;
+                }
+              }
             }
           }
           // Emit a usage event inline (carrying the running total) so the

--- a/homerail_worker/src/prompt-runner.ts
+++ b/homerail_worker/src/prompt-runner.ts
@@ -4,6 +4,7 @@
  * @version 0.1.0
  */
 
+import { randomUUID } from "node:crypto";
 import {
   DEFAULT_MANAGER_AGENT_RUNTIME_AGENT_TYPE,
   normalizeManagerAgentRuntimeAgentType,
@@ -421,6 +422,7 @@ export async function runPrompt(
   // Declared outside try so emitUsage() (a closure defined after the
   // try/catch) and the catch handler can read them even on early failure.
   const nodeUsage: AgentUsage = {};
+  const usageExecutionId = randomUUID();
   let nodeDurationMs: number | undefined;
   let nodeNumTurns: number | undefined;
   let lastUsageEmission: string | undefined;
@@ -746,6 +748,7 @@ export async function runPrompt(
     lastUsageEmission = signature;
     sendStream({
       event: "usage",
+      execution_id: usageExecutionId,
       usage,
       duration_ms: nodeDurationMs,
       num_turns: nodeNumTurns,

--- a/homerail_worker/src/prompt-runner.ts
+++ b/homerail_worker/src/prompt-runner.ts
@@ -423,6 +423,7 @@ export async function runPrompt(
   const nodeUsage: AgentUsage = {};
   let nodeDurationMs: number | undefined;
   let nodeNumTurns: number | undefined;
+  let lastUsageEmission: string | undefined;
   let workspaceBefore: WorkspaceSnapshot | undefined;
   let terminalActivityEmitted = false;
   let promptResult: PromptRunResult = {
@@ -594,6 +595,7 @@ export async function runPrompt(
           // we replace rather than accumulate. Other adapters that emit a
           // single final aggregate behave the same way.
           Object.assign(nodeUsage, event.usage);
+          emitUsage();
           break;
         case "done":
           if (event.usage) Object.assign(nodeUsage, event.usage);
@@ -729,14 +731,22 @@ export async function runPrompt(
       || nodeUsage.cache_read_input_tokens !== undefined
       || nodeUsage.cache_creation_input_tokens !== undefined;
     if (!hasUsage) return;
+    const usage = {
+      input_tokens: nodeUsage.input_tokens ?? 0,
+      output_tokens: nodeUsage.output_tokens ?? 0,
+      cache_read_input_tokens: nodeUsage.cache_read_input_tokens ?? 0,
+      cache_creation_input_tokens: nodeUsage.cache_creation_input_tokens ?? 0,
+    };
+    const signature = JSON.stringify({
+      usage,
+      duration_ms: nodeDurationMs,
+      num_turns: nodeNumTurns,
+    });
+    if (signature === lastUsageEmission) return;
+    lastUsageEmission = signature;
     sendStream({
       event: "usage",
-      usage: {
-        input_tokens: nodeUsage.input_tokens ?? 0,
-        output_tokens: nodeUsage.output_tokens ?? 0,
-        cache_read_input_tokens: nodeUsage.cache_read_input_tokens ?? 0,
-        cache_creation_input_tokens: nodeUsage.cache_creation_input_tokens ?? 0,
-      },
+      usage,
       duration_ms: nodeDurationMs,
       num_turns: nodeNumTurns,
     });


### PR DESCRIPTION
Closes #104.

## What changed

- records the resolved provider, exact/display model, Agent backend, and protocol used for each dispatched DAG node
- streams cumulative token snapshots during execution and persists the latest authoritative snapshot per session/round/generation/command scope
- aggregates multi-round Actor usage into cumulative node totals for live and historical runs
- adds input, output, cache-read, cache-creation, and total token metrics to the Manager API
- shows the execution identity and detailed token breakdown in the node drawer, with Manager-owned nodes explicitly marked as model-free
- adds English, Simplified Chinese, and Traditional Chinese labels and renders unavailable values as `—`

## Semantics and privacy

The displayed total is:

`input + output + cache read + cache creation`

Only explicitly whitelisted display fields cross the metrics API. Credentials, setting IDs, authorization data, and endpoint URLs are not exposed.

## Validation

- `npm run ci`
- all package typechecks and builds passed
- Protocol: 306 tests passed
- Manager: 1171 passed, 2 skipped
- Node: 187 passed, 2 skipped
- Worker: 330 passed, 1 skipped
- CLI: 257 passed
- Agent UI: 488 passed
- live-validator: 85 passed, 2 skipped
- additional UI regression verifies token values update while the drawer remains open
