### PR TITLE
fix(release): bridge Alpha clients to Beta channel

### DIFF
--- a/.github/workflows/desktop-release-candidate.yml
+++ b/.github/workflows/desktop-release-candidate.yml
@@ -316,6 +316,8 @@ jobs:
         run: |
           $metadataNames = if ($env:RELEASE_CHANNEL -eq 'latest') {
             @('latest.yml', 'alpha.yml', 'beta.yml')
+          } elseif ($env:RELEASE_CHANNEL -eq 'beta') {
+            @('beta.yml', 'alpha.yml')
           } else {
             @("$env:RELEASE_CHANNEL.yml")
           }
@@ -540,6 +542,8 @@ jobs:
           metadata_names=("${RELEASE_CHANNEL}-mac.yml")
           if [[ "$RELEASE_CHANNEL" == "latest" ]]; then
             metadata_names=("latest-mac.yml" "alpha-mac.yml" "beta-mac.yml")
+          elif [[ "$RELEASE_CHANNEL" == "beta" ]]; then
+            metadata_names=("beta-mac.yml" "alpha-mac.yml")
           fi
           asset_list="$RUNNER_TEMP/homerail-macos-release-assets.txt"
           find . -maxdepth 1 -type f \( -name '*.dmg' -o -name '*.zip' -o -name '*.blockmap' \) -print > "$asset_list"

--- a/.github/workflows/desktop-release-publish.yml
+++ b/.github/workflows/desktop-release-publish.yml
@@ -86,8 +86,8 @@ jobs:
           node - <<'NODE'
           const fs = require("node:fs");
           const manifest = JSON.parse(fs.readFileSync("candidate/release-manifest.json", "utf8"));
