### PR TITLE
fix(live-voice): honor nested plugin-tool status, prevent canvas drift (#168) 

### DIFF
--- a/agent-ui/src/agent/codex-live-voice-client.test.ts
+++ b/agent-ui/src/agent/codex-live-voice-client.test.ts
@@ -737,4 +737,44 @@ describe('CodexLiveVoiceClient', () => {
     })
     expect(vi.getTimerCount()).toBe(0)
   })
+
+  it('forwards events/state to callbacks with no client identity, so callers must bind them (issue #168)', async () => {
+    // The client invokes onEvent(message) and onState(state) with a single
+    // argument — no client reference, no sessionId. This pins the contract that
+    // makes the caller-side binding guard in AgentVoiceCockpit.startCodexLiveVoice
+    // (codexLiveVoiceClient !== client) necessary: a stale/old client's callbacks
+    // would otherwise keep firing into shared handlers. If this forwarding shape
+    // ever gains a client-identity argument, the cockpit guard can be tightened.
+    const socket = new FakeSocket()
+    const peer = new FakePeer()
+    const { stream } = fakeMedia()
+    const events: CodexLiveVoiceEvent[] = []
+    const states: CodexLiveVoiceState[] = []
+    const client = new CodexLiveVoiceClient({
+      sessionId: 'voice-callback-contract',
+      ticketProvider: async () => ({ ticket: 'single-use-ticket' }),
+      webSocketFactory: () => {
+        queueMicrotask(() => socket.open())
+        return socket as unknown as WebSocket
+      },
+      peerConnectionFactory: () => peer as unknown as RTCPeerConnection,
+      getUserMedia: async () => stream,
+      audioFactory: fakeAudio,
+      onEvent: event => events.push(event),
+      onState: state => states.push(state),
+    })
+    await client.start()
+
+    // Drive a transcript + a workspace event through the client.
+    socket.message({ type: 'transcript.delta', delta: 'hi', role: 'assistant' })
+    socket.message({ type: 'workspace', workspace: { session_id: 'voice-callback-contract' } })
+
+    // The forwarded event is exactly the message, with no extra identity arg.
+    expect(events.some(e => e.type === 'transcript.delta')).toBe(true)
+    expect(events.some(e => e.type === 'workspace')).toBe(true)
+    // onState is also forwarded with a single argument (no client identity).
+    expect(states.length).toBeGreaterThan(0)
+
+    await client.stop()
+  })
 })

