### PR TITLE
release: prepare HomeRail 0.1.0-beta.1

### DIFF
--- a/.github/workflows/desktop-release-candidate.yml
+++ b/.github/workflows/desktop-release-candidate.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Unified version, for example 0.1.0-alpha.1
+        description: Unified version, for example 0.1.0-beta.1
         type: string
         required: true
       desktop_sha:
@@ -69,14 +69,14 @@ jobs:
           printf 'channel=%s\n' "$channel" >> "$GITHUB_OUTPUT"
           printf 'prerelease=%s\n' "$prerelease" >> "$GITHUB_OUTPUT"
 
-      - name: Require Alpha while Windows signing is unavailable
+      - name: Allow Alpha and Beta release channels
         shell: bash
         env:
           RELEASE_CHANNEL: ${{ steps.release.outputs.channel }}
         run: |
           set -euo pipefail
-          if [[ "$RELEASE_CHANNEL" != "alpha" ]]; then
-            echo "Desktop Candidate currently supports Alpha only; Beta and Stable require trusted Windows Authenticode signing" >&2
+          if [[ "$RELEASE_CHANNEL" == "latest" ]]; then
+            echo "Desktop Candidate supports Alpha and Beta; Stable remains a separate release gate" >&2
             exit 1
           fi
 
@@ -202,22 +202,24 @@ jobs:
           HOMERAIL_HOME: ${{ runner.temp }}/homerail-candidate-desktop-ci
         run: npm run ci
 
-      - name: Require Alpha for unsigned Windows installer
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          if ($env:RELEASE_CHANNEL -ne 'alpha') {
-            throw "Unsigned Windows candidates are allowed only for Alpha; Beta and Stable require trusted Authenticode signing"
-          }
-
       - name: Build unsigned Windows Alpha installer
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && needs.prepare.outputs.channel == 'alpha'
         working-directory: desktop
         run: >-
           npm run dist -- --win nsis --x64 --publish never
           --config.win.signExecutable=false
           --config.win.verifyUpdateCodeSignature=false
+          --config.publish.channel="$env:RELEASE_CHANNEL"
+
+      - name: Build signed Windows Beta installer
+        if: runner.os == 'Windows' && needs.prepare.outputs.channel == 'beta'
+        working-directory: desktop
+        env:
+          CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
+        run: >-
+          npm run dist -- --win nsis --x64 --publish never
+          --config.forceCodeSigning=true
           --config.publish.channel="$env:RELEASE_CHANNEL"
 
       - name: Prepare and verify Windows update metadata
@@ -236,7 +238,7 @@ jobs:
             throw "Windows update metadata verification failed"
           }
 
-      - name: Verify unsigned Windows Alpha package
+      - name: Verify Windows package and signing policy
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
@@ -252,13 +254,33 @@ jobs:
           }
 
           $installer = $installers[0]