-          if (!["alpha", "beta"].includes(manifest.channel)) {
-            throw new Error(`only Alpha and Beta candidates may be published; got ${manifest.channel}`);
+          if (manifest.channel !== "beta") {
+            throw new Error(`only Beta candidates may be published; Alpha is retired and Stable remains gated; got ${manifest.channel}`);
           }
           if (manifest.source_commit !== process.env.EXPECTED_SOURCE_SHA) {
             throw new Error(`candidate source ${manifest.source_commit} does not match workflow ${process.env.EXPECTED_SOURCE_SHA}`);

--- a/docs/desktop-release.md
+++ b/docs/desktop-release.md
@@ -11,7 +11,8 @@ version across the public runtime packages and the private Desktop shell:
 0.1.0
 ```
 
-Alpha remains the legacy early-access channel, Beta is the active test channel,
+Alpha is a retired legacy feed retained only as an upgrade bridge for installed
+Alpha clients. Alpha publishing is retired, Beta is the active test channel,
 and Stable remains reserved for later quality gates. Git tags use the updater-compatible form
 `v0.1.0-alpha.1`; component prefixes such as `desktop-v` are not allowed.
 When npm publication is enabled, the matching dist-tags are `alpha`, `beta`,
@@ -140,12 +141,15 @@ The workflow:
 6. creates platform checksums and a combined release manifest;
 7. uploads one `desktop-release-candidate` Actions artifact for 30 days.
 
-Alpha emits `alpha.yml` / `alpha-mac.yml`; Beta emits `beta.yml` /
-`beta-mac.yml`. Stable emits canonical `latest.yml` / `latest-mac.yml` plus
-byte-identical Alpha and Beta compatibility metadata from the same build. Those
-aliases let a persisted Early Access installation traverse Alpha → Beta → Stable
-without relying on updater fallback behavior. Every emitted metadata file is
-covered by both the platform checksum list and the combined candidate manifest.
+Historical Alpha candidates emit `alpha.yml` / `alpha-mac.yml`. Beta emits
+canonical `beta.yml` / `beta-mac.yml` plus a byte-identical Alpha compatibility
+alias from the same build. That one-way bridge lets already-installed Alpha
+clients discover Beta without publishing another Alpha version. New Desktop
+clients always map Early Access to the Beta feed. Stable emits canonical
+`latest.yml` / `latest-mac.yml` plus byte-identical Alpha and Beta compatibility
+metadata from the same build, after the separate Stable gate is enabled. Every
+emitted metadata file is covered by both the platform checksum list and the
+combined candidate manifest.
 
 ### Windows channel signing policy
 
@@ -227,12 +231,14 @@ job:
 4. refuses to replace an existing tag or release;
 5. creates an annotated `v<version>` tag at the candidate's public source
    commit;
-6. creates a GitHub prerelease for the exact Alpha or Beta candidate without
+6. creates a GitHub prerelease for the exact Beta candidate without
    rebuilding.
 
-The Publish workflow accepts only Alpha or Beta manifests before tag and release
-lookup or creation. Stable publishing remains blocked until its policy is
-deliberately enabled.
+The Publish workflow accepts only Beta manifests before tag and release lookup
+or creation. Alpha publishing is retired; the Alpha-named files attached to a
+Beta Release are compatibility metadata pointing to the same immutable Beta
+assets, not a new Alpha release. Stable publishing remains blocked until its
+policy is deliberately enabled.
 
 This is the point at which the tag is created. Do not create the version tag
 when merging code or starting a candidate build.

--- a/scripts/desktop-release-contracts.test.mjs
+++ b/scripts/desktop-release-contracts.test.mjs
@@ -307,6 +307,10 @@ test("candidate signs Beta on Windows and macOS while preserving the unsigned Al
   assert.equal((candidateWorkflow.match(/--config\.publish\.channel=/g) ?? []).length, 3);
   assert.match(candidateWorkflow, /verify:update-metadata/);
   assert.match(candidateWorkflow, /metadata_release_channel=stable/);
+  assert.match(candidateWorkflow, /elseif \(\$env:RELEASE_CHANNEL -eq 'beta'\)/);
+  assert.match(candidateWorkflow, /@\('beta\.yml', 'alpha\.yml'\)/);
+  assert.match(candidateWorkflow, /elif \[\[ "\$RELEASE_CHANNEL" == "beta" \]\]/);
+  assert.match(candidateWorkflow, /metadata_names=\("beta-mac\.yml" "alpha-mac\.yml"\)/);
   assert.match(candidateWorkflow, /'latest\.yml', 'alpha\.yml', 'beta\.yml'/);
   assert.match(candidateWorkflow, /"latest-mac\.yml" "alpha-mac\.yml" "beta-mac\.yml"/);
   assert.match(candidateWorkflow, /asset_name="\$\{asset#\.\/\}"/);
@@ -481,7 +485,7 @@ test("publish consumes a successful candidate without rebuilding it", () => {
     'JSON.parse(fs.readFileSync("candidate/release-manifest.json", "utf8"))',
   );
   const prereleaseGuard = candidateVerification.indexOf(
-    'if (!["alpha", "beta"].includes(manifest.channel))',
+    'if (manifest.channel !== "beta")',
   );
   const tagCheck = publishWorkflow.indexOf(
     "Refuse to replace an existing tag or release",
@@ -492,7 +496,7 @@ test("publish consumes a successful candidate without rebuilding it", () => {
   );
   assert.match(
     candidateVerification,
-    /only Alpha and Beta candidates may be published/,
+    /only Beta candidates may be published; Alpha is retired/,
   );
   for (const index of [
     manifestRead,
@@ -521,7 +525,9 @@ test("release docs preserve candidate, publish, update-test, and fix-forward bou
   assert.match(releaseDocs, /0\.1\.0-alpha\.2/);
   assert.match(releaseDocs, /Fix forward with `0\.1\.0-alpha\.3`/i);
   assert.match(releaseDocs, /Do not create the version tag\s+when merging code/);
-  assert.match(releaseDocs, /byte-identical Alpha and Beta compatibility metadata/);
+  assert.match(releaseDocs, /byte-identical Alpha and Beta compatibility\s+metadata/);
+  assert.match(releaseDocs, /Beta.*byte-identical.*Alpha.*compatibility\s+alias/is);
+  assert.match(releaseDocs, /Alpha publishing is retired/i);
   assert.match(releaseDocs, /complete public Node 24 CI suite/);
   assert.match(releaseDocs, /does not replace.*real Windows machine/s);
   assert.match(releaseDocs, /SmartScreen/);
@@ -927,6 +933,70 @@ test("candidate rejects a Windows artifact set without a blockmap", () => {
     assert.match(create.stderr, /windowsBlockmap/);
   } finally {
     fs.rmSync(candidateDir, { recursive: true, force: true });
+  }
+});
+
+test("Beta candidates require byte-identical Alpha compatibility aliases", () => {
+  const goodDir = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-beta-candidate-"));
+  const badDir = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-beta-candidate-bad-"));
+  const script = path.join(repoRoot, "scripts", "desktop-release", "release-candidate.mjs");
+  const metadata = "version: 0.1.0-beta.1\n";
+
+  const writeBetaFixture = (candidateDir, alphaMacMetadata) => {
+    writePlatformFixture(
+      candidateDir,
+      "windows",
+      {
+        "HomeRail Setup 0.1.0-beta.1.exe": "windows-installer",
+        "HomeRail Setup 0.1.0-beta.1.exe.blockmap": "windows-blockmap",
+        "beta.yml": metadata,
+        "alpha.yml": metadata,
+      },
+      "SHA256SUMS-windows.txt",
+    );
+    writePlatformFixture(
+      candidateDir,
+      "macos",
+      {
+        "HomeRail-0.1.0-beta.1-arm64.dmg": "mac-dmg",
+        "HomeRail-0.1.0-beta.1-arm64.zip": "mac-zip",
+        "beta-mac.yml": metadata,
+        "alpha-mac.yml": alphaMacMetadata,
+      },
+      "SHA256SUMS-macos.txt",
+    );
+  };
+  const createArgs = (candidateDir) => [
+    script,
+    "create",
+    "--candidate-dir",
+    candidateDir,
+    "--version",
+    "0.1.0-beta.1",
+    "--tag",
+    "v0.1.0-beta.1",
+    "--channel",
+    "beta",
+    "--source-commit",
+    "a".repeat(40),
+    "--desktop-commit",
+    "b".repeat(40),
+    "--run-id",
+    "12351",
+  ];
+
+  try {
+    writeBetaFixture(goodDir, metadata);
+    const good = spawnSync(process.execPath, createArgs(goodDir), { encoding: "utf8" });
+    assert.equal(good.status, 0, good.stderr);
+
+    writeBetaFixture(badDir, "version: 0.1.0-beta.1\nbridge: stale\n");
+    const bad = spawnSync(process.execPath, createArgs(badDir), { encoding: "utf8" });
+    assert.notEqual(bad.status, 0);
+    assert.match(bad.stderr, /must be byte-identical/);
+  } finally {
+    fs.rmSync(goodDir, { recursive: true, force: true });
+    fs.rmSync(badDir, { recursive: true, force: true });
   }
 });
 

--- a/scripts/desktop-release/release-candidate.mjs
+++ b/scripts/desktop-release/release-candidate.mjs
@@ -73,6 +73,12 @@ function expectedMetadata(channel) {
       macos: ["latest-mac.yml", "alpha-mac.yml", "beta-mac.yml"],
     };
   }
+  if (channel === "beta") {
+    return {
+      windows: ["beta.yml", "alpha.yml"],
+      macos: ["beta-mac.yml", "alpha-mac.yml"],
+    };
+  }
   return {
     windows: [`${channel}.yml`],
     macos: [`${channel}-mac.yml`],
@@ -160,7 +166,7 @@ function validateUpdateMetadata(candidateDir, channel, version) {
         );
       }
     }
-    if (channel === "latest") {
+    if (files.length > 1) {
       const canonicalHash = sha256(files[0]);
       for (const alias of files.slice(1)) {
         if (sha256(alias) !== canonicalHash) {


### PR DESCRIPTION
## Summary

- require Beta candidates to carry byte-identical `alpha.yml` / `alpha-mac.yml` compatibility aliases
- cover both canonical and legacy metadata files with platform checksums and the immutable candidate manifest
- reject a candidate when a legacy alias differs from the canonical Beta metadata
- retire new Alpha publication while keeping Stable behind its separate release gate
- document the one-way Alpha.3 → Beta.1 bridge and future Beta ↔ Stable behavior

## Why

Installed Alpha clients already read the Alpha feed and cannot switch feeds before receiving another version. The first Beta Release must therefore expose the exact Beta metadata under the legacy Alpha filename. New Desktop clients read the Beta feed directly, so no later Alpha publication is needed.

## Validation

- release contract suite: 20/20 passed
- complete live-validator suite: 86 passed / 2 skipped
- Desktop companion CI: typecheck and Electron build passed; 112 tests passed / 3 skipped
- fixture proves Beta candidate creation rejects a non-identical Alpha compatibility alias

## Desktop dependency

Requires merged Desktop PR https://github.com/xiaotianfotos/homerail_desktop/pull/40 (`c2ebea54f10f952fef81fce55c203f97071c2de4`) so the Candidate job generates the compatibility aliases before assembly.
