### PR TITLE
fix(release): ship Windows Beta unsigned

### DIFF
--- a/.github/workflows/desktop-release-candidate.yml
+++ b/.github/workflows/desktop-release-candidate.yml
@@ -202,24 +202,13 @@ jobs:
           HOMERAIL_HOME: ${{ runner.temp }}/homerail-candidate-desktop-ci
         run: npm run ci
 
-      - name: Build unsigned Windows Alpha installer
-        if: runner.os == 'Windows' && needs.prepare.outputs.channel == 'alpha'
+      - name: Build unsigned Windows installer
+        if: runner.os == 'Windows'
         working-directory: desktop
         run: >-
           npm run dist -- --win nsis --x64 --publish never
           --config.win.signExecutable=false
           --config.win.verifyUpdateCodeSignature=false
-          --config.publish.channel="$env:RELEASE_CHANNEL"
-
-      - name: Build signed Windows Beta installer
-        if: runner.os == 'Windows' && needs.prepare.outputs.channel == 'beta'
-        working-directory: desktop
-        env:
-          CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
-        run: >-
-          npm run dist -- --win nsis --x64 --publish never
-          --config.forceCodeSigning=true
           --config.publish.channel="$env:RELEASE_CHANNEL"
 
       - name: Prepare and verify Windows update metadata
@@ -238,7 +227,7 @@ jobs:
             throw "Windows update metadata verification failed"
           }
 
-      - name: Verify Windows package and signing policy
+      - name: Verify Windows package and unsigned policy
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
@@ -261,25 +250,11 @@ jobs:
           foreach ($signedFile in @($installer.FullName, $appExecutable)) {
             $signature = Get-AuthenticodeSignature -LiteralPath $signedFile
             Write-Host "Authenticode status for ${signedFile}: $($signature.Status) ($($signature.StatusMessage))"
-            if ($env:RELEASE_CHANNEL -eq 'alpha') {
-              if ($signature.Status -ne 'NotSigned') {
-                throw "Windows Alpha binaries must be explicitly unsigned; got $($signature.Status) for $signedFile"
-              }
-              if ($null -ne $signature.SignerCertificate) {
-                throw "Windows Alpha binaries must not contain an Authenticode signer certificate"
-              }
-            } elseif ($env:RELEASE_CHANNEL -eq 'beta') {
-              if ($signature.Status -ne 'Valid') {
-                throw "Windows Beta binaries require a valid trusted Authenticode signature; got $($signature.Status) for $signedFile"
-              }
-              if ($null -eq $signature.SignerCertificate) {
-                throw "Windows Beta binaries are missing an Authenticode signer certificate"
-              }
-              if ($signature.SignerCertificate.NotAfter -le [DateTime]::UtcNow) {
-                throw "Windows Beta signer certificate is expired"
-              }
-            } else {
-              throw "Unsupported Windows release channel: $env:RELEASE_CHANNEL"
+            if ($signature.Status -ne 'NotSigned') {
+              throw "Windows $env:RELEASE_CHANNEL binaries must be explicitly unsigned; got $($signature.Status) for $signedFile"
+            }
+            if ($null -ne $signature.SignerCertificate) {
+              throw "Windows $env:RELEASE_CHANNEL binaries must not contain an Authenticode signer certificate"
             }
           }
 
@@ -291,11 +266,8 @@ jobs:
             (Resolve-Path -LiteralPath $appUpdateConfig).Path
           )
           $hasPublisherName = $appUpdateYaml -match '(?m)^\s*publisherName\s*:'
