### PR TITLE
feat(agent-ui): add Live Voice immersive interface

### DIFF
--- a/agent-ui/src/admin-proxy-trust.test.ts
+++ b/agent-ui/src/admin-proxy-trust.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   authorizeAdminProxyRequest,
   isProtectedApiMutation,
+  trustedWebSocketProxyFetchSite,
 } from './admin-proxy-trust'
 
 describe('Vite Manager mutation proxy trust', () => {
@@ -48,5 +49,19 @@ describe('Vite Manager mutation proxy trust', () => {
       origin: 'http://localhost:19194',
       secFetchSite: 'cross-site',
     })).toMatchObject({ allowed: false })
+  })
+
+  it('restores the same-origin marker only for a verified UI WebSocket upgrade', () => {
+    expect(trustedWebSocketProxyFetchSite({
+      protocol: 'http',
+      host: '127.0.0.1:19194',
+      origin: 'http://127.0.0.1:19194',
+    })).toBe('same-origin')
+
+    expect(trustedWebSocketProxyFetchSite({
+      protocol: 'http',
+      host: '127.0.0.1:19194',
+      origin: 'https://evil.example',
+    })).toBeUndefined()
   })
 })

--- a/agent-ui/src/admin-proxy-trust.ts
+++ b/agent-ui/src/admin-proxy-trust.ts
@@ -49,6 +49,17 @@ export function authorizeAdminProxyRequest(
   return { allowed: true }
 }
 