--- a/agent-ui/src/agent/voice-current-session-writer.test.ts
+++ b/agent-ui/src/agent/voice-current-session-writer.test.ts
@@ -40,7 +40,7 @@ function makeWriter() {
 }
 
 describe('VoiceCurrentSessionWriter (issue #168 session-write race)', () => {
-  it('drops a stale A write when B supersedes it before A settles', async () => {
+  it('serializes B after A and ends on B even when B supersedes A before A settles', async () => {
     const { guard, writer, dispatched, settle } = makeWriter()
     const genA = guard.begin() // user selects A
     writer.submit('A', genA)
@@ -103,5 +103,32 @@ describe('VoiceCurrentSessionWriter (issue #168 session-write race)', () => {
     settle('second')
     await writer.idle()
     expect(dispatched).toEqual(['first', 'second'])
+  })
+
+  it('a failed write does not block later writes or surface unhandled rejection', async () => {
+    // Custom writer whose first write rejects; the terminal .catch must swallow
+    // the rejection so the chain keeps going and settles cleanly.
+    const guard = new VoiceSessionTransitionGuard()
+    const dispatched: Array<string | null> = []
+    let call = 0
+    const writer = new VoiceCurrentSessionWriter(guard, async (sessionId) => {
+      call += 1
+      if (call === 1) throw new Error('network down')
+      dispatched.push(sessionId)
+    })
+    const unhandled: unknown[] = []
+    const onUnhandled = (reason: unknown): void => { unhandled.push(reason) }
+    process.on('unhandledRejection', onUnhandled)
+    try {
+      writer.submit('fails', undefined)
+      writer.submit('after', undefined)
+      await writer.idle()
+      // The failed write was swallowed; the later write still dispatched.
+      expect(dispatched).toEqual(['after'])
+      // No unhandled rejection escaped the chain.
+      expect(unhandled).toHaveLength(0)
+    } finally {
+      process.off('unhandledRejection', onUnhandled)
+    }
   })
 })

--- a/agent-ui/src/agent/voice-current-session-writer.test.ts
+++ b/agent-ui/src/agent/voice-current-session-writer.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+import { VoiceSessionTransitionGuard } from './voice-session-restore'
+import { VoiceCurrentSessionWriter } from './voice-current-session-writer'
+
+/**
+ * Regression coverage for issue #168: rapid A→B session switching must not let
+ * the older A write land after B and leave the server's current-session pointer
+ * stuck on A. The writer serializes writes and re-checks the transition
+ * generation after the previous write settles, dropping a superseded write.
+ */
+function makeWriter() {
+  const guard = new VoiceSessionTransitionGuard()
+  // Record each write that is actually dispatched, in dispatch order.
+  const dispatched: Array<string | null> = []
+  // Per-session controllable promises so the test can settle writes in any
+  // order regardless of enqueue order. `settled` lets a settle() that races
+  // ahead of the write callback resolve immediately when the promise is created.
+  const settled = new Set<string | null>()
+  const resolvers = new Map<string | null, () => void>()
+  const promises = new Map<string | null, Promise<void>>()
+  const pendingFor = (sessionId: string | null): Promise<void> => {
+    if (settled.has(sessionId)) return Promise.resolve()
+    const existing = promises.get(sessionId)
+    if (existing) return existing
+    let resolve!: () => void
+    const promise = new Promise<void>((r) => { resolve = r })
+    resolvers.set(sessionId, resolve)
+    promises.set(sessionId, promise)
+    return promise
+  }
+  const settle = (sessionId: string | null): void => {
+    settled.add(sessionId)
+    resolvers.get(sessionId)?.()
+  }
+  const writer = new VoiceCurrentSessionWriter(guard, async (sessionId) => {
+    dispatched.push(sessionId)
+    await pendingFor(sessionId)
+  })
+  return { guard, writer, dispatched, settle }
+}
+
+describe('VoiceCurrentSessionWriter (issue #168 session-write race)', () => {
+  it('drops a stale A write when B supersedes it before A settles', async () => {
+    const { guard, writer, dispatched, settle } = makeWriter()
+    const genA = guard.begin() // user selects A
+    writer.submit('A', genA)
+    // A is now in-flight (its write promise is pending). User switches to B
+    // before A settles:
+    const genB = guard.begin() // supersedes genA
+    writer.submit('B', genB)
+
+    // Settle A first, then B. Even though A resolves first, the writer must NOT
+    // dispatch B until A's chain step completes; and A's chain step must not
+    // dispatch A (it is stale) — actually A was dispatched at enqueue before B
+    // began. The real guard is: once B begins, A's *already-dispatched* PUT is
+    // unavoidable, but B is serialized behind it and will still be sent. The
+    // guarantee we provide client-side is that B is always sent AFTER A settles,
+    // so the server's last-writer-wins ends on B.
+    settle('A')
+    settle('B')
+    await writer.idle()
+
+    expect(dispatched).toContain('B')
+    expect(dispatched.at(-1)).toBe('B')
+  })
+
+  it('does not dispatch a superseded write that has not yet started', async () => {
+    const { guard, writer, dispatched, settle } = makeWriter()
+    // Block the first write so subsequent writes queue behind it.
+    const genA = guard.begin()
+    writer.submit('A', genA)
+    // Before A settles, a NEWER transition begins and enqueues a write.
+    const genB = guard.begin()
+    // A third stale write with the OLD generation queued behind A:
+    writer.submit('A-stale-but-same-gen', genA) // genA is no longer current
+    // Current-generation write:
+    writer.submit('B', genB)
+
+    settle('A')
+    settle('B')
+    await writer.idle()
+
+    // The genA-stale write must be dropped (genA superseded by genB); A (already
+    // in flight) and B dispatched. 'A-stale-but-same-gen' never dispatched.
+    expect(dispatched).not.toContain('A-stale-but-same-gen')
+    expect(dispatched.at(-1)).toBe('B')
+  })
+
+  it('dispatches generation-undefined writes without re-check (fast path)', async () => {
+    const { writer, dispatched, settle } = makeWriter()
+    writer.submit('same', undefined)
+    settle('same')
+    await writer.idle()
+    expect(dispatched).toEqual(['same'])
+  })
+
+  it('serializes: later writes wait for earlier ones to settle', async () => {
+    const { writer, dispatched, settle } = makeWriter()
+    writer.submit('first', undefined)
+    writer.submit('second', undefined)
+    // second must not dispatch before first settles
+    settle('first')
+    settle('second')
+    await writer.idle()
+    expect(dispatched).toEqual(['first', 'second'])
+  })
+})

--- a/agent-ui/src/agent/voice-current-session-writer.ts
+++ b/agent-ui/src/agent/voice-current-session-writer.ts
@@ -32,7 +32,11 @@ export class VoiceCurrentSessionWriter {
       if (generation !== undefined && !this.guard.isCurrent(generation)) return
       await this.write(sessionId)
     }
-    this.pending = this.pending.then(run, run)
+    // `.then(run, run)` resumes the chain on rejection (so one failed write
+    // never blocks later writes). The terminal `.catch` swallows any rejection
+    // from the LAST queued write so it does not surface as an unhandled promise
+    // rejection — the caller treats current-session writes as best-effort.
+    this.pending = this.pending.then(run, run).catch(() => undefined)
   }
 
   /** Resolved only when every enqueued write has settled. Test-only helper. */

--- a/agent-ui/src/agent/voice-current-session-writer.ts
+++ b/agent-ui/src/agent/voice-current-session-writer.ts
@@ -1,0 +1,42 @@
+import type { VoiceSessionTransitionGuard } from './voice-session-restore'
+
+/**
+ * Serialized, generation-gated writer for PUT /api/voice-agent/current-session.
+ *
+ * The server write is a blind last-writer-wins UPSERT, so fire-and-forget
+ * calls during rapid A→B session switching could let an older A request land
+ * AFTER B and leave the server pointer stuck on A (issue #168).
+ *
+ * This writer chains every write onto the previous one and re-checks the
+ * transition generation after the previous write settles: if a newer transition
+ * has begun (the user switched again), the stale write is dropped instead of
+ * dispatched. Extracted from AgentVoiceCockpit so the policy is unit-testable.
+ */
+export class VoiceCurrentSessionWriter {
+  private pending: Promise<unknown> = Promise.resolve()
+
+  constructor(
+    private readonly guard: VoiceSessionTransitionGuard,
+    private readonly write: (sessionId: string | null) => Promise<unknown>,
+  ) {}
+
+  /**
+   * Enqueue a current-session write.
+   * - `generation === undefined`: skip the re-check (the "already current"
+   *   fast path is mutually exclusive with the full switch flow).
+   * - otherwise: re-check `guard.isCurrent(generation)` after the previous write
+   *   settles and drop this write if a newer transition has superseded it.
+   */
+  submit(sessionId: string | null, generation: number | undefined): void {
+    const run = async (): Promise<void> => {
+      if (generation !== undefined && !this.guard.isCurrent(generation)) return
+      await this.write(sessionId)
+    }
+    this.pending = this.pending.then(run, run)
+  }
+
+  /** Resolved only when every enqueued write has settled. Test-only helper. */
+  idle(): Promise<unknown> {
+    return this.pending
+  }
+}

--- a/agent-ui/src/components/agent/AgentVoiceCockpit.vue
+++ b/agent-ui/src/components/agent/AgentVoiceCockpit.vue
@@ -38,6 +38,7 @@ import {
   resolveVoiceSessionProjectRestore,
   VoiceSessionTransitionGuard,
 } from '@/agent/voice-session-restore'
+import { VoiceCurrentSessionWriter } from '@/agent/voice-current-session-writer'
 import {
   CodexLiveVoiceClient,
   codexLiveVoiceOwnsAudio,
@@ -367,6 +368,17 @@ function beginVoiceSessionTransition(): number {
 
 function completeVoiceSessionTransition(generation: number): void {
   if (voiceSessionTransitions.isCurrent(generation)) sessionTransitioning.value = false
+}
+
+// Serialized, generation-gated writer for the current-session server pointer.
+// Prevents rapid A→B session switches from leaving the server pointer stuck on
+// the stale A request (issue #168). See voice-current-session-writer.ts.
+const currentSessionWriter = new VoiceCurrentSessionWriter(
+  voiceSessionTransitions,
+  (sessionId) => setCurrentVoiceSession(sessionId),
+)
+function submitCurrentSessionWrite(sessionId: string | null, generation: number | undefined): void {
+  currentSessionWriter.submit(sessionId, generation)
 }
 
 function selectGenerativeUiNode(payload: { node_id: string }): void {
@@ -1491,8 +1503,8 @@ async function startSession(): Promise<void> {
       const res = await createVoiceSession(store.managerProjectId)
       if (!voiceSessionTransitions.isCurrent(generation)) return
       workspace.value = res.data
-      // 新建的会话成为当前会话，更新服务端指针。
-      void setCurrentVoiceSession(workspace.value?.session_id ?? null)
+      // 新建的会话成为当前会话，更新服务端指针（串行化，避免乱序写）。
+      submitCurrentSessionWrite(workspace.value?.session_id ?? null, generation)
     }
     rememberSpokenAssistantMessages(workspace.value)
     optimisticConversationItems.value = []
@@ -1536,7 +1548,7 @@ async function createFreshVoiceSession(): Promise<void> {
       resetSubmittedTranscriptClear()
       statusFocusApplied = false
       completeVoiceSessionTransition(generation)
-      void setCurrentVoiceSession(reusableSessionId)
+      submitCurrentSessionWrite(reusableSessionId, generation)
       await loadVoiceSessionShortcuts()
       void voiceSidebarRef.value?.refresh()
       void nextTick(() => voiceSidebarRef.value?.ensureGamepadFocus())
@@ -1553,7 +1565,7 @@ async function createFreshVoiceSession(): Promise<void> {
     resetSubmittedTranscriptClear()
     statusFocusApplied = false
     completeVoiceSessionTransition(generation)
-    void setCurrentVoiceSession(workspace.value?.session_id ?? null)
+    submitCurrentSessionWrite(workspace.value?.session_id ?? null, generation)
     await loadVoiceSessionShortcuts()
     void voiceSidebarRef.value?.refresh()
     void nextTick(() => voiceSidebarRef.value?.ensureGamepadFocus())
@@ -1619,7 +1631,9 @@ async function handleVoiceProjectSelected(_projectId: string): Promise<void> {
 
 async function handleVoiceSessionSelected(sessionId: string): Promise<void> {
   if (workspace.value?.session_id === sessionId) {
-    void setCurrentVoiceSession(sessionId)
+    // 已选中即当前：快速路径，无 generation token，串行化但不做 generation 复检
+    // （此分支与完整切换流程互斥，不会与 A→B 竞态并发）。
+    submitCurrentSessionWrite(sessionId, undefined)
     return
   }
   const previousWorkspace = workspace.value
@@ -1646,8 +1660,8 @@ async function handleVoiceSessionSelected(sessionId: string): Promise<void> {
     const runId = workspace.value?.manager_run_id
     if (runId) store.setRunId(runId)
     completeVoiceSessionTransition(generation)
-    // 更新服务端当前 session 指针，让其他设备刷新后看到同一个 session。
-    void setCurrentVoiceSession(sessionId)
+    // 更新服务端当前 session 指针（串行化 + generation 复检，避免 A→B 乱序写）。
+    submitCurrentSessionWrite(sessionId, generation)
   } catch (err: any) {
     if (voiceSessionTransitions.isCurrent(generation)) {
       workspace.value = previousWorkspace
@@ -3955,8 +3969,20 @@ async function startCodexLiveVoice(): Promise<void> {
       if (codexLiveVoiceClient === client) startCodexLiveVoiceMeter(stream)
       return stream
     },
-    onState: applyCodexLiveVoiceState,
-    onEvent: handleCodexLiveVoiceEvent,
+    // Bind both callbacks to this specific client instance: once stopCodexLiveVoice
+    // (or a newer start) replaces codexLiveVoiceClient, any in-flight callback from
+    // this client (workspace, transcript, state, error) is dropped. This closes the
+    // fail-open gap — the previous shared callbacks kept accepting events from a
+    // stale/old client whenever codexLiveVoiceSessionId was null. Mirrors the
+    // getUserMedia guard above. See issue #168 acceptance criterion #3.
+    onState: (state) => {
+      if (codexLiveVoiceClient !== client) return
+      applyCodexLiveVoiceState(state)
+    },
+    onEvent: (event) => {
+      if (codexLiveVoiceClient !== client) return
+      handleCodexLiveVoiceEvent(event)
+    },
   })
   codexLiveVoiceClient = client
   try {

--- a/agent-ui/src/components/agent/AgentVoiceCockpit.vue
+++ b/agent-ui/src/components/agent/AgentVoiceCockpit.vue
@@ -3985,11 +3985,12 @@ async function startCodexLiveVoice(): Promise<void> {
     },
   })
   codexLiveVoiceClient = client
+  // Stamp the session identity before `await client.start()` so workspace
+  // events arriving during startup are already session-validated. The catch
+  // block clears it on failure, so a failed start does not claim the session.
+  codexLiveVoiceSessionId = sessionId
   try {
     await client.start()
-    // Only stamp the active session identity once the client has actually
-    // started, so a failed start does not claim the session.
-    if (codexLiveVoiceClient === client) codexLiveVoiceSessionId = sessionId
   } catch (err: any) {
     if (codexLiveVoiceClient !== client) return
     codexLiveVoiceClient = null

--- a/agent-ui/src/components/agent/AgentVoiceCockpit.vue
+++ b/agent-ui/src/components/agent/AgentVoiceCockpit.vue
@@ -375,6 +375,11 @@ function selectGenerativeUiNode(payload: { node_id: string }): void {
 
 let mediaStream: MediaStream | null = null
 let codexLiveVoiceClient: CodexLiveVoiceClient | null = null
+// Session identity of the currently active Live Voice client. Async workspace
+// events are only applied when they belong to this session, so a reconnect
+// (or a stale event from a previous client) cannot yank the canvas to a
+// different/empty owner. See issue #168 acceptance criterion #3.
+let codexLiveVoiceSessionId: string | null = null
 let codexLiveVoiceMeterAudioContext: AudioContext | null = null
 let codexLiveVoiceMeterAnalyser: AnalyserNode | null = null
 let codexLiveVoiceMeterSource: MediaStreamAudioSourceNode | null = null
@@ -3858,6 +3863,19 @@ function applyCodexLiveVoiceState(state: CodexLiveVoiceState): void {
 function handleCodexLiveVoiceEvent(event: CodexLiveVoiceEvent): void {
   const eventWorkspace = event.workspace
   if (eventWorkspace && typeof eventWorkspace === 'object' && !Array.isArray(eventWorkspace)) {
+    // Only apply workspace updates that belong to the active Live Voice
+    // session. A reconnect creates a new client bound to a session id; events
+    // arriving from a previous/stale client (or a transient empty
+    // manager_run_id) must not overwrite the current canvas owner.
+    const eventSessionId = (eventWorkspace as { session_id?: unknown }).session_id
+    if (
+      codexLiveVoiceSessionId
+      && typeof eventSessionId === 'string'
+      && eventSessionId
+      && eventSessionId !== codexLiveVoiceSessionId
+    ) {
+      return
+    }
     workspace.value = eventWorkspace as VoiceWorkspace
     const latestUserText = [...workspace.value.conversation]
       .reverse()
@@ -3940,9 +3958,13 @@ async function startCodexLiveVoice(): Promise<void> {
   codexLiveVoiceClient = client
   try {
     await client.start()
+    // Only stamp the active session identity once the client has actually
+    // started, so a failed start does not claim the session.
+    if (codexLiveVoiceClient === client) codexLiveVoiceSessionId = sessionId
   } catch (err: any) {
     if (codexLiveVoiceClient !== client) return
     codexLiveVoiceClient = null
+    codexLiveVoiceSessionId = null
     stopCodexLiveVoiceMeter()
     applyCodexLiveVoiceState('error')
     error.value = err?.message || t('voice.liveVoice.error')
@@ -3952,6 +3974,7 @@ async function startCodexLiveVoice(): Promise<void> {
 async function stopCodexLiveVoice(notifyServer = true): Promise<void> {
   const client = codexLiveVoiceClient
   codexLiveVoiceClient = null
+  codexLiveVoiceSessionId = null
   if (client) await client.stop(notifyServer).catch(() => undefined)
   stopCodexLiveVoiceMeter()
   codexLiveVoiceMuted.value = false

--- a/agent-ui/src/components/agent/AgentVoiceCockpit.vue
+++ b/agent-ui/src/components/agent/AgentVoiceCockpit.vue
@@ -3867,12 +3867,15 @@ function handleCodexLiveVoiceEvent(event: CodexLiveVoiceEvent): void {
     // session. A reconnect creates a new client bound to a session id; events
     // arriving from a previous/stale client (or a transient empty
     // manager_run_id) must not overwrite the current canvas owner.
+    //
+    // `session_id` is a required field on every persisted/sent VoiceWorkspace,
+    // so when we have an active client we require an exact match; an event
+    // without a usable session id is dropped rather than applied. See issue
+    // #168 acceptance criterion #3.
     const eventSessionId = (eventWorkspace as { session_id?: unknown }).session_id
     if (
       codexLiveVoiceSessionId
-      && typeof eventSessionId === 'string'
-      && eventSessionId
-      && eventSessionId !== codexLiveVoiceSessionId
+      && (typeof eventSessionId !== 'string' || !eventSessionId || eventSessionId !== codexLiveVoiceSessionId)
     ) {
       return
     }

--- a/agent-ui/src/components/generative-ui/DagTaskCanvas.vue
+++ b/agent-ui/src/components/generative-ui/DagTaskCanvas.vue
@@ -330,13 +330,19 @@ onMounted(() => {
     // canvas. Only refresh when the event actually belongs to this canvas's
     // run, so a reconnect burst of events from other runs does not churn this
     // surface or race the owner pointer. See issue #168 acceptance criterion #3.
+    //
+    // All run-relevant `dag:` events carry a `runId` (audited in
+    // homerail_manager/src/runtime + src/node + src/worker). If a future event
+    // type omits it, fall back to the previous behavior (refresh) rather than
+    // silently dropping it — we never want to be stricter than the old "refresh
+    // on any DAG_* / dag: prefix" behavior for events we cannot attribute.
     const payload = (message.payload ?? message.data ?? {}) as { runId?: unknown; run_id?: unknown }
     const eventRunId = typeof payload.runId === 'string'
       ? payload.runId
       : typeof payload.run_id === 'string'
         ? payload.run_id
         : ''
-    if (!eventRunId || eventRunId !== props.runId) return
+    if (eventRunId && eventRunId !== props.runId) return
     scheduleRefresh()
   })
   unsubscribeState = voiceWs.onStateChange(state => {

--- a/agent-ui/src/components/generative-ui/DagTaskCanvas.vue
+++ b/agent-ui/src/components/generative-ui/DagTaskCanvas.vue
@@ -325,7 +325,19 @@ onMounted(() => {
   window.addEventListener('online', scheduleRefresh)
   document.addEventListener('visibilitychange', onVisibilityChange)
   unsubscribeEvents = voiceWs.on('*', message => {
-    if (message.type.startsWith('DAG_') || message.type.startsWith('dag:')) scheduleRefresh()
+    if (!message.type.startsWith('DAG_') && !message.type.startsWith('dag:')) return
+    // The shared `voiceWs` singleton fans every DAG event to every mounted
+    // canvas. Only refresh when the event actually belongs to this canvas's
+    // run, so a reconnect burst of events from other runs does not churn this
+    // surface or race the owner pointer. See issue #168 acceptance criterion #3.
+    const payload = (message.payload ?? message.data ?? {}) as { runId?: unknown; run_id?: unknown }
+    const eventRunId = typeof payload.runId === 'string'
+      ? payload.runId
+      : typeof payload.run_id === 'string'
+        ? payload.run_id
+        : ''
+    if (!eventRunId || eventRunId !== props.runId) return
+    scheduleRefresh()
   })
   unsubscribeState = voiceWs.onStateChange(state => {
     if (state === 'connected') scheduleRefresh()

--- a/agent-ui/src/components/generative-ui/GenerativeUiHost.test.ts
+++ b/agent-ui/src/components/generative-ui/GenerativeUiHost.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { createApp, defineComponent, h, nextTick, type App } from 'vue'
+import { createApp, defineComponent, h, nextTick, ref, type App } from 'vue'
 import type {
   GenerativeUiCompositionItemV1,
   GenerativeUiCompositionV1,
@@ -101,6 +101,38 @@ function mount(component: Parameters<typeof createApp>[0], props: Record<string,
   app.use(i18n)
   app.mount(root)
   return root
+}
+
+/**
+ * Mount `component` with reactive `document` / `composition` refs so a test can
+ * drive a genuine revision change after the initial render. Returns setters to
+ * update each prop along with the root element.
+ */
+function mountReactive(
+  component: Parameters<typeof createApp>[0],
+  initial: {
+    document: GenerativeUiDocumentV1
+    composition: GenerativeUiCompositionV1
+    registry?: GenerativeUiRendererRegistry
+  },
+): { root: HTMLElement; setDocument: (next: GenerativeUiDocumentV1) => void } {
+  const documentRef = ref<GenerativeUiDocumentV1>(initial.document)
+  const compositionRef = ref<GenerativeUiCompositionV1>(initial.composition)
+  const wrapper = defineComponent({
+    render() {
+      return h(component, {
+        document: documentRef.value,
+        composition: compositionRef.value,
+        ...(initial.registry ? { registry: initial.registry } : {}),
+      })
+    },
+  })
+  root = document.createElement('div')
+  document.body.appendChild(root)
+  app = createApp(wrapper)
+  app.use(i18n)
+  app.mount(root)
+  return { root, setDocument: (next) => { documentRef.value = next } }
 }
 
 afterEach(() => {
@@ -322,7 +354,7 @@ describe('GenerativeUiSurfaceHost', () => {
       hidden_node_ids: [],
     }
 
-    const mounted = mount(GenerativeUiSurfaceHost, {
+    const { root: mounted, setDocument } = mountReactive(GenerativeUiSurfaceHost, {
       document: documentValue,
       composition: compositionValue,
       registry: new GenerativeUiRendererRegistry([]),
@@ -334,6 +366,22 @@ describe('GenerativeUiSurfaceHost', () => {
     expect(mounted.querySelector('.generative-ui-surface-host')?.getAttribute('data-content-layout')).toBe('flow')
     expect([...mounted.querySelectorAll('[data-canvas-size]')].map(element => element.getAttribute('data-canvas-size')))
       .toEqual(['1x1', '1x2', '3x3'])
+    // Issue #168: a fresh mount must NOT auto-focus the latest Block. No node
+    // should be focused after the initial population.
+    expect(document.activeElement?.getAttribute('data-generative-ui-node')).toBeFalsy()
+
+    // A genuine revision change to the latest-updated node focuses it.
+    setDocument({
+      ...documentValue,
+      revision: 4,
+      updated_at: '2026-07-11T19:02:00.000Z',
+      nodes: nodes.map((candidate) => candidate.id === 'graph'
+        ? { ...candidate, revision: 2, updated_at: '2026-07-11T19:02:00.000Z' }
+        : candidate),
+    })
+    // flush:'post' watcher needs a couple of ticks to settle.
+    await nextTick()
+    await nextTick()
     expect(document.activeElement?.getAttribute('data-generative-ui-node')).toBe('graph')
   })
 
@@ -342,23 +390,25 @@ describe('GenerativeUiSurfaceHost', () => {
     const nodes = [node('motion-card', {
       presentation: { density: 'summary', canvas_size: '1x2', motion_profile: 'standard' },
     })]
-    const mounted = mount(GenerativeUiSurfaceHost, {
-      document: {
-        ir_version: 1,
-        document_id: 'document-motion',
-        scope: { type: 'voice_session', id: 'session-motion' },
-        revision: 1,
-        nodes,
-        updated_at: '2026-07-11T19:00:00.000Z',
-      } satisfies GenerativeUiDocumentV1,
-      composition: {
-        composition_version: 1,
-        document_id: 'document-motion',
-        document_revision: 1,
-        context,
-        items: [placement('motion-card', 1)],
-        hidden_node_ids: [],
-      } satisfies GenerativeUiCompositionV1,
+    const documentValue = {
+      ir_version: 1,
+      document_id: 'document-motion',
+      scope: { type: 'voice_session', id: 'session-motion' },
+      revision: 1,
+      nodes,
+      updated_at: '2026-07-11T19:00:00.000Z',
+    } satisfies GenerativeUiDocumentV1
+    const compositionValue = {
+      composition_version: 1,
+      document_id: 'document-motion',
+      document_revision: 1,
+      context,
+      items: [placement('motion-card', 1)],
+      hidden_node_ids: [],
+    } satisfies GenerativeUiCompositionV1
+    const { root: mounted, setDocument } = mountReactive(GenerativeUiSurfaceHost, {
+      document: documentValue,
+      composition: compositionValue,
       registry: new GenerativeUiRendererRegistry([]),
     })
     await nextTick()
@@ -366,6 +416,22 @@ describe('GenerativeUiSurfaceHost', () => {
     const host = mounted.querySelector<HTMLElement>('[data-generative-ui-node="motion-card"]')!
     expect(mounted.querySelector('.generative-ui-surface-host')?.getAttribute('data-content-layout')).toBe('single')
     expect(host.dataset.motionProfile).toBe('standard')
+    // Issue #168: attention is not asserted on the initial mount; it must fire
+    // on a genuine revision change instead.
+    expect(host.dataset.attention).toBe('false')
+
+    // A real revision change drives the motion profile and Manager attention.
+    setDocument({
+      ...documentValue,
+      revision: 2,
+      updated_at: '2026-07-11T19:00:01.000Z',
+      nodes: [{ ...nodes[0], revision: 2, updated_at: '2026-07-11T19:00:01.000Z' }],
+    })
+    // flush:'post' watcher needs a couple of ticks to settle; under fake timers
+    // we also flush any timer-queued microtasks.
+    await nextTick()
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(0)
     expect(host.dataset.attention).toBe('true')
     expect(host.classList.contains('generative-ui-node-host--attention')).toBe(true)
 

--- a/agent-ui/src/components/generative-ui/GenerativeUiSurfaceHost.vue
+++ b/agent-ui/src/components/generative-ui/GenerativeUiSurfaceHost.vue
@@ -171,6 +171,13 @@ function focusNode(nodeId: string): boolean {
 }
 
 let renderedRevisions = new Map<string, number>()
+// Track whether the watcher has populated `renderedRevisions` at least once.
+// On a fresh mount (or any remount, e.g. canvas owner flip / v-if toggle) the
+// closure-captured map starts empty, so every node would otherwise look
+// "changed" and auto-focus would scroll to the latest block even when its
+// revision is identical to before. We only auto-focus on a *genuine* revision
+// change after the initial population, never on the initial mount itself.
+let hasPopulatedRevisions = false
 watch(
   renderedWithLayout,
   async (entries) => {
@@ -188,6 +195,8 @@ watch(
     const previousRevisions = renderedRevisions
     const changed = entries.filter(entry => previousRevisions.get(entry.node.id) !== entry.node.revision)
     renderedRevisions = new Map(entries.map(entry => [entry.node.id, entry.node.revision]))
+    const wasInitialPopulation = !hasPopulatedRevisions
+    hasPopulatedRevisions = true
     if (!changed.length) return
     for (const entry of changed) {
       if (!previousRevisions.has(entry.node.id)) continue
@@ -200,6 +209,10 @@ watch(
           : entry.motionProfile.updateDurationMs
       void showLifecycleMotion(entry.node.id, motion, duration)
     }
+    // Skip auto-focus on the initial population so remounting the same node set
+    // (e.g. after a Live Voice reconnect) does not yank focus to the latest
+    // block. Auto-focus only fires on a real revision change thereafter.
+    if (wasInitialPopulation) return
     if (!props.autoFocusLatest || props.focusedNodeId) return
     await nextTick()
     const latest = [...changed].sort((left, right) => (

--- a/homerail_manager/src/server/host-codex-manager-agent.ts
+++ b/homerail_manager/src/server/host-codex-manager-agent.ts
@@ -1928,7 +1928,12 @@ export function createManagerTools(
         } catch {
           throw new Error("Generated view Tool returned an invalid result");
         }
-        state.objectiveToolCalls.push({ name: "skill_view_present", success: true });
+        // Derive objective success from the plugin-tool result so a failed/
+        // denied/cancelled presentation (data.status failure surfaced as
+        // is_error by pluginToolResult) is not counted as a satisfied
+        // required tool call. Mirrors how the adapter and successfulToolCallNames
+        // classify results. See issue #168.
+        state.objectiveToolCalls.push({ name: "skill_view_present", success: result.is_error !== true });
         return { content: [{
           type: "text",
           text: JSON.stringify(compactManagerAgentSkillViewPresentResult(resultBody, responseText)),

--- a/homerail_manager/src/server/host-codex-manager-agent.ts
+++ b/homerail_manager/src/server/host-codex-manager-agent.ts
@@ -90,9 +90,12 @@ const PLUGIN_TOOL_FAILURE_STATUSES = new Set(["failed", "denied", "cancelled"]);
  * `error_code` (if any) should NOT be treated as a failure. Per the plugin-tool
  * protocol, `error_code` only accompanies terminal failure records, but we scope
  * defensively so an informational `error_code` on a `committed`/`running`
- * outcome is never misclassified as a tool error.
+ * outcome is never misclassified as a tool error. `projected` is included so the
+ * local-projection envelope invariant (projected is non-terminal and non-error,
+ * for host/worker parity) is enforced structurally even if a future change
+ * attaches an `error_code` to it.
  */
-const PLUGIN_TOOL_NON_FAILURE_STATUSES = new Set(["committed", "running"]);
+const PLUGIN_TOOL_NON_FAILURE_STATUSES = new Set(["committed", "running", "projected"]);
 
 /**
  * Inspect a raw plugin-tool response body (the value returned by
@@ -1933,11 +1936,19 @@ export function createManagerTools(
         // is_error by pluginToolResult) is not counted as a satisfied
         // required tool call. Mirrors how the adapter and successfulToolCallNames
         // classify results. See issue #168.
-        state.objectiveToolCalls.push({ name: "skill_view_present", success: result.is_error !== true });
-        return { content: [{
-          type: "text",
-          text: JSON.stringify(compactManagerAgentSkillViewPresentResult(resultBody, responseText)),
-        }] };
+        const presentIsError = result.is_error === true;
+        state.objectiveToolCalls.push({ name: "skill_view_present", success: !presentIsError });
+        // Propagate is_error onto the model-visible tool result too — otherwise a
+        // non-throwing failure envelope (data.status=failed) would still reach the
+        // model as success even though the objective is marked failed, recreating
+        // the #168 false-success on this path.
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(compactManagerAgentSkillViewPresentResult(resultBody, responseText)),
+          }],
+          is_error: presentIsError || undefined,
+        };
       },
     });
     tools.push({

--- a/homerail_manager/src/server/host-codex-manager-agent.ts
+++ b/homerail_manager/src/server/host-codex-manager-agent.ts
@@ -77,13 +77,22 @@ type ToolHandlerResult = {
 /**
  * Statuses that mark a plugin/Manager tool mutation as unsuccessful from the
  * model's point of view. Only `committed` represents a successful UI mutation;
- * `failed`, `denied`, and `cancelled` (and any unknown non-committed status)
- * must be surfaced to the model as tool errors so it does not claim a panel was
- * updated when no document revision actually changed.
+ * `failed`, `denied`, and `cancelled` must be surfaced to the model as tool
+ * errors so it does not claim a panel was updated when no document revision
+ * actually changed.
  *
  * See issue #168 (false canvas-update success).
  */
 const PLUGIN_TOOL_FAILURE_STATUSES = new Set(["failed", "denied", "cancelled"]);
+
+/**
+ * Statuses that represent an in-flight or successful outcome, where an
+ * `error_code` (if any) should NOT be treated as a failure. Per the plugin-tool
+ * protocol, `error_code` only accompanies terminal failure records, but we scope
+ * defensively so an informational `error_code` on a `committed`/`running`
+ * outcome is never misclassified as a tool error.
+ */
+const PLUGIN_TOOL_NON_FAILURE_STATUSES = new Set(["committed", "running"]);
 
 /**
  * Inspect a raw plugin-tool response body (the value returned by
@@ -93,7 +102,8 @@ const PLUGIN_TOOL_FAILURE_STATUSES = new Set(["failed", "denied", "cancelled"]);
  * The Manager wraps runtime tool outcomes as `{ success, data: { status,
  * error_code } }`. The host adapter only looks at `result.is_error`, so this
  * helper translates a nested `data.status` failure (or an explicit top-level
- * `success: false`, or a present `error_code`) into `is_error: true`.
+ * `success: false`, or a present `error_code` on a non-success status) into
+ * `is_error: true`.
  *
  * Note: a local projection envelope `{ status: "projected", committed: false }`
  * is intentionally NOT treated as an error. It is a legitimate non-terminal
@@ -115,12 +125,23 @@ export function isPluginToolEnvelopeFailure(body: unknown): boolean {
     const status = typeof inner.status === "string" ? inner.status : "";
     if (PLUGIN_TOOL_FAILURE_STATUSES.has(status)) return true;
     if (inner.success === false) return true;
-    if (typeof inner.error_code === "string" && inner.error_code) return true;
+    // Only treat error_code as a failure when the status is not an explicit
+    // success/in-flight state, so an informational error_code on a committed
+    // outcome is never misclassified.
+    if (
+      !PLUGIN_TOOL_NON_FAILURE_STATUSES.has(status)
+      && typeof inner.error_code === "string"
+      && inner.error_code
+    ) return true;
   }
 
   const status = typeof record.status === "string" ? record.status : "";
   if (PLUGIN_TOOL_FAILURE_STATUSES.has(status)) return true;
-  if (typeof record.error_code === "string" && record.error_code) return true;
+  if (
+    !PLUGIN_TOOL_NON_FAILURE_STATUSES.has(status)
+    && typeof record.error_code === "string"
+    && record.error_code
+  ) return true;
 
   return false;
 }

--- a/homerail_manager/src/server/host-codex-manager-agent.ts
+++ b/homerail_manager/src/server/host-codex-manager-agent.ts
@@ -74,6 +74,64 @@ type ToolHandlerResult = {
   is_error?: boolean;
 };
 
+/**
+ * Statuses that mark a plugin/Manager tool mutation as unsuccessful from the
+ * model's point of view. Only `committed` represents a successful UI mutation;
+ * `failed`, `denied`, and `cancelled` (and any unknown non-committed status)
+ * must be surfaced to the model as tool errors so it does not claim a panel was
+ * updated when no document revision actually changed.
+ *
+ * See issue #168 (false canvas-update success).
+ */
+const PLUGIN_TOOL_FAILURE_STATUSES = new Set(["failed", "denied", "cancelled"]);
+
+/**
+ * Inspect a raw plugin-tool response body (the value returned by
+ * `/plugins/tools/invoke` or a local projection envelope) and decide whether it
+ * must be reported to the model as a tool error.
+ *
+ * The Manager wraps tool outcomes as `{ success, data: { status, error_code } }`.
+ * The host adapter only looks at `result.is_error`, so this helper translates a
+ * nested `data.status` failure (or an explicit top-level `success: false`, or a
+ * projection envelope that never committed) into `is_error: true`.
+ */
+export function isPluginToolEnvelopeFailure(body: unknown): boolean {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return false;
+  const record = body as Record<string, unknown>;
+
+  // Local projection envelopes (`{ status: "projected", committed: false }`)
+  // are always non-terminal and must not be reported as success either.
+  if (record.committed === false) return true;
+
+  if (record.success === false) return true;
+
+  const data = record.data;
+  if (data && typeof data === "object" && !Array.isArray(data)) {
+    const inner = data as Record<string, unknown>;
+    const status = typeof inner.status === "string" ? inner.status : "";
+    if (PLUGIN_TOOL_FAILURE_STATUSES.has(status)) return true;
+    if (inner.success === false) return true;
+    if (typeof inner.error_code === "string" && inner.error_code) return true;
+  }
+
+  const status = typeof record.status === "string" ? record.status : "";
+  if (PLUGIN_TOOL_FAILURE_STATUSES.has(status)) return true;
+  if (typeof record.error_code === "string" && record.error_code) return true;
+
+  return false;
+}
+
+/**
+ * Wrap a plugin-tool response body into a {@link ToolHandlerResult}, honoring
+ * nested failure statuses so the adapter reports `is_error: true`.
+ */
+function pluginToolResult(body: unknown): ToolHandlerResult {
+  return {
+    content: [{ type: "text", text: JSON.stringify(body) }],
+    is_error: isPluginToolEnvelopeFailure(body),
+  };
+}
+
 export interface ToolDefinition {
   name: string;
   description: string;
@@ -1756,7 +1814,9 @@ export function createManagerTools(
     if (!currentPluginToolTurnToken) {
       const envelope = executeHomerailPluginTool(descriptor, args);
       state.voiceSurface.pluginProjections.push(envelope);
-      return { content: [{ type: "text", text: JSON.stringify(envelope) }] };
+      // Local projections are never committed; surface that as an error so the
+      // model does not claim a successful UI mutation.
+      return pluginToolResult(envelope);
     }
     const identity = stablePluginModelCallIdentifiers({
       turn_token: currentPluginToolTurnToken,
@@ -1775,7 +1835,7 @@ export function createManagerTools(
         arguments: args,
       }),
     });
-    return { content: [{ type: "text", text: JSON.stringify(result) }] };
+    return pluginToolResult(result);
   };
   const generatedViewDescriptor = responseMode === "voice"
     ? pluginContext?.tools.find((tool) => tool.qualified_id === "com.homerail.core:upsert_generated_view")

--- a/homerail_manager/src/server/host-codex-manager-agent.ts
+++ b/homerail_manager/src/server/host-codex-manager-agent.ts
@@ -90,18 +90,22 @@ const PLUGIN_TOOL_FAILURE_STATUSES = new Set(["failed", "denied", "cancelled"]);
  * `/plugins/tools/invoke` or a local projection envelope) and decide whether it
  * must be reported to the model as a tool error.
  *
- * The Manager wraps tool outcomes as `{ success, data: { status, error_code } }`.
- * The host adapter only looks at `result.is_error`, so this helper translates a
- * nested `data.status` failure (or an explicit top-level `success: false`, or a
- * projection envelope that never committed) into `is_error: true`.
+ * The Manager wraps runtime tool outcomes as `{ success, data: { status,
+ * error_code } }`. The host adapter only looks at `result.is_error`, so this
+ * helper translates a nested `data.status` failure (or an explicit top-level
+ * `success: false`, or a present `error_code`) into `is_error: true`.
+ *
+ * Note: a local projection envelope `{ status: "projected", committed: false }`
+ * is intentionally NOT treated as an error. It is a legitimate non-terminal
+ * "projected but not yet committed" state that both the voice host and the
+ * non-voice worker produce identically (see manager-agent-tool-parity); flagging
+ * it would break result-envelope parity. The false-success bug in #168 is about
+ * the runtime invoke path returning `data.status = "failed"`, which IS caught
+ * below.
  */
 export function isPluginToolEnvelopeFailure(body: unknown): boolean {
   if (!body || typeof body !== "object" || Array.isArray(body)) return false;
   const record = body as Record<string, unknown>;
-
-  // Local projection envelopes (`{ status: "projected", committed: false }`)
-  // are always non-terminal and must not be reported as success either.
-  if (record.committed === false) return true;
 
   if (record.success === false) return true;
 
@@ -1814,9 +1818,7 @@ export function createManagerTools(
     if (!currentPluginToolTurnToken) {
       const envelope = executeHomerailPluginTool(descriptor, args);
       state.voiceSurface.pluginProjections.push(envelope);
-      // Local projections are never committed; surface that as an error so the
-      // model does not claim a successful UI mutation.
-      return pluginToolResult(envelope);
+      return { content: [{ type: "text", text: JSON.stringify(envelope) }] };
     }
     const identity = stablePluginModelCallIdentifiers({
       turn_token: currentPluginToolTurnToken,

--- a/homerail_manager/src/server/routes.ts
+++ b/homerail_manager/src/server/routes.ts
@@ -881,11 +881,11 @@ export function inspectionRoutesHandler(
       json(res, 400, { success: false, message: "Invalid encoded run ID", error: "Invalid encoded run ID" });
       return true;
     }
-    if (!runId || !loadRunMetadata(runId)) {
+    const metadata = runId ? loadRunMetadata(runId) : null;
+    if (!runId || !metadata) {
       _notFound(res, runId ? `Run not found: ${runId}` : "Invalid run ID");
       return true;
     }
-    const metadata = loadRunMetadata(runId)!;
     const runStatus = typeof metadata.status === "string" ? metadata.status : "";
     // Once a run reaches a terminal state other than `completed`, its live
     // surface is no longer the active canvas owner. Return an empty surface so

--- a/homerail_manager/src/server/routes.ts
+++ b/homerail_manager/src/server/routes.ts
@@ -885,6 +885,23 @@ export function inspectionRoutesHandler(
       _notFound(res, runId ? `Run not found: ${runId}` : "Invalid run ID");
       return true;
     }
+    const metadata = loadRunMetadata(runId)!;
+    const runStatus = typeof metadata.status === "string" ? metadata.status : "";
+    // Once a run reaches a terminal state other than `completed`, its live
+    // surface is no longer the active canvas owner. Return an empty surface so
+    // the frontend's `available` flag flips false and the canonical view can
+    // mount after a committed block. `completed` keeps the surface so the last
+    // DAG result stays visible.
+    if (isTerminalDagRunStatus(runStatus) && runStatus !== "completed") {
+      _ok(res, `Live surfaces released (run ${runStatus})`, {
+        run_id: runId,
+        run_status: runStatus,
+        projections: [],
+        surface_states: [],
+        document: null,
+      });
+      return true;
+    }
     const projections = listDagLiveSurfaceProjections(runId);
     const projectionBySurface = new Map(projections.map((projection) => [projection.surface_id, projection]));
     const document = getDagLiveSurfaceDocument(runId);
@@ -909,6 +926,7 @@ export function inspectionRoutesHandler(
     });
     _ok(res, `Live surfaces retrieved (${projections.length} actors)`, {
       run_id: runId,
+      run_status: runStatus || null,
       projections,
       surface_states: surfaceStates,
       document: document

--- a/homerail_manager/src/server/voice-agent-bootstrap.ts
+++ b/homerail_manager/src/server/voice-agent-bootstrap.ts
@@ -778,6 +778,27 @@ export function shouldSyncLiveVoiceRunIds(runIds: readonly string[]): boolean {
   return runIds.length > 0;
 }
 
+/**
+ * Compute the merged run-id list a Live Voice flush should write: the latest
+ * persisted workspace history (`workspaceRunIds(workspace)`) followed by the
+ * runs created by this binding (`newRunIds`), de-duplicated, order-preserving.
+ *
+ * This is a MERGE, not an overwrite. The persisted history may have advanced to
+ * a newer canvas owner (run B) after this binding was established; merging
+ * keeps B in history and only advances the active pointer when this binding
+ * genuinely created a newer run (because `syncWorkspaceRunIds` sets
+ * `manager_run_id = merged.at(-1)`). Pure helper for unit testing. See #168.
+ */
+export function appendWorkspaceRunIds(
+  workspace: VoiceWorkspace,
+  newRunIds: readonly string[],
+): string[] {
+  const merged = [...workspaceRunIds(workspace), ...newRunIds]
+    .map((item) => String(item || "").trim())
+    .filter(Boolean);
+  return Array.from(new Set(merged));
+}
+
 function syncVoiceWorkspaceTables(workspace: VoiceWorkspace): void {
   const db = getDb();
   const sessionStatus = workspace.progress_brief.status === "error" ? "failed" : workspace.progress_brief.status;
@@ -1943,10 +1964,14 @@ export async function createCodexLiveVoiceBinding(input: {
     workspace: cwd,
     projectId: workspace.project_id ?? agentConfig.project_id,
     sessionId: workspace.session_id,
-    // Hydrate from the persisted workspace so a reconnect does not start from
-    // an empty list. Without this, the first `flush_tool_state` after reconnect
-    // would write `manager_run_id = null` and yank the canvas owner pointer.
-    createdRunIds: workspaceRunIds(workspace),
+    // Only record runs created BY THIS binding. Do NOT seed with the persisted
+    // history: `flush_tool_state` merges this list with the latest workspace
+    // (see appendWorkspaceRunIds), so seeding the full snapshot would turn a
+    // stale startup snapshot into write authority and let a later flush revert
+    // a newer canvas owner or reactivate a terminal run. An empty list is a
+    // no-op flush (shouldSyncLiveVoiceRunIds returns false), so reconnect never
+    // yanks the pointer either.
+    createdRunIds: [],
     finalNotes: [],
     objectiveToolCalls: [],
     voiceSurface: emptyVoiceSurface(),
@@ -2138,12 +2163,13 @@ export async function createCodexLiveVoiceBinding(input: {
     },
     flush_tool_state: () => {
       const next = currentWorkspace();
-      // Guard the sync like the non-Live-Voice turn path does: never overwrite a
-      // persisted canvas-owner pointer with an empty list. This keeps a
-      // reconnect (or any flush before a Manager tool has run) from clearing
-      // `manager_run_id` and forcing the UI back onto the canonical view.
+      // Merge — never overwrite. Only runs created by THIS binding are appended
+      // to the latest persisted history, so an external canvas-owner change
+      // (run B) stays in history and the active pointer only advances when this
+      // binding created something newer. An empty createdRunIds is a no-op and
+      // never yanks the pointer. See issue #168.
       if (shouldSyncLiveVoiceRunIds(state.createdRunIds)) {
-        syncWorkspaceRunIds(next, state.createdRunIds);
+        syncWorkspaceRunIds(next, appendWorkspaceRunIds(next, state.createdRunIds));
       }
       applyVoiceSurfaceFromResult(next, {
         voice_surface: {

--- a/homerail_manager/src/server/voice-agent-bootstrap.ts
+++ b/homerail_manager/src/server/voice-agent-bootstrap.ts
@@ -1930,7 +1930,10 @@ export async function createCodexLiveVoiceBinding(input: {
     workspace: cwd,
     projectId: workspace.project_id ?? agentConfig.project_id,
     sessionId: workspace.session_id,
-    createdRunIds: [],
+    // Hydrate from the persisted workspace so a reconnect does not start from
+    // an empty list. Without this, the first `flush_tool_state` after reconnect
+    // would write `manager_run_id = null` and yank the canvas owner pointer.
+    createdRunIds: workspaceRunIds(workspace),
     finalNotes: [],
     objectiveToolCalls: [],
     voiceSurface: emptyVoiceSurface(),
@@ -2122,7 +2125,13 @@ export async function createCodexLiveVoiceBinding(input: {
     },
     flush_tool_state: () => {
       const next = currentWorkspace();
-      syncWorkspaceRunIds(next, state.createdRunIds);
+      // Guard the sync like the non-Live-Voice turn path does: never overwrite a
+      // persisted canvas-owner pointer with an empty list. This keeps a
+      // reconnect (or any flush before a Manager tool has run) from clearing
+      // `manager_run_id` and forcing the UI back onto the canonical view.
+      if (state.createdRunIds.length) {
+        syncWorkspaceRunIds(next, state.createdRunIds);
+      }
       applyVoiceSurfaceFromResult(next, {
         voice_surface: {
           progress: state.voiceSurface.progress,

--- a/homerail_manager/src/server/voice-agent-bootstrap.ts
+++ b/homerail_manager/src/server/voice-agent-bootstrap.ts
@@ -765,6 +765,19 @@ function syncWorkspaceRunIds(workspace: VoiceWorkspace, runIds: string[]): void 
   workspace.manager_run_id = unique.length ? unique[unique.length - 1] : null;
 }
 
+/**
+ * Decide whether the current Live Voice run-id list should be written back to
+ * the persisted workspace. An empty list (e.g. right after reconnect, before any
+ * Manager tool has run) must NEVER clear an existing `manager_run_id` pointer —
+ * doing so yanks the canvas owner and forces the UI back onto the canonical
+ * view. This mirrors the guard the non-Live-Voice turn path already applies.
+ *
+ * Extracted as a pure helper so the policy is unit-testable. See issue #168.
+ */
+export function shouldSyncLiveVoiceRunIds(runIds: readonly string[]): boolean {
+  return runIds.length > 0;
+}
+
 function syncVoiceWorkspaceTables(workspace: VoiceWorkspace): void {
   const db = getDb();
   const sessionStatus = workspace.progress_brief.status === "error" ? "failed" : workspace.progress_brief.status;
@@ -2129,7 +2142,7 @@ export async function createCodexLiveVoiceBinding(input: {
       // persisted canvas-owner pointer with an empty list. This keeps a
       // reconnect (or any flush before a Manager tool has run) from clearing
       // `manager_run_id` and forcing the UI back onto the canonical view.
-      if (state.createdRunIds.length) {
+      if (shouldSyncLiveVoiceRunIds(state.createdRunIds)) {
         syncWorkspaceRunIds(next, state.createdRunIds);
       }
       applyVoiceSurfaceFromResult(next, {

--- a/homerail_manager/tests/live-surfaces-cancelled-run.test.ts
+++ b/homerail_manager/tests/live-surfaces-cancelled-run.test.ts
@@ -1,0 +1,110 @@
+import * as fs from "node:fs";
+import * as http from "node:http";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { parseDAGYaml } from "../src/orchestration/yaml-loader.js";
+import { closeDb } from "../src/persistence/db.js";
+import { _clearAllPersistence } from "../src/persistence/store.js";
+import {
+  _clearActiveRuns,
+  cancelActiveRun,
+  createActiveRun,
+} from "../src/runtime/active-runs.js";
+import { createServer } from "../src/server/http.js";
+
+/**
+ * Regression coverage for issue #168 scenario C: a cancelled DAG must release
+ * the live surface so the canonical UI can mount.
+ *
+ * `GET /api/runs/:run_id/live-surfaces` previously ignored `metadata.status`
+ * entirely and kept returning projections/document for a cancelled run, which
+ * kept `dagTaskCanvasPresent=true` on the frontend and suppressed the canonical
+ * view even after a Canonical Block commit.
+ */
+describe("GET /api/runs/:run_id/live-surfaces (issue #168 cancelled run)", () => {
+  let home: string;
+  let previousHome: string | undefined;
+  let server: http.Server | undefined;
+
+  beforeEach(() => {
+    previousHome = process.env.HOMERAIL_HOME;
+    home = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-live-surfaces-"));
+    process.env.HOMERAIL_HOME = home;
+    closeDb();
+    _clearActiveRuns();
+    _clearAllPersistence();
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve) => server!.close(() => resolve()));
+      server = undefined;
+    }
+    _clearActiveRuns();
+    _clearAllPersistence();
+    closeDb();
+    if (previousHome === undefined) delete process.env.HOMERAIL_HOME;
+    else process.env.HOMERAIL_HOME = previousHome;
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  function oneActorDag() {
+    return parseDAGYaml(`
+name: live-surfaces-cancelled
+workflow_id: live-surfaces-cancelled
+agents:
+  worker: { agent_type: deterministic }
+nodes:
+  research:
+    agent: worker
+    kind: task
+`);
+  }
+
+  async function listen(srv: http.Server): Promise<string> {
+    await new Promise<void>((resolve) => srv.listen(0, "127.0.0.1", resolve));
+    const address = srv.address();
+    if (!address || typeof address !== "object") throw new Error("server did not bind");
+    return `http://127.0.0.1:${address.port}`;
+  }
+
+  async function getJson(url: string): Promise<{ status: number; body: Record<string, unknown> }> {
+    const response = await fetch(url);
+    return { status: response.status, body: await response.json() as Record<string, unknown> };
+  }
+
+  it("releases the surface for a cancelled run", async () => {
+    const runId = "live-surfaces-cancelled-run";
+    createActiveRun(runId, oneActorDag());
+    cancelActiveRun(runId);
+
+    server = createServer(0, undefined, undefined, false, { autoDetectCodex: false });
+    const baseUrl = await listen(server);
+
+    const { status, body } = await getJson(`${baseUrl}/api/runs/${runId}/live-surfaces`);
+    expect(status).toBe(200);
+    const data = body.data as Record<string, unknown>;
+    expect(data.run_status).toBe("cancelled");
+    expect(data.projections).toEqual([]);
+    expect(data.surface_states).toEqual([]);
+    expect(data.document).toBeNull();
+  });
+
+  it("still returns projections for an active (non-terminal) run", async () => {
+    const runId = "live-surfaces-active-run";
+    createActiveRun(runId, oneActorDag());
+
+    server = createServer(0, undefined, undefined, false, { autoDetectCodex: false });
+    const baseUrl = await listen(server);
+
+    const { status, body } = await getJson(`${baseUrl}/api/runs/${runId}/live-surfaces`);
+    expect(status).toBe(200);
+    const data = body.data as Record<string, unknown>;
+    // Active run status is non-terminal; the surface must NOT be released.
+    expect(data.run_status).not.toBe("cancelled");
+    expect(data.run_status).not.toBe("failed");
+    expect(Array.isArray(data.projections)).toBe(true);
+    expect(data).toHaveProperty("document");
+  });
+});

--- a/homerail_manager/tests/live-voice-canvas-drift.test.ts
+++ b/homerail_manager/tests/live-voice-canvas-drift.test.ts
@@ -42,8 +42,14 @@ describe("isPluginToolEnvelopeFailure (issue #168 false-success)", () => {
     ).toBe(true);
   });
 
-  it("flags local projection envelopes that never commit", () => {
-    expect(isPluginToolEnvelopeFailure({ status: "projected", committed: false })).toBe(true);
+  it("does NOT flag a local projection envelope (non-terminal, parity with worker)", () => {
+    // A local projection `{ status: "projected", committed: false }` is a
+    // legitimate "projected but not yet committed" state produced identically by
+    // the voice host and the non-voice worker. Treating it as an error would
+    // break result-envelope parity (manager-agent-tool-parity). The #168
+    // false-success bug is about the runtime invoke path returning
+    // `data.status = "failed"`, which IS caught above.
+    expect(isPluginToolEnvelopeFailure({ status: "projected", committed: false })).toBe(false);
   });
 
   it("does not flag a committed outcome", () => {

--- a/homerail_manager/tests/live-voice-canvas-drift.test.ts
+++ b/homerail_manager/tests/live-voice-canvas-drift.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { isPluginToolEnvelopeFailure } from "../src/server/host-codex-manager-agent.js";
+
+/**
+ * Regression coverage for issue #168 (false canvas-update success).
+ *
+ * The Manager wraps plugin-tool outcomes as `{ success, data: { status,
+ * error_code } }`. The host adapter only honors `result.is_error`, so a nested
+ * `data.status = "failed"` must be translated into `is_error: true` — otherwise
+ * the model falsely claims a generated UI update succeeded (the exact envelope
+ * reported in the issue is asserted first).
+ *
+ * `invokePluginTool` routes every plugin/Generative-UI tool result through the
+ * `pluginToolResult` helper, which derives `is_error` from
+ * `isPluginToolEnvelopeFailure`. Locking the classification here is what
+ * prevents the false-success regression.
+ */
+describe("isPluginToolEnvelopeFailure (issue #168 false-success)", () => {
+  it("flags the exact envelope reported in the issue", () => {
+    expect(
+      isPluginToolEnvelopeFailure({
+        success: true,
+        data: { status: "failed", error_code: "invalid_output" },
+      }),
+    ).toBe(true);
+  });
+
+  it("flags every non-committed terminal status", () => {
+    for (const status of ["failed", "denied", "cancelled"]) {
+      expect(isPluginToolEnvelopeFailure({ success: true, data: { status } })).toBe(true);
+    }
+  });
+
+  it("flags top-level success:false", () => {
+    expect(isPluginToolEnvelopeFailure({ success: false })).toBe(true);
+    expect(isPluginToolEnvelopeFailure({ success: false, data: { status: "running" } })).toBe(true);
+  });
+
+  it("flags a nested error_code even without an explicit failure status", () => {
+    expect(
+      isPluginToolEnvelopeFailure({ success: true, data: { status: "running", error_code: "tool_failed" } }),
+    ).toBe(true);
+  });
+
+  it("flags local projection envelopes that never commit", () => {
+    expect(isPluginToolEnvelopeFailure({ status: "projected", committed: false })).toBe(true);
+  });
+
+  it("does not flag a committed outcome", () => {
+    expect(isPluginToolEnvelopeFailure({ success: true, data: { status: "committed" } })).toBe(false);
+  });
+
+  it("does not flag a still-running outcome", () => {
+    expect(isPluginToolEnvelopeFailure({ success: true, data: { status: "running" } })).toBe(false);
+  });
+
+  it("tolerates non-object bodies", () => {
+    expect(isPluginToolEnvelopeFailure(null)).toBe(false);
+    expect(isPluginToolEnvelopeFailure("ok")).toBe(false);
+    expect(isPluginToolEnvelopeFailure([1, 2, 3])).toBe(false);
+    expect(isPluginToolEnvelopeFailure(undefined)).toBe(false);
+  });
+});

--- a/homerail_manager/tests/live-voice-canvas-drift.test.ts
+++ b/homerail_manager/tests/live-voice-canvas-drift.test.ts
@@ -36,10 +36,25 @@ describe("isPluginToolEnvelopeFailure (issue #168 false-success)", () => {
     expect(isPluginToolEnvelopeFailure({ success: false, data: { status: "running" } })).toBe(true);
   });
 
-  it("flags a nested error_code even without an explicit failure status", () => {
+  it("flags a nested error_code when the status is neither committed nor running", () => {
+    // An error_code with an absent/unknown (non-success) status is a failure.
     expect(
-      isPluginToolEnvelopeFailure({ success: true, data: { status: "running", error_code: "tool_failed" } }),
+      isPluginToolEnvelopeFailure({ success: true, data: { error_code: "tool_failed" } }),
     ).toBe(true);
+    expect(
+      isPluginToolEnvelopeFailure({ success: true, data: { status: "awaiting_confirmation", error_code: "x" } }),
+    ).toBe(true);
+  });
+
+  it("does NOT flag a nested error_code on an explicit committed/running status", () => {
+    // Scope guard: an informational error_code accompanying a successful or
+    // in-flight outcome must never be misclassified as a failure.
+    expect(
+      isPluginToolEnvelopeFailure({ success: true, data: { status: "committed", error_code: "info" } }),
+    ).toBe(false);
+    expect(
+      isPluginToolEnvelopeFailure({ success: true, data: { status: "running", error_code: "info" } }),
+    ).toBe(false);
   });
 
   it("does NOT flag a local projection envelope (non-terminal, parity with worker)", () => {

--- a/homerail_manager/tests/live-voice-canvas-drift.test.ts
+++ b/homerail_manager/tests/live-voice-canvas-drift.test.ts
@@ -67,6 +67,13 @@ describe("isPluginToolEnvelopeFailure (issue #168 false-success)", () => {
     expect(isPluginToolEnvelopeFailure({ status: "projected", committed: false })).toBe(false);
   });
 
+  it("does NOT flag a projected envelope even if a future error_code is attached", () => {
+    // Defensive: the projected invariant must hold structurally, not rely on the
+    // runtime never attaching error_code to a projection.
+    expect(isPluginToolEnvelopeFailure({ status: "projected", committed: false, error_code: "x" })).toBe(false);
+    expect(isPluginToolEnvelopeFailure({ success: true, data: { status: "projected", error_code: "x" } })).toBe(false);
+  });
+
   it("does not flag a committed outcome", () => {
     expect(isPluginToolEnvelopeFailure({ success: true, data: { status: "committed" } })).toBe(false);
   });

--- a/homerail_manager/tests/live-voice-flush-guard.test.ts
+++ b/homerail_manager/tests/live-voice-flush-guard.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { shouldSyncLiveVoiceRunIds } from "../src/server/voice-agent-bootstrap.js";
+
+/**
+ * Regression coverage for issue #168 (reconnect clears the canvas owner).
+ *
+ * `flush_tool_state` writes the in-memory `createdRunIds` back to the persisted
+ * workspace via `syncWorkspaceRunIds`. A fresh binding starts with whatever was
+ * hydrated, but if a flush ever runs with an empty list (e.g. a reconnect before
+ * any Manager tool has run), it would set `manager_run_id = null` and yank the
+ * canvas to the canonical view. `shouldSyncLiveVoiceRunIds` encodes the guard:
+ * an empty list must never overwrite an existing pointer.
+ */
+describe("shouldSyncLiveVoiceRunIds (issue #168 reconnect guard)", () => {
+  it("refuses to sync an empty list (the reconnect-wipe guard)", () => {
+    expect(shouldSyncLiveVoiceRunIds([])).toBe(false);
+  });
+
+  it("syncs a non-empty list", () => {
+    expect(shouldSyncLiveVoiceRunIds(["run-1"])).toBe(true);
+    expect(shouldSyncLiveVoiceRunIds(["run-1", "run-2"])).toBe(true);
+  });
+
+  it("treats a freshly-hydrated list as syncable", () => {
+    // After hydration, createdRunIds mirrors the persisted workspace run ids;
+    // a subsequent flush should still be allowed to write them.
+    expect(shouldSyncLiveVoiceRunIds(["hydrated-run-1", "hydrated-run-2"])).toBe(true);
+  });
+});

--- a/homerail_manager/tests/live-voice-flush-guard.test.ts
+++ b/homerail_manager/tests/live-voice-flush-guard.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { shouldSyncLiveVoiceRunIds } from "../src/server/voice-agent-bootstrap.js";
+import {
+  appendWorkspaceRunIds,
+  shouldSyncLiveVoiceRunIds,
+} from "../src/server/voice-agent-bootstrap.js";
 
 /**
  * Regression coverage for issue #168 (reconnect clears the canvas owner).
@@ -25,5 +28,54 @@ describe("shouldSyncLiveVoiceRunIds (issue #168 reconnect guard)", () => {
     // After hydration, createdRunIds mirrors the persisted workspace run ids;
     // a subsequent flush should still be allowed to write them.
     expect(shouldSyncLiveVoiceRunIds(["hydrated-run-1", "hydrated-run-2"])).toBe(true);
+  });
+});
+
+/**
+ * Regression coverage for the pass-3 review finding: a stale createdRunIds
+ * snapshot must NOT overwrite a newer canvas owner. `appendWorkspaceRunIds`
+ * merges this binding's newly-created runs onto the LATEST persisted history
+ * instead of replacing it, so an external owner change is preserved.
+ */
+describe("appendWorkspaceRunIds (issue #168 merge-not-overwrite)", () => {
+  // Minimal workspace shape — appendWorkspaceRunIds only reads these two fields.
+  const ws = (manager_run_ids: string[], manager_run_id: string | null) =>
+    ({ session_id: "s", manager_run_ids, manager_run_id }) as never;
+
+  it("appends this binding's new runs after the latest persisted history", () => {
+    // Persisted owner advanced to run-B externally; this binding created run-C.
+    const merged = appendWorkspaceRunIds(ws(["run-A"], "run-B"), ["run-C"]);
+    expect(merged).toEqual(["run-A", "run-B", "run-C"]);
+    // syncWorkspaceRunIds sets manager_run_id = merged.at(-1), so the active
+    // pointer advances to run-C (the genuinely-newer run) while run-B stays in
+    // history instead of being reverted.
+    expect(merged.at(-1)).toBe("run-C");
+  });
+
+  it("preserves an external owner change when this binding created nothing new", () => {
+    // Empty newRunIds would be skipped by shouldSyncLiveVoiceRunIds anyway, but
+    // the helper still must not drop the persisted history.
+    const merged = appendWorkspaceRunIds(ws(["run-A"], "run-B"), []);
+    expect(merged).toEqual(["run-A", "run-B"]);
+    expect(merged.at(-1)).toBe("run-B");
+  });
+
+  it("does not reactivate a terminal run from history when only history exists", () => {
+    // Only historical (terminal) IDs persisted, no new runs this binding.
+    const merged = appendWorkspaceRunIds(ws(["run-old-1", "run-old-2"], null), []);
+    expect(merged.at(-1)).toBe("run-old-2");
+    // The active pointer stays on the latest history entry; no new run is
+    // fabricated and nothing older is promoted over it.
+    expect(merged).toHaveLength(2);
+  });
+
+  it("de-duplicates while preserving order", () => {
+    const merged = appendWorkspaceRunIds(ws(["run-A", "run-B"], "run-B"), ["run-B", "run-C"]);
+    expect(merged).toEqual(["run-A", "run-B", "run-C"]);
+  });
+
+  it("trims and filters blank/empty entries", () => {
+    const merged = appendWorkspaceRunIds(ws(["run-A", "  "], "run-A"), ["", "run-C"]);
+    expect(merged).toEqual(["run-A", "run-C"]);
   });
 });


### PR DESCRIPTION
## Fixes #168

Addresses **all four** root-cause defects from #168, the session-identity follow-up, and incorporates findings from **six rounds** of automated PR-review plus an independent review. Verified end-to-end in a clean independent checkout.

---

## Root causes fixed

**1. False canvas-update success** — `homerail_manager/.../host-codex-manager-agent.ts`
The host adapter only honored `result.is_error`, so a nested `data.status=failed` was reported as success. Added `isPluginToolEnvelopeFailure()`; runtime `invokePluginTool` results route through it so `failed`/`denied`/`cancelled`/`success:false`/non-committed `error_code` surface as `is_error:true`. `skill_view_present` now derives objective success AND propagates `is_error` onto the model-visible result. Local projections (`status:projected`) are structurally exempt (parity with worker).

**2. Reconnect clears / reverts the canvas owner** — `voice-agent-bootstrap.ts`
- `createdRunIds` records **only runs created by this binding** (no history hydration).
- `flush_tool_state` **merges** via `appendWorkspaceRunIds()` onto the latest persisted history — an external owner change is preserved; the active pointer only advances when this binding created something newer. `shouldSyncLiveVoiceRunIds()` guards empty lists.

**3. Cancelled DAG keeps owning the canvas** — `routes.ts`
`live-surfaces` reads `metadata.status` and releases the surface for terminal-but-not-`completed` runs; exposes `run_status`. Single `loadRunMetadata` read.

**4. Remount autofocus jumps** — `GenerativeUiSurfaceHost.vue`
Auto-focus is skipped on the initial population; fires only on a genuine revision change (`hasPopulatedRevisions`).

**5. Session identity at async boundaries** (acceptance criterion #3)
- `AgentVoiceCockpit`: `onEvent`/`onState` are **bound to the producing client instance**; `codexLiveVoiceSessionId` is stamped before `await client.start()` (no fail-open window) and validated on workspace events.
- `DagTaskCanvas`: shared-bus DAG events filtered by `runId` (with refresh fallback for unattributed events).
- **Current-session write race**: `VoiceCurrentSessionWriter` serializes `setCurrentVoiceSession` writes + re-checks the transition generation; terminal `.catch` swallows rejections.

---

## Review iterations
- **Automated PR-review bot** ran 6 times; each round's notes addressed: scoped `error_code`, removed redundant `loadRunMetadata`, `DagTaskCanvas` fallback, `skill_view_present` `is_error` propagation + objective success, terminal `.catch` in the writer, closing the `client.start()` fail-open window, structural `projected` exemption.
- **Independent review** (pass 3): three blocking findings (stale run snapshot, session-write race, client-bound callbacks) — all fixed.

## Tests
`live-voice-canvas-drift` (envelope classifier incl. projected+error_code), `live-surfaces-cancelled-run` (terminal-run release), `live-voice-flush-guard` (merge semantics), `voice-current-session-writer` (A→B race, superseded drop, fast path, serialization, failed-write no unhandled rejection), `codex-live-voice-client` (callback forwarding contract), `GenerativeUiHost` (no autofocus on mount).

## Independent verification
Clean checkout `homerail-issue168-indep-test` (fresh `npm ci` + `build:packages`):
- `homerail_manager`: `tsc --noEmit` clean; full suite **1191 passed / 2 skipped**.
- `agent-ui`: `vue-tsc --noEmit` clean; full suite **498 passed**.
- `homerail_protocol`: 306. `homerail_plugin_sdk`: 35.

Acceptance criteria from #168:
- [x] Only `committed` represents successful UI mutations
- [x] Reconnect hydrates active run state without empty/stale lists overwriting the pointer
- [x] Enforce session identity at async boundaries (client-bound callbacks + serialized current-session writes)
- [x] Avoid surprising focus jumps on remount