### PR TITLE
fix(ui): describe Early Access as Beta

### DIFF
--- a/agent-ui/src/components/agent/settings/DesktopUpdateSettings.test.ts
+++ b/agent-ui/src/components/agent/settings/DesktopUpdateSettings.test.ts
@@ -69,6 +69,21 @@ describe('DesktopUpdateSettings', () => {
     expect(root?.querySelector('[data-testid="desktop-update-channel-early-access"]')?.getAttribute('aria-checked')).toBe('true')
   })
 
+  it.each(['en-US', 'zh-Hans', 'zh-Hant'] as const)(
+    'describes the release channels without the retired Alpha channel in %s',
+    (locale) => {
+      i18n.global.locale.value = locale
+
+      const stableDescription = i18n.global.t('settings.general.updates.channels.stable.description')
+      const earlyAccessDescription = i18n.global.t('settings.general.updates.channels.early-access.description')
+
+      expect(stableDescription).toContain('Beta')
+      expect(earlyAccessDescription).toContain('Beta')
+      expect(stableDescription).not.toContain('Alpha')
+      expect(earlyAccessDescription).not.toContain('Alpha')
+    },
+  )
+
   it('explains that switching a prerelease to Stable will not downgrade it', async () => {
     mount({
       updateStatus: vi.fn().mockResolvedValue(updateStatus({

--- a/agent-ui/src/locales/en-US/settings.json
+++ b/agent-ui/src/locales/en-US/settings.json
@@ -59,11 +59,11 @@
       "channels": {
         "stable": {
           "label": "Stable",
-          "description": "Receive final releases only. Alpha and Beta releases stay hidden."
+          "description": "Receive final releases only. Beta prereleases stay hidden."
         },
         "early-access": {
           "label": "Early Access",
-          "description": "Follow the current Alpha train, then Beta and Stable without opting in again."
+          "description": "Follow the Beta channel and automatically receive future Beta and Stable releases."
         }
       },
       "currentVersion": "Installed version: {version}",

--- a/agent-ui/src/locales/zh-Hans/settings.json
+++ b/agent-ui/src/locales/zh-Hans/settings.json
@@ -59,11 +59,11 @@
       "channels": {
         "stable": {
           "label": "稳定版",
-          "description": "只接收正式版本，不会看到 Alpha 或 Beta 预发布版。"
+          "description": "只接收正式版本，不会看到 Beta 预发布版。"
         },
         "early-access": {
           "label": "抢先体验",
-          "description": "跟随当前 Alpha 通道，未来会自然升级到 Beta 和稳定版，无需再次选择。"
+          "description": "跟随 Beta 通道，自动接收后续 Beta 和稳定版更新。"
         }
       },
       "currentVersion": "当前安装版本：{version}",

--- a/agent-ui/src/locales/zh-Hant/settings.json
+++ b/agent-ui/src/locales/zh-Hant/settings.json
@@ -59,11 +59,11 @@
       "channels": {
         "stable": {
           "label": "穩定版",
-          "description": "只接收正式版本，不會看到 Alpha 或 Beta 預發佈版。"
+          "description": "只接收正式版本，不會看到 Beta 預發佈版。"
         },
         "early-access": {
           "label": "搶先體驗",
-          "description": "跟隨目前 Alpha 通道，未來會自然升級到 Beta 和穩定版，無需再次選擇。"
+          "description": "跟隨 Beta 通道，自動接收後續 Beta 和穩定版更新。"
         }
       },
       "currentVersion": "目前安裝版本：{version}",


### PR DESCRIPTION
## Summary

- describe Early Access as the Beta update channel in English, Simplified Chinese, and Traditional Chinese
- remove retired Alpha wording from the Stable channel description
- add a locale regression test that keeps Alpha out of release-channel copy

## Context

The stale wording was found while smoke-testing the signed and notarized macOS artifact from Desktop Release Candidate run 30687740111. The updater already maps Early Access to Beta; only the user-facing settings copy was stale.

## Validation

- `npm --prefix agent-ui test -- src/components/agent/settings/DesktopUpdateSettings.test.ts` (10 passed)
- `npm --prefix agent-ui run typecheck`
- `npm --prefix agent-ui test` (93 files, 528 tests passed; rerun outside the sandbox because the Chromium isolation test binds 127.0.0.1)
- `npm --prefix agent-ui run build`
- `node --test scripts/desktop-release-contracts.test.mjs` (20 passed)

## Release status

The macOS candidate passed checksums, Developer ID signing, notarization, Gatekeeper, and local Electron UI smoke. The unified candidate remains blocked by the existing Windows certificate chain, which terminates at an untrusted root; this PR does not weaken that signing gate.