+/**
+ * Browsers do not consistently forward Sec-Fetch-Site on WebSocket upgrades.
+ * Once the UI proxy has independently verified the browser-facing Origin and
+ * Host, it can restore the same-origin marker for Manager's upgrade boundary.
+ */
+export function trustedWebSocketProxyFetchSite(
+  request: UiMutationRequestTrust,
+): 'same-origin' | undefined {
+  return authorizeAdminProxyRequest(request).allowed ? 'same-origin' : undefined
+}
+
 function singleHeader(value: string | string[] | undefined): string | undefined {
   if (typeof value !== 'string' || !value || /[\r\n]/.test(value)) return undefined
   return value

--- a/agent-ui/src/components/agent/AgentSettingsPage.test.ts
+++ b/agent-ui/src/components/agent/AgentSettingsPage.test.ts
@@ -288,7 +288,7 @@ describe('AgentSettingsPage Android TV WireGuard settings', () => {
     app.unmount()
   })
 
-  it('exposes plugin and static Skill catalogs in user settings', async () => {
+  it('exposes experimental features, plugins, and static Skill catalogs in user settings', async () => {
     setBridge({
       isAndroidTV: () => false,
       getWireGuardConfig: () => '{}',
@@ -304,8 +304,18 @@ describe('AgentSettingsPage Android TV WireGuard settings', () => {
 
     const skillTab = root.querySelector<HTMLButtonElement>('[data-testid="agent-settings-tab-skills"]')
     const pluginTab = root.querySelector<HTMLButtonElement>('[data-testid="agent-settings-tab-plugins"]')
+    const experimentalTab = root.querySelector<HTMLButtonElement>(
+      '[data-testid="agent-settings-tab-experimental"]'
+    )
     expect(skillTab).not.toBeNull()
     expect(pluginTab).not.toBeNull()
+    expect(experimentalTab).not.toBeNull()
+
+    experimentalTab!.click()
+    await nextTick()
+    expect(
+      root.querySelector('[data-testid="agent-settings-section-experimental"]')
+    ).not.toBeNull()
 
     skillTab!.click()
     await nextTick()

--- a/agent-ui/src/components/agent/AgentSettingsPage.vue
+++ b/agent-ui/src/components/agent/AgentSettingsPage.vue
@@ -6,6 +6,7 @@ import {
   ArrowLeft,
   Brain,
   CheckCircle2,
+  FlaskConical,
   FolderTree,
   GitBranch,
   Loader2,
@@ -23,6 +24,7 @@ import {
 } from 'lucide-vue-next'
 import ModelSettings from './settings/ModelSettings.vue'
 import GeneralSettings from './settings/GeneralSettings.vue'
+import ExperimentalSettings from './settings/ExperimentalSettings.vue'
 import StorageRetentionSettings from './settings/StorageRetentionSettings.vue'
 import PluginSettings from './settings/PluginSettings.vue'
 import SkillSettings from './settings/SkillSettings.vue'
@@ -120,6 +122,7 @@ type SettingsTab =
   | 'git'
   | 'providers'
   | 'voice'
+  | 'experimental'
   | 'device'
   | 'skills'
   | 'plugins'
@@ -296,6 +299,7 @@ const tabs = computed<Array<{ id: SettingsTab; label: string; icon: typeof Setti
   { id: 'git', label: t('settings.tabs.git'), icon: GitBranch },
   { id: 'providers', label: t('settings.tabs.providers'), icon: Settings },
   { id: 'voice', label: t('settings.tabs.voice'), icon: Volume2 },
+  { id: 'experimental', label: t('settings.tabs.experimental'), icon: FlaskConical },
   { id: 'device', label: t('settings.tabs.device'), icon: Network },
   { id: 'skills', label: t('settings.tabs.skills'), icon: Package },
   { id: 'plugins', label: t('settings.tabs.plugins'), icon: Package },
@@ -313,6 +317,7 @@ const activeTabDescription = computed(() => {
   if (activeTab.value === 'git') return t('settings.descriptions.git')
   if (activeTab.value === 'providers') return t('settings.descriptions.providers')
   if (activeTab.value === 'voice') return t('settings.descriptions.voice')
+  if (activeTab.value === 'experimental') return t('settings.descriptions.experimental')
   if (activeTab.value === 'skills') return t('settings.descriptions.skills')
   if (activeTab.value === 'plugins') return t('settings.descriptions.plugins')
   if (activeTab.value === 'device') return ''
@@ -1492,6 +1497,8 @@ onUnmounted(() => {
           <GeneralSettings />
           <StorageRetentionSettings />
         </template>
+
+        <ExperimentalSettings v-if="activeTab === 'experimental'" />
 
         <section v-if="activeTab === 'workspace'" data-testid="agent-settings-section-workspace" class="mt-10 space-y-6">
           <div class="grid gap-3 sm:grid-cols-3">

--- a/agent-ui/src/components/agent/AgentVoiceCockpit.vue
+++ b/agent-ui/src/components/agent/AgentVoiceCockpit.vue
@@ -2,6 +2,7 @@
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAgentStore } from '@/stores/agent-store'
+import { useUiStore } from '@/stores/ui-store'
 import {
   closeVoiceSession,
   createVoiceSession,
@@ -154,6 +155,7 @@ import {
 } from 'lucide-vue-next'
 
 const store = useAgentStore()
+const uiStore = useUiStore()
 const { t, te } = useI18n()
 const { planLabel } = createProtocolLabels(t)
 // 新手引导配置状态检测（作为独立状态入口，不阻断模型选择）
@@ -284,6 +286,11 @@ const voiceInputAssist = ref(loadBooleanSetting(VOICE_INPUT_ASSIST_KEY, false))
 const VOICE_OUTPUT_ENABLED_KEY = 'homerail.voice.output-enabled'
 const voiceOutputEnabled = ref(loadBooleanSetting(VOICE_OUTPUT_ENABLED_KEY, true))
 const composerRef = ref<HTMLTextAreaElement | null>(null)
+const IMMERSIVE_RETURN_IDLE_MS = 3200
+const IMMERSIVE_EXIT_REVEAL_MS = 1600
+const immersiveMode = ref(false)
+const immersiveSuspended = ref(false)
+const immersiveExitVisible = ref(false)
 const fullscreenPromptVisible = ref(false)
 const fullscreenPromptDismissed = ref(false)
 const cockpitRoot = ref<HTMLElement | null>(null)
@@ -396,6 +403,8 @@ let voiceGamepadFrame = 0
 let voiceGamepadPressedButtons = new Set<number>()
 let voiceGamepadAxisLocks = new Set<VoiceGamepadDirection>()
 let voiceGamepadNoticeTimer = 0
+let immersiveExitTimer = 0
+let immersiveReturnTimer = 0
 let nativeGamepadAnalogAt = 0
 let asrSocket: WebSocket | null = null
 let asrTranscriptRaw = ''
@@ -541,6 +550,12 @@ const codexLiveVoiceConnecting = computed(
   () =>
     codexLiveVoiceState.value === 'connecting' ||
     codexLiveVoiceState.value === 'reconnecting'
+)
+const liveVoiceImmersiveActive = computed(
+  () =>
+    uiStore.liveVoiceImmersiveEnabled &&
+    codexLiveVoiceSessionActive.value &&
+    !codexLiveVoiceConnecting.value
 )
 const codexLiveVoiceHumanInputActive = computed(
   () =>
@@ -1101,7 +1116,8 @@ const voiceCockpitClasses = computed(() => [
     'voice-cockpit--mobile': isMobileDevice.value,
     'voice-cockpit--phone-portrait': isPhonePortrait.value,
     'voice-cockpit--phone-landscape': isCompactPhoneLandscape.value,
-    'voice-cockpit--tv-compact': isTvCompactViewport.value
+    'voice-cockpit--tv-compact': isTvCompactViewport.value,
+    'voice-cockpit--immersive': immersiveMode.value
   }
 ])
 const artifactPreviewModalStyle = computed(() => {
@@ -1190,9 +1206,12 @@ const captionKind = computed(() => {
   return 'state'
 })
 const voiceMainGridStyle = computed(() => ({
-  gridTemplateColumns: isPhonePortrait.value
-    ? 'minmax(0, 1fr)'
-    : `${sidebarColumnWidth()} minmax(0, 1fr) ${detailsColumnWidth()}`
+  gridTemplateColumns:
+    isPhonePortrait.value
+      ? 'minmax(0, 1fr)'
+      : immersiveMode.value
+        ? '0 minmax(0, 1fr) 0'
+        : `${sidebarColumnWidth()} minmax(0, 1fr) ${detailsColumnWidth()}`
 }))
 const voiceShellStyle = computed(() => {
   if (!isCompactPhoneLandscape.value) return {}
@@ -1282,6 +1301,8 @@ onMounted(() => {
   document.addEventListener('visibilitychange', handleVisibilityChange)
   document.addEventListener('pointerdown', closeModelMenuOnOutside)
   window.addEventListener('keydown', handleVoiceKeyboardButton, true)
+  window.addEventListener('keydown', handleImmersiveKeyboard, true)
+  window.addEventListener('pointermove', handleImmersivePointerMove, { passive: true })
   window.addEventListener('keydown', closeModelMenuOnEscape)
   window.addEventListener('gamepadconnected', handleVoiceGamepadConnected)
   window.addEventListener('gamepaddisconnected', handleVoiceGamepadDisconnected)
@@ -1327,6 +1348,15 @@ watch(
 watch(codexLiveVoiceEffective, effective => {
   if (!effective && codexLiveVoiceClient) void stopCodexLiveVoice()
 })
+
+watch(
+  liveVoiceImmersiveActive,
+  (active, previous) => {
+    if (active && !previous) activateLiveVoiceImmersiveMode()
+    else if (!active && previous) exitImmersiveMode()
+  },
+  { immediate: true }
+)
 
 watch(detailsOpen, value => saveBooleanSetting(VOICE_DETAILS_PANE_KEY, value))
 watch(voiceSidebarOpen, value => {
@@ -1392,6 +1422,8 @@ onUnmounted(() => {
   // /ws/events is shared with the DAG runtime store; component teardown only
   // removes this cockpit's subscriptions and must not close the singleton.
   if (widgetHighlightTimer) window.clearTimeout(widgetHighlightTimer)
+  if (immersiveExitTimer) window.clearTimeout(immersiveExitTimer)
+  if (immersiveReturnTimer) window.clearTimeout(immersiveReturnTimer)
   window.removeEventListener('resize', updateViewportSize)
   window.removeEventListener('orientationchange', updateViewportSize)
   document.removeEventListener('fullscreenchange', handleFullscreenChange)
@@ -1399,6 +1431,8 @@ onUnmounted(() => {
   document.removeEventListener('visibilitychange', handleVisibilityChange)
   document.removeEventListener('pointerdown', closeModelMenuOnOutside)
   window.removeEventListener('keydown', handleVoiceKeyboardButton, true)
+  window.removeEventListener('keydown', handleImmersiveKeyboard, true)
+  window.removeEventListener('pointermove', handleImmersivePointerMove)
   window.removeEventListener('keydown', closeModelMenuOnEscape)
   window.removeEventListener('gamepadconnected', handleVoiceGamepadConnected)
   window.removeEventListener('gamepaddisconnected', handleVoiceGamepadDisconnected)
@@ -4302,6 +4336,7 @@ function handleVoiceGamepadButton(index: number): void {
 function handleVoiceGamepadButtonIntent(
   intent: ReturnType<typeof resolveVoiceGamepadButtonIntent>
 ): void {
+  noteLiveVoiceImmersiveInteraction()
   if (intent === 'system_preview') openSelectedWidgetPreview()
   else if (intent === 'system_cancel') handleVoiceGamepadCancel()
   else if (intent === 'voice_toggle') void toggleListening()
@@ -4321,6 +4356,7 @@ function handleVoiceGamepadButtonIntent(
 }
 
 function handleVoiceGamepadDirection(direction: VoiceGamepadDirection): void {
+  noteLiveVoiceImmersiveInteraction()
   const context = currentVoiceGamepadInputContext()
   const intent = resolveVoiceGamepadDirectionIntent(context, direction)
   if (intent === 'preview_previous') prevArtifactPreviewImage()
@@ -4344,6 +4380,10 @@ function handleVoiceGamepadCancel(): void {
   }
   if (voiceSidebarOpen.value && isPhonePortrait.value) {
     voiceSidebarOpen.value = false
+    return
+  }
+  if (immersiveMode.value) {
+    suspendLiveVoiceImmersiveMode()
     return
   }
   if (effectiveDetailsOpen.value) toggleDetails()
@@ -4973,6 +5013,93 @@ function toggleDetails(): void {
   detailsOpen.value = !detailsOpen.value
 }
 
+function activateLiveVoiceImmersiveMode(): void {
+  if (!liveVoiceImmersiveActive.value) return
+  if (immersiveReturnTimer) window.clearTimeout(immersiveReturnTimer)
+  immersiveReturnTimer = 0
+  immersiveMode.value = true
+  immersiveSuspended.value = false
+  immersiveExitVisible.value = false
+  modelMenuOpen.value = false
+  voiceGamepadFocusMode.value = 'widgets'
+}
+
+function exitImmersiveMode(): void {
+  immersiveMode.value = false
+  immersiveSuspended.value = false
+  immersiveExitVisible.value = false
+  if (immersiveExitTimer) window.clearTimeout(immersiveExitTimer)
+  if (immersiveReturnTimer) window.clearTimeout(immersiveReturnTimer)
+  immersiveExitTimer = 0
+  immersiveReturnTimer = 0
+}
+
+function scheduleImmersiveReturn(): void {
+  if (immersiveReturnTimer) window.clearTimeout(immersiveReturnTimer)
+  immersiveReturnTimer = 0
+  if (
+    immersiveMode.value ||
+    !immersiveSuspended.value ||
+    !liveVoiceImmersiveActive.value
+  ) return
+  immersiveReturnTimer = window.setTimeout(() => {
+    immersiveReturnTimer = 0
+    if (immersiveSuspended.value && liveVoiceImmersiveActive.value) {
+      activateLiveVoiceImmersiveMode()
+    }
+  }, IMMERSIVE_RETURN_IDLE_MS)
+}
+
+function suspendLiveVoiceImmersiveMode(): void {
+  if (!liveVoiceImmersiveActive.value) {
+    exitImmersiveMode()
+    return
+  }
+  immersiveMode.value = false
+  immersiveSuspended.value = true
+  immersiveExitVisible.value = false
+  if (immersiveExitTimer) window.clearTimeout(immersiveExitTimer)
+  immersiveExitTimer = 0
+  scheduleImmersiveReturn()
+}
+
+function noteLiveVoiceImmersiveInteraction(): void {
+  if (immersiveSuspended.value && liveVoiceImmersiveActive.value) {
+    scheduleImmersiveReturn()
+  }
+}
+
+function handleImmersivePointerMove(): void {
+  if (!immersiveMode.value) {
+    noteLiveVoiceImmersiveInteraction()
+    return
+  }
+  immersiveExitVisible.value = true
+  if (immersiveExitTimer) window.clearTimeout(immersiveExitTimer)
+  immersiveExitTimer = window.setTimeout(() => {
+    immersiveExitVisible.value = false
+    immersiveExitTimer = 0
+  }, IMMERSIVE_EXIT_REVEAL_MS)
+}
+
+function handleImmersiveKeyboard(event: KeyboardEvent): void {
+  if (!immersiveMode.value) {
+    noteLiveVoiceImmersiveInteraction()
+    return
+  }
+  if (event.key === 'Escape' || event.key === 'BrowserBack') {
+    if (artifactPreviewModal.value) {
+      event.preventDefault()
+      event.stopPropagation()
+      closeArtifactPreview()
+      return
+    }
+    event.preventDefault()
+    event.stopPropagation()
+    suspendLiveVoiceImmersiveMode()
+  }
+}
+
 async function scrollConversationToLatest(): Promise<void> {
   await nextTick()
   const thread = conversationThreadRef.value
@@ -5053,11 +5180,13 @@ async function scrollCardGridToWidget(widgetId?: string): Promise<void> {
 }
 
 function openSettings(): void {
+  exitImmersiveMode()
   store.settingsPageOpen = true
   store.voiceCockpitOpen = false
 }
 
 function openRuntimeOverlay(): void {
+  exitImmersiveMode()
   store.runtimeOverlayOpen = true
 }
 
@@ -5067,6 +5196,7 @@ function openDevOnboarding(): void {
 
 function close(): void {
   if (props.voiceOnly) return
+  exitImmersiveMode()
   void endSession()
   store.voiceCockpitOpen = false
 }
@@ -5117,8 +5247,27 @@ function summarizeTask(value: string): string {
       <em>{{ fullscreenGateHint }}</em>
       <strong>{{ fullscreenGateAction }}</strong>
     </button>
+    <div
+      v-if="immersiveMode"
+      class="voice-immersive-exit-zone"
+      :class="{ 'voice-immersive-exit-zone--visible': immersiveExitVisible }"
+      data-testid="voice-immersive-exit-zone"
+    >
+      <button
+        class="voice-immersive-exit"
+        type="button"
+        :title="t('voice.immersive.exit')"
+        @click="suspendLiveVoiceImmersiveMode"
+      >
+        <X class="h-4 w-4" />
+      </button>
+    </div>
     <div class="voice-shell relative flex h-full min-h-0 flex-col p-4" :style="voiceShellStyle">
       <AgentModeTopBar
+        class="voice-topbar-motion"
+        :class="{ 'voice-topbar--immersive-hidden': immersiveMode }"
+        :aria-hidden="immersiveMode"
+        :inert="immersiveMode"
         active-mode="voice"
         :show-details="topbarAuxControlsVisible"
         :show-settings="topbarAuxControlsVisible"
@@ -5485,7 +5634,12 @@ function summarizeTask(value: string): string {
         <div
           v-if="!isPhonePortrait"
           class="voice-sidebar-slot min-w-0"
-          :class="{ 'voice-sidebar-slot--drawer': tvCompactSidebarDrawerOpen }"
+          :class="{
+            'voice-sidebar-slot--drawer': tvCompactSidebarDrawerOpen,
+            'voice-sidebar-slot--immersive-hidden': immersiveMode
+          }"
+          :aria-hidden="immersiveMode"
+          :inert="immersiveMode"
         >
           <VoiceSessionProjectSidebar
             v-if="effectiveSidebarOpen"
@@ -5962,6 +6116,9 @@ function summarizeTask(value: string): string {
               <button
                 v-if="agentActivityActive"
                 class="voice-agent-run-button voice-agent-run-button--running"
+                :class="{ 'voice-agent-run-button--immersive-hidden': immersiveMode }"
+                :aria-hidden="immersiveMode"
+                :inert="immersiveMode"
                 :title="speaking ? agentRunStateText : `${agentRunStateText}. ${t('voice.state.tapToStop')}`"
                 @click="speaking ? undefined : stopAgentLoop"
               >
@@ -6018,6 +6175,9 @@ function summarizeTask(value: string): string {
             <div
               v-if="isTvCompactViewport"
               class="voice-input-dock voice-input-dock--voice-only"
+              :class="{ 'voice-input-dock--immersive-hidden': immersiveMode }"
+              :aria-hidden="immersiveMode"
+              :inert="immersiveMode"
               data-testid="voice-input-dock"
             >
               <button
@@ -6107,6 +6267,9 @@ function summarizeTask(value: string): string {
             <form
               v-else
               class="voice-composer"
+              :class="{ 'voice-composer--immersive-hidden': immersiveMode }"
+              :aria-hidden="immersiveMode"
+              :inert="immersiveMode"
               data-testid="voice-composer"
               @submit.prevent="submitComposerDraft"
             >
@@ -6180,8 +6343,13 @@ function summarizeTask(value: string): string {
 
         <aside
           v-if="!isPhonePortrait"
-          class="min-w-0 overflow-hidden py-0 pr-6 transition-opacity duration-300"
-          :class="effectiveDetailsOpen ? 'opacity-100' : 'pointer-events-none opacity-0'"
+          class="voice-records-slot min-w-0 overflow-hidden py-0 pr-6"
+          :class="[
+            effectiveDetailsOpen ? 'opacity-100' : 'pointer-events-none opacity-0',
+            immersiveMode ? 'voice-records-slot--immersive-hidden' : ''
+          ]"
+          :aria-hidden="immersiveMode"
+          :inert="immersiveMode"
         >
           <section class="voice-records">
             <div class="voice-records__header">
@@ -6607,12 +6775,45 @@ function summarizeTask(value: string): string {
   height: 100svh;
   height: 100dvh;
   min-height: 0;
+  transition: padding 440ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.voice-main {
+  transition:
+    grid-template-columns 440ms cubic-bezier(0.22, 1, 0.36, 1),
+    margin-top 360ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 .voice-cockpit :deep(.agent-mode-topbar) {
   position: relative;
   z-index: 140;
   overflow: visible;
+}
+
+.voice-cockpit :deep(.voice-topbar-motion) {
+  max-height: 56px;
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  transform-origin: top center;
+  transition:
+    height 340ms cubic-bezier(0.22, 1, 0.36, 1),
+    min-height 340ms cubic-bezier(0.22, 1, 0.36, 1),
+    max-height 340ms cubic-bezier(0.22, 1, 0.36, 1),
+    border-width 260ms ease,
+    opacity 220ms ease,
+    transform 380ms cubic-bezier(0.22, 1, 0.36, 1);
+  transition-delay: 0ms;
+}
+
+.voice-cockpit :deep(.voice-topbar-motion.voice-topbar--immersive-hidden) {
+  height: 0 !important;
+  min-height: 0 !important;
+  max-height: 0;
+  overflow: hidden !important;
+  border-width: 0;
+  opacity: 0;
+  transform: translateY(-18px) scale(0.985);
+  pointer-events: none;
 }
 
 .voice-cockpit :deep(.agent-mode-topbar__left) {
@@ -6675,6 +6876,143 @@ function summarizeTask(value: string): string {
   color: var(--vc-text-1);
   font-size: 13px;
   font-weight: 700;
+}
+
+/* --------------------------------------------------------------------------
+   Immersive Voice Cockpit chrome
+   -------------------------------------------------------------------------- */
+.voice-immersive-exit-zone {
+  position: fixed;
+  top: var(--homerail-electron-titlebar-height, 0px);
+  left: 50%;
+  z-index: 220;
+  width: min(280px, 70vw);
+  height: 14px;
+  transform: translateX(-50%);
+  pointer-events: auto;
+}
+
+.voice-immersive-exit-zone::before {
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  height: 14px;
+  content: "";
+  pointer-events: auto;
+}
+
+.voice-immersive-exit {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  display: inline-flex;
+  min-height: 40px;
+  align-items: center;
+  width: 42px;
+  justify-content: center;
+  border: 1px solid var(--vc-border-strong);
+  border-radius: 0 0 16px 16px;
+  background: color-mix(in srgb, var(--vc-panel) 94%, transparent);
+  padding: 0;
+  color: var(--vc-text-1);
+  font-size: 13px;
+  font-weight: 700;
+  box-shadow: var(--hr-shadow-floating);
+  opacity: 0;
+  transform: translate(-50%, calc(-100% - 10px));
+  transition:
+    opacity 180ms ease,
+    transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
+  pointer-events: auto;
+  backdrop-filter: blur(20px);
+}
+
+.voice-immersive-exit-zone--visible .voice-immersive-exit,
+.voice-immersive-exit-zone:hover .voice-immersive-exit,
+.voice-immersive-exit:focus-visible {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+.voice-cockpit--immersive .voice-shell {
+  padding: 8px;
+}
+
+.voice-cockpit--immersive {
+  --voice-immersive-waveform-gutter: clamp(12px, 1.4vh, 16px);
+}
+
+.voice-cockpit--immersive .voice-main {
+  margin-top: 0;
+}
+
+.voice-cockpit--immersive .voice-stage {
+  margin: 0;
+  border-radius: 24px;
+  padding: clamp(14px, 1.8vw, 26px);
+  padding-bottom: var(--voice-immersive-waveform-gutter);
+  transition-delay: 45ms;
+}
+
+.voice-cockpit--immersive .voice-control {
+  z-index: 30;
+  min-height: 20px;
+  margin-top: var(--voice-immersive-waveform-gutter);
+  border-top-color: transparent;
+  padding-top: 0;
+  gap: 0;
+  pointer-events: none;
+  transition-delay: 90ms;
+}
+
+.voice-cockpit--immersive .voice-composer__preferences,
+.voice-cockpit--immersive .voice-caption-strip {
+  display: none;
+}
+
+.voice-cockpit--immersive .voice-control__deck {
+  justify-content: center;
+  gap: 0;
+}
+
+.voice-cockpit--immersive .codex-live-voice-meter {
+  display: block;
+  width: min(300px, 68vw);
+  height: 20px;
+  margin: 0 auto;
+  opacity: 0.14;
+  filter: grayscale(0.4);
+  mask-image: linear-gradient(90deg, transparent, #000 16%, #000 84%, transparent);
+}
+
+.voice-cockpit--immersive .codex-live-voice-meter--active {
+  opacity: 0.88;
+  filter: drop-shadow(0 0 6px var(--vc-accent-soft));
+  transform: scaleY(1.12);
+}
+
+.voice-cockpit--immersive .codex-live-voice-meter--muted {
+  opacity: 0.08;
+}
+
+.voice-cockpit--immersive .codex-live-voice-meter__connecting {
+  justify-content: center;
+  font-size: 0;
+}
+
+.voice-cockpit--immersive.voice-cockpit--tv-compact .voice-stage {
+  margin: 0;
+  border-radius: 24px;
+  padding: clamp(14px, 1.8vw, 26px);
+}
+
+.voice-cockpit--immersive.voice-cockpit--tv-compact .voice-control,
+.voice-cockpit--immersive.voice-cockpit--phone-portrait .voice-control {
+  min-height: 20px;
+  margin-top: var(--voice-immersive-waveform-gutter);
+  padding-top: 0;
+  gap: 0;
 }
 
 /* --------------------------------------------------------------------------
@@ -6844,6 +7182,22 @@ function summarizeTask(value: string): string {
    -------------------------------------------------------------------------- */
 .voice-sidebar-slot {
   overflow: hidden;
+  opacity: 1;
+  transform: translateX(0) scale(1);
+  transform-origin: left center;
+  transition:
+    opacity 260ms ease,
+    transform 420ms cubic-bezier(0.22, 1, 0.36, 1),
+    filter 320ms ease;
+  transition-delay: 0ms;
+}
+
+.voice-sidebar-slot--immersive-hidden {
+  opacity: 0;
+  transform: translateX(-26px) scale(0.97);
+  filter: blur(3px);
+  pointer-events: none;
+  transition-delay: 55ms;
 }
 
 .voice-stage {
@@ -6854,7 +7208,11 @@ function summarizeTask(value: string): string {
   box-shadow: var(--hr-shadow-panel);
   transition:
     background 260ms ease,
-    box-shadow 360ms ease;
+    box-shadow 360ms ease,
+    margin 460ms cubic-bezier(0.22, 1, 0.36, 1),
+    padding 460ms cubic-bezier(0.22, 1, 0.36, 1),
+    border-radius 400ms cubic-bezier(0.22, 1, 0.36, 1);
+  transition-delay: 0ms;
 }
 
 .voice-cockpit--listening .voice-stage {
@@ -7515,6 +7873,13 @@ function summarizeTask(value: string): string {
   min-height: 88px;
   flex-direction: column;
   gap: 10px;
+  transition:
+    min-height 420ms cubic-bezier(0.22, 1, 0.36, 1),
+    margin-top 420ms cubic-bezier(0.22, 1, 0.36, 1),
+    padding-top 380ms cubic-bezier(0.22, 1, 0.36, 1),
+    border-color 260ms ease,
+    gap 320ms ease;
+  transition-delay: 0ms;
 }
 
 .voice-control__deck {
@@ -7530,7 +7895,14 @@ function summarizeTask(value: string): string {
   margin-left: auto;
   overflow: hidden;
   opacity: 0.34;
-  transition: opacity 180ms ease, filter 180ms ease;
+  transform-origin: bottom center;
+  transition:
+    width 420ms cubic-bezier(0.22, 1, 0.36, 1),
+    height 360ms cubic-bezier(0.22, 1, 0.36, 1),
+    margin 420ms cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 180ms ease,
+    filter 180ms ease,
+    transform 180ms ease;
 }
 
 .codex-live-voice-meter--active {
@@ -7671,9 +8043,27 @@ function summarizeTask(value: string): string {
   color: var(--vc-accent);
   font-size: 13px;
   font-weight: 700;
+  max-width: 320px;
+  overflow: hidden;
+  opacity: 1;
+  transform: translateY(0) scale(1);
   transition:
     border-color 160ms ease,
-    background 160ms ease;
+    background 160ms ease,
+    max-width 320ms cubic-bezier(0.22, 1, 0.36, 1),
+    padding 320ms cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 180ms ease,
+    transform 280ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.voice-agent-run-button--immersive-hidden {
+  max-width: 0;
+  border-width: 0;
+  padding-right: 0;
+  padding-left: 0;
+  opacity: 0;
+  transform: translateY(8px) scale(0.92);
+  pointer-events: none;
 }
 
 .voice-agent-run-button:hover {
@@ -7800,6 +8190,24 @@ function summarizeTask(value: string): string {
   flex-direction: column;
   gap: 8px;
   width: 100%;
+  max-height: 180px;
+  overflow: hidden;
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  transform-origin: bottom center;
+  transition:
+    max-height 380ms cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 220ms ease,
+    transform 360ms cubic-bezier(0.22, 1, 0.36, 1);
+  transition-delay: 0ms;
+}
+
+.voice-composer--immersive-hidden {
+  max-height: 0;
+  opacity: 0;
+  transform: translateY(18px) scale(0.97);
+  pointer-events: none;
+  transition-delay: 95ms;
 }
 
 .voice-composer__row {
@@ -7977,8 +8385,26 @@ function summarizeTask(value: string): string {
 .voice-input-dock {
   display: grid;
   width: 100%;
+  max-height: 132px;
   align-items: stretch;
   gap: 10px;
+  overflow: hidden;
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  transform-origin: bottom center;
+  transition:
+    max-height 380ms cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 220ms ease,
+    transform 360ms cubic-bezier(0.22, 1, 0.36, 1);
+  transition-delay: 0ms;
+}
+
+.voice-input-dock--immersive-hidden {
+  max-height: 0;
+  opacity: 0;
+  transform: translateY(18px) scale(0.97);
+  pointer-events: none;
+  transition-delay: 95ms;
 }
 
 .voice-input-dock--voice-only {
@@ -8175,6 +8601,27 @@ function summarizeTask(value: string): string {
 /* --------------------------------------------------------------------------
    Records panel (conversation thread)
    -------------------------------------------------------------------------- */
+.voice-records-slot {
+  opacity: 1;
+  transform: translateX(0) scale(1);
+  transform-origin: right center;
+  transition:
+    padding-right 420ms cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 260ms ease,
+    transform 420ms cubic-bezier(0.22, 1, 0.36, 1),
+    filter 320ms ease;
+  transition-delay: 0ms;
+}
+
+.voice-records-slot--immersive-hidden {
+  padding-right: 0;
+  opacity: 0 !important;
+  transform: translateX(26px) scale(0.97);
+  filter: blur(3px);
+  pointer-events: none;
+  transition-delay: 55ms;
+}
+
 .voice-records {
   display: flex;
   height: 100%;
@@ -8804,6 +9251,23 @@ function summarizeTask(value: string): string {
   to {
     transform: translateY(0) scale(1);
     opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .voice-shell,
+  .voice-main,
+  .voice-sidebar-slot,
+  .voice-records-slot,
+  .voice-stage,
+  .voice-control,
+  .voice-composer,
+  .voice-input-dock,
+  .voice-agent-run-button,
+  .codex-live-voice-meter,
+  .voice-cockpit :deep(.voice-topbar-motion) {
+    transition-duration: 1ms !important;
+    transition-delay: 0ms !important;
   }
 }
 

--- a/agent-ui/src/components/agent/AgentVoiceCockpitLayout.test.ts
+++ b/agent-ui/src/components/agent/AgentVoiceCockpitLayout.test.ts
@@ -19,7 +19,7 @@ describe('AgentVoiceCockpit responsive layout', () => {
       'class="voice-stage relative mx-6 my-0 flex min-h-0 flex-col overflow-hidden rounded-[28px] p-6"'
     )
     expect(cockpitSource).toContain(
-      'class="min-w-0 overflow-hidden py-0 pr-6 transition-opacity duration-300"'
+      'class="voice-records-slot min-w-0 overflow-hidden py-0 pr-6"'
     )
   })
 
@@ -191,5 +191,57 @@ describe('AgentVoiceCockpit responsive layout', () => {
     expect(cockpitSource).toContain('installGamepadMonitorDebugApi(')
     expect(cockpitSource).toContain('setVoiceGamepadMonitorVisible')
     expect(cockpitSource).toContain('uninstallGamepadMonitorDebugApi?.()')
+  })
+
+  it('automatically presents a waveform-only canvas for Codex Live Voice', () => {
+    expect(cockpitSource).toContain('const immersiveMode = ref(false)')
+    expect(cockpitSource).toContain('const immersiveSuspended = ref(false)')
+    expect(cockpitSource).toContain('codexLiveVoiceSessionActive.value &&')
+    expect(cockpitSource).toContain('!codexLiveVoiceConnecting.value')
+    expect(cockpitSource).toContain('uiStore.liveVoiceImmersiveEnabled')
+    expect(cockpitSource).toContain('activateLiveVoiceImmersiveMode()')
+    expect(cockpitSource).not.toContain('data-testid="voice-immersive-enter"')
+    expect(cockpitSource).toContain('data-testid="voice-immersive-exit-zone"')
+    expect(cockpitSource).toContain("'voice-immersive-exit-zone--visible': immersiveExitVisible")
+    expect(cockpitSource).toContain(
+      "window.addEventListener('pointermove', handleImmersivePointerMove"
+    )
+    expect(cockpitSource).toContain("'voice-cockpit--immersive': immersiveMode.value")
+    expect(cockpitSource).toContain("? '0 minmax(0, 1fr) 0'")
+    expect(cockpitSource).toContain("voiceGamepadFocusMode.value = 'widgets'")
+    expect(cockpitSource).toContain('if (immersiveMode.value) {')
+    expect(cockpitSource).toContain('exitImmersiveMode()')
+    expect(cockpitSource).toContain('@click="suspendLiveVoiceImmersiveMode"')
+    expect(cockpitSource).toContain("'voice-topbar--immersive-hidden': immersiveMode")
+    expect(cockpitSource).toContain("'voice-sidebar-slot--immersive-hidden': immersiveMode")
+    expect(cockpitSource).toContain("immersiveMode ? 'voice-records-slot--immersive-hidden' : ''")
+    expect(cockpitSource).toContain("'voice-composer--immersive-hidden': immersiveMode")
+    expect(cockpitSource).toContain(
+      '.voice-cockpit--immersive .codex-live-voice-meter--active'
+    )
+  })
+
+  it('temporarily reveals Live Voice controls and returns after interaction becomes idle', () => {
+    expect(cockpitSource).toContain('const IMMERSIVE_RETURN_IDLE_MS = 3200')
+    expect(cockpitSource).toContain('function suspendLiveVoiceImmersiveMode(): void')
+    expect(cockpitSource).toContain('function scheduleImmersiveReturn(): void')
+    expect(cockpitSource).toContain('function noteLiveVoiceImmersiveInteraction(): void')
+    expect(cockpitSource).toContain(
+      'immersiveSuspended.value && liveVoiceImmersiveActive.value'
+    )
+    expect(cockpitSource).toContain('}, IMMERSIVE_RETURN_IDLE_MS)')
+    expect(cockpitSource).toContain('noteLiveVoiceImmersiveInteraction()')
+    expect(cockpitSource).toContain('max-height 380ms cubic-bezier(0.22, 1, 0.36, 1)')
+    expect(cockpitSource).toContain(
+      '--voice-immersive-waveform-gutter: clamp(12px, 1.4vh, 16px)'
+    )
+    expect(cockpitSource).toContain(
+      'padding-bottom: var(--voice-immersive-waveform-gutter)'
+    )
+    expect(cockpitSource).toContain(
+      'margin-top: var(--voice-immersive-waveform-gutter)'
+    )
+    expect(cockpitSource).toContain('@media (prefers-reduced-motion: reduce)')
+    expect(cockpitSource).not.toContain('v-if="!immersiveMode && !isPhonePortrait"')
   })
 })

--- a/agent-ui/src/components/agent/settings/ExperimentalSettings.test.ts
+++ b/agent-ui/src/components/agent/settings/ExperimentalSettings.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createApp, nextTick, type App } from 'vue'
+import { createPinia } from 'pinia'
+import { i18n } from '@/plugins/i18n'
+import {
+  LIVE_VOICE_IMMERSIVE_STORAGE_KEY,
+  useUiStore,
+} from '@/stores/ui-store'
+import ExperimentalSettings from './ExperimentalSettings.vue'
+
+describe('ExperimentalSettings', () => {
+  let app: App<Element> | null = null
+  let root: HTMLElement | null = null
+
+  beforeEach(() => {
+    localStorage.clear()
+    i18n.global.locale.value = 'zh-Hans'
+  })
+
+  afterEach(() => {
+    app?.unmount()
+    root?.remove()
+    app = null
+    root = null
+  })
+
+  it('enables Live Voice immersion by default and persists the device toggle', async () => {
+    const pinia = createPinia()
+    root = document.createElement('div')
+    document.body.appendChild(root)
+    app = createApp(ExperimentalSettings)
+    app.use(pinia)
+    app.use(i18n)
+    app.mount(root)
+
+    const uiStore = useUiStore(pinia)
+    const toggle = root.querySelector<HTMLButtonElement>(
+      '[data-testid="agent-settings-live-voice-immersive-toggle"]'
+    )
+
+    expect(uiStore.liveVoiceImmersiveEnabled).toBe(true)
+    expect(toggle?.getAttribute('aria-checked')).toBe('true')
+
+    toggle?.click()
+    await nextTick()
+
+    expect(uiStore.liveVoiceImmersiveEnabled).toBe(false)
+    expect(toggle?.getAttribute('aria-checked')).toBe('false')
+    expect(localStorage.getItem(LIVE_VOICE_IMMERSIVE_STORAGE_KEY)).toBe('false')
+  })
+})

--- a/agent-ui/src/components/agent/settings/ExperimentalSettings.test.ts
+++ b/agent-ui/src/components/agent/settings/ExperimentalSettings.test.ts
@@ -24,7 +24,7 @@ describe('ExperimentalSettings', () => {
     root = null
   })
 
-  it('enables Live Voice immersion by default and persists the device toggle', async () => {
+  it('disables Live Voice immersion by default and persists the device toggle', async () => {
     const pinia = createPinia()
     root = document.createElement('div')
     document.body.appendChild(root)
@@ -38,14 +38,14 @@ describe('ExperimentalSettings', () => {
       '[data-testid="agent-settings-live-voice-immersive-toggle"]'
     )
 
-    expect(uiStore.liveVoiceImmersiveEnabled).toBe(true)
-    expect(toggle?.getAttribute('aria-checked')).toBe('true')
+    expect(uiStore.liveVoiceImmersiveEnabled).toBe(false)
+    expect(toggle?.getAttribute('aria-checked')).toBe('false')
 
     toggle?.click()
     await nextTick()
 
-    expect(uiStore.liveVoiceImmersiveEnabled).toBe(false)
-    expect(toggle?.getAttribute('aria-checked')).toBe('false')
-    expect(localStorage.getItem(LIVE_VOICE_IMMERSIVE_STORAGE_KEY)).toBe('false')
+    expect(uiStore.liveVoiceImmersiveEnabled).toBe(true)
+    expect(toggle?.getAttribute('aria-checked')).toBe('true')
+    expect(localStorage.getItem(LIVE_VOICE_IMMERSIVE_STORAGE_KEY)).toBe('true')
   })
 })

--- a/agent-ui/src/components/agent/settings/ExperimentalSettings.vue
+++ b/agent-ui/src/components/agent/settings/ExperimentalSettings.vue
@@ -1,0 +1,100 @@
+<script setup lang="ts">
+import { FlaskConical, Focus } from 'lucide-vue-next'
+import { useI18n } from 'vue-i18n'
+import { useUiStore } from '@/stores/ui-store'
+
+const { t } = useI18n()
+const uiStore = useUiStore()
+</script>
+
+<template>
+  <section
+    data-testid="agent-settings-section-experimental"
+    class="mt-8 space-y-6"
+  >
+    <div>
+      <div class="flex items-center gap-2">
+        <FlaskConical class="h-5 w-5 text-[var(--hr-accent)]" />
+        <h2 class="text-lg font-semibold text-[var(--hr-text-1)]">
+          {{ t('settings.experimental.title') }}
+        </h2>
+      </div>
+      <p class="mt-1 text-sm text-[var(--hr-text-3)]">
+        {{ t('settings.experimental.description') }}
+      </p>
+    </div>
+
+    <div
+      class="rounded-2xl border border-[var(--hr-settings-divider)] bg-[var(--hr-settings-card)] p-5"
+    >
+      <div class="flex flex-col gap-5 sm:flex-row sm:items-center sm:justify-between">
+        <div class="flex min-w-0 items-start gap-3">
+          <div
+            class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl border border-[var(--hr-border)] bg-[var(--hr-surface-1)] text-[var(--hr-accent)]"
+          >
+            <Focus class="h-5 w-5" />
+          </div>
+          <div class="min-w-0">
+            <div class="flex flex-wrap items-center gap-2">
+              <h3 class="text-sm font-semibold text-[var(--hr-text-1)]">
+                {{ t('settings.experimental.liveVoiceImmersive.title') }}
+              </h3>
+              <span
+                class="rounded-full border border-[var(--hr-warning-border)] bg-[var(--hr-warning-soft)] px-2 py-0.5 text-[10px] font-medium text-[var(--hr-warning)]"
+              >
+                {{ t('settings.experimental.badge') }}
+              </span>
+            </div>
+            <p class="mt-1 max-w-2xl text-sm leading-6 text-[var(--hr-text-3)]">
+              {{ t('settings.experimental.liveVoiceImmersive.description') }}
+            </p>
+          </div>
+        </div>
+
+        <div class="inline-flex flex-shrink-0 items-center gap-3 sm:pl-4">
+          <span
+            class="text-xs font-medium"
+            :class="
+              uiStore.liveVoiceImmersiveEnabled
+                ? 'text-[var(--hr-info)]'
+                : 'text-[var(--hr-text-3)]'
+            "
+          >
+            {{
+              uiStore.liveVoiceImmersiveEnabled
+                ? t('settings.actions.enabled')
+                : t('settings.actions.disabled')
+            }}
+          </span>
+          <button
+            data-testid="agent-settings-live-voice-immersive-toggle"
+            type="button"
+            role="switch"
+            class="relative h-7 w-12 rounded-full border transition"
+            :class="
+              uiStore.liveVoiceImmersiveEnabled
+                ? 'border-[var(--hr-info-border)] bg-[var(--hr-info)]'
+                : 'border-[var(--hr-border-strong)] bg-[var(--hr-surface-2)]'
+            "
+            :aria-checked="uiStore.liveVoiceImmersiveEnabled"
+            :aria-label="t('settings.experimental.liveVoiceImmersive.title')"
+            @click="
+              uiStore.setLiveVoiceImmersiveEnabled(
+                !uiStore.liveVoiceImmersiveEnabled
+              )
+            "
+          >
+            <span
+              class="absolute left-1 top-1 h-5 w-5 rounded-full bg-white shadow transition-transform"
+              :class="
+                uiStore.liveVoiceImmersiveEnabled
+                  ? 'translate-x-5'
+                  : 'translate-x-0'
+              "
+            />
+          </button>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>

--- a/agent-ui/src/locales/en-US/settings.json
+++ b/agent-ui/src/locales/en-US/settings.json
@@ -8,6 +8,7 @@
     "git": "Git",
     "providers": "Providers & Models",
     "voice": "Voice",
+    "experimental": "Experimental",
     "device": "WireGuard",
     "skills": "Skills",
     "plugins": "Plugins",
@@ -20,6 +21,7 @@
     "git": "Manage Git server tokens. Projects and repositories are linked when adding a directory.",
     "providers": "Manage providers, model capabilities, and locally encrypted model settings.",
     "voice": "Configure voice output and button controls.",
+    "experimental": "Manage interface capabilities that are still being refined.",
     "skills": "Inspect capabilities detected from the static Skills directory.",
     "plugins": "Inspect resolved plugin capabilities and enable or disable optional scenes.",
     "default": "Configure local capabilities used by HomeRail Agent UI."
@@ -78,6 +80,15 @@
         "not-available": "No newer update on this channel",
         "error": "Update check failed"
       }
+    }
+  },
+  "experimental": {
+    "title": "Experimental features",
+    "description": "These features are still being validated and may change as feedback comes in.",
+    "badge": "Experimental",
+    "liveVoiceImmersive": {
+      "title": "Live Voice immersive interface",
+      "description": "After Codex Live Voice connects, automatically collapse the top bar, sidebars, and composer so only generative UI and the bottom input waveform remain. Restore the full interface when the connection ends."
     }
   },
   "environment": {

--- a/agent-ui/src/locales/en-US/voice.json
+++ b/agent-ui/src/locales/en-US/voice.json
@@ -87,6 +87,9 @@
     "composerPlaceholder": "Send text through the active Live Voice session...",
     "textUnavailable": "Live Voice is reconnecting. Wait until it is listening before sending text."
   },
+  "immersive": {
+    "exit": "Exit immersive"
+  },
   "task": {
     "title": "Task",
     "prompt": "Describe a request to organize into a task draft.",

--- a/agent-ui/src/locales/zh-Hans/settings.json
+++ b/agent-ui/src/locales/zh-Hans/settings.json
@@ -8,6 +8,7 @@
     "git": "Git",
     "providers": "供应商与模型",
     "voice": "语音",
+    "experimental": "实验性功能",
     "device": "WireGuard",
     "skills": "Skills",
     "plugins": "插件",
@@ -20,6 +21,7 @@
     "git": "管理 Git Server token。项目和仓库在新增目录时关联。",
     "providers": "维护供应商、模型能力和本地加密保存的模型配置。",
     "voice": "配置语音播报和按键控制。",
+    "experimental": "管理仍在打磨、可能继续调整的界面能力。",
     "skills": "查看从静态 Skills 目录检测到的能力说明。",
     "plugins": "查看已解析的插件能力，并启用或停用可选场景。",
     "default": "配置 HomeRail Agent UI 使用的本地能力。"
@@ -78,6 +80,15 @@
         "not-available": "此通道暂无更高版本",
         "error": "更新检查失败"
       }
+    }
+  },
+  "experimental": {
+    "title": "实验性功能",
+    "description": "这些功能仍在验证中，可能随着使用反馈继续调整。",
+    "badge": "实验性",
+    "liveVoiceImmersive": {
+      "title": "Live Voice 沉浸界面",
+      "description": "Codex Live Voice 连接成功后自动收起顶部栏、侧栏和输入区，仅保留生成式 UI 与底部音量波形；断开连接后自动恢复完整界面。"
     }
   },
   "environment": {

--- a/agent-ui/src/locales/zh-Hans/voice.json
+++ b/agent-ui/src/locales/zh-Hans/voice.json
@@ -87,6 +87,9 @@
     "composerPlaceholder": "通过当前 Live Voice 会话发送文字…",
     "textUnavailable": "Live Voice 正在重连，请等待恢复聆听后再发送文字。"
   },
+  "immersive": {
+    "exit": "退出沉浸"
+  },
   "task": {
     "title": "任务",
     "prompt": "说出一个需要整理成任务草稿的需求。",

--- a/agent-ui/src/locales/zh-Hant/settings.json
+++ b/agent-ui/src/locales/zh-Hant/settings.json
@@ -8,6 +8,7 @@
     "git": "Git",
     "providers": "供應商與模型",
     "voice": "語音",
+    "experimental": "實驗性功能",
     "device": "WireGuard",
     "skills": "Skills",
     "plugins": "外掛",
@@ -20,6 +21,7 @@
     "git": "管理 Git Server token。項目和倉庫在新增目錄時關聯。",
     "providers": "維護供應商、模型能力和本地加密保存的模型配置。",
     "voice": "配置語音播報和按鍵控制。",
+    "experimental": "管理仍在打磨、可能繼續調整的介面能力。",
     "skills": "查看從靜態 Skills 目錄偵測到的能力說明。",
     "plugins": "查看已解析的外掛能力，並啓用或停用可選場景。",
     "default": "配置 HomeRail Agent UI 使用的本地能力。"
@@ -78,6 +80,15 @@
         "not-available": "此通道暫無更高版本",
         "error": "更新檢查失敗"
       }
+    }
+  },
+  "experimental": {
+    "title": "實驗性功能",
+    "description": "這些功能仍在驗證中，可能隨著使用回饋繼續調整。",
+    "badge": "實驗性",
+    "liveVoiceImmersive": {
+      "title": "Live Voice 沉浸介面",
+      "description": "Codex Live Voice 連線成功後自動收起頂部列、側欄和輸入區，只保留生成式 UI 與底部音量波形；中斷連線後自動恢復完整介面。"
     }
   },
   "environment": {

--- a/agent-ui/src/locales/zh-Hant/voice.json
+++ b/agent-ui/src/locales/zh-Hant/voice.json
@@ -87,6 +87,9 @@
     "composerPlaceholder": "透過目前 Live Voice 工作階段傳送文字…",
     "textUnavailable": "Live Voice 正在重新連線，請等待恢復聆聽後再傳送文字。"
   },
+  "immersive": {
+    "exit": "退出沉浸"
+  },
   "task": {
     "title": "任務",
     "prompt": "說出一個需要整理成任務草稿的需求。",

--- a/agent-ui/src/stores/ui-store.ts
+++ b/agent-ui/src/stores/ui-store.ts
@@ -77,7 +77,7 @@ export const useUiStore = defineStore('ui', () => {
   const locale = useStorage<AppLocale>(LOCALE_STORAGE_KEY, resolveInitialLocale())
   const liveVoiceImmersiveEnabled = useStorage<boolean>(
     LIVE_VOICE_IMMERSIVE_STORAGE_KEY,
-    true,
+    false,
   )
 
   // --------------------------------------------------------------------------

--- a/agent-ui/src/stores/ui-store.ts
+++ b/agent-ui/src/stores/ui-store.ts
@@ -39,6 +39,8 @@ import {
 } from '@/appearance/appearance-registry'
 
 export type NotificationType = 'success' | 'error' | 'warning' | 'info'
+export const LIVE_VOICE_IMMERSIVE_STORAGE_KEY =
+  'homerail.experimental.liveVoiceImmersive'
 
 export interface Notification {
   id: string
@@ -73,6 +75,10 @@ export const useUiStore = defineStore('ui', () => {
   const notifications = ref<Notification[]>([])
 
   const locale = useStorage<AppLocale>(LOCALE_STORAGE_KEY, resolveInitialLocale())
+  const liveVoiceImmersiveEnabled = useStorage<boolean>(
+    LIVE_VOICE_IMMERSIVE_STORAGE_KEY,
+    true,
+  )
 
   // --------------------------------------------------------------------------
   // Getters
@@ -187,6 +193,10 @@ export const useUiStore = defineStore('ui', () => {
     applyLocaleToDocument(normalized)
   }
 
+  function setLiveVoiceImmersiveEnabled(enabled: boolean) {
+    liveVoiceImmersiveEnabled.value = enabled
+  }
+
   // --------------------------------------------------------------------------
   // Initialization
   // --------------------------------------------------------------------------
@@ -218,6 +228,7 @@ export const useUiStore = defineStore('ui', () => {
     loadingMessage,
     notifications,
     locale,
+    liveVoiceImmersiveEnabled,
 
     // Getters
     isDarkMode,
@@ -239,6 +250,7 @@ export const useUiStore = defineStore('ui', () => {
     showWarning,
     showInfo,
     setLocale,
+    setLiveVoiceImmersiveEnabled,
     initialize
   }
 })

--- a/agent-ui/vite.config.ts
+++ b/agent-ui/vite.config.ts
@@ -8,6 +8,7 @@ import viteCompression from 'vite-plugin-compression2'
 import {
   authorizeAdminProxyRequest,
   isProtectedApiMutation,
+  trustedWebSocketProxyFetchSite,
 } from './src/admin-proxy-trust'
 
 // Dev server gzip compression plugin
@@ -113,6 +114,17 @@ export default defineConfig({
         changeOrigin: true,
         secure: false,
         rewrite: (path) => path,
+        configure(proxy) {
+          proxy.on('proxyReqWs', (proxyReq, req) => {
+            const fetchSite = trustedWebSocketProxyFetchSite({
+              protocol: 'encrypted' in req.socket && req.socket.encrypted ? 'https' : 'http',
+              host: req.headers.host,
+              origin: req.headers.origin,
+              secFetchSite: req.headers['sec-fetch-site'],
+            })
+            if (fetchSite) proxyReq.setHeader('sec-fetch-site', fetchSite)
+          })
+        },
       },
       '/artifacts': {
         target: managerHttpTarget,


### PR DESCRIPTION
## What changed

- Add an experimental Live Voice immersive interface for the Agent UI.
- Enter the interface only after Codex Live Voice connects successfully, then animate the top bar, side panels, and composer out of view.
- Keep a low-emphasis, centered microphone waveform visible at the bottom so users can confirm speech input is being detected.
- Reveal a compact exit control on pointer activity and automatically return to the immersive layout after 3.2 seconds of inactivity while voice remains connected.
- Restore the complete interface immediately when Live Voice disconnects, closes, or errors.
- Add a device-local toggle under Settings → Experimental Features; it is enabled by default.
- Harden the Agent UI WebSocket proxy trust handling and add Simplified Chinese, Traditional Chinese, and English copy.

## Why

During real-time voice interaction, typing controls and persistent application chrome consume space without contributing to the main task. Collapsing those controls gives generated UI substantially more room while preserving clear input feedback and a discoverable escape path.

## Impact

The behavior is limited to connected Codex Live Voice sessions and can be disabled from Experimental Features. Normal text interaction and disconnected voice states keep the existing layout.

## Validation

- `npm run build`
- `npm run typecheck`
- `npm test`
- Started the production Agent UI with LAN binding via `hr ui start --public`
- Verified the LAN-served UI and the enabled Experimental Features switch in a browser