-          if ($env:RELEASE_CHANNEL -eq 'alpha' -and $hasPublisherName) {
-            throw "Unsigned Windows Alpha app-update.yml must not contain publisherName"
-          }
-          if ($env:RELEASE_CHANNEL -eq 'beta' -and -not $hasPublisherName) {
-            throw "Signed Windows Beta app-update.yml must contain publisherName"
+          if ($hasPublisherName) {
+            throw "Unsigned Windows $env:RELEASE_CHANNEL app-update.yml must not contain publisherName"
           }
           foreach ($expectedLine in @(
             'provider: github',
@@ -308,7 +280,7 @@ jobs:
               throw "Windows app-update.yml is missing expected update target: $expectedLine"
             }
           }
-          Write-Host "Verified Windows $env:RELEASE_CHANNEL signing and updater policy"
+          Write-Host "Verified unsigned Windows $env:RELEASE_CHANNEL package and updater policy"
 
       - name: Write Windows checksums
         if: runner.os == 'Windows'

--- a/docs/desktop-release.md
+++ b/docs/desktop-release.md
@@ -44,8 +44,6 @@ Add these environment secrets:
 | Secret | Value |
 | --- | --- |
 | `HOMERAIL_DESKTOP_READ_TOKEN` | Fine-grained token with read-only Contents access to `xiaotianfotos/homerail_desktop` only |
-| `WIN_CSC_LINK` | Base64-encoded trusted Windows Authenticode PFX/P12 |
-| `WIN_CSC_KEY_PASSWORD` | Password for the Windows signing certificate |
 | `MAC_CSC_LINK` | Base64-encoded Developer ID Application P12 |
 | `MAC_CSC_KEY_PASSWORD` | Password for the Mac P12 |
 | `APPLE_API_KEY_P8` | Base64-encoded App Store Connect `.p8` key |
@@ -61,12 +59,10 @@ Both workflow environments set `deployment: false`. They retain environment
 secrets and approvals without creating public Deployment records for signing or
 release administration.
 
-The Candidate workflow keeps Windows Alpha explicitly unsigned. For Beta it
-injects the Windows signing secrets only into the signed Windows build step and
-requires both the NSIS installer and packaged executable to report a `Valid`
-trusted Authenticode signature. A self-signed or otherwise untrusted secret
-fails the candidate. macOS always requires Developer ID signing and Apple
-notarization.
+The Candidate workflow keeps Windows packages explicitly unsigned for both the
+historical Alpha channel and the active Beta channel. It requires both the NSIS
+installer and packaged executable to report `NotSigned` with no signer
+certificate. macOS always requires Developer ID signing and Apple notarization.
 
 Keep all certificate passwords, private keys, and repository tokens out of Git.
 The candidate workflow writes the Apple API key only to the ephemeral macOS
@@ -80,16 +76,17 @@ Version changes are code changes and must be reviewed before building:
 2. Update `homerail_desktop/package.json` and its lock to the same version.
 3. Push the private Desktop branch and record its full 40-character commit SHA.
 4. For Alpha, run the unsigned public **Desktop Build Gate** against that exact
-   unmerged SHA. For Beta, run local CI and merge before using protected signing.
+   unmerged SHA. For Beta, run local CI and merge before using the protected
+   Candidate environment.
 5. Merge the Desktop and public version changes.
-6. Run the immutable Candidate workflow and test its signed artifacts on the
+6. Run the immutable Candidate workflow and test its platform artifacts on the
    real Windows and macOS test machines.
 
 The workflows never rewrite package versions while building. They fail if the
 requested version differs from any public or Desktop package manifest, or if the
 pinned checkout differs from the requested SHA. The Build Gate deliberately
-accepts an unmerged private commit; the signed Candidate additionally requires
-that commit to be merged to `homerail_desktop/main`.
+accepts an unmerged private commit; the Candidate additionally requires that
+commit to be merged to `homerail_desktop/main`.
 
 ## Build an unsigned pre-merge package gate
 
@@ -134,8 +131,8 @@ The workflow:
    versions;
 2. checks out the private Desktop source by full commit SHA;
 3. builds Windows x64 and macOS arm64 on isolated hosted runners;
-4. applies the channel policy: Alpha Windows is explicitly unsigned, Beta
-   Windows is trusted Authenticode-signed, and macOS is signed and notarized;
+4. applies the channel policy: Windows is explicitly unsigned, while macOS is
+   Developer ID signed and Apple-notarized;
 5. asks the pinned Desktop release tooling to prepare and verify channel-specific
    metadata against the packaged files;
 6. creates platform checksums and a combined release manifest;
@@ -151,11 +148,11 @@ metadata from the same build, after the separate Stable gate is enabled. Every
 emitted metadata file is covered by both the platform checksum list and the
 combined candidate manifest.
 
-### Windows channel signing policy
+### Windows unsigned policy
 
-Windows installers are explicitly unsigned while HomeRail is in Alpha. The
-Candidate workflow passes `win.signExecutable=false` and
-`win.verifyUpdateCodeSignature=false` only on the Windows Alpha
+Windows Alpha and Beta installers are explicitly unsigned. The Candidate
+workflow passes `win.signExecutable=false` and
+`win.verifyUpdateCodeSignature=false` on the Windows candidate
 electron-builder command. It does not disable updater signature verification
 globally in Desktop production code. The unsigned pre-merge Build Gate remains
 Alpha-only.
@@ -166,21 +163,20 @@ packaged `app-update.yml` containing `publisherName`. Users should expect
 Windows SmartScreen and an **Unknown Publisher** warning. Update integrity
 currently depends on delivery from the GitHub Release and electron-updater's
 SHA-512 metadata check, supplemented by the candidate SHA-256 manifests. That
-does not authenticate a publisher and is weaker than trusted Authenticode, so
-this exception is only permitted for Alpha.
+does not authenticate a publisher and is weaker than trusted Authenticode.
+Windows Beta is explicitly unsigned under the current release policy.
 
 Omitting `publisherName` also preserves a migration path to a future
-trusted-signed Windows build. An unsigned Alpha can discover and install that
-signed build, but the first update from an unsigned Alpha to a signed installer
-does not verify that installer with Authenticode; the old client's updater
-configuration still relies on GitHub and SHA-512 for that hop. After the signed
-version is installed, its own `app-update.yml` can restore `publisherName` and
-signature verification for subsequent updates.
+trusted-signed Windows build. An unsigned Alpha or Beta can discover and install
+that signed build, but the first update from an unsigned build to a future signed
+installer does not verify that installer with Authenticode; the old client's
+updater configuration still relies on GitHub and SHA-512 for that hop. After the
+signed version is installed, its own `app-update.yml` can restore `publisherName`
+and signature verification for subsequent updates.
 
-Windows Beta uses `WIN_CSC_LINK` and `WIN_CSC_KEY_PASSWORD`, enables
-`forceCodeSigning`, and rejects the candidate unless Authenticode reports
-`Valid` for both the installer and packaged `HomeRail.exe`. Its packaged
-`app-update.yml` must restore `publisherName` and target the `beta` channel.
+Windows Beta rejects a candidate unless the Authenticode status is `NotSigned`
+for both the installer and packaged `HomeRail.exe`. Its packaged
+`app-update.yml` must omit `publisherName` and target the `beta` channel.
 
 [SignPath Foundation](https://signpath.org/) is a possible no-cost signing path
 for qualifying open-source projects. HomeRail has not been applied for or
@@ -201,9 +197,9 @@ does not replace the following acceptance checks on a real Windows machine.
 After the hosted-runner gates pass, download the candidate from the workflow
 run and perform direct-install checks:
 
-- Windows Alpha: acknowledge the expected SmartScreen / Unknown Publisher
-  warning. Windows Beta: confirm the trusted publisher and no Unknown Publisher
-  warning. Install, launch HomeRail, complete onboarding, restart, and uninstall once.
+- Windows Beta: acknowledge the expected SmartScreen / Unknown Publisher
+  warning, then install, launch HomeRail, complete onboarding, restart, and
+  uninstall once.
 - macOS: mount the DMG, install HomeRail, confirm Gatekeeper accepts it, launch,
   complete onboarding, quit, and relaunch.
 - Both: verify the packaged CLI, Manager/Node/Worker startup, settings
@@ -282,7 +278,8 @@ Create the version tag only when all of these are true:
 - release notes and the source commits in `release-manifest.json` were reviewed;
 - the publishing environment approval is intentional.
 
-Beta additionally requires trusted Windows signing, a reliable Alpha upgrade
-history, stable configuration/data migrations, no known data-loss or security
-issue, and a substantially frozen core feature set. Stable likewise requires
-trusted Windows signing and is not part of the current release plan.
+Beta additionally requires explicit acceptance of unsigned Windows
+distribution, a reliable Alpha upgrade history, stable configuration/data
+migrations, no known data-loss or security issue, and a substantially frozen
+core feature set. Stable still requires trusted Windows signing and is not part
+of the current release plan.

--- a/scripts/desktop-release-contracts.test.mjs
+++ b/scripts/desktop-release-contracts.test.mjs
@@ -255,10 +255,8 @@ test("candidate uses protected release environment without Deployment records", 
   assert.doesNotMatch(candidateWorkflow, /runs-on:.*self-hosted/);
 });
 
-test("candidate signs Beta on Windows and macOS while preserving the unsigned Alpha policy", () => {
+test("candidate keeps Windows unsigned while signing and notarizing macOS", () => {
   for (const secret of [
-    "WIN_CSC_LINK",
-    "WIN_CSC_KEY_PASSWORD",
     "MAC_CSC_LINK",
     "MAC_CSC_KEY_PASSWORD",
     "APPLE_API_KEY_P8",
@@ -268,24 +266,18 @@ test("candidate signs Beta on Windows and macOS while preserving the unsigned Al
   ]) {
     assert.match(candidateWorkflow, new RegExp(`secrets\\.${secret}`));
   }
+  assert.doesNotMatch(candidateWorkflow, /secrets\.WIN_CSC_(?:LINK|KEY_PASSWORD)/);
 
   const prepareGuard = candidateStep("Allow Alpha and Beta release channels");
   assert.match(prepareGuard, /\[\[ "\$RELEASE_CHANNEL" == "latest" \]\]/);
   assert.match(prepareGuard, /supports Alpha and Beta/);
 
-  const windowsAlphaBuild = candidateStep("Build unsigned Windows Alpha installer");
-  assert.match(windowsAlphaBuild, /needs\.prepare\.outputs\.channel == 'alpha'/);
-  assert.match(windowsAlphaBuild, /--config\.win\.signExecutable=false/);
-  assert.match(windowsAlphaBuild, /--config\.win\.verifyUpdateCodeSignature=false/);
-  assert.match(windowsAlphaBuild, /--config\.publish\.channel=/);
-  assert.doesNotMatch(windowsAlphaBuild, /forceCodeSigning|WIN_CSC/);
-
-  const windowsBetaBuild = candidateStep("Build signed Windows Beta installer");
-  assert.match(windowsBetaBuild, /needs\.prepare\.outputs\.channel == 'beta'/);
-  assert.match(windowsBetaBuild, /secrets\.WIN_CSC_LINK/);
-  assert.match(windowsBetaBuild, /secrets\.WIN_CSC_KEY_PASSWORD/);
-  assert.match(windowsBetaBuild, /--config\.forceCodeSigning=true/);
-  assert.match(windowsBetaBuild, /--config\.publish\.channel=/);
+  const windowsBuild = candidateStep("Build unsigned Windows installer");
+  assert.match(windowsBuild, /if: runner\.os == 'Windows'/);
+  assert.match(windowsBuild, /--config\.win\.signExecutable=false/);
+  assert.match(windowsBuild, /--config\.win\.verifyUpdateCodeSignature=false/);
+  assert.match(windowsBuild, /--config\.publish\.channel=/);
+  assert.doesNotMatch(windowsBuild, /forceCodeSigning|WIN_CSC/);
   assert.equal(
     (candidateWorkflow.match(/--config\.win\.signExecutable=false/g) ?? []).length,
     1,
@@ -303,8 +295,8 @@ test("candidate signs Beta on Windows and macOS while preserving the unsigned Al
   assert.match(macBuild, /--config\.mac\.notarize=true/);
   assert.match(macBuild, /--config\.mac\.entitlements=/);
   assert.match(macBuild, /--config\.mac\.entitlementsInherit=/);
-  assert.equal((candidateWorkflow.match(/--config\.forceCodeSigning=true/g) ?? []).length, 2);
-  assert.equal((candidateWorkflow.match(/--config\.publish\.channel=/g) ?? []).length, 3);
+  assert.equal((candidateWorkflow.match(/--config\.forceCodeSigning=true/g) ?? []).length, 1);
+  assert.equal((candidateWorkflow.match(/--config\.publish\.channel=/g) ?? []).length, 2);
   assert.match(candidateWorkflow, /verify:update-metadata/);
   assert.match(candidateWorkflow, /metadata_release_channel=stable/);
   assert.match(candidateWorkflow, /elseif \(\$env:RELEASE_CHANNEL -eq 'beta'\)/);
@@ -338,7 +330,7 @@ test("macOS release entitlements enable microphone input for the app and helpers
   );
 });
 
-test("Windows candidate runs Node 24 CI before channel-specific signing and installation smoke", () => {
+test("Windows candidate runs Node 24 CI before unsigned packaging and installation smoke", () => {
   assert.match(candidateWorkflow, /RELEASE_NODE_VERSION: 24\.18\.0/);
   assert.match(candidateWorkflow, /name: Run public Windows Node 24 CI/);
   assert.match(candidateWorkflow, /npm --prefix homerail-source run ci/);
@@ -350,7 +342,7 @@ test("Windows candidate runs Node 24 CI before channel-specific signing and inst
   assert.match(candidateWorkflow, /VITEST_TEST_TIMEOUT: "15000"/);
   assert.match(candidateWorkflow, /VITEST_HOOK_TIMEOUT: "30000"/);
 
-  const packageVerificationStep = candidateStep("Verify Windows package and signing policy");
+  const packageVerificationStep = candidateStep("Verify Windows package and unsigned policy");
   assert.match(packageVerificationStep, /npm --prefix desktop run verify:package/);
   assert.match(packageVerificationStep, /if \(\$LASTEXITCODE -ne 0\)/);
   assert.match(packageVerificationStep, /\$installers\.Count -ne 1/);
@@ -364,7 +356,7 @@ test("Windows candidate runs Node 24 CI before channel-specific signing and inst
   );
   assert.match(packageVerificationStep, /\$signature\.StatusMessage/);
   assert.match(packageVerificationStep, /if \(\$signature\.Status -ne 'NotSigned'\)/);
-  assert.match(packageVerificationStep, /if \(\$signature\.Status -ne 'Valid'\)/);
+  assert.doesNotMatch(packageVerificationStep, /\$signature\.Status -ne 'Valid'/);
   assert.match(
     packageVerificationStep,
     /if \(\$null -ne \$signature\.SignerCertificate\)/,
@@ -383,7 +375,7 @@ test("Windows candidate runs Node 24 CI before channel-specific signing and inst
     ),
   );
   assert.match(packageVerificationStep, /must not contain publisherName/);
-  assert.match(packageVerificationStep, /must contain publisherName/);
+  assert.doesNotMatch(packageVerificationStep, /must contain publisherName/);
   for (const expectedUpdateTarget of [
     "provider: github",
     "owner: xiaotianfotos",
@@ -422,10 +414,9 @@ test("Windows candidate runs Node 24 CI before channel-specific signing and inst
   const publicCi = candidateWorkflow.indexOf("Run public Windows Node 24 CI");
   const publicCliVersion = candidateWorkflow.indexOf("Verify public Windows CLI release version");
   const desktopCi = candidateWorkflow.indexOf("Run Desktop Windows CI");
-  const alphaBuild = candidateWorkflow.indexOf("Build unsigned Windows Alpha installer");
-  const betaBuild = candidateWorkflow.indexOf("Build signed Windows Beta installer");
+  const windowsBuild = candidateWorkflow.indexOf("Build unsigned Windows installer");
   const metadata = candidateWorkflow.indexOf("Prepare and verify Windows update metadata");
-  const packageVerification = candidateWorkflow.indexOf("Verify Windows package and signing policy");
+  const packageVerification = candidateWorkflow.indexOf("Verify Windows package and unsigned policy");
   const checksums = candidateWorkflow.indexOf("Write Windows checksums");
   const installSmoke = candidateWorkflow.indexOf("Smoke-test silent Windows installation");
   const upload = candidateWorkflow.indexOf("Upload Windows candidate assets");
@@ -434,8 +425,7 @@ test("Windows candidate runs Node 24 CI before channel-specific signing and inst
     publicCi,
     publicCliVersion,
     desktopCi,
-    alphaBuild,
-    betaBuild,
+    windowsBuild,
     metadata,
     packageVerification,
     checksums,
@@ -448,9 +438,8 @@ test("Windows candidate runs Node 24 CI before channel-specific signing and inst
     install < publicCi
       && publicCi < publicCliVersion
       && publicCliVersion < desktopCi
-      && desktopCi < alphaBuild
-      && alphaBuild < betaBuild
-      && betaBuild < metadata
+      && desktopCi < windowsBuild
+      && windowsBuild < metadata
       && metadata < packageVerification
       && packageVerification < checksums
       && checksums < installSmoke
@@ -534,15 +523,14 @@ test("release docs preserve candidate, publish, update-test, and fix-forward bou
   assert.match(releaseDocs, /Unknown Publisher/);
   assert.match(releaseDocs, /GitHub Release[\s\S]*SHA-512/);
   assert.match(releaseDocs, /weaker than trusted Authenticode/i);
-  assert.match(releaseDocs, /only permitted for Alpha/i);
   assert.match(releaseDocs, /Beta is the active test channel/i);
-  assert.match(releaseDocs, /Windows Beta uses `WIN_CSC_LINK`/i);
-  assert.match(releaseDocs, /Authenticode reports\s+`Valid`/i);
+  assert.match(releaseDocs, /Windows Beta is explicitly unsigned/i);
+  assert.match(releaseDocs, /Authenticode status is `NotSigned`/i);
   assert.match(releaseDocs, /SignPath Foundation/);
   assert.match(releaseDocs, /not been applied for or\s+approved/i);
   assert.match(
     releaseDocs,
-    /first update from an unsigned Alpha to a signed installer[\s\S]*does not verify that installer with Authenticode/i,
+    /first update from an unsigned build to a future signed\s+installer[\s\S]*does not verify that installer with Authenticode/i,
   );
   assert.match(
     releaseDocs,
@@ -550,9 +538,9 @@ test("release docs preserve candidate, publish, update-test, and fix-forward bou
   );
   assert.match(
     releaseDocs,
-    /only on the Windows Alpha\s+electron-builder command/i,
+    /Windows candidate\s+electron-builder command/i,
   );
-  assert.match(releaseDocs, /WIN_CSC_LINK|WIN_CSC_KEY_PASSWORD/);
+  assert.doesNotMatch(releaseDocs, /WIN_CSC_LINK|WIN_CSC_KEY_PASSWORD/);
 });
 
 test("candidate pins a merged Desktop commit before installing or signing", () => {
@@ -989,6 +977,15 @@ test("Beta candidates require byte-identical Alpha compatibility aliases", () =>
     writeBetaFixture(goodDir, metadata);
     const good = spawnSync(process.execPath, createArgs(goodDir), { encoding: "utf8" });
     assert.equal(good.status, 0, good.stderr);
+    const releaseNotes = fs.readFileSync(
+      path.join(goodDir, "release-notes.md"),
+      "utf8",
+    );
+    assert.match(
+      releaseNotes,
+      /Windows: explicitly unsigned Beta prerelease installer/,
+    );
+    assert.doesNotMatch(releaseNotes, /trusted Authenticode signing is required/);
 
     writeBetaFixture(badDir, "version: 0.1.0-beta.1\nbridge: stale\n");
     const bad = spawnSync(process.execPath, createArgs(badDir), { encoding: "utf8" });

--- a/scripts/desktop-release/release-candidate.mjs
+++ b/scripts/desktop-release/release-candidate.mjs
@@ -283,8 +283,10 @@ function writeCandidate(args) {
   const phase = manifest.prerelease ? `${args.channel} prerelease` : "stable release";
   const windowsPolicyNote =
     args.channel === "alpha"
-      ? "- Windows: explicitly unsigned Alpha installer, verified as unsigned under the Alpha release policy."
-      : `- Windows: trusted Authenticode signing is required for this ${phase}.`;
+      ? "- Windows: explicitly unsigned Alpha installer, verified as unsigned under the current release policy."
+      : args.channel === "beta"
+        ? "- Windows: explicitly unsigned Beta prerelease installer, verified as unsigned under the current release policy."
+        : `- Windows: trusted Authenticode signing is required for this ${phase}.`;
   const prereleaseWarning =
     args.channel === "alpha"
       ? [


### PR DESCRIPTION
## Summary

- build Windows Alpha and Beta candidates without Authenticode signing
- fail closed unless both the NSIS installer and packaged executable are actually unsigned
- omit `publisherName` from Windows updater metadata while preserving Beta/Alpha channel aliases
- keep macOS Developer ID signing and notarization unchanged
- document the SmartScreen / Unknown Publisher tradeoff and future signed-update migration path

## Why

The previous Beta candidate used a private/untrusted Windows certificate. Windows reported an untrusted root, so the strict trusted-Authenticode gate failed. The current Beta policy is now explicitly unsigned instead of treating a private certificate as publicly trusted.

## Validation

- `npm run ci` with isolated `RUNNER_TEMP` and `HOMERAIL_HOME`: passed
- `node --test scripts/desktop-release-contracts.test.mjs`: 20/20 passed
- branch is based on the latest `origin/main`
