### PR TITLE
fix(release): parse Windows signing verification script

### DIFF
--- a/.github/workflows/desktop-release-candidate.yml
+++ b/.github/workflows/desktop-release-candidate.yml
@@ -260,7 +260,7 @@ jobs:
           }
           foreach ($signedFile in @($installer.FullName, $appExecutable)) {
             $signature = Get-AuthenticodeSignature -LiteralPath $signedFile
-            Write-Host "Authenticode status for $signedFile: $($signature.Status) ($($signature.StatusMessage))"
+            Write-Host "Authenticode status for ${signedFile}: $($signature.Status) ($($signature.StatusMessage))"
             if ($env:RELEASE_CHANNEL -eq 'alpha') {
               if ($signature.Status -ne 'NotSigned') {
                 throw "Windows Alpha binaries must be explicitly unsigned; got $($signature.Status) for $signedFile"

--- a/scripts/desktop-release-contracts.test.mjs
+++ b/scripts/desktop-release-contracts.test.mjs
@@ -354,6 +354,10 @@ test("Windows candidate runs Node 24 CI before channel-specific signing and inst
     packageVerificationStep,
     /Get-AuthenticodeSignature -LiteralPath \$signedFile/,
   );
+  assert.ok(
+    packageVerificationStep.includes("Authenticode status for ${signedFile}:"),
+    "PowerShell variables followed by a colon must use delimited interpolation",
+  );
   assert.match(packageVerificationStep, /\$signature\.StatusMessage/);
   assert.match(packageVerificationStep, /if \(\$signature\.Status -ne 'NotSigned'\)/);
   assert.match(packageVerificationStep, /if \(\$signature\.Status -ne 'Valid'\)/);


### PR DESCRIPTION
Fix the Beta candidate Windows signing verification step so PowerShell parses the signed-file path followed by a colon correctly.\n\nThe failed candidate run 30682071774 built and signed the Windows installer successfully, but the verification script failed before reading Authenticode status because `$signedFile:` is invalid interpolation. Delimit the variable as `${signedFile}:` and add a release-contract regression assertion.\n\nValidation:\n- `node --test scripts/desktop-release-contracts.test.mjs` (19/19)\n- candidate workflow YAML parse