-          $signature = Get-AuthenticodeSignature -LiteralPath $installer.FullName
-          Write-Host "Authenticode status for $($installer.Name): $($signature.Status) ($($signature.StatusMessage))"
-          if ($signature.Status -ne 'NotSigned') {
-            throw "Windows Alpha installer must be explicitly unsigned; got $($signature.Status)"
+          $appExecutable = 'desktop/dist-electron/win-unpacked/HomeRail.exe'
+          if (-not (Test-Path -LiteralPath $appExecutable -PathType Leaf)) {
+            throw "Packaged Windows executable is missing: $appExecutable"
           }
-          if ($null -ne $signature.SignerCertificate) {
-            throw "Windows Alpha installer must not contain an Authenticode signer certificate"
+          foreach ($signedFile in @($installer.FullName, $appExecutable)) {
+            $signature = Get-AuthenticodeSignature -LiteralPath $signedFile
+            Write-Host "Authenticode status for $signedFile: $($signature.Status) ($($signature.StatusMessage))"
+            if ($env:RELEASE_CHANNEL -eq 'alpha') {
+              if ($signature.Status -ne 'NotSigned') {
+                throw "Windows Alpha binaries must be explicitly unsigned; got $($signature.Status) for $signedFile"
+              }
+              if ($null -ne $signature.SignerCertificate) {
+                throw "Windows Alpha binaries must not contain an Authenticode signer certificate"
+              }
+            } elseif ($env:RELEASE_CHANNEL -eq 'beta') {
+              if ($signature.Status -ne 'Valid') {
+                throw "Windows Beta binaries require a valid trusted Authenticode signature; got $($signature.Status) for $signedFile"
+              }
+              if ($null -eq $signature.SignerCertificate) {
+                throw "Windows Beta binaries are missing an Authenticode signer certificate"
+              }
+              if ($signature.SignerCertificate.NotAfter -le [DateTime]::UtcNow) {
+                throw "Windows Beta signer certificate is expired"
+              }
+            } else {
+              throw "Unsupported Windows release channel: $env:RELEASE_CHANNEL"
+            }
           }
 
           $appUpdateConfig = 'desktop/dist-electron/win-unpacked/resources/app-update.yml'
@@ -268,21 +290,25 @@ jobs:
           $appUpdateYaml = [System.IO.File]::ReadAllText(
             (Resolve-Path -LiteralPath $appUpdateConfig).Path
           )
-          if ($appUpdateYaml -match '(?m)^\s*publisherName\s*:') {
+          $hasPublisherName = $appUpdateYaml -match '(?m)^\s*publisherName\s*:'
+          if ($env:RELEASE_CHANNEL -eq 'alpha' -and $hasPublisherName) {
             throw "Unsigned Windows Alpha app-update.yml must not contain publisherName"
+          }
+          if ($env:RELEASE_CHANNEL -eq 'beta' -and -not $hasPublisherName) {
+            throw "Signed Windows Beta app-update.yml must contain publisherName"
           }
           foreach ($expectedLine in @(
             'provider: github',
             'owner: xiaotianfotos',
             'repo: homerail',
-            'channel: alpha'
+            "channel: $env:RELEASE_CHANNEL"
           )) {
             $pattern = '(?m)^\s*' + [regex]::Escape($expectedLine) + '\s*$'
             if ($appUpdateYaml -notmatch $pattern) {
-              throw "Unsigned Windows Alpha app-update.yml is missing expected update target: $expectedLine"
+              throw "Windows app-update.yml is missing expected update target: $expectedLine"
             }
           }
-          Write-Host "Verified explicitly unsigned Windows Alpha installer without updater publisherName"
+          Write-Host "Verified Windows $env:RELEASE_CHANNEL signing and updater policy"
 
       - name: Write Windows checksums
         if: runner.os == 'Windows'

--- a/.github/workflows/desktop-release-publish.yml
+++ b/.github/workflows/desktop-release-publish.yml
@@ -8,7 +8,7 @@ on:
         type: string
         required: true
       version:
-        description: Candidate version, for example 0.1.0-alpha.1
+        description: Candidate version, for example 0.1.0-beta.1
         type: string
         required: true
 
@@ -86,8 +86,8 @@ jobs:
           node - <<'NODE'
           const fs = require("node:fs");
           const manifest = JSON.parse(fs.readFileSync("candidate/release-manifest.json", "utf8"));
-          if (manifest.channel !== "alpha") {
-            throw new Error(`only Alpha candidates may be published while Windows installers are unsigned; got ${manifest.channel}`);
+          if (!["alpha", "beta"].includes(manifest.channel)) {
+            throw new Error(`only Alpha and Beta candidates may be published; got ${manifest.channel}`);
           }
           if (manifest.source_commit !== process.env.EXPECTED_SOURCE_SHA) {
             throw new Error(`candidate source ${manifest.source_commit} does not match workflow ${process.env.EXPECTED_SOURCE_SHA}`);
@@ -171,5 +171,5 @@ jobs:
             echo
             echo "Tag: \`$RELEASE_TAG\`"
             echo
-            echo "The release is now visible to its update channel. Test the previous Alpha upgrading to this exact release before announcing it publicly. If it fails, do not replace this tag or its assets; fix forward with the next Alpha."
+            echo "The release is now visible to its update channel. Test the previous release upgrading to this exact release before announcing it publicly. If it fails, do not replace this tag or its assets; fix forward with the next prerelease."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/agent-ui/package-lock.json
+++ b/agent-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homerail-agent-ui",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homerail-agent-ui",
-      "version": "0.1.0-alpha.3",
+      "version": "0.1.0-beta.1",
       "dependencies": {
         "@dagrejs/dagre": "^1.1.4",
         "@headlessui/vue": "^1.7.23",
@@ -85,7 +85,7 @@
     },
     "../homerail_protocol": {
       "name": "homerail-protocol",
-      "version": "0.1.0-alpha.3",
+      "version": "0.1.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/agent-ui/package.json
+++ b/agent-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homerail-agent-ui",
   "private": true,
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-beta.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/docs/desktop-release.md
+++ b/docs/desktop-release.md
@@ -1,6 +1,6 @@
 # Desktop release train
 
-HomeRail currently ships Alpha releases. The release train uses one SemVer
+HomeRail is entering its Beta release channel. The release train uses one SemVer
 version across the public runtime packages and the private Desktop shell:
 
 ```text
@@ -11,8 +11,8 @@ version across the public runtime packages and the private Desktop shell:
 0.1.0
 ```
 
-Only Alpha is an active release channel today. Beta and Stable are reserved for
-later quality gates. Git tags use the updater-compatible form
+Alpha remains the legacy early-access channel, Beta is the active test channel,
+and Stable remains reserved for later quality gates. Git tags use the updater-compatible form
 `v0.1.0-alpha.1`; component prefixes such as `desktop-v` are not allowed.
 When npm publication is enabled, the matching dist-tags are `alpha`, `beta`,
 and `latest`. These Desktop workflows do not publish npm packages.
@@ -43,6 +43,8 @@ Add these environment secrets:
 | Secret | Value |
 | --- | --- |
 | `HOMERAIL_DESKTOP_READ_TOKEN` | Fine-grained token with read-only Contents access to `xiaotianfotos/homerail_desktop` only |
+| `WIN_CSC_LINK` | Base64-encoded trusted Windows Authenticode PFX/P12 |
+| `WIN_CSC_KEY_PASSWORD` | Password for the Windows signing certificate |
 | `MAC_CSC_LINK` | Base64-encoded Developer ID Application P12 |
 | `MAC_CSC_KEY_PASSWORD` | Password for the Mac P12 |
 | `APPLE_API_KEY_P8` | Base64-encoded App Store Connect `.p8` key |
@@ -58,10 +60,11 @@ Both workflow environments set `deployment: false`. They retain environment
 secrets and approvals without creating public Deployment records for signing or
 release administration.
 
-The Candidate workflow intentionally reads no Windows code-signing secrets.
-Legacy self-signed secrets, if they still exist in the GitHub environment, are
-not injected into this build. Windows Alpha packaging is unsigned under the
-temporary policy below. macOS still requires Developer ID signing and Apple
+The Candidate workflow keeps Windows Alpha explicitly unsigned. For Beta it
+injects the Windows signing secrets only into the signed Windows build step and
+requires both the NSIS installer and packaged executable to report a `Valid`
+trusted Authenticode signature. A self-signed or otherwise untrusted secret
+fails the candidate. macOS always requires Developer ID signing and Apple
 notarization.
 
 Keep all certificate passwords, private keys, and repository tokens out of Git.
@@ -75,10 +78,11 @@ Version changes are code changes and must be reviewed before building:
 1. Update every public package and package lock to the same version.
 2. Update `homerail_desktop/package.json` and its lock to the same version.
 3. Push the private Desktop branch and record its full 40-character commit SHA.
-4. Run the public **Desktop Build Gate** against that exact unmerged SHA.
-5. After the build passes and the maintainer authorizes human testing, test the
-   downloaded artifacts on the real Windows and macOS test machines.
-6. Merge the tested Desktop commit, then run the immutable Candidate workflow.
+4. For Alpha, run the unsigned public **Desktop Build Gate** against that exact
+   unmerged SHA. For Beta, run local CI and merge before using protected signing.
+5. Merge the Desktop and public version changes.
+6. Run the immutable Candidate workflow and test its signed artifacts on the
+   real Windows and macOS test machines.
 
 The workflows never rewrite package versions while building. They fail if the
 requested version differs from any public or Desktop package manifest, or if the
@@ -120,7 +124,7 @@ Open **Actions → Desktop Release Candidate → Run workflow** on `main`.
 
 Enter:
 
-- the unified version, such as `0.1.0-alpha.1`;
+- the unified version, such as `0.1.0-beta.1`;
 - the full `homerail_desktop` commit SHA.
 
 The workflow:
@@ -129,8 +133,8 @@ The workflow:
    versions;
 2. checks out the private Desktop source by full commit SHA;
 3. builds Windows x64 and macOS arm64 on isolated hosted runners;
-4. verifies an explicitly unsigned Windows Alpha installer, and signs,
-   notarizes, and verifies the macOS package;
+4. applies the channel policy: Alpha Windows is explicitly unsigned, Beta
+   Windows is trusted Authenticode-signed, and macOS is signed and notarized;
 5. asks the pinned Desktop release tooling to prepare and verify channel-specific
    metadata against the packaged files;
 6. creates platform checksums and a combined release manifest;
@@ -143,15 +147,14 @@ aliases let a persisted Early Access installation traverse Alpha → Beta → St
 without relying on updater fallback behavior. Every emitted metadata file is
 covered by both the platform checksum list and the combined candidate manifest.
 
-### Windows Alpha signing policy
+### Windows channel signing policy
 
 Windows installers are explicitly unsigned while HomeRail is in Alpha. The
 Candidate workflow passes `win.signExecutable=false` and
 `win.verifyUpdateCodeSignature=false` only on the Windows Alpha
 electron-builder command. It does not disable updater signature verification
-globally in Desktop production code. Both the early Prepare gate and the
-Windows build gate reject any non-Alpha version; Beta and Stable require
-trusted Windows signing.
+globally in Desktop production code. The unsigned pre-merge Build Gate remains
+Alpha-only.
 
 The Windows gate requires exactly one NSIS installer, verifies its
 Authenticode status is `NotSigned` with no signer certificate, and rejects a
@@ -170,14 +173,19 @@ configuration still relies on GitHub and SHA-512 for that hop. After the signed
 version is installed, its own `app-update.yml` can restore `publisherName` and
 signature verification for subsequent updates.
 
+Windows Beta uses `WIN_CSC_LINK` and `WIN_CSC_KEY_PASSWORD`, enables
+`forceCodeSigning`, and rejects the candidate unless Authenticode reports
+`Valid` for both the installer and packaged `HomeRail.exe`. Its packaged
+`app-update.yml` must restore `publisherName` and target the `beta` channel.
+
 [SignPath Foundation](https://signpath.org/) is a possible no-cost signing path
 for qualifying open-source projects. HomeRail has not been applied for or
 approved, so it is a future option rather than a current release capability.
 
 The candidate does not create a Git tag or GitHub Release.
 
-The hosted Windows build gate runs the complete public Node 24 CI suite and the
-private Desktop CI suite before packaging. After unsigned-policy and static
+The hosted Windows candidate runs the complete public Node 24 CI suite and the
+private Desktop CI suite before packaging. After signing-policy and static
 package verification, it uses an isolated temporary profile to silently install
 the NSIS package, execute the packaged CLI and verify its release version, keep
 the Desktop process alive for a bounded startup smoke, and silently uninstall
@@ -189,9 +197,9 @@ does not replace the following acceptance checks on a real Windows machine.
 After the hosted-runner gates pass, download the candidate from the workflow
 run and perform direct-install checks:
 
-- Windows: acknowledge the expected SmartScreen / Unknown Publisher warning,
-  install the NSIS package, launch HomeRail, complete onboarding, restart, and
-  uninstall once.
+- Windows Alpha: acknowledge the expected SmartScreen / Unknown Publisher
+  warning. Windows Beta: confirm the trusted publisher and no Unknown Publisher
+  warning. Install, launch HomeRail, complete onboarding, restart, and uninstall once.
 - macOS: mount the DMG, install HomeRail, confirm Gatekeeper accepts it, launch,
   complete onboarding, quit, and relaunch.
 - Both: verify the packaged CLI, Manager/Node/Worker startup, settings
@@ -219,12 +227,12 @@ job:
 4. refuses to replace an existing tag or release;
 5. creates an annotated `v<version>` tag at the candidate's public source
    commit;
-6. creates a GitHub prerelease for the exact Alpha candidate without
+6. creates a GitHub prerelease for the exact Alpha or Beta candidate without
    rebuilding.
 
-The Publish workflow rejects a non-Alpha manifest before any tag or release
-lookup or creation. Beta and Stable publishing remain blocked until trusted
-Windows signing is implemented and the policy is deliberately updated.
+The Publish workflow accepts only Alpha or Beta manifests before tag and release
+lookup or creation. Stable publishing remains blocked until its policy is
+deliberately enabled.
 
 This is the point at which the tag is created. Do not create the version tag
 when merging code or starting a candidate build.

--- a/homerail_cli/package-lock.json
+++ b/homerail_cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homerail-cli",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homerail-cli",
-      "version": "0.1.0-alpha.3",
+      "version": "0.1.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",
@@ -29,7 +29,7 @@
     },
     "../homerail_plugin_sdk": {
       "name": "homerail-plugin-sdk",
-      "version": "0.1.0-alpha.3",
+      "version": "0.1.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",
@@ -48,7 +48,7 @@
     },
     "../homerail_protocol": {
       "name": "homerail-protocol",
-      "version": "0.1.0-alpha.3",
+      "version": "0.1.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/homerail_cli/package.json
+++ b/homerail_cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homerail-cli",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-beta.1",
   "private": true,
   "description": "HomeRail TypeScript CLI for configuring, running, and inspecting DAG workflows.",
   "license": "MIT",

--- a/homerail_manager/package-lock.json
+++ b/homerail_manager/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homerail-manager",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homerail-manager",
-      "version": "0.1.0-alpha.3",
+      "version": "0.1.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.34.51",
@@ -33,7 +33,7 @@
     },
     "../homerail_plugin_sdk": {
       "name": "homerail-plugin-sdk",
-      "version": "0.1.0-alpha.3",
+      "version": "0.1.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",
@@ -52,7 +52,7 @@
     },
     "../homerail_protocol": {
       "name": "homerail-protocol",
-      "version": "0.1.0-alpha.3",
+      "version": "0.1.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/homerail_manager/package.json
+++ b/homerail_manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homerail-manager",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-beta.1",
   "private": true,
   "description": "HomeRail TypeScript Manager service and DAG coordinator.",
   "license": "MIT",

--- a/homerail_manager/tests/transport-fence-websocket.test.ts
+++ b/homerail_manager/tests/transport-fence-websocket.test.ts
@@ -749,9 +749,11 @@ describe("round-aware terminal websocket transport", () => {
         expect(listDagActivityEvents({ run_id: runId }).events).toEqual([]);
         expect(JSON.stringify(loadSessionTranscript(sessionId))).not.toContain("sk-websocket-secret");
         expect(JSON.stringify(warn.mock.calls)).not.toContain("sk-websocket-secret");
-        expect(warn).toHaveBeenCalledWith(expect.stringContaining(
-          "Actor surface patch identity does not match the transport stream context",
-        ));
+        await vi.waitFor(() => {
+          expect(warn).toHaveBeenCalledWith(expect.stringContaining(
+            "Actor surface patch identity does not match the transport stream context",
+          ));
+        }, { timeout: 1_000 });
       } finally {
         warn.mockRestore();
         ws.terminate();

--- a/homerail_node/package-lock.json
+++ b/homerail_node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homerail-node",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homerail-node",
-      "version": "0.1.0-alpha.3",
+      "version": "0.1.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "dockerode": "^5.0.0",
@@ -30,7 +30,7 @@
     },
     "../homerail_protocol": {
       "name": "homerail-protocol",
-      "version": "0.1.0-alpha.3",
+      "version": "0.1.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/homerail_node/package.json
+++ b/homerail_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homerail-node",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-beta.1",
   "private": true,
   "description": "HomeRail TypeScript Node service for Docker-backed Worker provisioning.",
   "license": "MIT",

--- a/homerail_plugin_sdk/package-lock.json
+++ b/homerail_plugin_sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homerail-plugin-sdk",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homerail-plugin-sdk",
-      "version": "0.1.0-alpha.3",
+      "version": "0.1.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",
@@ -25,7 +25,7 @@
     },
     "../homerail_protocol": {
       "name": "homerail-protocol",
-      "version": "0.1.0-alpha.3",
+      "version": "0.1.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/homerail_plugin_sdk/package.json
+++ b/homerail_plugin_sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homerail-plugin-sdk",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-beta.1",
   "description": "HomeRail declarative plugin development kit and deterministic HRP package codec.",
   "license": "MIT",
   "type": "module",

--- a/homerail_protocol/package-lock.json
+++ b/homerail_protocol/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homerail-protocol",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homerail-protocol",
-      "version": "0.1.0-alpha.3",
+      "version": "0.1.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/homerail_protocol/package.json
+++ b/homerail_protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homerail-protocol",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-beta.1",
   "description": "HomeRail protocol contract package \u2014 single source of truth for runtime communication between homerail_worker, homerail_node, and homerail_manager",
   "license": "MIT",
   "type": "module",

--- a/homerail_protocol/src/index.ts
+++ b/homerail_protocol/src/index.ts
@@ -3,7 +3,7 @@
  *
  * Single source of truth for all runtime communication between
  * homerail_worker, homerail_node, and homerail_manager.
- * @version 0.1.0-alpha.3
+ * @version 0.1.0-beta.1
  */
 
 /**

--- a/homerail_protocol/tests/cross-version.test.ts
+++ b/homerail_protocol/tests/cross-version.test.ts
@@ -1,6 +1,6 @@
 /**
  * Cross-version compatibility tests.
- * @version 0.1.0-alpha.3
+ * @version 0.1.0-beta.1
  */
 
 import { describe, it, expect } from "vitest";

--- a/homerail_worker/package-lock.json
+++ b/homerail_worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homerail-worker",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homerail-worker",
-      "version": "0.1.0-alpha.3",
+      "version": "0.1.0-beta.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -30,7 +30,7 @@
     },
     "../homerail_protocol": {
       "name": "homerail-protocol",
-      "version": "0.1.0-alpha.3",
+      "version": "0.1.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/homerail_worker/package.json
+++ b/homerail_worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homerail-worker",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-beta.1",
   "private": true,
   "description": "HomeRail TypeScript Worker runtime for Claude Agent SDK and compatible agent backends.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homerail",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-beta.1",
   "private": true,
   "description": "Voice-first local agent orchestration runtime for auditable DAG workflows.",
   "license": "MIT",

--- a/scripts/desktop-release-contracts.test.mjs
+++ b/scripts/desktop-release-contracts.test.mjs
@@ -255,8 +255,10 @@ test("candidate uses protected release environment without Deployment records", 
   assert.doesNotMatch(candidateWorkflow, /runs-on:.*self-hosted/);
 });
 
-test("candidate signs macOS, explicitly leaves Windows Alpha unsigned, and creates metadata", () => {
+test("candidate signs Beta on Windows and macOS while preserving the unsigned Alpha policy", () => {
   for (const secret of [
+    "WIN_CSC_LINK",
+    "WIN_CSC_KEY_PASSWORD",
     "MAC_CSC_LINK",
     "MAC_CSC_KEY_PASSWORD",
     "APPLE_API_KEY_P8",
@@ -266,23 +268,24 @@ test("candidate signs macOS, explicitly leaves Windows Alpha unsigned, and creat
   ]) {
     assert.match(candidateWorkflow, new RegExp(`secrets\\.${secret}`));
   }
-  assert.doesNotMatch(candidateWorkflow, /WIN_CSC_LINK|WIN_CSC_KEY_PASSWORD/);
-  assert.doesNotMatch(candidateWorkflow, /Build signed candidate/);
 
-  const prepareGuard = candidateStep("Require Alpha while Windows signing is unavailable");
-  assert.match(prepareGuard, /\[\[ "\$RELEASE_CHANNEL" != "alpha" \]\]/);
-  assert.match(prepareGuard, /Beta and Stable require trusted Windows Authenticode signing/);
+  const prepareGuard = candidateStep("Allow Alpha and Beta release channels");
+  assert.match(prepareGuard, /\[\[ "\$RELEASE_CHANNEL" == "latest" \]\]/);
+  assert.match(prepareGuard, /supports Alpha and Beta/);
 
-  const windowsGuard = candidateStep("Require Alpha for unsigned Windows installer");
-  assert.match(windowsGuard, /if: runner\.os == 'Windows'/);
-  assert.match(windowsGuard, /if \(\$env:RELEASE_CHANNEL -ne 'alpha'\)/);
-  assert.match(windowsGuard, /Beta and Stable require trusted Authenticode signing/);
+  const windowsAlphaBuild = candidateStep("Build unsigned Windows Alpha installer");
+  assert.match(windowsAlphaBuild, /needs\.prepare\.outputs\.channel == 'alpha'/);
+  assert.match(windowsAlphaBuild, /--config\.win\.signExecutable=false/);
+  assert.match(windowsAlphaBuild, /--config\.win\.verifyUpdateCodeSignature=false/);
+  assert.match(windowsAlphaBuild, /--config\.publish\.channel=/);
+  assert.doesNotMatch(windowsAlphaBuild, /forceCodeSigning|WIN_CSC/);
 
-  const windowsBuild = candidateStep("Build unsigned Windows Alpha installer");
-  assert.match(windowsBuild, /--config\.win\.signExecutable=false/);
-  assert.match(windowsBuild, /--config\.win\.verifyUpdateCodeSignature=false/);
-  assert.match(windowsBuild, /--config\.publish\.channel=/);
-  assert.doesNotMatch(windowsBuild, /forceCodeSigning|WIN_CSC/);
+  const windowsBetaBuild = candidateStep("Build signed Windows Beta installer");
+  assert.match(windowsBetaBuild, /needs\.prepare\.outputs\.channel == 'beta'/);
+  assert.match(windowsBetaBuild, /secrets\.WIN_CSC_LINK/);
+  assert.match(windowsBetaBuild, /secrets\.WIN_CSC_KEY_PASSWORD/);
+  assert.match(windowsBetaBuild, /--config\.forceCodeSigning=true/);
+  assert.match(windowsBetaBuild, /--config\.publish\.channel=/);
   assert.equal(
     (candidateWorkflow.match(/--config\.win\.signExecutable=false/g) ?? []).length,
     1,
@@ -300,8 +303,8 @@ test("candidate signs macOS, explicitly leaves Windows Alpha unsigned, and creat
   assert.match(macBuild, /--config\.mac\.notarize=true/);
   assert.match(macBuild, /--config\.mac\.entitlements=/);
   assert.match(macBuild, /--config\.mac\.entitlementsInherit=/);
-  assert.equal((candidateWorkflow.match(/--config\.forceCodeSigning=true/g) ?? []).length, 1);
-  assert.equal((candidateWorkflow.match(/--config\.publish\.channel=/g) ?? []).length, 2);
+  assert.equal((candidateWorkflow.match(/--config\.forceCodeSigning=true/g) ?? []).length, 2);
+  assert.equal((candidateWorkflow.match(/--config\.publish\.channel=/g) ?? []).length, 3);
   assert.match(candidateWorkflow, /verify:update-metadata/);
   assert.match(candidateWorkflow, /metadata_release_channel=stable/);
   assert.match(candidateWorkflow, /'latest\.yml', 'alpha\.yml', 'beta\.yml'/);
@@ -331,7 +334,7 @@ test("macOS release entitlements enable microphone input for the app and helpers
   );
 });
 
-test("Windows candidate runs Node 24 CI before building and smoke-testing unsigned Alpha", () => {
+test("Windows candidate runs Node 24 CI before channel-specific signing and installation smoke", () => {
   assert.match(candidateWorkflow, /RELEASE_NODE_VERSION: 24\.18\.0/);
   assert.match(candidateWorkflow, /name: Run public Windows Node 24 CI/);
   assert.match(candidateWorkflow, /npm --prefix homerail-source run ci/);
@@ -343,16 +346,17 @@ test("Windows candidate runs Node 24 CI before building and smoke-testing unsign
   assert.match(candidateWorkflow, /VITEST_TEST_TIMEOUT: "15000"/);
   assert.match(candidateWorkflow, /VITEST_HOOK_TIMEOUT: "30000"/);
 
-  const packageVerificationStep = candidateStep("Verify unsigned Windows Alpha package");
+  const packageVerificationStep = candidateStep("Verify Windows package and signing policy");
   assert.match(packageVerificationStep, /npm --prefix desktop run verify:package/);
   assert.match(packageVerificationStep, /if \(\$LASTEXITCODE -ne 0\)/);
   assert.match(packageVerificationStep, /\$installers\.Count -ne 1/);
   assert.match(
     packageVerificationStep,
-    /Get-AuthenticodeSignature -LiteralPath \$installer\.FullName/,
+    /Get-AuthenticodeSignature -LiteralPath \$signedFile/,
   );
   assert.match(packageVerificationStep, /\$signature\.StatusMessage/);
   assert.match(packageVerificationStep, /if \(\$signature\.Status -ne 'NotSigned'\)/);
+  assert.match(packageVerificationStep, /if \(\$signature\.Status -ne 'Valid'\)/);
   assert.match(
     packageVerificationStep,
     /if \(\$null -ne \$signature\.SignerCertificate\)/,
@@ -367,18 +371,19 @@ test("Windows candidate runs Node 24 CI before building and smoke-testing unsign
   );
   assert.ok(
     packageVerificationStep.includes(
-      "if ($appUpdateYaml -match '(?m)^\\s*publisherName\\s*:')",
+      "$hasPublisherName = $appUpdateYaml -match '(?m)^\\s*publisherName\\s*:'",
     ),
   );
   assert.match(packageVerificationStep, /must not contain publisherName/);
+  assert.match(packageVerificationStep, /must contain publisherName/);
   for (const expectedUpdateTarget of [
     "provider: github",
     "owner: xiaotianfotos",
     "repo: homerail",
-    "channel: alpha",
   ]) {
     assert.match(packageVerificationStep, new RegExp(expectedUpdateTarget));
   }
+  assert.match(packageVerificationStep, /"channel: \$env:RELEASE_CHANNEL"/);
   assert.match(packageVerificationStep, /\[regex\]::Escape\(\$expectedLine\)/);
   assert.match(packageVerificationStep, /\$appUpdateYaml -notmatch \$pattern/);
 
@@ -409,10 +414,10 @@ test("Windows candidate runs Node 24 CI before building and smoke-testing unsign
   const publicCi = candidateWorkflow.indexOf("Run public Windows Node 24 CI");
   const publicCliVersion = candidateWorkflow.indexOf("Verify public Windows CLI release version");
   const desktopCi = candidateWorkflow.indexOf("Run Desktop Windows CI");
-  const guard = candidateWorkflow.indexOf("Require Alpha for unsigned Windows installer");
-  const build = candidateWorkflow.indexOf("Build unsigned Windows Alpha installer");
+  const alphaBuild = candidateWorkflow.indexOf("Build unsigned Windows Alpha installer");
+  const betaBuild = candidateWorkflow.indexOf("Build signed Windows Beta installer");
   const metadata = candidateWorkflow.indexOf("Prepare and verify Windows update metadata");
-  const packageVerification = candidateWorkflow.indexOf("Verify unsigned Windows Alpha package");
+  const packageVerification = candidateWorkflow.indexOf("Verify Windows package and signing policy");
   const checksums = candidateWorkflow.indexOf("Write Windows checksums");
   const installSmoke = candidateWorkflow.indexOf("Smoke-test silent Windows installation");
   const upload = candidateWorkflow.indexOf("Upload Windows candidate assets");
@@ -421,8 +426,8 @@ test("Windows candidate runs Node 24 CI before building and smoke-testing unsign
     publicCi,
     publicCliVersion,
     desktopCi,
-    guard,
-    build,
+    alphaBuild,
+    betaBuild,
     metadata,
     packageVerification,
     checksums,
@@ -435,9 +440,9 @@ test("Windows candidate runs Node 24 CI before building and smoke-testing unsign
     install < publicCi
       && publicCi < publicCliVersion
       && publicCliVersion < desktopCi
-      && desktopCi < guard
-      && guard < build
-      && build < metadata
+      && desktopCi < alphaBuild
+      && alphaBuild < betaBuild
+      && betaBuild < metadata
       && metadata < packageVerification
       && packageVerification < checksums
       && checksums < installSmoke
@@ -471,8 +476,8 @@ test("publish consumes a successful candidate without rebuilding it", () => {
   const manifestRead = candidateVerification.indexOf(
     'JSON.parse(fs.readFileSync("candidate/release-manifest.json", "utf8"))',
   );
-  const alphaGuard = candidateVerification.indexOf(
-    'if (manifest.channel !== "alpha")',
+  const prereleaseGuard = candidateVerification.indexOf(
+    'if (!["alpha", "beta"].includes(manifest.channel))',
   );
   const tagCheck = publishWorkflow.indexOf(
     "Refuse to replace an existing tag or release",
@@ -483,11 +488,11 @@ test("publish consumes a successful candidate without rebuilding it", () => {
   );
   assert.match(
     candidateVerification,
-    /only Alpha candidates may be published while Windows installers are unsigned/,
+    /only Alpha and Beta candidates may be published/,
   );
   for (const index of [
     manifestRead,
-    alphaGuard,
+    prereleaseGuard,
     tagCheck,
     tagCreation,
     releaseCreation,
@@ -495,7 +500,7 @@ test("publish consumes a successful candidate without rebuilding it", () => {
     assert.notEqual(index, -1);
   }
   assert.ok(
-    manifestRead < alphaGuard
+    manifestRead < prereleaseGuard
       && publishWorkflow.indexOf("Verify candidate identity, assets, and checksums")
         < tagCheck
       && tagCheck < tagCreation
@@ -520,7 +525,9 @@ test("release docs preserve candidate, publish, update-test, and fix-forward bou
   assert.match(releaseDocs, /GitHub Release[\s\S]*SHA-512/);
   assert.match(releaseDocs, /weaker than trusted Authenticode/i);
   assert.match(releaseDocs, /only permitted for Alpha/i);
-  assert.match(releaseDocs, /Beta and Stable[\s\S]*trusted Windows signing/i);
+  assert.match(releaseDocs, /Beta is the active test channel/i);
+  assert.match(releaseDocs, /Windows Beta uses `WIN_CSC_LINK`/i);
+  assert.match(releaseDocs, /Authenticode reports\s+`Valid`/i);
   assert.match(releaseDocs, /SignPath Foundation/);
   assert.match(releaseDocs, /not been applied for or\s+approved/i);
   assert.match(
@@ -535,7 +542,7 @@ test("release docs preserve candidate, publish, update-test, and fix-forward bou
     releaseDocs,
     /only on the Windows Alpha\s+electron-builder command/i,
   );
-  assert.doesNotMatch(releaseDocs, /WIN_CSC_LINK|WIN_CSC_KEY_PASSWORD/);
+  assert.match(releaseDocs, /WIN_CSC_LINK|WIN_CSC_KEY_PASSWORD/);
 });
 
 test("candidate pins a merged Desktop commit before installing or signing", () => {


### PR DESCRIPTION
## Summary

- set every HomeRail package and lock snapshot to `0.1.0-beta.1`
- enable immutable Beta candidates with trusted Windows Authenticode signing
- keep Windows Alpha explicitly unsigned and keep Stable publishing blocked
- allow verified Alpha and Beta candidates through the exact-artifact publish workflow
- include the transport warning test stabilization found during PR #171 Beta validation

## Validation

- full HomeRail CI: typecheck, builds, and all package/live-validator tests pass
- desktop release contract tests: 19/19 pass
- unified public/Desktop version validation passes for `0.1.0-beta.1`
- local signed macOS DMG/ZIP package and Beta update metadata verified

The workflow creates no tag or public Release. The first output is an immutable private Candidate for direct-install testing.
