### PR TITLE
feat: add document-first AutoFix v2 DAG

### DIFF
--- a/assets/orchestrations/auto-fix-v2.yaml.template
+++ b/assets/orchestrations/auto-fix-v2.yaml.template
@@ -311,7 +311,7 @@ spec:
           allowed_builtin_tools: [Bash, Edit, Glob, Grep, LS, Read, Write]
           allowed_dag_tools: [handoff]
           max_builtin_tool_calls: 80
-          workspace_access: { writable_paths: [], readonly_paths: [input] }
+          workspace_access: { writable_paths: ["{{fanout_workspace}}"], readonly_paths: [input] }
         workspace_strategy: isolated_git_worktree
         workspace_root: workers
         repository_path: repo
@@ -395,7 +395,7 @@ spec:
           allowed_builtin_tools: [Bash, Edit, Glob, Grep, LS, Read, Write]
           allowed_dag_tools: [handoff, credential_broker_call]
           max_builtin_tool_calls: 100
-          workspace_access: { writable_paths: [], readonly_paths: [input] }
+          workspace_access: { writable_paths: ["{{fanout_workspace}}"], readonly_paths: [input] }
           credentials:
             - credential_ref: github-autofix
               purpose: apply one bounded review revision to the Draft PR

--- a/assets/orchestrations/auto-fix-v2.yaml.template
+++ b/assets/orchestrations/auto-fix-v2.yaml.template
@@ -1,0 +1,467 @@
+api_version: homerail.ai/v1
+kind: Workflow
+
+metadata:
+  id: auto-fix-v2
+  name: HomeRail Auto Fix v2
+  labels:
+    scenario: document-first-draft-pr-autofix
+    safety: manager-broker-only
+
+spec:
+  description: |
+    A document-first Auto Fix workflow. A K3 analyzer creates a bounded task
+    plan, dynamic DeepSeek V4 Flash workers implement isolated sub-tasks, one
+    DeepSeek aggregator publishes a candidate through the GitHub broker, and a
+    fresh-context GLM-5.2 reviewer drives at most five total review rounds.
+    Revisions are performed by newly generated DeepSeek workers. The immutable
+    task document and PR binding are mounted below /workspace/input.
+
+  workspace: { mode: shared }
+
+  pattern:
+    id: auto-fix-v2
+    version: 2.0.0
+    source: HomeRail document-first dynamic worker review loop
+    parameters:
+      max_plan_items: 3
+      max_parallel_implementers: 3
+      max_review_rounds: 5
+      github_mutation: manager_broker
+
+  contracts:
+    Start:
+      type: object
+
+    RepositoryReady:
+      type: object
+      additionalProperties: false
+      required: [repository_path, head]
+      properties:
+        repository_path: { type: string, const: repo }
+        head: { type: string, pattern: '^(?:[0-9a-f]{40}|[0-9a-f]{64})$' }
+
+    TaskItem:
+      type: object
+      additionalProperties: false
+      required: [id, title, description, acceptance]
+      properties:
+        id: { type: string, pattern: '^[a-z][a-z0-9_-]{0,63}$' }
+        title: { type: string, minLength: 1, maxLength: 300 }
+        description: { type: string, minLength: 1, maxLength: 6000 }
+        files:
+          type: array
+          maxItems: 50
+          items: { type: string, minLength: 1, maxLength: 1000 }
+        acceptance:
+          type: array
+          minItems: 1
+          maxItems: 30
+          items: { type: string, minLength: 1, maxLength: 2000 }
+        dependencies:
+          type: array
+          maxItems: 3
+          items: { type: string, pattern: '^[a-z][a-z0-9_-]{0,63}$' }
+
+    TaskPlan:
+      type: object
+      additionalProperties: false
+      required: [tasks, shared]
+      properties:
+        tasks:
+          type: array
+          minItems: 1
+          maxItems: 3
+          items:
+            type: object
+            additionalProperties: false
+            required: [id, title, description, acceptance]
+            properties:
+              id: { type: string, pattern: '^[a-z][a-z0-9_-]{0,63}$' }
+              title: { type: string, minLength: 1, maxLength: 300 }
+              description: { type: string, minLength: 1, maxLength: 6000 }
+              files:
+                type: array
+                maxItems: 50
+                items: { type: string, minLength: 1, maxLength: 1000 }
+              acceptance:
+                type: array
+                minItems: 1
+                maxItems: 30
+                items: { type: string, minLength: 1, maxLength: 2000 }
+              dependencies:
+                type: array
+                maxItems: 3
+                items: { type: string, pattern: '^[a-z][a-z0-9_-]{0,63}$' }
+        shared:
+          type: object
+          additionalProperties: false
+          required: [repository_path, task_document, pr_context]
+          properties:
+            repository_path: { type: string, const: repo }
+            task_document: { type: string, const: input/task.md }
+            pr_context: { type: string, const: input/pr-context.json }
+
+    WorkerResult:
+      type: object
+      additionalProperties: false
+      required: [status, task_id, commit_sha, workspace_path, summary, tests]
+      properties:
+        status: { type: string, enum: [implemented, cannot_implement] }
+        task_id: { type: string, minLength: 1, maxLength: 64 }
+        commit_sha: { type: string, pattern: '^(?:[0-9a-f]{40}|[0-9a-f]{64})$' }
+        workspace_path: { type: string, minLength: 1, maxLength: 1000 }
+        summary: { type: string, minLength: 1, maxLength: 8000 }
+        tests:
+          type: array
+          maxItems: 30
+          items: { type: string, minLength: 1, maxLength: 2000 }
+
+    Candidate:
+      type: object
+      additionalProperties: false
+      required: [head_sha, review_round, summary, tests]
+      properties:
+        head_sha: { type: string, pattern: '^(?:[0-9a-f]{40}|[0-9a-f]{64})$' }
+        review_round: { type: integer, const: 1 }
+        summary: { type: string, minLength: 1, maxLength: 12000 }
+        tests:
+          type: array
+          maxItems: 50
+          items: { type: string, minLength: 1, maxLength: 2000 }
+
+    ReviewDecision:
+      type: object
+      additionalProperties: false
+      required: [verdict, head_sha, review_round, summary, feedback, fix_tasks]
+      properties:
+        verdict: { type: string, enum: [approve, changes_requested] }
+        head_sha: { type: string, pattern: '^(?:[0-9a-f]{40}|[0-9a-f]{64})$' }
+        review_round: { type: integer, minimum: 1, maximum: 5 }
+        summary: { type: string, minLength: 1, maxLength: 12000 }
+        feedback:
+          type: array
+          maxItems: 30
+          items: { type: string, minLength: 1, maxLength: 4000 }
+        fix_tasks:
+          type: array
+          maxItems: 1
+          items:
+            type: object
+            additionalProperties: false
+            required: [id, feedback]
+            properties:
+              id: { type: string, minLength: 1, maxLength: 64 }
+              feedback:
+                type: array
+                minItems: 1
+                maxItems: 30
+                items: { type: string, minLength: 1, maxLength: 4000 }
+
+    FixResult:
+      type: object
+      additionalProperties: false
+      required: [status, previous_head_sha, head_sha, summary, tests]
+      properties:
+        status: { type: string, enum: [fixed, cannot_fix] }
+        previous_head_sha: { type: string, pattern: '^(?:[0-9a-f]{40}|[0-9a-f]{64})$' }
+        head_sha: { type: string, pattern: '^(?:[0-9a-f]{40}|[0-9a-f]{64})$' }
+        summary: { type: string, minLength: 1, maxLength: 8000 }
+        tests:
+          type: array
+          maxItems: 30
+          items: { type: string, minLength: 1, maxLength: 2000 }
+
+  artifacts:
+    - name: task-plan.json
+      source: { type: handoff, node: analyze, port: planned }
+      media_type: application/json
+      contract: TaskPlan
+      required: true
+      publish: always
+    - name: initial-candidate.json
+      source: { type: handoff, node: aggregate, port: candidate }
+      media_type: application/json
+      contract: Candidate
+      required: false
+      publish: always
+    - name: final-review.json
+      source:
+        type: handoff
+        node: review_gate
+        port: approved
+        json_pointer: /input
+      media_type: application/json
+      contract: ReviewDecision
+      required: false
+      publish: success
+
+  agents:
+    analyzer:
+      description: K3 task analyst
+      system: |
+        Read /workspace/input/task.md as the immutable authoritative task and
+        /workspace/input/pr-context.json as immutable PR identity. Inspect the
+        read-only repository at /workspace/repo. Produce a minimal independent
+        task list. Do not edit files and do not access GitHub. Finish only with
+        handoff(planned) matching TaskPlan. Set shared paths exactly to repo,
+        input/task.md, and input/pr-context.json.
+
+    implementer:
+      description: DeepSeek V4 Flash isolated implementation worker
+      system: |
+        Implement only input.item inside input.workspace_path. Read the mounted
+        task document for authoritative acceptance criteria. Never access the
+        PR or credentials. Run focused tests, commit the changes in the detached
+        Git worktree, and hand off result with the exact commit SHA and workspace
+        path. Do not modify another worker's directory.
+
+    aggregator:
+      description: DeepSeek V4 Flash candidate integrator
+      system: |
+        Treat the dynamic worker results as proposals. Inspect every commit,
+        integrate compatible changes in /workspace/repo, resolve overlap, and
+        run focused tests. Use github_pr/pull_request_snapshot to obtain the
+        exact current Draft PR head. Publish changed file bytes only through
+        github_pr/commit_files with expected_head_sha; never use git push or a
+        raw token. Then hand off candidate with review_round 1 and the broker's
+        returned head SHA. Refuse unrelated or workflow-file changes.
+
+    reviewer:
+      description: GLM-5.2 fresh-context reviewer
+      system: |
+        Review only the immutable task document and the current Draft PR state
+        obtained through github_pr/pull_request_snapshot and checks_snapshot.
+        Every dispatch is a fresh provider session: do not rely on prior chat.
+        For the initial candidate set review_round to 1. For a revision, derive
+        review_round as input.fixes.context.review_round + 1. Approve only when
+        all acceptance criteria are met and checks/evidence are sufficient.
+        On approval return empty feedback and fix_tasks. Otherwise return clear
+        feedback and exactly one fix_tasks item containing the whole feedback.
+
+    fixer:
+      description: DeepSeek V4 Flash dynamically generated PR fixer
+      system: |
+        You are a newly generated fixer for one review round. Work only in
+        input.workspace_path. Use github_pr/pull_request_snapshot to bind the
+        latest Draft PR head, apply all feedback in input.item, run focused
+        tests, and publish file bytes only through github_pr/commit_files with
+        the snapshot head as expected_head_sha. Never git push and never modify
+        .github/workflows. Hand off fixed with both previous and new head SHAs.
+
+  nodes:
+    prepare_repository:
+      kind: command
+      inputs: { start: { contract: Start } }
+      outputs: { ready: { contract: RepositoryReady }, failed: {} }
+      config:
+        command:
+          - node
+          - -e
+          - >-
+            const fs=require('fs'),cp=require('child_process'),crypto=require('crypto');
+            const ctx=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));
+            const fail=m=>{throw new Error(m)};
+            if(ctx.version!==1||ctx.clone_url!==`https://github.com/${ctx.owner}/${ctx.repo}.git`)fail('clone_url does not match repository');
+            if(!ctx.base_ref||!ctx.head_ref)fail('missing branch binding');
+            const task=fs.readFileSync(process.argv[2]);
+            if(crypto.createHash('sha256').update(task).digest('hex')!==ctx.task_document_sha256)fail('task document digest mismatch');
+            if(!/^[0-9a-f]{40}(?:[0-9a-f]{24})?$/.test(ctx.initial_head_sha||''))fail('invalid head');
+            const run=a=>{const r=cp.spawnSync('git',a,{encoding:'utf8',timeout:120000,stdio:['ignore','pipe','pipe']});if(r.status!==0)fail(String(r.stderr||r.error));return String(r.stdout).trim()};
+            if(!fs.existsSync('repo/.git'))run(['clone','--no-checkout','--',ctx.clone_url,'repo']);
+            run(['-C','repo','fetch','--no-tags','origin',ctx.initial_head_sha]);
+            run(['-C','repo','checkout','--detach',ctx.initial_head_sha]);
+            const head=run(['-C','repo','rev-parse','HEAD']).toLowerCase();
+            if(head!==ctx.initial_head_sha.toLowerCase())fail('checkout head mismatch');
+            process.stdout.write(JSON.stringify({repository_path:'repo',head}));
+          - $run_input/pr_context
+          - $run_input/task_document
+        cwd: $run_workspace
+        timeout_ms: 180000
+        parse_stdout: json
+        result_payload: value
+        success_port: ready
+        failure_port: failed
+
+    analyze:
+      kind: agent
+      agent: analyzer
+      session_scope: dispatch
+      workspace_access: { writable_paths: [], readonly_paths: [input, repo] }
+      allowed_builtin_tools: [Glob, Grep, LS, Read]
+      allowed_dag_tools: [handoff]
+      inputs: { repository: { contract: RepositoryReady } }
+      outputs: { planned: { contract: TaskPlan }, failed: {} }
+
+    implement:
+      kind: fanout
+      inputs: { plan: { contract: TaskPlan } }
+      outputs: { implemented: {}, failed: {} }
+      config:
+        input: plan
+        item_field: tasks
+        context_field: shared
+        worker_agent: implementer
+        worker_policy:
+          session_scope: dispatch
+          allowed_builtin_tools: [Bash, Edit, Glob, Grep, LS, Read, Write]
+          allowed_dag_tools: [handoff]
+          max_builtin_tool_calls: 80
+          workspace_access: { writable_paths: [], readonly_paths: [input] }
+        workspace_strategy: isolated_git_worktree
+        workspace_root: workers
+        repository_path: repo
+        max_items: 3
+        max_parallelism: 3
+        completion: all
+        result_contract: WorkerResult
+        success_field: status
+        success_values: [implemented]
+        result_port: implemented
+        failed_port: failed
+
+    aggregate:
+      kind: agent
+      agent: aggregator
+      session_scope: dispatch
+      workspace_access: { writable_paths: [repo], readonly_paths: [input, workers] }
+      allowed_builtin_tools: [Bash, Edit, Glob, Grep, LS, Read, Write]
+      allowed_dag_tools: [handoff, credential_broker_call]
+      max_builtin_tool_calls: 120
+      credentials:
+        - credential_ref: github-autofix
+          purpose: integrate the candidate into the bound Draft PR
+          inject:
+            mode: manager_broker
+            broker: github_pr
+            allowed_actions: [pull_request_snapshot, commit_files]
+      inputs: { workers: {} }
+      outputs: { candidate: { contract: Candidate }, failed: {} }
+
+    review_initial:
+      kind: agent
+      agent: reviewer
+      session_scope: dispatch
+      workspace_access: { writable_paths: [], readonly_paths: [input, repo, workers] }
+      allowed_builtin_tools: [Glob, Grep, LS, Read]
+      allowed_dag_tools: [handoff, credential_broker_call]
+      max_builtin_tool_calls: 60
+      credentials:
+        - credential_ref: github-autofix
+          purpose: review the bound Draft PR without mutation
+          inject:
+            mode: manager_broker
+            broker: github_pr
+            allowed_actions: [pull_request_snapshot, checks_snapshot]
+      inputs: { candidate: { contract: Candidate } }
+      outputs: { reviewed: { contract: ReviewDecision }, failed: {} }
+
+    review_gate:
+      kind: while
+      inputs: { state: { contract: ReviewDecision } }
+      outputs: { fix: {}, approved: {}, exhausted: {} }
+      config:
+        field: verdict
+        operator: eq
+        value: approve
+        continue_port: fix
+        done_port: approved
+        exhausted_port: exhausted
+        max_iterations: 4
+
+    fix:
+      kind: fanout
+      inputs: { review: {} }
+      outputs: { fixed: {}, failed: {} }
+      config:
+        input: review
+        item_field: input.fix_tasks
+        context_field: input
+        worker_agent: fixer
+        worker_policy:
+          session_scope: dispatch
+          allowed_builtin_tools: [Bash, Edit, Glob, Grep, LS, Read, Write]
+          allowed_dag_tools: [handoff, credential_broker_call]
+          max_builtin_tool_calls: 100
+          workspace_access: { writable_paths: [], readonly_paths: [input] }
+          credentials:
+            - credential_ref: github-autofix
+              purpose: apply one bounded review revision to the Draft PR
+              inject:
+                mode: manager_broker
+                broker: github_pr
+                allowed_actions: [pull_request_snapshot, commit_files]
+        workspace_strategy: isolated_git_worktree
+        workspace_root: fixers
+        repository_path: repo
+        revision_field: head_sha
+        max_items: 1
+        max_parallelism: 1
+        completion: all
+        result_contract: FixResult
+        success_field: status
+        success_values: [fixed]
+        result_port: fixed
+        failed_port: failed
+
+    review_revision:
+      kind: agent
+      agent: reviewer
+      depends_on: [review_gate]
+      session_scope: dispatch
+      workspace_access: { writable_paths: [], readonly_paths: [input, repo, fixers] }
+      allowed_builtin_tools: [Glob, Grep, LS, Read]
+      allowed_dag_tools: [handoff, credential_broker_call]
+      max_builtin_tool_calls: 60
+      credentials:
+        - credential_ref: github-autofix
+          purpose: re-review the bound Draft PR without mutation
+          inject:
+            mode: manager_broker
+            broker: github_pr
+            allowed_actions: [pull_request_snapshot, checks_snapshot]
+      inputs: { fixes: {} }
+      outputs: { reviewed: { contract: ReviewDecision }, failed: {} }
+
+    done: { kind: terminal, outcome: success, inputs: { result: {} } }
+    preparation_failed: { kind: terminal, outcome: failure, inputs: { result: {} } }
+    analysis_failed: { kind: terminal, outcome: failure, inputs: { result: {} } }
+    implementation_failed: { kind: terminal, outcome: failure, inputs: { result: {} } }
+    aggregation_failed: { kind: terminal, outcome: failure, inputs: { result: {} } }
+    initial_review_failed: { kind: terminal, outcome: failure, inputs: { result: {} } }
+    revision_review_failed: { kind: terminal, outcome: failure, inputs: { result: {} } }
+    fix_failed: { kind: terminal, outcome: failure, inputs: { result: {} } }
+    needs_human: { kind: terminal, outcome: cancelled, inputs: { result: {} } }
+
+  edges:
+    - { from: $run.input, to: prepare_repository.start }
+    - { from: prepare_repository.ready, to: analyze.repository }
+    - { from: prepare_repository.failed, to: preparation_failed.result, condition: on_failure }
+    - { from: analyze.planned, to: implement.plan }
+    - { from: analyze.failed, to: analysis_failed.result, condition: on_failure }
+    - { from: implement.implemented, to: aggregate.workers }
+    - { from: implement.failed, to: implementation_failed.result, condition: on_failure }
+    - { from: aggregate.candidate, to: review_initial.candidate }
+    - { from: aggregate.failed, to: aggregation_failed.result, condition: on_failure }
+    - { from: review_initial.reviewed, to: review_gate.state }
+    - { from: review_initial.failed, to: initial_review_failed.result, condition: on_failure }
+    - { from: review_gate.fix, to: fix.review }
+    - { from: review_gate.approved, to: done.result }
+    - { from: review_gate.exhausted, to: needs_human.result }
+    - { from: fix.fixed, to: review_revision.fixes }
+    - { from: fix.failed, to: fix_failed.result, condition: on_failure }
+    - kind: feedback
+      from: review_revision.reviewed
+      to: review_gate.state
+      max_traversals: 4
+    - { from: review_revision.failed, to: revision_review_failed.result, condition: on_failure }
+
+  policies:
+    max_nodes: 40
+    max_edges: 32
+    max_parallelism: 4
+    max_dispatches: 32
+    max_handoffs: 48
+    max_corrections_per_node: 2
+    max_edge_traversals: 4
+    max_tool_calls_per_node: 120

--- a/assets/orchestrations/auto-fix-v2.yaml.template
+++ b/assets/orchestrations/auto-fix-v2.yaml.template
@@ -236,8 +236,11 @@ spec:
         For the initial candidate set review_round to 1. For a revision, derive
         review_round as input.fixes.context.review_round + 1. Approve only when
         all acceptance criteria are met and checks/evidence are sufficient.
-        On approval return empty feedback and fix_tasks. Otherwise return clear
-        feedback and exactly one fix_tasks item containing the whole feedback.
+        Before handing off a verdict of approve, call github_pr/required_checks;
+        Manager will reject the reviewed handoff unless every immutable required
+        check passed for this dispatch. On approval return empty feedback and
+        fix_tasks. Otherwise return clear feedback and exactly one fix_tasks item
+        containing the whole feedback.
 
     fixer:
       description: DeepSeek V4 Flash dynamically generated PR fixer
@@ -247,7 +250,8 @@ spec:
         latest Draft PR head, apply all feedback in input.item, run focused
         tests, and publish file bytes only through github_pr/commit_files with
         the snapshot head as expected_head_sha. Never git push and never modify
-        .github/workflows. Hand off fixed with both previous and new head SHAs.
+        any path below .github. Hand off fixed with both previous and new head
+        SHAs.
 
   nodes:
     prepare_repository:
@@ -352,9 +356,17 @@ spec:
           inject:
             mode: manager_broker
             broker: github_pr
-            allowed_actions: [pull_request_snapshot, checks_snapshot]
+            allowed_actions: [pull_request_snapshot, checks_snapshot, required_checks]
       inputs: { candidate: { contract: Candidate } }
-      outputs: { reviewed: { contract: ReviewDecision }, failed: {} }
+      outputs:
+        reviewed:
+          contract: ReviewDecision
+          required_broker_actions:
+            - credential_ref: github-autofix
+              broker: github_pr
+              action: required_checks
+              when: { field: verdict, equals: approve }
+        failed: {}
 
     review_gate:
       kind: while
@@ -419,9 +431,17 @@ spec:
           inject:
             mode: manager_broker
             broker: github_pr
-            allowed_actions: [pull_request_snapshot, checks_snapshot]
+            allowed_actions: [pull_request_snapshot, checks_snapshot, required_checks]
       inputs: { fixes: {} }
-      outputs: { reviewed: { contract: ReviewDecision }, failed: {} }
+      outputs:
+        reviewed:
+          contract: ReviewDecision
+          required_broker_actions:
+            - credential_ref: github-autofix
+              broker: github_pr
+              action: required_checks
+              when: { field: verdict, equals: approve }
+        failed: {}
 
     done: { kind: terminal, outcome: success, inputs: { result: {} } }
     preparation_failed: { kind: terminal, outcome: failure, inputs: { result: {} } }

--- a/docs/architecture/autofix-v2.md
+++ b/docs/architecture/autofix-v2.md
@@ -1,0 +1,491 @@
+# Auto Fix v2: Document-First, Draft-PR-Backed Repair
+
+Status: Opt-in MVP implemented and locally verified; real Draft-PR pilot and
+trusted deterministic validation gate pending
+
+This document defines a replacement architecture for the current Auto Fix
+scenario. It keeps the existing workflow available for rollback and introduces
+`auto-fix-v2` as a manual, shadow-mode scenario until the new control-plane
+primitives have been proven on real Draft pull requests.
+
+The central rule is that an immutable task document is the source of truth.
+The Draft pull request is a mutable delivery surface, and model conversation
+history is never required to recover the task.
+
+The current MVP enforces immutable inputs, secure dynamic fan-out, fresh review
+sessions, and fenced PR reads/writes. It exposes trusted GitHub check snapshots
+to the reviewer, but it does not yet make successful required checks a
+Manager-enforced precondition for approval. That production hardening remains a
+pilot gate rather than an implemented invariant.
+
+## Problem Statement
+
+The current [`auto-fix.yaml.template`](../scenarios/auto-fix.md) combines issue
+sanitization, repository preparation, investigation, implementation, patch
+capture, three independent reviews, revision, re-review, arbitration,
+publication, checkpointing, validation, and Draft PR creation.
+
+The compiled workflow has 47 nodes and 70 edges against limits of 48 nodes and
+80 edges. Twenty-four nodes are terminal outcomes. The workflow also contains
+two nearly identical patch collectors for the initial implementation and the
+single revision.
+
+Recent production runs have failed at multiple unrelated layers: orchestration,
+external fetches, timeout handling, publication, and deterministic build
+validation. In one run the model reviewers approved a candidate that later
+failed the real Vite build. More review roles therefore do not solve the core
+problem: the workflow has too many states, and model consensus is being asked
+to stand in for durable task state and deterministic evidence.
+
+## Goals
+
+- Bind every run to an immutable, content-addressed task document.
+- Bind every mutable PR operation to an exact repository, PR number, branch,
+  base SHA, and expected head SHA.
+- Use K3 to produce a bounded work plan.
+- Dynamically fan out one to three independent DeepSeek V4 Flash implementers.
+- Use a DeepSeek V4 Flash aggregator to integrate worker patches.
+- Use a fresh-context GLM-5.2 reviewer for every review round.
+- Dynamically create a fresh DeepSeek V4 Flash fixer when validation or review
+  rejects the current candidate.
+- Bound the complete candidate/review loop to five rounds.
+- Give remote PR write capability only to the aggregator and fixers, through a
+  Manager-side broker. Reviewers receive read-only PR capability.
+- Preserve enough durable state to recover without an Agent transcript.
+- Put deterministic validation before model approval.
+
+## Non-Goals
+
+- Automatically approving, marking ready, merging, retargeting, or closing a
+  pull request.
+- Force-pushing or deleting a branch.
+- Passing GitHub tokens, SSH keys, or credential files into Workers.
+- Mounting arbitrary caller-selected host paths into Workers.
+- Supporting fork pull requests, cross-repository changes, or multiple PRs in
+  the first release.
+- Letting the planner emit arbitrary graph patches. The first release supports
+  a bounded list of parallel-safe work items only.
+- Replacing the current Auto Fix workflow before the pilot gates pass.
+
+## Invariants
+
+1. `task_document_sha256` never changes during a run.
+2. Every patch names the exact source tree SHA against which it was produced.
+3. Every PR write uses an `expected_head_sha` precondition and is
+   fast-forward-only.
+4. A dynamic child receives an explicit, fail-closed tool, workspace,
+   credential, and session policy.
+5. Implementers never receive remote repository credentials or PR mutation
+   tools.
+6. A model claim that a command passed is not validation evidence. Only a
+   trusted command result can satisfy a validation gate.
+7. A review round uses a new provider session and receives no prior model
+   transcript.
+8. Missing evidence, head drift, invalid contracts, exhausted rounds, and
+   incomplete validation produce explicit non-success outcomes.
+9. The final successful outcome is `ready_for_human`, not merge approval.
+
+## Proposed Flow
+
+```text
+caller creates immutable task input and identifies an existing Draft PR
+  -> bind task SHA + immutable PR base/head snapshot
+  -> K3 planner emits 1..3 parallel-safe WorkItems
+  -> dynamic DeepSeek implementers work in isolated worktrees
+  -> deterministic patch collection and safety checks
+  -> DeepSeek aggregator integrates patches in declared order
+       -> broker fast-forward pushes candidate round 1 to Draft PR
+  -> candidate round 1
+       -> deterministic required validation of the exact pushed head
+       -> fresh GLM review of task + current diff + validation evidence
+       -> approve: final evidence publication -> ready_for_human
+       -> reject: fresh DeepSeek fixer -> broker pushes next candidate round
+  -> candidate round 5 rejection: needs_human
+```
+
+One round is one candidate evaluation. A validation failure and a GLM review
+failure both consume the current round. Rounds 1 through 4 may create a fixer.
+A failure in round 5 terminates as `needs_human`; it does not create a fixer
+whose output would require a sixth evaluation.
+
+## Run Input Artifacts
+
+### Why prompt text is insufficient
+
+The current Manager Agent `create_and_run` surface accepts a workflow, profile,
+prompt, and run id. A prompt does not provide immutable file identity, durable
+content storage, or a safe way for a Worker to access a caller-local design
+document. Workers also cannot see arbitrary host paths.
+
+### Proposed API
+
+Add a staging operation that writes bounded content to Manager-owned,
+content-addressed storage:
+
+```json
+{
+  "name": "task.md",
+  "media_type": "text/markdown",
+  "content": "..."
+}
+```
+
+It returns an immutable descriptor:
+
+```json
+{
+  "artifact_id": "run-input-...",
+  "sha256": "...",
+  "size_bytes": 12345,
+  "media_type": "text/markdown"
+}
+```
+
+`create_and_run` and `start_supervised_dag` then accept bounded input bindings:
+
+```json
+{
+  "workflow_id": "auto-fix-v2",
+  "profile": "auto-fix-v2-mixed",
+  "input_artifacts": [
+    {
+      "artifact_id": "run-input-...",
+      "logical_name": "task_document",
+      "mount_path": "input/task.md"
+    }
+  ]
+}
+```
+
+Requirements:
+
+- accept at most 16 files and 1 MiB per file in the first version;
+- allow only declared text and JSON media types;
+- validate names and relative mount paths before storage;
+- bind artifacts atomically when the run is created;
+- store the descriptor and digest in immutable run provenance;
+- expose the content to Workers through a Manager/Node-controlled read-only
+  projection, never a caller-selected host bind mount;
+- expose a read-only `$run_input/<logical_name>` resolver to trusted command
+  nodes;
+- verify the digest when materializing and whenever recovery reconstructs a
+  run;
+- retain inputs at least as long as run evidence and checkpoints;
+- reject writes to the projected input path at the sandbox boundary.
+
+The task document itself should contain the objective, constraints, detailed
+design, acceptance criteria, excluded paths, and required validation. PR
+metadata belongs in the structured run input, not in the document body. Use the
+[`Auto Fix v2 task template`](../scenarios/auto-fix-v2-task-template.md) as the
+caller-facing authoring contract.
+
+## PR Binding
+
+The caller creates or selects an existing Draft PR before starting the DAG. The
+run binds this immutable context:
+
+```json
+{
+  "repo": "owner/name",
+  "pr": 123,
+  "draft": true,
+  "clone_url": "https://github.com/owner/name.git",
+  "base_ref": "main",
+  "base_sha": "...",
+  "head_branch": "autofix/task-123",
+  "head_sha": "...",
+  "task_document_sha256": "..."
+}
+```
+
+The binding command verifies that the PR is open, is a Draft, is in the same
+repository, targets an allowed base branch, and has an allowed automation head
+branch. Each successful push returns a new head SHA, which becomes the only
+valid precondition for the next round.
+
+If a human or another automation changes the PR head during a run, the run
+enters `head_drift` and stops mutating the PR. It must not silently merge,
+rebase, force-push, or re-plan against the new head. A caller may start a new run
+using the same task document revision and a new PR snapshot.
+
+## Workflow Contracts
+
+The WorkflowSpec should define these bounded contracts:
+
+| Contract | Required content |
+| --- | --- |
+| `TaskManifest` | artifact id, digest, media type, size, logical path |
+| `PRContext` | repo, PR, draft state, base/head branches and SHAs |
+| `BoundTask` | task manifest plus verified PR context and policy id |
+| `WorkPlan` | plan digest, 1..3 work items, integration order, global validation |
+| `WorkItem` | id, objective, allowed paths, acceptance checks, context paths, risk |
+| `ImplementationResult` | work item id, base SHA, patch artifact, files, tests, status |
+| `AggregateCandidate` | ordered input patch digests, candidate patch, files, tests |
+| `ValidationResult` | exact command ids, exit status, bounded logs, evidence digest |
+| `ReviewVerdict` | round, reviewed head SHA, approve/request_changes, findings |
+| `FixResult` | round, reviewed head SHA, patch artifact, resolved finding ids |
+| `LoopState` | task SHA, current PR head, round, candidate and evidence digests |
+| `AutoFixV2Result` | ready_for_human/needs_human/blocked and complete provenance |
+
+Every finding must have a stable id, severity, file, optional line, evidence,
+and a concrete expected correction. The fixer reports which finding ids it
+resolved or rejected.
+
+### Planner restrictions
+
+The K3 planner may emit one to three work items. In the first release every item
+must be parallel-safe:
+
+- no dependencies on another work item's uncommitted output;
+- an explicit allowed-path set;
+- an explicit acceptance check;
+- a declared integration order;
+- overlapping paths identified as a conflict risk.
+
+If the task cannot be represented safely, the planner emits one combined work
+item or `needs_human`. It does not request arbitrary dynamic nodes or edges.
+
+## Secure Dynamic Fan-Out
+
+The current `fanout` gateway records only a worker Agent and bounded execution
+settings. Dynamically appended child nodes do not currently inherit the full
+Agent node runtime policy.
+
+Extend the strict v1 fan-out configuration with a validated worker template:
+
+```yaml
+config:
+  input: plan
+  item_field: work_items
+  max_items: 3
+  max_parallelism: 3
+  completion: all
+  worker:
+    agent: implementer
+    session_scope: dispatch
+    allowed_builtin_tools: [Bash, Read, Write, Edit, Grep, Glob]
+    allowed_dag_tools: [handoff]
+    max_builtin_tool_calls: 50
+    workspace_access:
+      writable_paths: [worktree]
+      readonly_paths: [input, evidence]
+    credentials: []
+    workspace:
+      mode: isolated_worktree
+      source: repository
+```
+
+The exact final syntax may reuse a common `AgentRuntimePolicy` schema, but its
+semantics must be:
+
+- the compiler validates the complete template;
+- every child receives a canonical copy of it;
+- omitted tool allowlists are empty for dynamic children;
+- omitted credentials mean no credentials;
+- omitted workspace access means no writable paths;
+- only `handoff` is available unless DAG tools are declared explicitly;
+- each child has a unique logical actor, provider session, and isolated
+  worktree based on the same immutable source SHA;
+- child corrections retain the same policy and cannot broaden it;
+- runtime events expose the effective policy digest for audit.
+
+The existing `worker_agent` form may remain for compatibility, but it must not
+create write-capable or credential-bearing children through permissive defaults.
+
+## Aggregation
+
+Implementers hand off patch artifacts; they do not merge branches or push.
+Trusted patch collection verifies each artifact against its declared base SHA,
+rejects forbidden paths and binary/symlink/submodule changes, and records the
+patch digest.
+
+The DeepSeek aggregator receives the immutable task, WorkPlan, bounded worker
+reports, patches, and conflict metadata. It applies patches in the WorkPlan's
+declared order to a separate integration worktree. It may resolve integration
+conflicts and add glue changes, but all resulting changes remain subject to the
+global path policy and deterministic patch collector.
+
+The aggregator is the first model node allowed to request a PR write. It does
+so by passing the collected patch artifact and exact expected head SHA to the
+Manager broker. It never receives the underlying credential.
+
+## Deterministic Validation
+
+Each implementer runs focused checks named by its WorkItem. After the aggregator
+or fixer pushes a patch-safe candidate, and before any model review in that
+round, a trusted validation node runs the task's required repository validation
+against the exact pushed head.
+
+- A validation failure skips GLM review and becomes structured fixer input.
+- A validation success is included verbatim, within log bounds, in GLM review
+  context.
+- The validation command is selected by trusted scenario configuration, not by
+  a model.
+- The final result requires validation of the exact final PR head SHA.
+
+The Draft PR may temporarily contain a candidate that fails validation; it is a
+WIP delivery surface. This ordering still prevents model approval of code that
+has not built or tested, while keeping the PR write capability on the
+aggregator/fixer dispatch that produced the patch.
+
+## Fresh-Context Review And Fix Rounds
+
+Add a declarative dispatch-scoped session policy for Agent nodes and dynamic
+workers. `session_scope: dispatch` means:
+
+- Manager creates a new provider session id for every dispatch;
+- no provider-native transcript is resumed;
+- corrections and later loop iterations receive new session ids unless a node
+  explicitly declares another supported scope;
+- the run still retains all transcripts as audit evidence, but they are not
+  model input.
+
+GLM receives only the immutable task, current PR context and diff, current
+validation result, and bounded repository evidence. A new DeepSeek fixer
+receives those inputs plus the current structured findings. Neither receives
+previous review prose that is absent from the current contract.
+
+Tests must assert unique provider session ids, not merely different logical
+round ids.
+
+## GitHub PR Capability Broker
+
+Add a Manager-side `github_pr` broker. Recommended first-version actions:
+
+| Action | Purpose |
+| --- | --- |
+| `snapshot` | Return bounded immutable PR metadata and diff identity |
+| `read_checks` | Return checks for an exact head SHA |
+| `push_patch` | Apply a validated patch and fast-forward the bound head branch |
+| `post_comment` | Optional bounded informational comment; disabled by default |
+
+`push_patch` must enforce:
+
+- the run's exact repository, PR, base branch, and head branch binding;
+- `expected_head_sha` equals the remote PR head immediately before push;
+- the patch's declared base equals the expected head;
+- no force push and no non-fast-forward update;
+- a repository policy for allowed and forbidden paths;
+- patch size, file count, binary, symlink, submodule, and secret-path limits;
+- disabled Git hooks and credential helpers in the trusted checkout;
+- a fixed bot noreply identity and bounded commit message;
+- result provenance containing old head, new head, commit, patch digest, action,
+  run, node, session, actor generation, and timestamp.
+
+The broker must never expose token values or provider error bodies containing
+secrets. It must reject calls from nodes that lack both the
+`credential_broker_call` DAG tool and the exact declared action.
+
+### Node permission matrix
+
+| Role | Repository workspace | Built-in tools | PR broker |
+| --- | --- | --- | --- |
+| Binder | trusted command | fixed command only | `snapshot` |
+| K3 planner | read-only evidence | Read/Grep/Glob | none |
+| DeepSeek implementer | isolated worktree | bounded read/write/shell | none |
+| DeepSeek aggregator | integration worktree | bounded read/write/shell | `snapshot`, `push_patch` |
+| GLM reviewer | read-only snapshot/evidence | Read/Grep/Glob | `snapshot`, `read_checks` |
+| DeepSeek fixer | fresh integration worktree | bounded read/write/shell | `snapshot`, `push_patch` |
+| Finalizer | trusted command | fixed command only | `snapshot`, `read_checks` |
+
+Reviewer mutation is intentionally excluded. If operator-visible comments are
+required later, add only `post_comment`; never grant review approval or merge
+actions.
+
+## Model Routing
+
+The workflow remains provider-neutral. Model bindings live in a DB runtime
+profile:
+
+| Agent role | Required setting |
+| --- | --- |
+| `planner` | K3 |
+| `implementer` | DeepSeek V4 Flash |
+| `aggregator` | DeepSeek V4 Flash |
+| `fixer` | DeepSeek V4 Flash |
+| `reviewer` | GLM-5.2 |
+
+Before a real run, the stable adapter resolves each selector to exactly one
+active LLM setting, confirms the required compatible harness and endpoint, and
+runs bounded capability smokes for tool use, structured handoff, and fresh
+session behavior. DeepSeek V4 Flash is not currently a built-in catalog model,
+so the pilot must treat it as an explicitly configured custom setting rather
+than silently selecting another DeepSeek model.
+
+## Recovery And Durable State
+
+The durable loop state is data, not conversation:
+
+```text
+task document artifact + SHA
+PR binding + current expected head SHA
+WorkPlan + digest
+worker patch artifacts + digests
+aggregate/fix candidate + digest
+round number
+deterministic validation result
+current ReviewVerdict
+broker action receipts
+```
+
+On recovery:
+
+1. verify the task artifact digest;
+2. restore the exact WorkflowSpec revision and runtime profile identity;
+3. resolve the current PR head through the broker;
+4. continue only when it equals the stored expected head;
+5. otherwise enter `head_drift` and retain all evidence.
+
+Outer CI timeout handling should stop or suspend the logical run explicitly and
+retain all input, actor, handoff, patch, review, validation, and broker records.
+
+## Observability
+
+The run summary and CLI should expose:
+
+- task document digest and PR base/head binding;
+- planner model and WorkPlan digest;
+- number of fan-out children, their effective policy digests, worktree ids,
+  status, patch digest, and focused tests;
+- aggregation order and conflicts;
+- candidate round, validation status, reviewer provider session id, finding
+  ids, and fixer id;
+- every broker call with redacted input and immutable receipt;
+- final outcome and the next human action.
+
+Template listing and validation should report dynamic worker templates and
+their effective node/parallelism limits instead of showing zero nodes for a
+strict v1 template.
+
+## Pilot And Rollout
+
+1. Land the four control-plane prerequisites behind explicit feature flags.
+2. Test them with deterministic providers and a fake GitHub remote.
+3. Add `auto-fix-v2` as a new workflow id; do not change `auto-fix`.
+4. Run `dry_run` mode, which produces patches and broker requests but cannot
+   push.
+5. Select an owner-authored, low-risk Issue with an existing Draft PR, at most
+   three independent work items, and fewer than approximately twenty changed
+   files.
+6. Exclude workflows, credentials, dependency upgrades, migrations, release
+   automation, and security-sensitive infrastructure from the first pilot.
+7. Run one real Draft-PR pilot with no auto-ready or merge behavior.
+8. Expand only after at least four of five eligible pilots produce a validated
+   Draft PR within the agreed runtime budget and no capability boundary is
+   violated.
+
+The current Auto Fix workflow can be deprecated only after the pilot evidence
+shows that v2 has better completion rate, wall time, recovery, and operator
+clarity.
+
+## Open Decisions
+
+- Whether run input blobs live in the Manager database or a Manager-owned
+  content-addressed file store. The public contract should not depend on this.
+- Whether `session_scope` belongs to `AgentNode`, the reusable runtime policy,
+  or both. The canonical IR must resolve it to one explicit value.
+- Whether validation failures and model review failures share one five-round
+  budget. This proposal says yes to preserve a hard upper bound.
+- Whether reviewer comments should be posted during the pilot. The safer
+  default is to keep review evidence inside HomeRail and post only the final
+  summary after human inspection.

--- a/docs/architecture/autofix-v2.md
+++ b/docs/architecture/autofix-v2.md
@@ -1,7 +1,7 @@
 # Auto Fix v2: Document-First, Draft-PR-Backed Repair
 
-Status: Opt-in MVP implemented and locally verified; real Draft-PR pilot and
-trusted deterministic validation gate pending
+Status: Opt-in MVP implemented and locally verified; real Draft-PR pilot
+pending
 
 This document defines a replacement architecture for the current Auto Fix
 scenario. It keeps the existing workflow available for rollback and introduces
@@ -13,10 +13,10 @@ The Draft pull request is a mutable delivery surface, and model conversation
 history is never required to recover the task.
 
 The current MVP enforces immutable inputs, secure dynamic fan-out, fresh review
-sessions, and fenced PR reads/writes. It exposes trusted GitHub check snapshots
-to the reviewer, but it does not yet make successful required checks a
-Manager-enforced precondition for approval. That production hardening remains a
-pilot gate rather than an implemented invariant.
+sessions, fenced PR reads/writes, and a Manager-side required-checks approval
+gate. The gate binds an immutable list of exact GitHub check names to the
+current PR head and the current fresh reviewer dispatch. A real Draft-PR pilot
+remains necessary before production adoption.
 
 ## Problem Statement
 
@@ -83,7 +83,9 @@ to stand in for durable task state and deterministic evidence.
    transcript.
 8. Missing evidence, head drift, invalid contracts, exhausted rounds, and
    incomplete validation produce explicit non-success outcomes.
-9. The final successful outcome is `ready_for_human`, not merge approval.
+9. A handoff whose verdict is `approve` requires a successful receipt for all
+   immutable required checks from that same reviewer dispatch.
+10. The final successful outcome is `ready_for_human`, not merge approval.
 
 ## Proposed Flow
 
@@ -96,9 +98,10 @@ caller creates immutable task input and identifies an existing Draft PR
   -> DeepSeek aggregator integrates patches in declared order
        -> broker fast-forward pushes candidate round 1 to Draft PR
   -> candidate round 1
-       -> deterministic required validation of the exact pushed head
+       -> trusted required checks are evaluated on the exact pushed head
        -> fresh GLM review of task + current diff + validation evidence
-       -> approve: final evidence publication -> ready_for_human
+       -> approve: Manager verifies the current-dispatch checks receipt
+                   -> final evidence publication -> ready_for_human
        -> reject: fresh DeepSeek fixer -> broker pushes next candidate round
   -> candidate round 5 rejection: needs_human
 ```
@@ -186,15 +189,19 @@ run binds this immutable context:
 
 ```json
 {
-  "repo": "owner/name",
-  "pr": 123,
-  "draft": true,
+  "version": 1,
+  "owner": "owner",
+  "repo": "name",
+  "pull_number": 123,
   "clone_url": "https://github.com/owner/name.git",
+  "head_ref": "autofix/task-123",
   "base_ref": "main",
+  "initial_head_sha": "...",
   "base_sha": "...",
-  "head_branch": "autofix/task-123",
-  "head_sha": "...",
-  "task_document_sha256": "..."
+  "task_document_sha256": "...",
+  "require_draft": true,
+  "writable_paths": ["src", "tests"],
+  "required_checks": ["Core (Linux, Node 24)"]
 }
 ```
 
@@ -215,7 +222,7 @@ The WorkflowSpec should define these bounded contracts:
 | Contract | Required content |
 | --- | --- |
 | `TaskManifest` | artifact id, digest, media type, size, logical path |
-| `PRContext` | repo, PR, draft state, base/head branches and SHAs |
+| `PRContext` | repo, PR, draft state, base/head branches and SHAs, explicit writable prefixes, exact required-check names |
 | `BoundTask` | task manifest plus verified PR context and policy id |
 | `WorkPlan` | plan digest, 1..3 work items, integration order, global validation |
 | `WorkItem` | id, objective, allowed paths, acceptance checks, context paths, risk |
@@ -306,27 +313,32 @@ conflicts and add glue changes, but all resulting changes remain subject to the
 global path policy and deterministic patch collector.
 
 The aggregator is the first model node allowed to request a PR write. It does
-so by passing the collected patch artifact and exact expected head SHA to the
-Manager broker. It never receives the underlying credential.
+so by passing bounded file bytes and the exact expected head SHA to the Manager
+broker. It never receives the underlying credential.
 
-## Deterministic Validation
+## Trusted Required-Checks Approval Gate
 
 Each implementer runs focused checks named by its WorkItem. After the aggregator
-or fixer pushes a patch-safe candidate, and before any model review in that
-round, a trusted validation node runs the task's required repository validation
-against the exact pushed head.
+or fixer pushes a candidate, trusted repository validation publishes GitHub
+check runs on that exact head. The immutable `PRContext.required_checks` list is
+selected by the caller, not by a model.
 
-- A validation failure skips GLM review and becomes structured fixer input.
-- A validation success is included verbatim, within log bounds, in GLM review
-  context.
-- The validation command is selected by trusted scenario configuration, not by
-  a model.
-- The final result requires validation of the exact final PR head SHA.
+- `checks_snapshot` provides bounded evidence to GLM but cannot authorize an
+  approval.
+- Before handing off `verdict: approve`, the fresh reviewer dispatch must call
+  `required_checks` through its read-only Manager broker capability.
+- The broker requires the newest run for every exact configured check name to
+  be `completed` with conclusion `success` on the bound current head.
+- Runtime records only a bounded action receipt, never the credential or
+  provider body, and accepts it only for the same node provider session.
+- The handoff requirement is conditional on the structured verdict, so changing
+  an output port cannot bypass the approval fence.
 
 The Draft PR may temporarily contain a candidate that fails validation; it is a
-WIP delivery surface. This ordering still prevents model approval of code that
-has not built or tested, while keeping the PR write capability on the
-aggregator/fixer dispatch that produced the patch.
+WIP delivery surface. Missing, pending, cancelled, or failed checks block only
+approval, so GLM can still request a bounded fix. In this repository Draft PR
+CI is skipped by default, so the operator must manually dispatch trusted CI on
+the exact automation head branch before an approval can complete.
 
 ## Fresh-Context Review And Fix Rounds
 
@@ -345,32 +357,40 @@ validation result, and bounded repository evidence. A new DeepSeek fixer
 receives those inputs plus the current structured findings. Neither receives
 previous review prose that is absent from the current contract.
 
+An approval receipt from one dispatch is not valid in a later dispatch, even
+when it is the same logical review node after recovery or a loop iteration.
+
 Tests must assert unique provider session ids, not merely different logical
 round ids.
 
 ## GitHub PR Capability Broker
 
-Add a Manager-side `github_pr` broker. Recommended first-version actions:
+The Manager-side `github_pr` broker implements these first-version actions:
 
 | Action | Purpose |
 | --- | --- |
-| `snapshot` | Return bounded immutable PR metadata and diff identity |
-| `read_checks` | Return checks for an exact head SHA |
-| `push_patch` | Apply a validated patch and fast-forward the bound head branch |
-| `post_comment` | Optional bounded informational comment; disabled by default |
+| `pull_request_snapshot` | Return bounded immutable PR metadata and diff identity |
+| `checks_snapshot` | Return bounded checks for the current exact head SHA |
+| `required_checks` | Fail unless every immutable required check succeeds on that head |
+| `commit_files` | Create bounded blobs/tree/commit and fast-forward the bound head branch |
 
-`push_patch` must enforce:
+`commit_files` enforces:
 
 - the run's exact repository, PR, base branch, and head branch binding;
 - `expected_head_sha` equals the remote PR head immediately before push;
-- the patch's declared base equals the expected head;
 - no force push and no non-fast-forward update;
-- a repository policy for allowed and forbidden paths;
-- patch size, file count, binary, symlink, submodule, and secret-path limits;
-- disabled Git hooks and credential helpers in the trusted checkout;
-- a fixed bot noreply identity and bounded commit message;
-- result provenance containing old head, new head, commit, patch digest, action,
-  run, node, session, actor generation, and timestamp.
+- explicit writable prefixes (`"."` is invalid) and an unconditional deny for
+  `.github/**`, `.git/**`, and mounted input paths;
+- at most 64 unique regular-file paths and 1 MiB total decoded bytes;
+- regular or executable blob modes only, with no delete, symlink, or submodule
+  operation;
+- a bounded single-line commit message;
+- durable current/pending-head reconciliation across Manager recovery.
+
+GitHub's blob/tree/commit/ref calls are not atomic as a group. A failure before
+the final non-force ref update may leave unreachable Git objects, but cannot
+advance the PR head. File/byte bounds, expected-head recovery, and operator
+rate-limit discipline keep this failure mode bounded.
 
 The broker must never expose token values or provider error bodies containing
 secrets. It must reject calls from nodes that lack both the
@@ -380,13 +400,13 @@ secrets. It must reject calls from nodes that lack both the
 
 | Role | Repository workspace | Built-in tools | PR broker |
 | --- | --- | --- | --- |
-| Binder | trusted command | fixed command only | `snapshot` |
+| Binder | trusted command | fixed command only | `pull_request_snapshot` |
 | K3 planner | read-only evidence | Read/Grep/Glob | none |
 | DeepSeek implementer | isolated worktree | bounded read/write/shell | none |
-| DeepSeek aggregator | integration worktree | bounded read/write/shell | `snapshot`, `push_patch` |
-| GLM reviewer | read-only snapshot/evidence | Read/Grep/Glob | `snapshot`, `read_checks` |
-| DeepSeek fixer | fresh integration worktree | bounded read/write/shell | `snapshot`, `push_patch` |
-| Finalizer | trusted command | fixed command only | `snapshot`, `read_checks` |
+| DeepSeek aggregator | integration worktree | bounded read/write/shell | `pull_request_snapshot`, `commit_files` |
+| GLM reviewer | read-only snapshot/evidence | Read/Grep/Glob | `pull_request_snapshot`, `checks_snapshot`, `required_checks` |
+| DeepSeek fixer | fresh integration worktree | bounded read/write/shell | `pull_request_snapshot`, `commit_files` |
+| Finalizer | trusted command | fixed command only | `pull_request_snapshot`, `required_checks` |
 
 Reviewer mutation is intentionally excluded. If operator-visible comments are
 required later, add only `post_comment`; never grant review approval or merge
@@ -467,7 +487,7 @@ strict v1 template.
 5. Select an owner-authored, low-risk Issue with an existing Draft PR, at most
    three independent work items, and fewer than approximately twenty changed
    files.
-6. Exclude workflows, credentials, dependency upgrades, migrations, release
+6. Exclude `.github/**`, credentials, dependency upgrades, migrations, release
    automation, and security-sensitive infrastructure from the first pilot.
 7. Run one real Draft-PR pilot with no auto-ready or merge behavior.
 8. Expand only after at least four of five eligible pilots produce a validated

--- a/docs/architecture/autofix-v2.md
+++ b/docs/architecture/autofix-v2.md
@@ -254,11 +254,12 @@ item or `needs_human`. It does not request arbitrary dynamic nodes or edges.
 
 ## Secure Dynamic Fan-Out
 
-The current `fanout` gateway records only a worker Agent and bounded execution
-settings. Dynamically appended child nodes do not currently inherit the full
-Agent node runtime policy.
+The v1 `fanout` gateway records a bounded worker Agent policy and materializes
+that policy onto every dynamically appended child node.
 
-Extend the strict v1 fan-out configuration with a validated worker template:
+The strict v1 fan-out configuration uses a validated worker policy. An
+isolated Git worktree must opt in with the reserved
+`{{fanout_workspace}}` placeholder:
 
 ```yaml
 config:
@@ -267,29 +268,32 @@ config:
   max_items: 3
   max_parallelism: 3
   completion: all
-  worker:
-    agent: implementer
+  worker_agent: implementer
+  worker_policy:
     session_scope: dispatch
     allowed_builtin_tools: [Bash, Read, Write, Edit, Grep, Glob]
     allowed_dag_tools: [handoff]
     max_builtin_tool_calls: 50
     workspace_access:
-      writable_paths: [worktree]
+      writable_paths: ["{{fanout_workspace}}"]
       readonly_paths: [input, evidence]
     credentials: []
-    workspace:
-      mode: isolated_worktree
-      source: repository
+  workspace_strategy: isolated_git_worktree
+  workspace_root: workers
+  repository_path: repo
 ```
 
-The exact final syntax may reuse a common `AgentRuntimePolicy` schema, but its
-semantics must be:
+Its semantics are:
 
 - the compiler validates the complete template;
 - every child receives a canonical copy of it;
 - omitted tool allowlists are empty for dynamic children;
 - omitted credentials mean no credentials;
 - omitted workspace access means no writable paths;
+- `isolated_git_worktree` is rejected unless the worker policy declares
+  exactly `{{fanout_workspace}}`; Manager replaces that placeholder with the
+  unique child worktree path before dispatch, so isolation does not imply a
+  hidden write grant;
 - only `handoff` is available unless DAG tools are declared explicitly;
 - each child has a unique logical actor, provider session, and isolated
   worktree based on the same immutable source SHA;
@@ -345,10 +349,13 @@ the exact automation head branch before an approval can complete.
 Add a declarative dispatch-scoped session policy for Agent nodes and dynamic
 workers. `session_scope: dispatch` means:
 
-- Manager creates a new provider session id for every dispatch;
+- Manager creates a new provider session id for every completed node re-entry
+  or review/fix round;
 - no provider-native transcript is resumed;
-- corrections and later loop iterations receive new session ids unless a node
-  explicitly declares another supported scope;
+- a bounded handoff-contract correction retains the same provider session and
+  same-session broker receipts because it retries the rejected logical
+  dispatch; after a valid handoff, the next loop iteration receives a fresh
+  session id;
 - the run still retains all transcripts as audit evidence, but they are not
   model input.
 
@@ -357,8 +364,12 @@ validation result, and bounded repository evidence. A new DeepSeek fixer
 receives those inputs plus the current structured findings. Neither receives
 previous review prose that is absent from the current contract.
 
-An approval receipt from one dispatch is not valid in a later dispatch, even
-when it is the same logical review node after recovery or a loop iteration.
+An approval receipt from one completed dispatch is not valid in a later review
+round, even when it is the same logical review node after recovery or a loop
+iteration. A correction of that dispatch may reuse its already-recorded receipt
+or repeat only the specifically declared broker verification action in the same
+session before handing off; it cannot use built-in tools, mutate the PR, or
+broaden the permitted broker actions.
 
 Tests must assert unique provider session ids, not merely different logical
 round ids.

--- a/docs/autofix-v2-implementation-plan.md
+++ b/docs/autofix-v2-implementation-plan.md
@@ -1,0 +1,383 @@
+# Auto Fix v2 Implementation Plan
+
+Proposed GitHub Issue title:
+
+> feat(autofix-v2): document-first Draft-PR repair DAG with secure dynamic fan-out
+
+Status: Opt-in MVP implemented and locally verified on 2026-08-01. The real
+Draft-PR pilot and production adoption gates remain open. This is the umbrella
+delivery plan for [`Auto Fix v2`](architecture/autofix-v2.md); it does not
+authorize replacing the existing `auto-fix` workflow or enabling automatic PR
+publication.
+
+## Implementation checkpoint (2026-08-01)
+
+Implemented in the MVP:
+
+- content-addressed, immutable run inputs with read-only Worker projection and
+  recovery verification;
+- fail-closed dynamic worker policy inheritance, unique repeated-fanout node
+  ids, and isolated Git worktrees;
+- `session_scope: dispatch` for transcript-free review re-entry;
+- a Manager-only `github_pr` broker for bounded PR/files/check snapshots and
+  expected-head, non-force file commits;
+- an opt-in eight-static-node `auto-fix-v2` WorkflowSpec, mixed-model profile
+  configurator, CLI input staging, operator runbook, and deterministic fake
+  remote/recovery proof.
+
+Required before the first real Issue #172 pilot:
+
+- create the same-repository Draft PR and immutable `pr-context.json`;
+- install `github-autofix` as an encrypted fine-grained PAT or GitHub App
+  credential;
+- verify the stable Manager still has active, runnable K3, DeepSeek V4 Flash,
+  and GLM-5.2 settings after deploying the v2-capable release;
+- sync the opt-in workflow and mixed-model profile, then run a
+  broker-write-disabled real PR snapshot dry run;
+- add a trusted validation gateway that prevents approval unless required
+  checks for the exact current head are complete and successful. The MVP
+  exposes `checks_snapshot` to GLM but does not make that result an
+  orchestration-level approval fence.
+
+## Outcome
+
+Deliver a manual `auto-fix-v2` workflow in which:
+
+- a caller stages an immutable local task document and binds it to a Draft PR;
+- K3 creates a bounded plan of one to three parallel-safe work items;
+- dynamically created DeepSeek V4 Flash implementers work without remote
+  credentials in isolated worktrees;
+- a DeepSeek V4 Flash aggregator integrates their patches;
+- deterministic validation runs before review;
+- GLM-5.2 reviews each candidate with a fresh provider context;
+- a new DeepSeek V4 Flash fixer handles each rejected round;
+- no more than five candidate/review rounds run;
+- only the aggregator and fixers can request fast-forward PR writes through a
+  least-privilege Manager broker;
+- the successful outcome remains a Draft PR marked `ready_for_human` in
+  HomeRail, not approved or merged on GitHub.
+
+## Delivery Rules
+
+- Keep `assets/orchestrations/auto-fix.yaml.template` and workflow id
+  `auto-fix` unchanged during the pilot.
+- Introduce a new workflow id, profile id, scenario documentation, and trigger.
+- Keep provider/model names out of WorkflowSpec. Bind active LLM setting ids in
+  the runtime profile.
+- Never store provider or GitHub secrets in repository files, workflow source,
+  run prompts, artifacts, comments, or logs.
+- Treat every task document, PR body, comment, diff, patch, and model output as
+  untrusted input.
+- Keep Manager changes inside lifecycle, persistence, public API, provider
+  routing, or stable inspection/mutation boundaries.
+- Require deterministic evidence for every hard gate.
+
+## Phase 0: Freeze And Characterize
+
+### AFV2-001: Record the current Auto Fix baseline
+
+- [ ] Add a fixture that asserts the current compiled node/edge/kind counts.
+- [ ] Record the five observed production failure classes without embedding
+      private logs or credentials.
+- [ ] Characterize current candidate checkpoint recovery and Draft PR adapter
+      behavior.
+- [ ] Add a regression assertion that v2 work does not change workflow id
+      `auto-fix` or its existing runtime graph.
+
+Done when the existing scenario has a stable compatibility baseline and can be
+kept as a rollback path.
+
+## Phase 1: Immutable Run Inputs
+
+### AFV2-101: Persist content-addressed run input artifacts
+
+- [ ] Define the public protocol descriptor and bounded staging request.
+- [ ] Persist immutable metadata and content digest under Manager ownership.
+- [ ] Enforce file count, size, media type, name, and relative-path limits.
+- [ ] Bind staged artifact ids atomically to a newly created run.
+- [ ] Retain inputs with run evidence and apply the existing redaction rules.
+- [ ] Reject an artifact id owned by another project/caller scope.
+
+Likely code areas:
+
+- `homerail_protocol/src/manager-agent-tools.ts`
+- Manager run-creation protocol and persistence modules
+- Manager Agent tool implementations
+- CLI `run` and supervised-run argument handling
+
+### AFV2-102: Project run inputs read-only
+
+- [ ] Expose logical inputs at a stable `$run_input/<logical_name>` resolver.
+- [ ] Materialize or mount Worker input paths read-only through Manager/Node
+      policy, never through arbitrary caller host paths.
+- [ ] Verify the content digest before first dispatch and cold recovery.
+- [ ] Reject traversal, symlink, remount, overwrite, and mutable-alias attacks.
+- [ ] Expose input descriptors and digests through run inspection.
+
+Tests:
+
+- [ ] staging and idempotent content-addressing;
+- [ ] atomic run binding and recovery;
+- [ ] size, type, path, and project-scope rejection;
+- [ ] write denial from Agent and command nodes;
+- [ ] Worker cannot access any unstaged host path.
+
+## Phase 2: Secure Dynamic Workers
+
+### AFV2-201: Add a canonical fan-out worker runtime policy
+
+- [ ] Add a strict WorkflowSpec worker template or node reference containing
+      Agent, tool, workspace, credential, call-budget, and session policy.
+- [ ] Compile the worker policy into canonical IR and include it in workflow
+      hashing.
+- [ ] Copy the canonical policy to every dynamically appended child.
+- [ ] Make dynamic-child defaults fail closed.
+- [ ] Preserve the effective policy across correction and replay.
+- [ ] Persist and expose an effective policy digest per child.
+
+Likely code areas:
+
+- `homerail_manager/src/orchestration/workflow-spec-v1-schema.ts`
+- `homerail_manager/src/orchestration/workflow-spec-v1.ts`
+- `homerail_manager/src/runtime/active-runs.ts`
+- dispatch capability and runtime-policy projection
+
+Tests:
+
+- [ ] child inherits exact built-in and DAG tool allowlists;
+- [ ] child inherits workspace restrictions and tool-call budget;
+- [ ] child cannot acquire undeclared credentials or broker actions;
+- [ ] correction and recovery do not widen policy;
+- [ ] old `worker_agent` workflows remain compatible without permissive
+      write/credential defaults.
+
+### AFV2-202: Add isolated fan-out worktrees
+
+- [ ] Create one credential-free worktree or equivalent immutable snapshot per
+      dynamic child from the same source SHA.
+- [ ] Restrict each child to its own writable root.
+- [ ] Return bounded patch artifacts instead of shared working-tree mutations.
+- [ ] Clean up physical worktrees without deleting durable patch evidence.
+- [ ] Detect overlapping files and provide deterministic conflict metadata to
+      aggregation.
+
+Tests:
+
+- [ ] two workers editing the same path cannot race through a shared checkout;
+- [ ] one worker cannot read or write another worker's private mutable state;
+- [ ] all patch artifacts declare the same expected base SHA;
+- [ ] cleanup is safe after success, failure, timeout, and Manager restart.
+
+## Phase 3: Fresh Dispatch Context
+
+### AFV2-301: Add explicit provider session scope
+
+- [ ] Add `session_scope: dispatch` to the reusable Agent runtime policy.
+- [ ] Allocate a new provider session id for every dispatch and loop iteration.
+- [ ] Prevent provider-native transcript resume in dispatch scope.
+- [ ] Retain transcript evidence without feeding it into the next dispatch.
+- [ ] Make the selected scope visible through run/node inspection.
+
+Tests:
+
+- [ ] repeated execution of one logical review node uses distinct provider
+      session ids;
+- [ ] a dynamic fixer gets a new provider session;
+- [ ] review prompts contain only declared task, PR, validation, and finding
+      inputs;
+- [ ] restart/replay cannot accidentally resume an old provider transcript.
+
+## Phase 4: GitHub PR Capability Broker
+
+### AFV2-401: Implement read-only PR snapshots
+
+- [ ] Add a `github_pr` Manager broker with `snapshot` and `read_checks`.
+- [ ] Bind repo, PR, Draft state, base branch/SHA, head branch/SHA, and policy id
+      to the run.
+- [ ] Reject fork PRs, non-Draft PRs, disallowed branches, closed PRs, and
+      mismatched repositories in the pilot.
+- [ ] Return bounded, redacted, immutable receipts.
+
+### AFV2-402: Implement fast-forward `push_patch`
+
+- [ ] Accept only a persisted patch artifact and exact `expected_head_sha`.
+- [ ] Revalidate path, file count, size, binary, symlink, submodule, and secret
+      restrictions in trusted code.
+- [ ] Apply the patch to a fresh trusted checkout with hooks and credential
+      helpers disabled.
+- [ ] Commit with a fixed bot noreply identity.
+- [ ] Re-read the remote head immediately before a fast-forward-only push.
+- [ ] Return old/new head, commit, patch digest, run/node/session/generation, and
+      timestamp in an immutable receipt.
+- [ ] Reject force push, merge, approve, ready, close, retarget, branch delete,
+      and arbitrary GitHub API operations.
+
+Tests:
+
+- [ ] unauthorized node and action rejection;
+- [ ] secret values never enter Worker input, error output, or audit events;
+- [ ] expected-head mismatch produces `head_drift` and no push;
+- [ ] forbidden paths and malformed patches are rejected twice: collection and
+      broker application;
+- [ ] concurrent push race cannot overwrite a remote commit;
+- [ ] exact idempotent retry returns the original receipt.
+
+## Phase 5: Auto Fix v2 Workflow
+
+### AFV2-501: Define bounded workflow contracts
+
+- [ ] Adopt the caller-facing
+      [`task document template`](scenarios/auto-fix-v2-task-template.md) and
+      validate that its staged digest is the run's task identity.
+- [ ] Add `TaskManifest`, `PRContext`, `BoundTask`, `WorkPlan`, `WorkItem`,
+      `ImplementationResult`, `AggregateCandidate`, `ValidationResult`,
+      `ReviewVerdict`, `FixResult`, `LoopState`, and `AutoFixV2Result`.
+- [ ] Bound every string, array, patch, log, finding set, file set, and round.
+- [ ] Require stable finding ids and exact source/head SHAs.
+- [ ] Reject incomplete success handoffs rather than synthesizing success.
+
+### AFV2-502: Build the planner and implementation fan-out
+
+- [ ] K3 emits one to three independent WorkItems or `needs_human`.
+- [ ] Reject arbitrary graph mutation and dependent parallel tasks.
+- [ ] Dynamically create one DeepSeek V4 Flash implementer per item.
+- [ ] Run each child in its isolated worktree without a PR broker.
+- [ ] Capture and validate one patch artifact per successful child.
+
+### AFV2-503: Build aggregation and validation
+
+- [ ] Apply worker patches in the WorkPlan's declared order.
+- [ ] Give DeepSeek V4 Flash an integration worktree and bounded conflict
+      metadata.
+- [ ] Deterministically collect the aggregate patch.
+- [ ] Let the aggregator push the patch-safe first candidate through the
+      fenced broker.
+- [ ] Run trusted repository validation against the exact pushed head before
+      any GLM review.
+- [ ] Convert validation failures into structured fixer findings.
+
+### AFV2-504: Build the five-round review/fix loop
+
+- [ ] Push each collected candidate through `push_patch` using exact head
+      fencing; a Draft PR may temporarily hold a candidate that later fails
+      validation.
+- [ ] Dispatch GLM-5.2 with fresh context against the exact pushed head.
+- [ ] On rejection, dynamically create one fresh DeepSeek V4 Flash fixer.
+- [ ] Make every fix produce a new validated patch and broker receipt.
+- [ ] Allow fixers after rounds 1 through 4 only.
+- [ ] End a round-5 failure as `needs_human` with complete evidence.
+- [ ] End approval as `ready_for_human`; never change Draft state.
+
+### AFV2-505: Add the mixed-model runtime profile
+
+- [ ] Resolve one active K3 setting for `planner`.
+- [ ] Resolve one active DeepSeek V4 Flash setting for `implementer`,
+      `aggregator`, and `fixer`.
+- [ ] Resolve one active GLM-5.2 setting for `reviewer`.
+- [ ] Require the compatible harness and endpoint for every setting.
+- [ ] Add preflight smokes for built-in tools, structured handoff, and fresh
+      context.
+- [ ] Fail explicitly when DeepSeek V4 Flash is unavailable; do not substitute
+      `deepseek-chat`, `deepseek-reasoner`, or another model.
+
+Likely new assets:
+
+- `assets/orchestrations/auto-fix-v2.yaml.template`
+- `scripts/configure-auto-fix-v2-runtime-profile.mjs`
+- `docs/scenarios/auto-fix-v2.md`
+
+## Phase 6: Evidence, CLI, And Recovery
+
+### AFV2-601: Make the run inspectable
+
+- [ ] Show task digest, PR binding, current expected head, round, WorkPlan
+      digest, dynamic children, policy digests, patches, validation, findings,
+      fixers, and broker receipts in supported inspection surfaces.
+- [ ] Make `hr templates list` report strict v1 static nodes and bounded dynamic
+      worker capacity accurately.
+- [ ] Ensure `hr dag quick`, chats, handoffs, scorecard, eval-run, and replay
+      retain enough evidence to explain every terminal outcome.
+
+### AFV2-602: Recover without transcript state
+
+- [ ] Recover from task artifact, workflow revision, profile identity, PR head,
+      WorkPlan, patches, loop state, and receipts.
+- [ ] Continue only when task digest and current PR head match durable state.
+- [ ] Preserve and report `head_drift`, expired input, invalid artifact, and
+      missing-evidence outcomes.
+- [ ] Stop or suspend the logical run explicitly when the outer CI job times
+      out.
+
+## Phase 7: Pilot
+
+### AFV2-701: Deterministic and fake-remote proof
+
+- [ ] Run schema, compiler, policy, recovery, and broker tests with deterministic
+      Agents and a local fake Git remote.
+- [ ] Demonstrate at least two fan-out children and one rejected review/fix
+      round.
+- [ ] Demonstrate denial of an implementer PR write and denial of a Reviewer
+      push.
+- [ ] Demonstrate round-5 `needs_human` without a sixth candidate.
+
+### AFV2-702: Dry-run shadow mode
+
+- [ ] Run against a real Draft PR snapshot with broker writes disabled.
+- [ ] Produce the exact patches and broker requests that would have occurred.
+- [ ] Verify no remote mutation and complete retained evidence.
+
+### AFV2-703: First real Draft-PR pilot
+
+Select an owner-authored task with:
+
+- [ ] one to three independent work items;
+- [ ] fewer than approximately twenty changed files;
+- [ ] no workflow, credential, dependency, migration, release, or
+      security-sensitive infrastructure changes;
+- [ ] a pre-created same-repository Draft PR and automation-owned head branch;
+- [ ] explicit deterministic validation commands in the task document.
+
+As of 2026-08-01, the recommended multi-worker pilot candidate is
+[`xiaotianfotos/homerail#172`](https://github.com/xiaotianfotos/homerail/issues/172).
+It has two parallel-safe work areas: deterministic reviewer-identity
+canonicalization and terminal-state classification. It has concrete production
+evidence and regression criteria, and does not require credentials, migrations,
+dependency changes, release automation, or GitHub workflow edits. The caller
+must still create a new same-repository Draft PR and revalidate the Issue state
+before the run starts.
+
+The pilot passes when:
+
+- [ ] the immutable task digest remains stable across the complete run;
+- [ ] every implementation child is isolated and credential-free;
+- [ ] every GLM review has a distinct provider session;
+- [ ] at least one candidate is pushed fast-forward through the broker;
+- [ ] the exact final head passes deterministic validation;
+- [ ] the PR remains Draft and unapproved;
+- [ ] the result is `ready_for_human` with complete evidence;
+- [ ] no capability policy violation occurs.
+
+## Adoption Gate
+
+Do not replace the current workflow until at least four of five eligible pilot
+tasks:
+
+- produce a deterministically validated Draft PR;
+- complete within the agreed wall-time budget;
+- survive retry/recovery without task loss;
+- require no hidden credentials or host mounts;
+- produce an operator-readable terminal reason;
+- show zero unauthorized PR operations or workspace-policy violations.
+
+After the gate, decide separately whether to deprecate `auto-fix`, retain it as
+a compatibility fixture, or migrate its public trigger to v2.
+
+## Explicitly Out Of Scope
+
+- automatic merge, approval, ready-for-review transition, or branch deletion;
+- force push or conflict resolution against human head drift;
+- arbitrary host mounts and caller-selected shell commands;
+- fork or cross-repository PRs;
+- more than three initial implementation children;
+- arbitrary planner-generated graphs or dependent child DAGs;
+- self-hosting the first pilot by asking Auto Fix v2 to implement itself.

--- a/docs/autofix-v2-implementation-plan.md
+++ b/docs/autofix-v2-implementation-plan.md
@@ -4,13 +4,13 @@ Proposed GitHub Issue title:
 
 > feat(autofix-v2): document-first Draft-PR repair DAG with secure dynamic fan-out
 
-Status: Opt-in MVP implemented and locally verified on 2026-08-01. The real
+Status: Opt-in MVP implemented and locally verified on 2026-08-02. The real
 Draft-PR pilot and production adoption gates remain open. This is the umbrella
 delivery plan for [`Auto Fix v2`](architecture/autofix-v2.md); it does not
 authorize replacing the existing `auto-fix` workflow or enabling automatic PR
 publication.
 
-## Implementation checkpoint (2026-08-01)
+## Implementation checkpoint (2026-08-02)
 
 Implemented in the MVP:
 
@@ -19,8 +19,12 @@ Implemented in the MVP:
 - fail-closed dynamic worker policy inheritance, unique repeated-fanout node
   ids, and isolated Git worktrees;
 - `session_scope: dispatch` for transcript-free review re-entry;
-- a Manager-only `github_pr` broker for bounded PR/files/check snapshots and
-  expected-head, non-force file commits;
+- a Manager-only `github_pr` broker for bounded PR/files/check snapshots,
+  exact-head required-check enforcement, and expected-head, non-force file
+  commits;
+- generic conditional output handoff requirements backed by same-dispatch
+  Manager-broker action receipts, used to prevent `approve` when an immutable
+  required check is missing or unsuccessful;
 - an opt-in eight-static-node `auto-fix-v2` WorkflowSpec, mixed-model profile
   configurator, CLI input staging, operator runbook, and deterministic fake
   remote/recovery proof.
@@ -34,10 +38,10 @@ Required before the first real Issue #172 pilot:
   and GLM-5.2 settings after deploying the v2-capable release;
 - sync the opt-in workflow and mixed-model profile, then run a
   broker-write-disabled real PR snapshot dry run;
-- add a trusted validation gateway that prevents approval unless required
-  checks for the exact current head are complete and successful. The MVP
-  exposes `checks_snapshot` to GLM but does not make that result an
-  orchestration-level approval fence.
+- configure immutable exact required-check names in `pr-context.json` and
+  arrange trusted CI to publish those checks on the exact Draft head. This
+  repository skips Draft PR CI by default, so the pilot operator must manually
+  dispatch CI with the Draft head branch selected before approval can complete.
 
 ## Outcome
 
@@ -48,7 +52,7 @@ Deliver a manual `auto-fix-v2` workflow in which:
 - dynamically created DeepSeek V4 Flash implementers work without remote
   credentials in isolated worktrees;
 - a DeepSeek V4 Flash aggregator integrates their patches;
-- deterministic validation runs before review;
+- exact-head required checks form a Manager-enforced approval fence;
 - GLM-5.2 reviews each candidate with a fresh provider context;
 - a new DeepSeek V4 Flash fixer handles each rejected round;
 - no more than five candidate/review rounds run;
@@ -189,23 +193,25 @@ Tests:
 
 ## Phase 4: GitHub PR Capability Broker
 
-### AFV2-401: Implement read-only PR snapshots
+### AFV2-401: Implement read-only PR and check gates
 
-- [ ] Add a `github_pr` Manager broker with `snapshot` and `read_checks`.
+- [ ] Add a `github_pr` Manager broker with `pull_request_snapshot`,
+      `checks_snapshot`, and `required_checks`.
 - [ ] Bind repo, PR, Draft state, base branch/SHA, head branch/SHA, and policy id
       to the run.
 - [ ] Reject fork PRs, non-Draft PRs, disallowed branches, closed PRs, and
       mismatched repositories in the pilot.
 - [ ] Return bounded, redacted, immutable receipts.
+- [ ] Reject an approval handoff unless the same reviewer dispatch has a
+      successful `required_checks` receipt for the exact current head.
 
-### AFV2-402: Implement fast-forward `push_patch`
+### AFV2-402: Implement fast-forward `commit_files`
 
-- [ ] Accept only a persisted patch artifact and exact `expected_head_sha`.
+- [ ] Accept only bounded file bytes and an exact `expected_head_sha`.
 - [ ] Revalidate path, file count, size, binary, symlink, submodule, and secret
       restrictions in trusted code.
-- [ ] Apply the patch to a fresh trusted checkout with hooks and credential
-      helpers disabled.
-- [ ] Commit with a fixed bot noreply identity.
+- [ ] Create bounded Git blobs, a tree, and a commit without giving the Worker
+      a checkout credential or Git transport.
 - [ ] Re-read the remote head immediately before a fast-forward-only push.
 - [ ] Return old/new head, commit, patch digest, run/node/session/generation, and
       timestamp in an immutable receipt.
@@ -258,7 +264,7 @@ Tests:
 
 ### AFV2-504: Build the five-round review/fix loop
 
-- [ ] Push each collected candidate through `push_patch` using exact head
+- [ ] Push each collected candidate through `commit_files` using exact head
       fencing; a Draft PR may temporarily hold a candidate that later fails
       validation.
 - [ ] Dispatch GLM-5.2 with fresh context against the exact pushed head.

--- a/docs/autofix-v2-implementation-plan.md
+++ b/docs/autofix-v2-implementation-plan.md
@@ -177,7 +177,9 @@ Tests:
 ### AFV2-301: Add explicit provider session scope
 
 - [ ] Add `session_scope: dispatch` to the reusable Agent runtime policy.
-- [ ] Allocate a new provider session id for every dispatch and loop iteration.
+- [ ] Allocate a new provider session id for every completed node re-entry and
+      loop iteration; keep bounded handoff corrections in the same logical
+      dispatch so same-session verification receipts remain recoverable.
 - [ ] Prevent provider-native transcript resume in dispatch scope.
 - [ ] Retain transcript evidence without feeding it into the next dispatch.
 - [ ] Make the selected scope visible through run/node inspection.

--- a/docs/scenarios/auto-fix-v2-task-template.md
+++ b/docs/scenarios/auto-fix-v2-task-template.md
@@ -77,13 +77,15 @@ Layer Decision:
 
 ### Explicitly forbidden paths
 
-- `.github/workflows/**`
+- `.github/**`
 - `.gitmodules`
 - credential, secret, signing-key, and private environment files
 - `<task-specific forbidden path>`
 
 The runtime repository policy remains authoritative and may be stricter than
 this list. This document cannot grant access that the run policy denies.
+Allowed paths must be explicit repository-relative prefixes;
+`writable_paths: ["."]` is rejected.
 
 ## Work Decomposition Guidance
 

--- a/docs/scenarios/auto-fix-v2-task-template.md
+++ b/docs/scenarios/auto-fix-v2-task-template.md
@@ -1,0 +1,130 @@
+# Auto Fix v2 Task Document Template
+
+This template is the human-readable source document staged as the immutable
+`task_document` input of an Auto Fix v2 run. The caller may generate it through
+Manager Agent or another trusted client, but must review it before staging.
+
+The run binds the staged document by SHA-256. Do not edit the staged content in
+place. A task change creates a new document revision and a new run.
+
+PR number, repository, branches, base/head SHAs, credentials, and executable
+validation commands are structured control-plane inputs. They must not be
+copied into this document as authoritative runtime configuration.
+
+---
+
+# <Task title>
+
+## Task Identity
+
+- Source Issue: `<owner/repository>#<number>`
+- Task revision: `<caller-defined revision>`
+- Prepared by: `<Manager Agent, person, or external caller>`
+- Prepared at: `<ISO-8601 timestamp>`
+
+These fields are provenance for readers. The staged artifact digest is the
+runtime identity.
+
+## Objective
+
+Describe one concrete outcome. State what a user or operator can do after the
+change that they cannot do now.
+
+## Current Behavior And Evidence
+
+Describe the observed behavior and why it is wrong or incomplete. Include
+bounded, reproducible evidence such as relevant files, failing test names,
+error categories, or public references. Separate verified facts from
+assumptions.
+
+## Desired Behavior
+
+Describe the expected externally visible and internal behavior. Include failure
+and recovery behavior where relevant.
+
+## Proposed Design
+
+Provide the implementation direction in enough detail that the K3 planner can
+divide it without rediscovering the architecture. Identify the preferred
+product layer and explain any Manager change under the allowed Manager
+categories.
+
+```text
+Layer Decision:
+- Problem layer:
+- Preferred fix layer:
+- Manager touched: yes/no
+- Manager Change Justification: <allowed category or n/a>
+- Rejected shortcuts:
+- Public entry path:
+- Validation path:
+```
+
+## Required Invariants
+
+- `<invariant that must remain true>`
+- `<security, compatibility, persistence, or recovery invariant>`
+
+## Repository Scope
+
+### Allowed paths
+
+- `<path or bounded path prefix>`
+
+### Read-only context paths
+
+- `<path or bounded path prefix>`
+
+### Explicitly forbidden paths
+
+- `.github/workflows/**`
+- `.gitmodules`
+- credential, secret, signing-key, and private environment files
+- `<task-specific forbidden path>`
+
+The runtime repository policy remains authoritative and may be stricter than
+this list. This document cannot grant access that the run policy denies.
+
+## Work Decomposition Guidance
+
+List likely independent areas, if known. These are hints rather than dynamic
+graph instructions.
+
+1. `<parallel-safe area and expected output>`
+2. `<parallel-safe area and expected output>`
+
+If two areas depend on uncommitted output from each other, say so. The first
+Auto Fix v2 release must combine dependent work into one WorkItem rather than
+pretending it is parallel-safe.
+
+## Acceptance Criteria
+
+- [ ] `<observable behavior or contract>`
+- [ ] `<failure/recovery behavior>`
+- [ ] `<compatibility expectation>`
+- [ ] No unrelated changes.
+
+## Validation Requirements
+
+Name the expected trusted validation profile and the evidence it must produce.
+Raw commands in this document are explanatory only; the DAG executes commands
+from the operator-approved scenario policy.
+
+- Validation profile: `<registered profile id>`
+- Focused evidence: `<test suite, fixture, or behavior>`
+- Required final evidence: `<build/typecheck/test/scan subset>`
+
+## Risks And Edge Cases
+
+- `<known risk and expected handling>`
+- `<head drift, restart, platform, concurrency, or compatibility case>`
+
+## Out Of Scope
+
+- `<explicitly excluded adjacent work>`
+- Automatic PR approval, ready transition, merge, force push, or branch delete.
+
+## Human Review Notes
+
+Call out anything the final human reviewer must verify that cannot be proven by
+the trusted validation profile.

--- a/docs/scenarios/auto-fix-v2.md
+++ b/docs/scenarios/auto-fix-v2.md
@@ -1,0 +1,149 @@
+# Auto Fix v2 operator runbook
+
+Auto Fix v2 is implemented as a separate, opt-in workflow. It does not replace
+the existing `auto-fix` trigger.
+
+Local deterministic coverage is green. Before a live pilot, deploy a Manager
+release containing this workflow, sync its mixed-model profile, install the
+`github-autofix` encrypted credential, and create a dedicated Draft PR for
+Issue #172. Do not sync the v2 workflow into an older Manager release that
+predates the runtime and broker support described below.
+
+## What is enforced
+
+- `task_document` and `pr_context` are staged as content-addressed Manager
+  artifacts and projected read-only below `/workspace/input`.
+- K3 analyzes the task. Dynamic DeepSeek V4 Flash implementers receive isolated
+  Git worktrees and no GitHub credential.
+- The DeepSeek aggregator may read and update only the bound Draft PR through
+  the `github_pr` Manager broker.
+- GLM-5.2 reviewer nodes have `session_scope: dispatch`; every re-entry gets a
+  new provider session and no portable checkpoint/transcript.
+- Each rejected review creates one fresh dynamic DeepSeek fixer. Four fix
+  rounds plus the initial review give exactly five total review rounds.
+- GitHub writes are expected-head, fast-forward-only, non-force, bounded to 64
+  files/1 MiB, and restricted by `pr_context.writable_paths`. Workflow files,
+  `.git`, and the mounted input directory are always denied.
+
+## GitHub credential
+
+For a pilot, a repository-scoped fine-grained PAT is acceptable. Give it only:
+
+- Contents: read and write
+- Pull requests: read-only
+- Checks: read-only
+
+Store it as an encrypted Manager credential; it is never placed in a Worker:
+
+```bash
+printf '%s' "$GITHUB_AUTOFIX_TOKEN" | hr credential set github-autofix \
+  --type api_key --name 'GitHub Auto Fix fine-grained PAT'
+```
+
+For production, prefer a GitHub App installed only on the target repositories.
+Use Contents read/write, Pull requests read, and Checks read. Store the App
+material as an opaque JSON credential with fields `app_id`, `installation_id`,
+and `private_key`; the broker mints a short-lived installation token for each
+call.
+
+```bash
+printf '%s' "$GITHUB_AUTOFIX_APP_JSON" | hr credential set github-autofix \
+  --type opaque --name 'GitHub Auto Fix App' --json-stdin
+```
+
+Issue comments should use a separate outer-runner credential with Issues
+read/write. Do not widen the DAG credential merely to post status comments.
+
+## Immutable PR context
+
+Create `pr-context.json` from the already-created same-repository Draft PR:
+
+```bash
+shasum -a 256 /absolute/path/to/task.md
+```
+
+Put that digest into `task_document_sha256`; the Manager verifies it against
+the actually staged `task_document` before any PR action.
+
+```json
+{
+  "version": 1,
+  "owner": "xiaotianfotos",
+  "repo": "homerail",
+  "pull_number": 999,
+  "clone_url": "https://github.com/xiaotianfotos/homerail.git",
+  "head_ref": "autofix/issue-172",
+  "base_ref": "main",
+  "initial_head_sha": "40-character-head-sha",
+  "base_sha": "40-character-base-sha",
+  "task_document_sha256": "64-character-sha256-of-task.md",
+  "require_draft": true,
+  "writable_paths": ["homerail_manager/src", "homerail_manager/tests"]
+}
+```
+
+The broker refuses a non-Draft PR, a different base/head/branch, an external
+head update, a fork/cross-repository PR, a task-document digest mismatch, or a
+write outside the path allowlist.
+
+The broker's token permissions are necessary but not the only boundary. The
+WorkflowSpec also limits which nodes can call which broker actions, the Worker
+transport is fenced to the current lease/session/generation, and `commit_files`
+enforces the immutable PR identity, expected head, writable path allowlist,
+file/byte limits, and `force: false`.
+
+## Model profile
+
+The stable Manager must contain active Anthropic-compatible settings whose
+identities match K3, DeepSeek V4 Flash, and GLM-5.2. Configure the profile with:
+
+```bash
+export HOMERAIL_AUTO_FIX_V2_ANALYZER_MODEL='<K3 setting id>'
+export HOMERAIL_AUTO_FIX_V2_IMPLEMENTATION_MODEL='<DeepSeek V4 Flash setting id>'
+export HOMERAIL_AUTO_FIX_V2_REVIEW_MODEL='<GLM-5.2 setting id>'
+node scripts/configure-auto-fix-v2-runtime-profile.mjs
+```
+
+The analyzer uses the `kimi-code` harness. DeepSeek and GLM use the
+Claude-compatible harness; no coding role uses direct chat-completions.
+
+## Start a local or stable run
+
+```bash
+hr run auto-fix-v2 --sync \
+  --prompt '{}' \
+  --profile auto-fix-v2-mixed \
+  --input-scope issue-172-pilot \
+  --input-file task_document:input/task.md=/absolute/path/to/task.md \
+  --input-file pr_context:input/pr-context.json=/absolute/path/to/pr-context.json
+```
+
+The caller supplies only the immutable files and a small bootstrap object. The
+task itself is never reconstructed from Agent conversation history.
+
+## Local proof without GitHub or model spend
+
+```bash
+npm --prefix homerail_protocol run build
+npm --prefix homerail_manager exec vitest run \
+  tests/auto-fix-v2-scenario.test.ts \
+  tests/github-pr-broker.test.ts \
+  tests/run-input-artifacts.test.ts \
+  tests/dag-runtime-primitives.test.ts
+npm --prefix homerail_node exec vitest run \
+  src/storage/__tests__/workspace-inputs.test.ts \
+  src/control-plane/__tests__/lifecycle-handler.test.ts
+npm --prefix homerail_cli exec vitest run tests/run-inputs.test.ts
+node scripts/auto-fix-v2-runtime-profile.test.mjs
+```
+
+The fake-remote scenario proves two dynamic implementers, four dynamically
+generated fixers, five total reviews with distinct sessions, cold recovery,
+read-only input projection, per-node GitHub actions, non-force head fencing,
+path denial, task/PR identity binding, fork/closed-PR denial, and
+external-head-drift rejection.
+
+This proof does not spend model tokens or mutate GitHub. Before production,
+add a trusted required-checks gate: today GLM can read `checks_snapshot`, but
+the DAG runtime does not independently prevent an approval handoff when checks
+are missing or failing.

--- a/docs/scenarios/auto-fix-v2.md
+++ b/docs/scenarios/auto-fix-v2.md
@@ -14,11 +14,17 @@ predates the runtime and broker support described below.
 - `task_document` and `pr_context` are staged as content-addressed Manager
   artifacts and projected read-only below `/workspace/input`.
 - K3 analyzes the task. Dynamic DeepSeek V4 Flash implementers receive isolated
-  Git worktrees and no GitHub credential.
+  Git worktrees and no GitHub credential. Their worker policy must explicitly
+  declare `{{fanout_workspace}}`; Manager resolves it to the unique child
+  worktree, so isolation never creates an implicit write grant.
 - The DeepSeek aggregator may read and update only the bound Draft PR through
   the `github_pr` Manager broker.
 - GLM-5.2 reviewer nodes have `session_scope: dispatch`; every re-entry gets a
-  new provider session and no portable checkpoint/transcript.
+  new provider session and no portable checkpoint/transcript. A rejected
+  handoff-contract correction stays in that same logical dispatch so a valid
+  same-session `required_checks` receipt remains usable; if the receipt was
+  missing, correction mode permits only that declared read-only verification
+  call before the final handoff.
 - Each rejected review creates one fresh dynamic DeepSeek fixer. Four fix
   rounds plus the initial review give exactly five total review rounds.
 - GitHub writes are expected-head, fast-forward-only, non-force, bounded to 64
@@ -93,6 +99,10 @@ write outside the path allowlist. `required_checks` contains one to 32 unique,
 exact GitHub check-run names. It is immutable for the run; the broker selects
 the newest run with each exact name and requires `completed`/`success` on the
 current head.
+
+CLI input bindings declare their media type through the immutable mount suffix:
+`.md` is Markdown, `.json` is validated JSON, and `.txt` is plain text. The CLI
+rejects other suffixes, invalid UTF-8, and invalid JSON before staging.
 
 The broker's token permissions are necessary but not the only boundary. The
 WorkflowSpec also limits which nodes can call which broker actions, the Worker

--- a/docs/scenarios/auto-fix-v2.md
+++ b/docs/scenarios/auto-fix-v2.md
@@ -22,8 +22,12 @@ predates the runtime and broker support described below.
 - Each rejected review creates one fresh dynamic DeepSeek fixer. Four fix
   rounds plus the initial review give exactly five total review rounds.
 - GitHub writes are expected-head, fast-forward-only, non-force, bounded to 64
-  files/1 MiB, and restricted by `pr_context.writable_paths`. Workflow files,
-  `.git`, and the mounted input directory are always denied.
+  files/1 MiB, and restricted by explicit `pr_context.writable_paths` prefixes.
+  `writable_paths: ["."]` is invalid; `.github/**`, `.git/**`, and the mounted
+  input directory are always denied even when a broader prefix is declared.
+- An `approve` handoff is rejected by Manager unless the same fresh reviewer
+  dispatch successfully called `github_pr/required_checks` and every immutable
+  required check passed on the exact current PR head.
 
 ## GitHub credential
 
@@ -78,19 +82,36 @@ the actually staged `task_document` before any PR action.
   "base_sha": "40-character-base-sha",
   "task_document_sha256": "64-character-sha256-of-task.md",
   "require_draft": true,
-  "writable_paths": ["homerail_manager/src", "homerail_manager/tests"]
+  "writable_paths": ["homerail_manager/src", "homerail_manager/tests"],
+  "required_checks": ["Core (Linux, Node 24)"]
 }
 ```
 
 The broker refuses a non-Draft PR, a different base/head/branch, an external
 head update, a fork/cross-repository PR, a task-document digest mismatch, or a
-write outside the path allowlist.
+write outside the path allowlist. `required_checks` contains one to 32 unique,
+exact GitHub check-run names. It is immutable for the run; the broker selects
+the newest run with each exact name and requires `completed`/`success` on the
+current head.
 
 The broker's token permissions are necessary but not the only boundary. The
 WorkflowSpec also limits which nodes can call which broker actions, the Worker
 transport is fenced to the current lease/session/generation, and `commit_files`
 enforces the immutable PR identity, expected head, writable path allowlist,
 file/byte limits, and `force: false`.
+
+This repository's pull-request CI intentionally skips Draft PRs and does not
+run on Draft `synchronize` events. Before a reviewer can approve, an operator
+or trusted outer automation must manually dispatch CI with the Draft head
+branch selected as the workflow ref, then verify that the configured exact
+check name appears on that head SHA. The DAG credential remains Checks
+read-only and cannot manufacture or override check results.
+
+`commit_files` uses GitHub's bounded Git Data API sequence (blob, tree, commit,
+then non-force ref update). A failure before the ref update can leave
+unreachable Git objects, but cannot advance the PR. Operators should respect
+GitHub rate limits and retry only after re-reading the bound PR head; the broker
+reconciles a pending update during recovery.
 
 ## Model profile
 
@@ -140,10 +161,10 @@ node scripts/auto-fix-v2-runtime-profile.test.mjs
 The fake-remote scenario proves two dynamic implementers, four dynamically
 generated fixers, five total reviews with distinct sessions, cold recovery,
 read-only input projection, per-node GitHub actions, non-force head fencing,
-path denial, task/PR identity binding, fork/closed-PR denial, and
-external-head-drift rejection.
+path denial (including `.github/actions/**`), task/PR identity binding,
+fork/closed-PR denial, external-head-drift rejection, and a Manager-enforced
+required-checks approval fence that cannot reuse a prior dispatch receipt.
 
-This proof does not spend model tokens or mutate GitHub. Before production,
-add a trusted required-checks gate: today GLM can read `checks_snapshot`, but
-the DAG runtime does not independently prevent an approval handoff when checks
-are missing or failing.
+This proof does not spend model tokens or mutate GitHub. A real Draft-PR pilot,
+including creation of the configured check run on the exact Draft head, remains
+required before production adoption.

--- a/homerail_cli/src/commands/run.ts
+++ b/homerail_cli/src/commands/run.ts
@@ -10,6 +10,23 @@ function collectInputFile(value: string, previous: string[]): string[] {
   return [...previous, value];
 }
 
+type RunInputMediaType = "text/markdown" | "text/plain" | "application/json";
+
+function declaredRunInputMediaType(mountPath: string, content: string): RunInputMediaType {
+  const extension = path.posix.extname(mountPath).toLowerCase();
+  if (extension === ".json") {
+    try {
+      JSON.parse(content);
+    } catch {
+      throw new Error(`run input mounted at ${mountPath} must contain valid JSON`);
+    }
+    return "application/json";
+  }
+  if (extension === ".md") return "text/markdown";
+  if (extension === ".txt") return "text/plain";
+  throw new Error(`run input mount path must end in .md, .json, or .txt: ${mountPath}`);
+}
+
 export async function stageRunInputFiles(
   client: HomeRailClient,
   scopeId: string | undefined,
@@ -40,12 +57,16 @@ export async function stageRunInputFiles(
     const stat = fs.statSync(localPath);
     if (!stat.isFile() || stat.size < 1 || stat.size > 1024 * 1024) throw new Error(`input file must contain 1 byte to 1 MiB: ${localPath}`);
     const bytes = fs.readFileSync(localPath);
-    const content = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
-    const extension = path.extname(localPath).toLowerCase();
-    const mediaType = extension === ".json" ? "application/json" : extension === ".md" ? "text/markdown" : "text/plain";
+    let content: string;
+    try {
+      content = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    } catch {
+      throw new Error(`input file must contain valid UTF-8 text: ${localPath}`);
+    }
+    const mediaType = declaredRunInputMediaType(mountPath, content);
     const response = await client.post<BaseResponse>("/api/run-inputs", {
       scope_id: scope,
-      name: path.basename(localPath),
+      name: path.posix.basename(mountPath),
       media_type: mediaType,
       content,
     });
@@ -70,7 +91,7 @@ export function registerRunCommand(program: Command): void {
     .option("--input-scope <scope>", "Scope for immutable run input artifacts")
     .option(
       "--input-file <binding>",
-      "Stage logical_name[:input/mount]=local_path as an immutable read-only run input",
+      "Stage logical_name[:input/mount]=local_path as immutable UTF-8 input (.md, .json, or .txt mount)",
       collectInputFile,
       [],
     )

--- a/homerail_cli/src/commands/run.ts
+++ b/homerail_cli/src/commands/run.ts
@@ -2,9 +2,60 @@ import type { Command } from "commander";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { getClient } from "../index.js";
-import type { BaseResponse } from "../client.js";
+import type { BaseResponse, HomeRailClient } from "../client.js";
 import { parseSettingIdOption } from "../command-options.js";
 import { orchestrationsDir, resolveTemplatePath } from "./templates.js";
+
+function collectInputFile(value: string, previous: string[]): string[] {
+  return [...previous, value];
+}
+
+export async function stageRunInputFiles(
+  client: HomeRailClient,
+  scopeId: string | undefined,
+  specifications: string[],
+): Promise<Array<{ artifact_id: string; logical_name: string; mount_path: string }>> {
+  if (specifications.length === 0) return [];
+  const scope = scopeId?.trim();
+  if (!scope) throw new Error("--input-scope is required with --input-file");
+  if (specifications.length > 16) throw new Error("at most 16 --input-file values are allowed");
+  const logicalNames = new Set<string>();
+  const mountPaths = new Set<string>();
+  const bindings = [];
+  for (const specification of specifications) {
+    const equals = specification.indexOf("=");
+    if (equals < 1 || equals === specification.length - 1) {
+      throw new Error("--input-file must use logical_name[:input/mount]=local_path");
+    }
+    const target = specification.slice(0, equals);
+    const localPath = path.resolve(specification.slice(equals + 1));
+    const colon = target.indexOf(":");
+    const logicalName = (colon < 0 ? target : target.slice(0, colon)).trim();
+    const mountPath = (colon < 0 ? `input/${path.basename(localPath)}` : target.slice(colon + 1)).trim();
+    if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(logicalName)) throw new Error(`invalid input logical name: ${logicalName}`);
+    if (!/^input\/(?:[A-Za-z0-9._-]+\/)*[A-Za-z0-9._-]+$/.test(mountPath)) throw new Error(`invalid input mount path: ${mountPath}`);
+    if (logicalNames.has(logicalName) || mountPaths.has(mountPath)) throw new Error("input logical names and mount paths must be unique");
+    logicalNames.add(logicalName);
+    mountPaths.add(mountPath);
+    const stat = fs.statSync(localPath);
+    if (!stat.isFile() || stat.size < 1 || stat.size > 1024 * 1024) throw new Error(`input file must contain 1 byte to 1 MiB: ${localPath}`);
+    const bytes = fs.readFileSync(localPath);
+    const content = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    const extension = path.extname(localPath).toLowerCase();
+    const mediaType = extension === ".json" ? "application/json" : extension === ".md" ? "text/markdown" : "text/plain";
+    const response = await client.post<BaseResponse>("/api/run-inputs", {
+      scope_id: scope,
+      name: path.basename(localPath),
+      media_type: mediaType,
+      content,
+    });
+    const data = response.data as { artifact?: { artifact_id?: unknown } } | undefined;
+    const artifactId = data?.artifact?.artifact_id;
+    if (typeof artifactId !== "string" || !artifactId) throw new Error(`Manager did not return an artifact id for ${localPath}`);
+    bindings.push({ artifact_id: artifactId, logical_name: logicalName, mount_path: mountPath });
+  }
+  return bindings;
+}
 
 export function registerRunCommand(program: Command): void {
   program
@@ -16,6 +67,13 @@ export function registerRunCommand(program: Command): void {
     .option("--sync", "Sync the template to the Manager database before running it")
     .option("--profile <profile>", "Runtime profile id, or a profile YAML file to sync before running")
     .option("--setting-id <id>", "Database LLM setting id for this DAG run", parseSettingIdOption)
+    .option("--input-scope <scope>", "Scope for immutable run input artifacts")
+    .option(
+      "--input-file <binding>",
+      "Stage logical_name[:input/mount]=local_path as an immutable read-only run input",
+      collectInputFile,
+      [],
+    )
     .action(
       async (
         template: string | undefined,
@@ -26,6 +84,8 @@ export function registerRunCommand(program: Command): void {
           sync?: boolean;
           profile?: string;
           settingId?: string;
+          inputScope?: string;
+          inputFile: string[];
         },
       ) => {
         const globalOpts = program.opts() as {
@@ -96,6 +156,11 @@ export function registerRunCommand(program: Command): void {
           }
           if (opts.settingId) {
             payload.llm_setting_id = opts.settingId;
+          }
+          const inputArtifacts = await stageRunInputFiles(client, opts.inputScope, opts.inputFile);
+          if (inputArtifacts.length > 0) {
+            payload.input_scope = opts.inputScope!.trim();
+            payload.input_artifacts = inputArtifacts;
           }
           const resp = await client.post<BaseResponse>(
             "/api/runs/create-and-run",

--- a/homerail_cli/tests/run-inputs.test.ts
+++ b/homerail_cli/tests/run-inputs.test.ts
@@ -1,0 +1,52 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { HomeRailClient } from "../src/client.js";
+import { stageRunInputFiles } from "../src/commands/run.js";
+
+describe("CLI immutable run inputs", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("stages local text files before returning scoped run bindings", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-cli-inputs-"));
+    roots.push(root);
+    const task = path.join(root, "design.md");
+    const pr = path.join(root, "pr.json");
+    fs.writeFileSync(task, "# Plan\n");
+    fs.writeFileSync(pr, '{"version":1}\n');
+    const post = vi.fn()
+      .mockResolvedValueOnce({ data: { artifact: { artifact_id: "artifact-task" } } })
+      .mockResolvedValueOnce({ data: { artifact: { artifact_id: "artifact-pr" } } });
+    const client = { post } as unknown as HomeRailClient;
+
+    await expect(stageRunInputFiles(client, "pilot-172", [
+      `task_document:input/task.md=${task}`,
+      `pr_context:input/pr-context.json=${pr}`,
+    ])).resolves.toEqual([
+      { artifact_id: "artifact-task", logical_name: "task_document", mount_path: "input/task.md" },
+      { artifact_id: "artifact-pr", logical_name: "pr_context", mount_path: "input/pr-context.json" },
+    ]);
+    expect(post).toHaveBeenNthCalledWith(1, "/api/run-inputs", expect.objectContaining({
+      scope_id: "pilot-172",
+      media_type: "text/markdown",
+      content: "# Plan\n",
+    }));
+    expect(post).toHaveBeenNthCalledWith(2, "/api/run-inputs", expect.objectContaining({
+      media_type: "application/json",
+    }));
+  });
+
+  it("requires an explicit scope and safe unique mount paths", async () => {
+    const client = { post: vi.fn() } as unknown as HomeRailClient;
+    await expect(stageRunInputFiles(client, undefined, ["task=input/task.md"]))
+      .rejects.toThrow("--input-scope");
+    await expect(stageRunInputFiles(client, "pilot", ["task:../escape=/tmp/task.md"]))
+      .rejects.toThrow("invalid input mount path");
+  });
+});

--- a/homerail_cli/tests/run-inputs.test.ts
+++ b/homerail_cli/tests/run-inputs.test.ts
@@ -34,12 +34,44 @@ describe("CLI immutable run inputs", () => {
     ]);
     expect(post).toHaveBeenNthCalledWith(1, "/api/run-inputs", expect.objectContaining({
       scope_id: "pilot-172",
+      name: "task.md",
       media_type: "text/markdown",
       content: "# Plan\n",
     }));
     expect(post).toHaveBeenNthCalledWith(2, "/api/run-inputs", expect.objectContaining({
+      name: "pr-context.json",
       media_type: "application/json",
     }));
+  });
+
+  it("derives and validates media type from the declared mount path", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-cli-inputs-"));
+    roots.push(root);
+    const source = path.join(root, "payload.txt");
+    fs.writeFileSync(source, '{"version":1}\n');
+    const post = vi.fn().mockResolvedValue({ data: { artifact: { artifact_id: "artifact-json" } } });
+    const client = { post } as unknown as HomeRailClient;
+
+    await expect(stageRunInputFiles(client, "pilot", [
+      `pr_context:input/pr-context.json=${source}`,
+    ])).resolves.toEqual([{
+      artifact_id: "artifact-json",
+      logical_name: "pr_context",
+      mount_path: "input/pr-context.json",
+    }]);
+    expect(post).toHaveBeenCalledWith("/api/run-inputs", {
+      scope_id: "pilot",
+      name: "pr-context.json",
+      media_type: "application/json",
+      content: '{"version":1}\n',
+    });
+
+    fs.writeFileSync(source, "not-json");
+    post.mockClear();
+    await expect(stageRunInputFiles(client, "pilot", [
+      `pr_context:input/pr-context.json=${source}`,
+    ])).rejects.toThrow("must contain valid JSON");
+    expect(post).not.toHaveBeenCalled();
   });
 
   it("requires an explicit scope and safe unique mount paths", async () => {

--- a/homerail_manager/src/events/bus.ts
+++ b/homerail_manager/src/events/bus.ts
@@ -9,6 +9,7 @@ export type DAGEventType =
   | "dag:node_correction_requested"
   | "dag:node_auto_handoff"
   | "dag:node_dispatch_retry"
+  | "dag:node_session_reset"
   | "dag:checkpoint_resume"
   | "dag:stale_session_ignored"
   | "dag:stale_lease_ignored"
@@ -86,6 +87,7 @@ export const DAG_EVENT_TYPES: DAGEventType[] = [
   "dag:node_correction_requested",
   "dag:node_auto_handoff",
   "dag:node_dispatch_retry",
+  "dag:node_session_reset",
   "dag:checkpoint_resume",
   "dag:stale_session_ignored",
   "dag:stale_lease_ignored",

--- a/homerail_manager/src/node/lifecycle-request.ts
+++ b/homerail_manager/src/node/lifecycle-request.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { getNode, type NodeState } from "./registry.js";
 import type { LifecycleRequestMessage } from "./types.js";
+import type { DagWorkspaceInputProjection } from "homerail-protocol";
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 
@@ -90,6 +91,7 @@ export interface WorkerCreateOptions {
   extraHosts?: string[];
   workspace?: Record<string, unknown>;
   workspaceReadOnly?: boolean;
+  workspaceInputs?: DagWorkspaceInputProjection[];
   timeoutMs?: number;
 }
 
@@ -110,6 +112,7 @@ export function sendWorkerCreateRequest(
       extra_hosts: options.extraHosts,
       workspace: options.workspace,
       workspace_read_only: options.workspaceReadOnly === true,
+      workspace_inputs: options.workspaceInputs,
     },
     { timeoutMs: options.timeoutMs },
   );

--- a/homerail_manager/src/node/worker-provisioner.ts
+++ b/homerail_manager/src/node/worker-provisioner.ts
@@ -12,6 +12,7 @@ import {
   sendWorkerRemoveRequest,
   type LifecycleResult,
 } from "./lifecycle-request.js";
+import type { DagWorkspaceInputProjection } from "homerail-protocol";
 
 /* -------------------------------------------------------------------------- */
 /*  Public interfaces                                                         */
@@ -21,6 +22,7 @@ export interface ProvisionerOptions {
   image?: string;
   workspace?: Record<string, unknown>;
   workspaceReadOnly?: boolean;
+  workspaceInputs?: DagWorkspaceInputProjection[];
   env?: Record<string, string>;
   labels?: Record<string, string>;
   extraHosts?: string[];
@@ -38,6 +40,7 @@ export interface ProvisionerOptions {
       image?: string;
       workspace?: Record<string, unknown>;
       workspaceReadOnly?: boolean;
+      workspaceInputs?: DagWorkspaceInputProjection[];
       env?: Record<string, string>;
       labels?: Record<string, string>;
       extraHosts?: string[];
@@ -133,6 +136,7 @@ export async function provisionWorkerContainer(
     image: options?.image,
     workspace: options?.workspace,
     workspaceReadOnly: options?.workspaceReadOnly,
+    workspaceInputs: options?.workspaceInputs,
     env: options?.env,
     labels: options?.labels,
     extraHosts: options?.extraHosts,

--- a/homerail_manager/src/orchestration/change-orchestrator.ts
+++ b/homerail_manager/src/orchestration/change-orchestrator.ts
@@ -29,6 +29,8 @@ import {
   type ResumeWaitingRunRequest,
 } from "../runtime/active-runs.js";
 import type { DagApprovalRecord } from "../persistence/dag-runtime-primitives.js";
+import type { DagRunInputBindingRequest } from "homerail-protocol";
+import { resolveDagRunInputBindings } from "../persistence/run-input-artifacts.js";
 import type { InjectResult, CancelAllResult, CheckpointResumeRequest } from "../runtime/active-runs.js";
 import { emit } from "../events/bus.js";
 import {
@@ -59,6 +61,8 @@ export interface CreateRunRequest {
   expectedWorkflowRevision?: number;
   expectedCanonicalHash?: string;
   expectedProfileUpdatedAt?: string;
+  inputScope?: string;
+  inputArtifacts?: DagRunInputBindingRequest[];
 }
 
 export interface CreateRunResponse {
@@ -320,6 +324,9 @@ export class ChangeOrchestrator {
     assertProviderPolicy(dagWithRuntime);
 
     const runId = request.runId ?? _generateRunId();
+    const inputArtifacts = request.inputArtifacts && request.inputArtifacts.length > 0
+      ? resolveDagRunInputBindings(request.inputScope ?? "", request.inputArtifacts)
+      : undefined;
     const workflowId = dagWithRuntime.meta.workflow_id?.trim();
     const reservation = workflowId
       ? reserveWorkflowRun({
@@ -331,7 +338,7 @@ export class ChangeOrchestrator {
       : { reserved: false };
     const run = (() => {
       try {
-        return this.graphExecutor.createRun(runId, dagWithRuntime, request.prompt);
+        return this.graphExecutor.createRun(runId, dagWithRuntime, request.prompt, inputArtifacts);
       } finally {
         if (reservation.reserved) {
           try {

--- a/homerail_manager/src/orchestration/change-orchestrator.ts
+++ b/homerail_manager/src/orchestration/change-orchestrator.ts
@@ -324,9 +324,13 @@ export class ChangeOrchestrator {
     assertProviderPolicy(dagWithRuntime);
 
     const runId = request.runId ?? _generateRunId();
-    const inputArtifacts = request.inputArtifacts && request.inputArtifacts.length > 0
-      ? resolveDagRunInputBindings(request.inputScope ?? "", request.inputArtifacts)
-      : undefined;
+    const requestedInputArtifacts = request.inputArtifacts ?? [];
+    const inputScope = request.inputScope?.trim();
+    let inputArtifacts: ReturnType<typeof resolveDagRunInputBindings> | undefined;
+    if (requestedInputArtifacts.length > 0) {
+      if (!inputScope) throw new Error("input_scope is required when input_artifacts are bound");
+      inputArtifacts = resolveDagRunInputBindings(inputScope, requestedInputArtifacts);
+    }
     const workflowId = dagWithRuntime.meta.workflow_id?.trim();
     const reservation = workflowId
       ? reserveWorkflowRun({

--- a/homerail_manager/src/orchestration/graph-executor.ts
+++ b/homerail_manager/src/orchestration/graph-executor.ts
@@ -1,6 +1,7 @@
 import type { DAGDispatcher } from "./dag-dispatcher.js";
 import type { ParsedDAG } from "./graph.js";
 import type { ActiveRun } from "../runtime/active-runs.js";
+import type { DagRunInputBinding } from "homerail-protocol";
 import {
   createActiveRun,
   dispatchReadyNodes,
@@ -11,8 +12,13 @@ import { isRunTerminal } from "./dag-engine.js";
 export class GraphExecutor {
   constructor(private dispatcher: DAGDispatcher) {}
 
-  createRun(runId: string, parsedDAG: ParsedDAG, initialPrompt?: string): ActiveRun {
-    return createActiveRun(runId, parsedDAG, { initialPrompt });
+  createRun(
+    runId: string,
+    parsedDAG: ParsedDAG,
+    initialPrompt?: string,
+    inputArtifacts?: DagRunInputBinding[],
+  ): ActiveRun {
+    return createActiveRun(runId, parsedDAG, { initialPrompt, inputArtifacts });
   }
 
   tick(runId: string): number {

--- a/homerail_manager/src/orchestration/graph.ts
+++ b/homerail_manager/src/orchestration/graph.ts
@@ -104,6 +104,11 @@ export interface DAGGatewayConfig {
   item_field?: string;
   context_field?: string;
   worker_agent?: string;
+  worker_policy?: Record<string, unknown>;
+  workspace_strategy?: "shared" | "isolated_git_worktree";
+  workspace_root?: string;
+  repository_path?: string;
+  revision_field?: string;
   max_parallelism?: number;
   completion?: "all" | "any" | "n_of_m" | string;
   result_contract?: string;

--- a/homerail_manager/src/orchestration/workflow-spec-v1-schema.ts
+++ b/homerail_manager/src/orchestration/workflow-spec-v1-schema.ts
@@ -82,12 +82,37 @@ const ContractSchema = Type.Recursive((This) => Type.Object({
   pattern: Type.Optional(Type.String({ maxLength: 512 })),
 }, { additionalProperties: false }));
 
-const Port = Type.Object({
+const InputPort = Type.Object({
   contract: Type.Optional(ContractIdentifier),
   description: Type.Optional(ShortText),
 }, { additionalProperties: false });
 
-const PortMap = Type.Record(Identifier, Port, { maxProperties: 128 });
+const BrokerActionRequirement = Type.Object({
+  credential_ref: Type.String({ minLength: 1, maxLength: 128, pattern: "^[A-Za-z0-9][A-Za-z0-9._:-]*$" }),
+  broker: Type.String({ minLength: 1, maxLength: 128, pattern: "^[A-Za-z0-9][A-Za-z0-9._:-]*$" }),
+  action: Type.String({ minLength: 1, maxLength: 128, pattern: "^[A-Za-z0-9][A-Za-z0-9._:-]*$" }),
+  when: Type.Optional(Type.Object({
+    field: Type.String({
+      minLength: 1,
+      maxLength: 256,
+      pattern: "^[A-Za-z_][A-Za-z0-9_-]*(?:\\.[A-Za-z_][A-Za-z0-9_-]*)*$",
+    }),
+    equals: JsonValue,
+  }, { additionalProperties: false })),
+}, { additionalProperties: false });
+
+const OutputPort = Type.Object({
+  contract: Type.Optional(ContractIdentifier),
+  description: Type.Optional(ShortText),
+  required_broker_actions: Type.Optional(Type.Array(BrokerActionRequirement, {
+    minItems: 1,
+    maxItems: 8,
+    uniqueItems: true,
+  })),
+}, { additionalProperties: false });
+
+const InputPortMap = Type.Record(Identifier, InputPort, { maxProperties: 128 });
+const OutputPortMap = Type.Record(Identifier, OutputPort, { maxProperties: 128 });
 
 const NodeBase = {
   description: Type.Optional(ShortText),
@@ -95,8 +120,8 @@ const NodeBase = {
     uniqueItems: true,
     maxItems: 256,
   })),
-  inputs: Type.Optional(PortMap),
-  outputs: Type.Optional(PortMap),
+  inputs: Type.Optional(InputPortMap),
+  outputs: Type.Optional(OutputPortMap),
 };
 
 const AdvisorBinding = Type.Object({
@@ -308,7 +333,7 @@ const AwaitCommandNode = Type.Object({
     uniqueItems: true,
     maxItems: 256,
   })),
-  inputs: Type.Optional(PortMap),
+  inputs: Type.Optional(InputPortMap),
   config: Type.Object({
     primitive_version: Type.Literal(1),
     target_actors: Type.Optional(Type.Array(Identifier, {
@@ -389,7 +414,7 @@ const TerminalNode = Type.Object({
     uniqueItems: true,
     maxItems: 256,
   })),
-  inputs: Type.Optional(PortMap),
+  inputs: Type.Optional(InputPortMap),
   outcome: Type.Union([
     Type.Literal("success"),
     Type.Literal("failure"),

--- a/homerail_manager/src/orchestration/workflow-spec-v1-schema.ts
+++ b/homerail_manager/src/orchestration/workflow-spec-v1-schema.ts
@@ -157,9 +157,7 @@ const CredentialBinding = Type.Object({
   ]),
 }, { additionalProperties: false });
 
-const AgentNode = Type.Object({
-  kind: Type.Literal("agent"),
-  agent: Identifier,
+const AgentRuntimeFields = {
   advisors: Type.Optional(Type.Array(AdvisorBinding, { uniqueItems: true, maxItems: 16 })),
   workspace_access: Type.Optional(WorkspaceAccess),
   allowed_builtin_tools: Type.Optional(Type.Array(AgentBuiltinToolName, {
@@ -181,6 +179,18 @@ const AgentNode = Type.Object({
     maxItems: 16,
     description: "Credential references and turn-scoped injection policy; secret values are never valid WorkflowSpec fields.",
   })),
+  session_scope: Type.Optional(Type.Union([
+    Type.Literal("node"),
+    Type.Literal("dispatch"),
+  ], {
+    description: "node resumes one provider session; dispatch creates a fresh provider context for every dispatch.",
+  })),
+};
+
+const AgentNode = Type.Object({
+  kind: Type.Literal("agent"),
+  agent: Identifier,
+  ...AgentRuntimeFields,
   ...NodeBase,
 }, { additionalProperties: false });
 
@@ -270,6 +280,14 @@ const FanoutNode = Type.Object({
     item_field: Type.Optional(Type.String({ minLength: 1, maxLength: 256 })),
     context_field: Type.Optional(Type.String({ minLength: 1, maxLength: 256 })),
     worker_agent: Identifier,
+    worker_policy: Type.Optional(Type.Object(AgentRuntimeFields, { additionalProperties: false })),
+    workspace_strategy: Type.Optional(Type.Union([
+      Type.Literal("shared"),
+      Type.Literal("isolated_git_worktree"),
+    ])),
+    workspace_root: Type.Optional(Type.String({ minLength: 1, maxLength: 512 })),
+    repository_path: Type.Optional(Type.String({ minLength: 1, maxLength: 512 })),
+    revision_field: Type.Optional(Type.String({ minLength: 1, maxLength: 256 })),
     max_items: Type.Integer({ minimum: 1, maximum: 256 }),
     max_parallelism: Type.Integer({ minimum: 1, maximum: 256 }),
     completion: Type.Union([Type.Literal("all"), Type.Literal("any"), Type.Literal("n_of_m")]),

--- a/homerail_manager/src/orchestration/workflow-spec-v1.ts
+++ b/homerail_manager/src/orchestration/workflow-spec-v1.ts
@@ -592,6 +592,23 @@ function semanticDiagnostics(context: SourceContext, workflow: WorkflowSpecV1): 
           "fanout workers with manager_broker credentials must allow credential_broker_call",
         );
       }
+      const writablePaths = workerPolicy?.workspace_access?.writable_paths ?? [];
+      const declaresIsolatedWorkspace = writablePaths.length === 1
+        && writablePaths[0] === "{{fanout_workspace}}";
+      if (node.config.workspace_strategy === "isolated_git_worktree" && !declaresIsolatedWorkspace) {
+        add(
+          `${nodePath}/config/worker_policy/workspace_access/writable_paths`,
+          "DAG_SEMANTIC_FANOUT_WORKSPACE_REQUIRED",
+          "isolated_git_worktree fanout must declare exactly ['{{fanout_workspace}}'] as its writable path",
+        );
+      }
+      if (node.config.workspace_strategy !== "isolated_git_worktree" && writablePaths.includes("{{fanout_workspace}}")) {
+        add(
+          `${nodePath}/config/worker_policy/workspace_access/writable_paths`,
+          "DAG_SEMANTIC_FANOUT_WORKSPACE_UNAVAILABLE",
+          "{{fanout_workspace}} is only available with isolated_git_worktree fanout",
+        );
+      }
     }
     if (node.kind === "await_command") {
       for (let index = 0; index < (node.config.target_actors ?? []).length; index++) {

--- a/homerail_manager/src/orchestration/workflow-spec-v1.ts
+++ b/homerail_manager/src/orchestration/workflow-spec-v1.ts
@@ -40,6 +40,12 @@ export interface CanonicalPort {
   name: string;
   contract?: string;
   description?: string;
+  required_broker_actions?: Array<{
+    credential_ref: string;
+    broker: string;
+    action: string;
+    when?: { field: string; equals: unknown };
+  }>;
 }
 
 export interface CanonicalNode {
@@ -249,13 +255,29 @@ function splitPortReference(reference: string): { node: string; port: string } {
   return { node: reference.slice(0, index), port: reference.slice(index + 1) };
 }
 
-function portEntries(ports: Record<string, { contract?: string; description?: string }> | undefined): CanonicalPort[] {
+function portEntries(ports: Record<string, {
+  contract?: string;
+  description?: string;
+  required_broker_actions?: Array<{
+    credential_ref: string;
+    broker: string;
+    action: string;
+    when?: { field: string; equals: unknown };
+  }>;
+}> | undefined): CanonicalPort[] {
   return Object.entries(ports ?? {})
     .sort(([left], [right]) => left.localeCompare(right))
     .map(([name, port]) => ({
       name,
       ...(port.contract ? { contract: port.contract } : {}),
       ...(port.description ? { description: port.description } : {}),
+      ...(port.required_broker_actions ? {
+        required_broker_actions: [...port.required_broker_actions]
+          .sort((left, right) => (
+            `${left.credential_ref}\0${left.broker}\0${left.action}\0${JSON.stringify(left.when ?? null)}`
+              .localeCompare(`${right.credential_ref}\0${right.broker}\0${right.action}\0${JSON.stringify(right.when ?? null)}`)
+          )),
+      } : {}),
     }));
 }
 
@@ -372,6 +394,34 @@ function semanticDiagnostics(context: SourceContext, workflow: WorkflowSpecV1): 
 
   for (const [nodeId, node] of Object.entries(nodes)) {
     const nodePath = `/spec/nodes/${nodeId}`;
+    for (const [portName, port] of Object.entries(node.kind === "terminal" || node.kind === "await_command" ? {} : node.outputs ?? {})) {
+      const requirements = port.required_broker_actions ?? [];
+      if (requirements.length === 0) continue;
+      if (node.kind !== "agent") {
+        add(
+          `${nodePath}/outputs/${portName}/required_broker_actions`,
+          "DAG_SEMANTIC_BROKER_REQUIREMENT_AGENT_ONLY",
+          "required broker actions are supported only on agent output ports",
+        );
+        continue;
+      }
+      for (let index = 0; index < requirements.length; index++) {
+        const requirement = requirements[index];
+        const declared = (node.credentials ?? []).some((binding) => (
+          binding.credential_ref === requirement.credential_ref
+          && binding.inject.mode === "manager_broker"
+          && binding.inject.broker === requirement.broker
+          && binding.inject.allowed_actions.includes(requirement.action)
+        ));
+        if (!declared) {
+          add(
+            `${nodePath}/outputs/${portName}/required_broker_actions/${index}`,
+            "DAG_SEMANTIC_UNDECLARED_BROKER_REQUIREMENT",
+            "required broker action must match a manager_broker credential and allowed action declared on the same node",
+          );
+        }
+      }
+    }
     if (node.kind === "agent" && !agents[node.agent]) {
       add(`${nodePath}/agent`, "DAG_SEMANTIC_UNKNOWN_AGENT", `unknown agent '${node.agent}'`);
     }
@@ -1357,6 +1407,9 @@ export function projectCanonicalWorkflowToParsedDAG(canonical: CanonicalWorkflow
   const graphNodes: DAGGraphNode[] = executableNodes.map((node) => {
     const inputContracts = Object.fromEntries(node.inputs.filter((port) => port.contract).map((port) => [port.name, port.contract!]));
     const outputContracts = Object.fromEntries(node.outputs.filter((port) => port.contract).map((port) => [port.name, port.contract!]));
+    const outputBrokerRequirements = Object.fromEntries(node.outputs
+      .filter((port) => port.required_broker_actions?.length)
+      .map((port) => [port.name, port.required_broker_actions!]));
     return {
       node_id: node.id,
       name: node.id,
@@ -1370,6 +1423,7 @@ export function projectCanonicalWorkflowToParsedDAG(canonical: CanonicalWorkflow
         workflow_spec_v1: {
           input_contracts: inputContracts,
           output_contracts: outputContracts,
+          output_broker_requirements: outputBrokerRequirements,
         },
         ...(node.kind === "agent" && node.config ? { agent_runtime: node.config } : {}),
       },
@@ -1417,11 +1471,21 @@ export function projectCanonicalWorkflowToParsedDAG(canonical: CanonicalWorkflow
   };
 }
 
-function authoringPorts(ports: CanonicalPort[]): Record<string, { contract?: string; description?: string }> | undefined {
+function authoringPorts(ports: CanonicalPort[]): Record<string, {
+  contract?: string;
+  description?: string;
+  required_broker_actions?: Array<{
+    credential_ref: string;
+    broker: string;
+    action: string;
+    when?: { field: string; equals: unknown };
+  }>;
+}> | undefined {
   if (ports.length === 0) return undefined;
   return Object.fromEntries(ports.map((port) => [port.name, {
     ...(port.contract ? { contract: port.contract } : {}),
     ...(port.description ? { description: port.description } : {}),
+    ...(port.required_broker_actions ? { required_broker_actions: port.required_broker_actions } : {}),
   }]));
 }
 

--- a/homerail_manager/src/orchestration/workflow-spec-v1.ts
+++ b/homerail_manager/src/orchestration/workflow-spec-v1.ts
@@ -524,6 +524,24 @@ function semanticDiagnostics(context: SourceContext, workflow: WorkflowSpecV1): 
       if (node.config.max_parallelism > node.config.max_items) {
         add(`${nodePath}/config/max_parallelism`, "DAG_SEMANTIC_INVALID_PARALLELISM", "max_parallelism cannot exceed max_items");
       }
+      const workerPolicy = node.config.worker_policy;
+      if (workerPolicy?.allowed_dag_tools !== undefined && !workerPolicy.allowed_dag_tools.includes("handoff")) {
+        add(
+          `${nodePath}/config/worker_policy/allowed_dag_tools`,
+          "DAG_SEMANTIC_HANDOFF_TOOL_REQUIRED",
+          "fanout worker_policy must allow the handoff DAG tool",
+        );
+      }
+      if (
+        (workerPolicy?.credentials ?? []).some((binding) => binding.inject.mode === "manager_broker")
+        && !workerPolicy?.allowed_dag_tools?.includes("credential_broker_call")
+      ) {
+        add(
+          `${nodePath}/config/worker_policy/allowed_dag_tools`,
+          "DAG_SEMANTIC_CREDENTIAL_BROKER_TOOL_REQUIRED",
+          "fanout workers with manager_broker credentials must allow credential_broker_call",
+        );
+      }
     }
     if (node.kind === "await_command") {
       for (let index = 0; index < (node.config.target_actors ?? []).length; index++) {
@@ -758,6 +776,7 @@ function canonicalNode(id: string, node: WorkflowSpecV1Node): CanonicalNode {
         ? { allowed_dag_tools: [...node.allowed_dag_tools].sort() }
         : {}),
       ...(node.credentials !== undefined ? { credentials: node.credentials } : {}),
+      ...(node.session_scope !== undefined ? { session_scope: node.session_scope } : {}),
     };
     return {
       ...base,
@@ -1438,6 +1457,12 @@ function authoringNode(node: CanonicalNode, canonical: CanonicalWorkflowIR): Rec
         : {}),
       ...(Array.isArray(node.config?.allowed_dag_tools)
         ? { allowed_dag_tools: node.config.allowed_dag_tools }
+        : {}),
+      ...(typeof node.config?.session_scope === "string"
+        ? { session_scope: node.config.session_scope }
+        : {}),
+      ...(Array.isArray(node.config?.credentials)
+        ? { credentials: node.config.credentials }
         : {}),
     };
   }

--- a/homerail_manager/src/orchestration/ws-dispatch-adapter.ts
+++ b/homerail_manager/src/orchestration/ws-dispatch-adapter.ts
@@ -52,6 +52,7 @@ import {
   summarizeDagWorkerSkillContextV1,
 } from "homerail-protocol";
 import WebSocket from "ws";
+import { dagWorkspaceInputProjections } from "../persistence/run-input-artifacts.js";
 
 const OFFLINE_RETRY_MIN_MS = 1_000;
 const OFFLINE_RETRY_MAX_MS = 30_000;
@@ -607,6 +608,7 @@ export class WsDispatchAdapter implements DAGDispatcher {
       workspace: this.provisionerOpts?.workspace ?? envelope.workspace,
       workspaceReadOnly: Array.isArray(envelope.workspaceAccess?.writable_paths) &&
         envelope.workspaceAccess.writable_paths.length === 0,
+      workspaceInputs: dagWorkspaceInputProjections(envelope.runId),
       env: {
         ...(this.provisionerOpts?.env ?? {}),
         ...(agentBackend ? { AGENT_BACKEND: agentBackend } : {}),

--- a/homerail_manager/src/orchestration/ws-dispatch-adapter.ts
+++ b/homerail_manager/src/orchestration/ws-dispatch-adapter.ts
@@ -602,13 +602,14 @@ export class WsDispatchAdapter implements DAGDispatcher {
       `provisioned-${envelope.runId}-${envelope.nodeId}-${randomUUID()}`,
     );
     const agentBackend = normalizeAgentBackend(envelope.agentConfig.agent_type);
+    const workspaceInputs = dagWorkspaceInputProjections(envelope.runId);
     const provisionerOpts: ProvisionerOptions = {
       ...this.provisionerOpts,
       image: envelope.image ?? this.provisionerOpts?.image,
       workspace: this.provisionerOpts?.workspace ?? envelope.workspace,
       workspaceReadOnly: Array.isArray(envelope.workspaceAccess?.writable_paths) &&
         envelope.workspaceAccess.writable_paths.length === 0,
-      workspaceInputs: dagWorkspaceInputProjections(envelope.runId),
+      ...(workspaceInputs.length > 0 ? { workspaceInputs } : {}),
       env: {
         ...(this.provisionerOpts?.env ?? {}),
         ...(agentBackend ? { AGENT_BACKEND: agentBackend } : {}),

--- a/homerail_manager/src/persistence/db.ts
+++ b/homerail_manager/src/persistence/db.ts
@@ -34,6 +34,8 @@ const CLEARABLE_TABLES = new Set([
   "dag_chats",
   "dag_handoffs",
   "dag_artifacts",
+  "dag_run_inputs",
+  "dag_input_artifacts",
   "dag_actor_surface_snapshots",
   "dag_actor_surface_views",
   "dag_actor_surface_patch_queue",
@@ -1941,6 +1943,42 @@ function validateDagRunHotPathIndexesV33(db: SqliteDatabase): void {
       || actualColumns.some((column, position) => column !== expectedColumns[position])
     ) {
       throw new Error(`Schema migration 33 is incomplete: index ${name} has invalid columns`);
+    }
+  }
+}
+
+function validateDagRunInputSchemaV34(db: SqliteDatabase): void {
+  for (const table of ["dag_input_artifacts", "dag_run_inputs"]) {
+    if (!hasTable(db, table)) {
+      throw new Error(`Schema migration 34 is incomplete: missing table ${table}`);
+    }
+  }
+  const artifactColumns = new Set(
+    (db.prepare("PRAGMA table_info(dag_input_artifacts)").all() as Array<{ name: string }>)
+      .map((entry) => entry.name),
+  );
+  for (const column of [
+    "artifact_id", "scope_id", "name", "media_type", "sha256", "size_bytes", "created_at",
+  ]) {
+    if (!artifactColumns.has(column)) {
+      throw new Error(`Schema migration 34 is incomplete: dag_input_artifacts is missing ${column}`);
+    }
+  }
+  const bindingColumns = new Set(
+    (db.prepare("PRAGMA table_info(dag_run_inputs)").all() as Array<{ name: string }>)
+      .map((entry) => entry.name),
+  );
+  for (const column of [
+    "run_id", "logical_name", "artifact_id", "mount_path", "sha256", "size_bytes",
+    "media_type", "name", "created_at",
+  ]) {
+    if (!bindingColumns.has(column)) {
+      throw new Error(`Schema migration 34 is incomplete: dag_run_inputs is missing ${column}`);
+    }
+  }
+  for (const trigger of ["trg_dag_input_artifacts_no_update", "trg_dag_run_inputs_no_update"]) {
+    if (!db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'trigger' AND name = ?").get(trigger)) {
+      throw new Error(`Schema migration 34 is incomplete: missing trigger ${trigger}`);
     }
   }
 }
@@ -4119,6 +4157,64 @@ const SCHEMA_MIGRATIONS: readonly SchemaMigration[] = [
       `);
     },
     validate: validateDagRunHotPathIndexesV33,
+  },
+  {
+    version: 34,
+    up: (db) => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS dag_input_artifacts (
+          artifact_id TEXT PRIMARY KEY,
+          scope_id TEXT NOT NULL CHECK(length(scope_id) BETWEEN 1 AND 128),
+          name TEXT NOT NULL CHECK(length(name) BETWEEN 1 AND 128),
+          media_type TEXT NOT NULL CHECK(media_type IN (
+            'text/markdown', 'text/plain', 'application/json'
+          )),
+          sha256 TEXT NOT NULL CHECK(
+            length(sha256) = 64 AND sha256 NOT GLOB '*[^0-9a-f]*'
+          ),
+          size_bytes INTEGER NOT NULL CHECK(size_bytes BETWEEN 1 AND 1048576),
+          created_at INTEGER NOT NULL CHECK(created_at >= 0),
+          UNIQUE(scope_id, name, media_type, sha256)
+        );
+        CREATE INDEX IF NOT EXISTS idx_dag_input_artifacts_scope_created
+          ON dag_input_artifacts(scope_id, created_at, artifact_id);
+        CREATE TRIGGER IF NOT EXISTS trg_dag_input_artifacts_no_update
+        BEFORE UPDATE ON dag_input_artifacts
+        BEGIN
+          SELECT RAISE(ABORT, 'DAG input artifacts are immutable');
+        END;
+
+        CREATE TABLE IF NOT EXISTS dag_run_inputs (
+          run_id TEXT NOT NULL,
+          logical_name TEXT NOT NULL CHECK(length(logical_name) BETWEEN 1 AND 128),
+          artifact_id TEXT NOT NULL,
+          mount_path TEXT NOT NULL CHECK(length(mount_path) BETWEEN 7 AND 512),
+          sha256 TEXT NOT NULL CHECK(
+            length(sha256) = 64 AND sha256 NOT GLOB '*[^0-9a-f]*'
+          ),
+          size_bytes INTEGER NOT NULL CHECK(size_bytes BETWEEN 1 AND 1048576),
+          media_type TEXT NOT NULL CHECK(media_type IN (
+            'text/markdown', 'text/plain', 'application/json'
+          )),
+          name TEXT NOT NULL CHECK(length(name) BETWEEN 1 AND 128),
+          created_at INTEGER NOT NULL CHECK(created_at >= 0),
+          PRIMARY KEY(run_id, logical_name),
+          UNIQUE(run_id, mount_path),
+          FOREIGN KEY(run_id) REFERENCES dag_runs(run_id)
+            ON UPDATE RESTRICT ON DELETE CASCADE,
+          FOREIGN KEY(artifact_id) REFERENCES dag_input_artifacts(artifact_id)
+            ON UPDATE RESTRICT ON DELETE RESTRICT
+        );
+        CREATE INDEX IF NOT EXISTS idx_dag_run_inputs_artifact
+          ON dag_run_inputs(artifact_id, run_id);
+        CREATE TRIGGER IF NOT EXISTS trg_dag_run_inputs_no_update
+        BEFORE UPDATE ON dag_run_inputs
+        BEGIN
+          SELECT RAISE(ABORT, 'DAG run input bindings are immutable');
+        END;
+      `);
+    },
+    validate: validateDagRunInputSchemaV34,
   },
 ];
 

--- a/homerail_manager/src/persistence/run-input-artifacts.ts
+++ b/homerail_manager/src/persistence/run-input-artifacts.ts
@@ -1,0 +1,360 @@
+import { createHash, randomUUID } from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type {
+  DagRunInputArtifactDescriptor,
+  DagRunInputBinding,
+  DagRunInputBindingRequest,
+  DagRunInputMediaType,
+  DagWorkspaceInputProjection,
+  StageDagRunInputRequest,
+} from "homerail-protocol";
+import { getDataRoot, getHomerailHome } from "../config/env.js";
+import { getDb } from "./db.js";
+
+export const MAX_DAG_RUN_INPUT_FILES = 16;
+export const MAX_DAG_RUN_INPUT_BYTES = 1024 * 1024;
+
+const SCOPE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const IDENTIFIER_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const FILE_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const MEDIA_TYPES = new Set<string>(["text/markdown", "text/plain", "application/json"]);
+
+interface InputArtifactRow {
+  artifact_id: string;
+  scope_id: string;
+  name: string;
+  media_type: DagRunInputMediaType;
+  sha256: string;
+  size_bytes: number;
+  created_at: number;
+}
+
+interface RunInputRow extends InputArtifactRow {
+  run_id: string;
+  logical_name: string;
+  mount_path: string;
+  bound_at: number;
+}
+
+function assertScope(value: string): string {
+  const normalized = value.trim();
+  if (!SCOPE_PATTERN.test(normalized)) {
+    throw new Error("input_scope must be a 1-128 character stable identifier");
+  }
+  return normalized;
+}
+
+function assertName(value: string): string {
+  const normalized = value.trim();
+  if (!FILE_NAME_PATTERN.test(normalized) || normalized === "." || normalized === "..") {
+    throw new Error("run input name must be a safe file name");
+  }
+  return normalized;
+}
+
+function assertLogicalName(value: string): string {
+  const normalized = value.trim();
+  if (!IDENTIFIER_PATTERN.test(normalized)) {
+    throw new Error("run input logical_name must be a safe identifier");
+  }
+  return normalized;
+}
+
+function assertArtifactId(value: string): string {
+  const normalized = value.trim();
+  if (!/^input-[0-9a-f]{64}$/.test(normalized)) {
+    throw new Error("run input artifact_id is invalid");
+  }
+  return normalized;
+}
+
+function mountPathSegments(value: string): string[] {
+  const normalized = value.replace(/\\/g, "/").trim();
+  if (!normalized || normalized.startsWith("/") || /^[A-Za-z]:\//.test(normalized)) {
+    throw new Error("run input mount_path must be relative");
+  }
+  const segments = normalized.split("/");
+  if (
+    segments.length < 2
+    || segments[0] !== "input"
+    || segments.some((segment) => (
+      !segment
+      || segment === "."
+      || segment === ".."
+      || !/^[A-Za-z0-9._-]+$/.test(segment)
+    ))
+  ) {
+    throw new Error("run input mount_path must be a safe path below input/");
+  }
+  if (normalized.length > 512) throw new Error("run input mount_path exceeds 512 characters");
+  return segments;
+}
+
+function mediaType(value: string): DagRunInputMediaType {
+  if (!MEDIA_TYPES.has(value)) throw new Error(`unsupported run input media_type: ${value}`);
+  return value as DagRunInputMediaType;
+}
+
+function artifactDescriptor(row: InputArtifactRow): DagRunInputArtifactDescriptor {
+  return {
+    artifact_id: row.artifact_id,
+    scope_id: row.scope_id,
+    name: row.name,
+    media_type: row.media_type,
+    sha256: row.sha256,
+    size_bytes: row.size_bytes,
+    created_at: row.created_at,
+  };
+}
+
+function blobPath(sha256: string): string {
+  return path.join(getDataRoot(), "run-inputs", "blobs", sha256.slice(0, 2), sha256, "blob");
+}
+
+function ensurePrivateDir(value: string): void {
+  fs.mkdirSync(value, { recursive: true, mode: 0o700 });
+  try { fs.chmodSync(value, 0o700); } catch { /* Best effort on non-POSIX filesystems. */ }
+}
+
+function verifyBytes(bytes: Uint8Array, expectedSha256: string, expectedSize: number): void {
+  if (bytes.byteLength !== expectedSize) throw new Error("run input artifact size does not match its descriptor");
+  const digest = createHash("sha256").update(bytes).digest("hex");
+  if (digest !== expectedSha256) throw new Error("run input artifact digest does not match its descriptor");
+}
+
+function readArtifactBytes(record: Pick<InputArtifactRow, "sha256" | "size_bytes">): Buffer {
+  const file = blobPath(record.sha256);
+  const bytes = fs.readFileSync(file);
+  verifyBytes(bytes, record.sha256, record.size_bytes);
+  return bytes;
+}
+
+function persistBlob(bytes: Uint8Array, sha256: string): void {
+  const file = blobPath(sha256);
+  if (fs.existsSync(file)) {
+    verifyBytes(fs.readFileSync(file), sha256, bytes.byteLength);
+    return;
+  }
+  const dir = path.dirname(file);
+  ensurePrivateDir(dir);
+  const temporary = path.join(dir, `.blob-${randomUUID()}.tmp`);
+  fs.writeFileSync(temporary, bytes, { flag: "wx", mode: 0o600 });
+  try {
+    fs.renameSync(temporary, file);
+  } finally {
+    try { fs.unlinkSync(temporary); } catch { /* Rename already consumed it. */ }
+  }
+  verifyBytes(fs.readFileSync(file), sha256, bytes.byteLength);
+}
+
+export function stageDagRunInputArtifact(request: StageDagRunInputRequest): DagRunInputArtifactDescriptor {
+  const scopeId = assertScope(request.scope_id);
+  const name = assertName(request.name);
+  const normalizedMediaType = mediaType(request.media_type);
+  if (typeof request.content !== "string") throw new Error("run input content must be a string");
+  const bytes = Buffer.from(request.content, "utf8");
+  if (bytes.byteLength < 1 || bytes.byteLength > MAX_DAG_RUN_INPUT_BYTES) {
+    throw new Error(`run input content must contain 1-${MAX_DAG_RUN_INPUT_BYTES} UTF-8 bytes`);
+  }
+  if (normalizedMediaType === "application/json") {
+    try { JSON.parse(request.content); } catch { throw new Error("application/json run input must contain valid JSON"); }
+  }
+  const sha256 = createHash("sha256").update(bytes).digest("hex");
+  const identity = createHash("sha256")
+    .update(`${scopeId}\0${name}\0${normalizedMediaType}\0${sha256}`)
+    .digest("hex");
+  const artifactId = `input-${identity}`;
+  persistBlob(bytes, sha256);
+  const createdAt = Date.now();
+  getDb().prepare(`
+    INSERT OR IGNORE INTO dag_input_artifacts(
+      artifact_id, scope_id, name, media_type, sha256, size_bytes, created_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run(artifactId, scopeId, name, normalizedMediaType, sha256, bytes.byteLength, createdAt);
+  const record = getDagRunInputArtifact(artifactId);
+  if (!record
+    || record.scope_id !== scopeId
+    || record.name !== name
+    || record.media_type !== normalizedMediaType
+    || record.sha256 !== sha256
+    || record.size_bytes !== bytes.byteLength) {
+    throw new Error("run input artifact identity conflicts with persisted metadata");
+  }
+  return record;
+}
+
+export function getDagRunInputArtifact(artifactId: string): DagRunInputArtifactDescriptor | undefined {
+  const row = getDb().prepare(`
+    SELECT artifact_id, scope_id, name, media_type, sha256, size_bytes, created_at
+    FROM dag_input_artifacts
+    WHERE artifact_id = ?
+  `).get(assertArtifactId(artifactId)) as InputArtifactRow | undefined;
+  return row ? artifactDescriptor(row) : undefined;
+}
+
+export function resolveDagRunInputBindings(
+  scopeId: string,
+  requests: DagRunInputBindingRequest[],
+): DagRunInputBinding[] {
+  const scope = assertScope(scopeId);
+  if (!Array.isArray(requests) || requests.length < 1 || requests.length > MAX_DAG_RUN_INPUT_FILES) {
+    throw new Error(`input_artifacts must contain 1-${MAX_DAG_RUN_INPUT_FILES} bindings`);
+  }
+  const logicalNames = new Set<string>();
+  const mountPaths = new Set<string>();
+  return requests.map((request) => {
+    const artifactId = assertArtifactId(request.artifact_id);
+    const logicalName = assertLogicalName(request.logical_name);
+    const mountPath = mountPathSegments(request.mount_path).join("/");
+    if (logicalNames.has(logicalName)) throw new Error(`duplicate run input logical_name: ${logicalName}`);
+    if (mountPaths.has(mountPath)) throw new Error(`duplicate run input mount_path: ${mountPath}`);
+    logicalNames.add(logicalName);
+    mountPaths.add(mountPath);
+    const artifact = getDagRunInputArtifact(artifactId);
+    if (!artifact) throw new Error(`run input artifact was not found: ${artifactId}`);
+    if (artifact.scope_id !== scope) throw new Error(`run input artifact belongs to a different scope: ${artifactId}`);
+    return {
+      ...artifact,
+      run_id: "",
+      logical_name: logicalName,
+      mount_path: mountPath,
+      bound_at: 0,
+    };
+  });
+}
+
+export function bindDagRunInputs(runId: string, bindings: DagRunInputBinding[]): DagRunInputBinding[] {
+  const now = Date.now();
+  const insert = getDb().prepare(`
+    INSERT INTO dag_run_inputs(
+      run_id, logical_name, artifact_id, mount_path, sha256, size_bytes,
+      media_type, name, created_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  for (const binding of bindings) {
+    const boundAt = binding.bound_at > 0 ? binding.bound_at : now;
+    insert.run(
+      runId,
+      binding.logical_name,
+      binding.artifact_id,
+      binding.mount_path,
+      binding.sha256,
+      binding.size_bytes,
+      binding.media_type,
+      binding.name,
+      boundAt,
+    );
+  }
+  return listDagRunInputs(runId);
+}
+
+export function listDagRunInputs(runId: string): DagRunInputBinding[] {
+  const rows = getDb().prepare(`
+    SELECT i.artifact_id, a.scope_id, i.name, i.media_type, i.sha256, i.size_bytes,
+           a.created_at, i.run_id, i.logical_name, i.mount_path, i.created_at AS bound_at
+    FROM dag_run_inputs i
+    JOIN dag_input_artifacts a ON a.artifact_id = i.artifact_id
+    WHERE i.run_id = ?
+    ORDER BY i.logical_name
+  `).all(runId) as RunInputRow[];
+  return rows.map((row) => ({ ...artifactDescriptor(row),
+    run_id: row.run_id,
+    logical_name: row.logical_name,
+    mount_path: row.mount_path,
+    bound_at: row.bound_at,
+  }));
+}
+
+function runWorkspacePath(runId: string): string {
+  const segments = runId.replace(/\\/g, "/").split("/");
+  if (segments.some((segment) => !segment || segment === "." || segment === ".." || !/^[A-Za-z0-9._-]+$/.test(segment))) {
+    throw new Error("run id cannot be projected into a workspace path");
+  }
+  const root = path.resolve(getHomerailHome(), "workspace");
+  const target = path.resolve(root, ...segments);
+  const relative = path.relative(root, target);
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error("run input workspace path is unsafe");
+  }
+  return target;
+}
+
+function assertNoSymlinkPath(root: string, segments: string[]): void {
+  let current = root;
+  for (const segment of segments) {
+    current = path.join(current, segment);
+    if (!fs.existsSync(current)) continue;
+    if (fs.lstatSync(current).isSymbolicLink()) throw new Error("run input projection cannot traverse a symlink");
+  }
+}
+
+export function materializeDagRunInputs(
+  runId: string,
+  bindings: DagRunInputBinding[] = listDagRunInputs(runId),
+): string {
+  const workspace = runWorkspacePath(runId);
+  const inputRoot = path.join(workspace, "input");
+  ensurePrivateDir(inputRoot);
+  const directories = new Set<string>([inputRoot]);
+  for (const binding of bindings) {
+    const segments = mountPathSegments(binding.mount_path);
+    assertNoSymlinkPath(workspace, segments);
+    const target = path.resolve(workspace, ...segments);
+    const relative = path.relative(inputRoot, target);
+    if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+      throw new Error("run input projection escaped input root");
+    }
+    const parent = path.dirname(target);
+    fs.mkdirSync(parent, { recursive: true, mode: 0o700 });
+    let cursor = parent;
+    while (cursor === inputRoot || cursor.startsWith(`${inputRoot}${path.sep}`)) {
+      directories.add(cursor);
+      if (cursor === inputRoot) break;
+      cursor = path.dirname(cursor);
+    }
+    const bytes = readArtifactBytes(binding);
+    if (fs.existsSync(target)) {
+      if (!fs.lstatSync(target).isFile()) throw new Error("run input projection target is not a regular file");
+      verifyBytes(fs.readFileSync(target), binding.sha256, binding.size_bytes);
+    } else {
+      const temporary = path.join(parent, `.input-${randomUUID()}.tmp`);
+      fs.writeFileSync(temporary, bytes, { flag: "wx", mode: 0o400 });
+      fs.renameSync(temporary, target);
+    }
+    try { fs.chmodSync(target, 0o444); } catch { /* Mount policy is the hard boundary. */ }
+  }
+  for (const directory of Array.from(directories).sort((left, right) => right.length - left.length)) {
+    try { fs.chmodSync(directory, 0o555); } catch { /* Best effort on non-POSIX filesystems. */ }
+  }
+  return inputRoot;
+}
+
+export function verifyDagRunInputs(runId: string): DagRunInputBinding[] {
+  const bindings = listDagRunInputs(runId);
+  for (const binding of bindings) readArtifactBytes(binding);
+  if (bindings.length > 0) materializeDagRunInputs(runId, bindings);
+  return bindings;
+}
+
+export function dagWorkspaceInputProjections(runId: string): DagWorkspaceInputProjection[] {
+  return listDagRunInputs(runId).map((binding) => {
+    const bytes = readArtifactBytes(binding);
+    return {
+      logical_name: binding.logical_name,
+      mount_path: binding.mount_path,
+      media_type: binding.media_type,
+      sha256: binding.sha256,
+      size_bytes: binding.size_bytes,
+      content_base64: bytes.toString("base64"),
+    };
+  });
+}
+
+export function dagRunInputPath(runId: string, logicalName: string): string {
+  const wanted = assertLogicalName(logicalName);
+  const binding = listDagRunInputs(runId).find((entry) => entry.logical_name === wanted);
+  if (!binding) throw new Error(`run input is not bound: ${wanted}`);
+  materializeDagRunInputs(runId, [binding]);
+  return path.resolve(runWorkspacePath(runId), ...mountPathSegments(binding.mount_path));
+}

--- a/homerail_manager/src/persistence/store.ts
+++ b/homerail_manager/src/persistence/store.ts
@@ -16,7 +16,7 @@ import { DAG_EVENT_TYPES, emit, subscribe, type DAGEventPayload } from "../event
 import type { DAGRunCounters, DAGRunLimits } from "../runtime/active-runs.js";
 import { assertStatus, type DagRunStatus } from "./status.js";
 import { assertEpochMs, nowEpochMs } from "./time.js";
-import { redactTelemetry } from "homerail-protocol";
+import { redactTelemetry, type DagRunInputBinding } from "homerail-protocol";
 
 // Contract marker for regression: "dag:instruction_terminal_no_active_target"
 // is persisted through DAG_EVENT_TYPES.
@@ -31,6 +31,8 @@ export interface SerializableRun {
   contracts?: Record<string, unknown>;
   artifacts?: DAGArtifactDeclaration[];
   runInputTargets?: Array<{ node: string; port: string; contract?: string }>;
+  inputArtifacts?: DagRunInputBinding[];
+  brokerState?: Record<string, unknown>;
   initialPrompt?: string;
   nodeCount?: number;
   agents?: Record<string, { agent_type?: string; model?: string; system?: string; description?: string; skills?: string[]; allowed_surface_views?: string[]; extra?: Record<string, unknown> }>;
@@ -266,6 +268,8 @@ export function serializeRunMetadata(run: SerializableRun): PersistedRunMetadata
     contracts: run.contracts,
     artifacts: run.artifacts,
     runInputTargets: run.runInputTargets,
+    inputArtifacts: run.inputArtifacts ? structuredClone(run.inputArtifacts) : undefined,
+    brokerState: run.brokerState ? structuredClone(run.brokerState) : undefined,
     initialPrompt: run.initialPrompt,
     nodeCount: run.nodeCount,
     agents: run.agents,

--- a/homerail_manager/src/persistence/types.ts
+++ b/homerail_manager/src/persistence/types.ts
@@ -8,7 +8,7 @@ import type {
 } from "../orchestration/graph.js";
 import type { DAGRunCounters, DAGRunLimits } from "../runtime/active-runs.js";
 import type { DagRunStatus } from "./status.js";
-import type { DagNodeUsageScope } from "homerail-protocol";
+import type { DagNodeUsageScope, DagRunInputBinding } from "homerail-protocol";
 
 export interface PersistedGraphNode {
   node_id: string;
@@ -78,6 +78,8 @@ export interface PersistedRunMetadata {
   contracts?: Record<string, unknown>;
   artifacts?: DAGArtifactDeclaration[];
   runInputTargets?: Array<{ node: string; port: string; contract?: string }>;
+  inputArtifacts?: DagRunInputBinding[];
+  brokerState?: Record<string, unknown>;
   initialPrompt?: string;
   nodeCount?: number;
   agents?: Record<string, { agent_type?: string; model?: string; system?: string; description?: string; skills?: string[]; allowed_surface_views?: string[]; extra?: Record<string, unknown> }>;

--- a/homerail_manager/src/runtime/active-runs.ts
+++ b/homerail_manager/src/runtime/active-runs.ts
@@ -47,6 +47,7 @@ import {
   type DagAgentToolName,
   type DagWorkspaceAccess,
   type DagCredentialProjection,
+  type DagRunInputBinding,
 } from "homerail-protocol";
 import { resolveAgentRuntimeConfig } from "./agent-runtime-resolver.js";
 import {
@@ -88,6 +89,12 @@ import { getDagActivitySequenceCursor } from "../persistence/dag-activity-journa
 import { getDagActorSurfaceView } from "../persistence/dag-actor-surface-patches.js";
 import { getDb } from "../persistence/db.js";
 import { getCredential, materializeCredential } from "../persistence/credentials.js";
+import {
+  bindDagRunInputs,
+  dagRunInputPath,
+  materializeDagRunInputs,
+  verifyDagRunInputs,
+} from "../persistence/run-input-artifacts.js";
 import {
   createInitialDagRunRound,
   getCurrentDagRunRound,
@@ -231,6 +238,8 @@ export interface ActiveRun {
   contracts?: Record<string, unknown>;
   artifacts?: DAGArtifactDeclaration[];
   runInputTargets?: Array<{ node: string; port: string; contract?: string }>;
+  inputArtifacts?: DagRunInputBinding[];
+  brokerState: Record<string, unknown>;
   initialPrompt?: string;
   nodeCount?: number;
   agents?: Record<string, DAGAgentConfig>;
@@ -342,6 +351,7 @@ export interface DAGRunCounters {
   dispatch_retries: Record<string, number>;
   gateway_iterations: Record<string, number>;
   gateway_results: Record<string, unknown[]>;
+  fanout_invocations: Record<string, number>;
   abort_reason?: string;
 }
 
@@ -360,6 +370,7 @@ export interface AppendRunNodeResult {
 
 export interface CreateActiveRunOptions {
   initialPrompt?: string;
+  inputArtifacts?: DagRunInputBinding[];
 }
 
 const store = new Map<string, ActiveRun>();
@@ -416,6 +427,7 @@ function _initialCounters(): DAGRunCounters {
     dispatch_retries: {},
     gateway_iterations: {},
     gateway_results: {},
+    fanout_invocations: {},
   };
 }
 
@@ -433,6 +445,7 @@ function _restoreCounters(counters: DAGRunCounters | undefined): DAGRunCounters 
     dispatch_retries: { ...(counters.dispatch_retries ?? {}) },
     gateway_iterations: { ...(counters.gateway_iterations ?? {}) },
     gateway_results: { ...(counters.gateway_results ?? {}) },
+    fanout_invocations: { ...(counters.fanout_invocations ?? {}) },
   };
 }
 
@@ -642,6 +655,29 @@ function _ensureNodeSession(run: ActiveRun, nodeId: string): NodeSessionState {
   return _persistNodeSession(run, nodeId, state);
 }
 
+function _nodeSessionScope(node: DAGGraphNode | undefined): "node" | "dispatch" {
+  return _agentRuntimeConfig(node ?? {} as DAGGraphNode).session_scope === "dispatch" ? "dispatch" : "node";
+}
+
+function _prepareNodeSessionForDispatch(run: ActiveRun, node: DAGGraphNode): NodeSessionState {
+  const current = _ensureNodeSession(run, node.node_id);
+  if (_nodeSessionScope(node) !== "dispatch") return current;
+  if (!new Set(["completed", "failed", "cancelled"]).has(current.status)) return current;
+  const fresh = _persistNodeSession(run, node.node_id, {
+    sessionId: _newSessionId(run.runId, node.node_id),
+    attempt: current.attempt + 1,
+    status: "active",
+  });
+  emit("dag:node_session_reset", {
+    runId: run.runId,
+    nodeId: node.node_id,
+    previousSessionId: current.sessionId,
+    sessionId: fresh.sessionId,
+    attempt: fresh.attempt,
+  });
+  return fresh;
+}
+
 function _markNodeSessionStatus(run: ActiveRun, nodeId: string, status: string): void {
   const current = run.nodeSessions.get(nodeId);
   if (!current) return;
@@ -764,6 +800,14 @@ export function createActiveRun(
   });
   const dagRun = createDAGRun(parsedDAG, runId);
   const createdAt = Date.now();
+  const inputArtifacts = options.inputArtifacts?.map((binding) => ({
+    ...structuredClone(binding),
+    run_id: runId,
+    bound_at: createdAt,
+  }));
+  if (inputArtifacts && inputArtifacts.length > 0) {
+    materializeDagRunInputs(runId, inputArtifacts);
+  }
   seedInitialPrompt(
     dagRun,
     options.initialPrompt,
@@ -785,6 +829,8 @@ export function createActiveRun(
     runInputTargets: parsedDAG.meta.run_input_targets
       ? parsedDAG.meta.run_input_targets.map((target) => ({ ...target }))
       : undefined,
+    inputArtifacts,
+    brokerState: {},
     initialPrompt: options.initialPrompt,
     nodeCount: parsedDAG.graph.nodes.length,
     agents: parsedDAG.meta.agents
@@ -811,6 +857,7 @@ export function createActiveRun(
   _assertLogicalActorIdentities(run.dagRun.graph.nodes);
   dbTransaction(() => {
     writeRunMetadata(runId, serializeRunMetadata(run));
+    if (inputArtifacts && inputArtifacts.length > 0) bindDagRunInputs(runId, inputArtifacts);
     pinDagRunSkillContexts({
       run_id: runId,
       contexts: skillContexts,
@@ -1084,6 +1131,16 @@ export function restoreActiveRun(
     return { status: "skipped", reason: "run already active in this process" };
   }
 
+  const verifiedInputArtifacts = verifyDagRunInputs(metadata.runId);
+  if ((metadata.inputArtifacts?.length ?? 0) !== verifiedInputArtifacts.length) {
+    throw new Error(`persisted run input provenance does not match bound inputs for ${metadata.runId}`);
+  }
+  if (metadata.inputArtifacts && !isDeepStrictEqual(
+    metadata.inputArtifacts.map((entry) => ({ ...entry })).sort((left, right) => left.logical_name.localeCompare(right.logical_name)),
+    verifiedInputArtifacts.map((entry) => ({ ...entry })).sort((left, right) => left.logical_name.localeCompare(right.logical_name)),
+  )) {
+    throw new Error(`persisted run input provenance changed for ${metadata.runId}`);
+  }
   const { dagRun, nodes } = _rebuildDagRunFromPersisted(metadata, metadata.graph);
   if (!metadata.dagRuntimeState) {
     seedInitialPrompt(dagRun, metadata.initialPrompt, metadata.runInputTargets, metadata.contracts);
@@ -1130,6 +1187,8 @@ export function restoreActiveRun(
     runInputTargets: metadata.runInputTargets
       ? metadata.runInputTargets.map((target) => ({ ...target }))
       : undefined,
+    inputArtifacts: verifiedInputArtifacts.length > 0 ? verifiedInputArtifacts : undefined,
+    brokerState: metadata.brokerState ? structuredClone(metadata.brokerState) : {},
     initialPrompt: metadata.initialPrompt,
     nodeCount: metadata.nodeCount,
     agents: metadata.agents
@@ -1250,6 +1309,24 @@ export function dispatchRecoveredRuns(dispatcher: DAGDispatcher): number {
 
 export function getActiveRun(runId: string): ActiveRun | undefined {
   return store.get(runId);
+}
+
+export function getActiveRunBrokerState(runId: string, key: string): unknown {
+  const run = store.get(runId);
+  if (!run || !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(key)) return undefined;
+  return run.brokerState[key] === undefined ? undefined : structuredClone(run.brokerState[key]);
+}
+
+export function setActiveRunBrokerState(runId: string, key: string, value: unknown): void {
+  const run = store.get(runId);
+  if (!run || run.status !== "active") throw new Error("Broker state run is not active");
+  if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(key)) throw new Error("Broker state key is invalid");
+  const encoded = JSON.stringify(value);
+  if (encoded === undefined || Buffer.byteLength(encoded, "utf8") > 64 * 1024) {
+    throw new Error("Broker state exceeds 64 KiB");
+  }
+  run.brokerState[key] = structuredClone(value);
+  writeRunMetadata(runId, serializeRunMetadata(run));
 }
 
 export function getCurrentNodeSession(runId: string, nodeId: string): NodeSessionState | undefined {
@@ -1899,6 +1976,8 @@ export function requestNodeCorrection(
   resetSkippedSuccessDescendants(run.dagRun, nodeId);
   run.dagRun.nodeStates.set(nodeId, "READY");
   run.dagRun.handoffedNodes.delete(nodeId);
+  const node = run.dagRun.graph.nodes.find((candidate) => candidate.node_id === nodeId);
+  if (_nodeSessionScope(node) === "dispatch") _markNodeSessionStatus(run, nodeId, "completed");
   writeRunMetadata(runId, serializeRunMetadata(run));
   _emitNodeStateChanges(run, before);
   emit("dag:node_correction_requested", { runId, nodeId, reason, attempt, maxAttempts });
@@ -3587,6 +3666,7 @@ function _commandAllowlist(): Set<string> {
 }
 
 const RUN_WORKSPACE_CWD = "$run_workspace";
+const RUN_INPUT_ARGUMENT_PREFIX = "$run_input/";
 
 function _pathIsWithin(root: string, target: string): boolean {
   const relative = path.relative(root, target);
@@ -3650,6 +3730,28 @@ function _commandGatewayResult(run: ActiveRun, node: DAGGraphNode): { port: stri
   if (!Array.isArray(command) || command.length === 0 || command.some((part) => typeof part !== "string")) {
     return { port: config?.failure_port || "failed", payload: { ok: false, error: "invalid command configuration" } };
   }
+  if (command[0].startsWith(RUN_INPUT_ARGUMENT_PREFIX)) {
+    return {
+      port: config?.failure_port || "failed",
+      payload: { ok: false, error: "$run_input cannot be used as a command executable" },
+    };
+  }
+  let resolvedCommand: string[];
+  try {
+    resolvedCommand = command.map((part, index) => {
+      if (index === 0 || !part.startsWith(RUN_INPUT_ARGUMENT_PREFIX)) return part;
+      const logicalName = part.slice(RUN_INPUT_ARGUMENT_PREFIX.length);
+      if (!logicalName || logicalName.includes("/") || logicalName.includes("\\")) {
+        throw new Error("$run_input arguments must reference one logical input name");
+      }
+      return dagRunInputPath(run.runId, logicalName);
+    });
+  } catch (error) {
+    return {
+      port: config?.failure_port || "failed",
+      payload: { ok: false, error: error instanceof Error ? error.message : String(error) },
+    };
+  }
   if (config?.command_field && process.env.HOMERAIL_DAG_ALLOW_DYNAMIC_COMMANDS !== "true") {
     return {
       port: config?.failure_port || "failed",
@@ -3679,7 +3781,7 @@ function _commandGatewayResult(run: ActiveRun, node: DAGGraphNode): { port: stri
       : undefined;
   const captureLimit = Math.max(1, Math.floor(config?.capture_limit ?? 64_000));
   const startedAt = Date.now();
-  const result = spawnSync(command[0], command.slice(1), {
+  const result = spawnSync(resolvedCommand[0], resolvedCommand.slice(1), {
     cwd,
     encoding: "utf8",
     timeout: Math.max(100, Math.floor(config?.timeout_ms ?? 30_000)),
@@ -3966,6 +4068,7 @@ function _startAwaitCommand(run: ActiveRun, node: DAGGraphNode): boolean {
 }
 
 interface FanoutRuntimeState {
+  invocation: number;
   items: unknown[];
   context?: unknown;
   next_index: number;
@@ -3979,12 +4082,134 @@ function _fanoutState(node: DAGGraphNode): FanoutRuntimeState | undefined {
   return raw as unknown as FanoutRuntimeState;
 }
 
+function _fanoutSafeRelativePath(raw: unknown, fallback: string): string {
+  const value = typeof raw === "string" && raw.trim() ? raw.trim().replace(/\\/g, "/") : fallback;
+  const segments = value.split("/");
+  if (path.isAbsolute(value) || segments.some((segment) => !segment || segment === "." || segment === ".." || !/^[A-Za-z0-9._-]+$/.test(segment))) {
+    throw new Error(`fanout workspace path '${value}' is unsafe`);
+  }
+  return segments.join("/");
+}
+
+function _fanoutChildWorkspacePath(node: DAGGraphNode, state: FanoutRuntimeState, index: number): string {
+  const root = _fanoutSafeRelativePath(node.gateway_config?.workspace_root, "workers");
+  return `${root}/${node.node_id}/inv_${String(state.invocation).padStart(4, "0")}/item_${String(index + 1).padStart(4, "0")}`;
+}
+
+function _fanoutWorkerRuntime(
+  node: DAGGraphNode,
+  state: FanoutRuntimeState,
+  index: number,
+  childId: string,
+  workspacePath?: string,
+): Record<string, unknown> {
+  const configured = node.gateway_config?.worker_policy;
+  const policy = configured && typeof configured === "object" && !Array.isArray(configured)
+    ? structuredClone(configured as Record<string, unknown>)
+    : {};
+  const replacements: Record<string, string> = {
+    "{{fanout_parent}}": node.node_id,
+    "{{fanout_invocation}}": String(state.invocation),
+    "{{fanout_index}}": String(index + 1),
+    "{{fanout_child}}": childId,
+  };
+  const replacePath = (value: unknown): unknown => {
+    if (typeof value !== "string") return value;
+    return Object.entries(replacements).reduce((result, [token, replacement]) => result.split(token).join(replacement), value);
+  };
+  const rawAccess = policy.workspace_access;
+  const access = rawAccess && typeof rawAccess === "object" && !Array.isArray(rawAccess)
+    ? structuredClone(rawAccess as Record<string, unknown>)
+    : {};
+  if (workspacePath) {
+    access.writable_paths = [workspacePath];
+  } else {
+    access.writable_paths = Array.isArray(access.writable_paths) ? access.writable_paths.map(replacePath) : [];
+  }
+  access.readonly_paths = Array.from(new Set([
+    "input",
+    ...(Array.isArray(access.readonly_paths) ? access.readonly_paths.map(replacePath).filter((entry): entry is string => typeof entry === "string") : []),
+  ])).sort();
+  policy.workspace_access = access;
+  policy.allowed_builtin_tools = Array.isArray(policy.allowed_builtin_tools) ? policy.allowed_builtin_tools : [];
+  policy.allowed_dag_tools = Array.isArray(policy.allowed_dag_tools) ? policy.allowed_dag_tools : ["handoff"];
+  policy.credentials = Array.isArray(policy.credentials) ? policy.credentials : [];
+  return policy;
+}
+
+function _prepareFanoutGitWorktree(
+  run: ActiveRun,
+  node: DAGGraphNode,
+  state: FanoutRuntimeState,
+  index: number,
+): string | undefined {
+  if (node.gateway_config?.workspace_strategy !== "isolated_git_worktree") return undefined;
+  const workspacePath = _fanoutChildWorkspacePath(node, state, index);
+  const resolved = _commandGatewayCwd(run, RUN_WORKSPACE_CWD);
+  if ("error" in resolved) throw new Error(resolved.error);
+  const runWorkspace = resolved.cwd;
+  const repositoryPath = node.gateway_config?.repository_path === "."
+    ? "."
+    : _fanoutSafeRelativePath(node.gateway_config?.repository_path, "repo");
+  const repository = path.resolve(runWorkspace, repositoryPath);
+  const target = path.resolve(runWorkspace, workspacePath);
+  if (!_pathIsWithin(runWorkspace, repository) || !_pathIsWithin(runWorkspace, target)) {
+    throw new Error("fanout git worktree path escaped the run workspace");
+  }
+  mkdirSync(path.dirname(target), { recursive: true, mode: 0o700 });
+  const existing = spawnSync("git", ["-C", target, "rev-parse", "--is-inside-work-tree"], {
+    encoding: "utf8",
+    timeout: 10_000,
+    shell: false,
+  });
+  if (existing.status === 0 && String(existing.stdout).trim() === "true") return workspacePath;
+  const selectedRevision = node.gateway_config?.revision_field
+    ? _fieldValue(state.context, node.gateway_config.revision_field)
+    : undefined;
+  const revision = typeof selectedRevision === "string" && /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i.test(selectedRevision)
+    ? selectedRevision.toLowerCase()
+    : "HEAD";
+  if (revision !== "HEAD") {
+    const local = spawnSync("git", ["-C", repository, "cat-file", "-e", `${revision}^{commit}`], {
+      encoding: "utf8",
+      timeout: 10_000,
+      shell: false,
+    });
+    if (local.status !== 0) {
+      const fetched = spawnSync("git", ["-C", repository, "fetch", "--no-tags", "origin", revision], {
+        encoding: "utf8",
+        timeout: 60_000,
+        maxBuffer: 256_000,
+        shell: false,
+      });
+      if (fetched.status !== 0 || fetched.error) {
+        const detail = String(fetched.stderr || fetched.error?.message || "unknown error").trim().slice(0, 1_000);
+        throw new Error(`fanout git revision fetch failed: ${detail}`);
+      }
+    }
+  }
+  const created = spawnSync("git", ["-C", repository, "worktree", "add", "--detach", target, revision], {
+    encoding: "utf8",
+    timeout: 60_000,
+    maxBuffer: 256_000,
+    shell: false,
+  });
+  if (created.status !== 0 || created.error) {
+    const detail = String(created.stderr || created.error?.message || "unknown error").trim().slice(0, 1_000);
+    throw new Error(`fanout git worktree creation failed: ${detail}`);
+  }
+  return workspacePath;
+}
+
 function _spawnFanoutChildren(run: ActiveRun, node: DAGGraphNode, state: FanoutRuntimeState): void {
   const config = node.gateway_config;
   const maxParallelism = Math.max(1, Math.floor(config?.max_parallelism ?? 1));
   while (state.active.length < maxParallelism && state.next_index < state.items.length) {
     const index = state.next_index++;
-    const childId = `${node.node_id}__item_${String(index + 1).padStart(4, "0")}`;
+    const childId = state.invocation === 1
+      ? `${node.node_id}__item_${String(index + 1).padStart(4, "0")}`
+      : `${node.node_id}__inv_${String(state.invocation).padStart(4, "0")}__item_${String(index + 1).padStart(4, "0")}`;
+    const workspacePath = _prepareFanoutGitWorktree(run, node, state, index);
     const child: DAGGraphNode = {
       node_id: childId,
       name: `${node.name} item ${index + 1}`,
@@ -3997,7 +4222,8 @@ function _spawnFanoutChildren(run: ActiveRun, node: DAGGraphNode, state: FanoutR
         failed: { to: "", condition: "on_failure" },
       },
       extra: {
-        dynamic_fanout: { parent_node: node.node_id, index },
+        dynamic_fanout: { parent_node: node.node_id, index, invocation: state.invocation },
+        agent_runtime: _fanoutWorkerRuntime(node, state, index, childId, workspacePath),
         ...(config?.result_contract ? {
           workflow_spec_v1: {
             input_contracts: {},
@@ -4013,6 +4239,7 @@ function _spawnFanoutChildren(run: ActiveRun, node: DAGGraphNode, state: FanoutR
       index,
       total: state.items.length,
       ...(state.context === undefined ? {} : { context: state.context }),
+      ...(workspacePath === undefined ? {} : { workspace_path: workspacePath }),
     }]);
     state.active.push(childId);
   }
@@ -4041,10 +4268,17 @@ function _startFanout(run: ActiveRun, node: DAGGraphNode): boolean {
       ...(context === undefined ? {} : { context }),
     }));
   }
-  const state: FanoutRuntimeState = { items, context, next_index: 0, active: [], results: [] };
+  const invocation = (run.counters.fanout_invocations[node.node_id] ?? 0) + 1;
+  run.counters.fanout_invocations[node.node_id] = invocation;
+  const state: FanoutRuntimeState = { invocation, items, context, next_index: 0, active: [], results: [] };
   node.extra = { ...(node.extra ?? {}), fanout_runtime: state as unknown as Record<string, unknown> };
   run.dagRun.nodeStates.set(node.node_id, "RUNNING");
-  _spawnFanoutChildren(run, node, state);
+  try {
+    _spawnFanoutChildren(run, node, state);
+  } catch (error) {
+    abortActiveRun(run.runId, error instanceof Error ? error.message : String(error), node.node_id);
+    return false;
+  }
   emit("dag:fanout_started", { runId: run.runId, nodeId: node.node_id, total: items.length, maxParallelism: config?.max_parallelism ?? 1 });
   return true;
 }
@@ -4070,9 +4304,10 @@ function _recordFanoutChild(run: ActiveRun, child: DAGGraphNode, port: string, c
   const info = dynamic as Record<string, unknown>;
   const parentId = typeof info.parent_node === "string" ? info.parent_node : "";
   const index = typeof info.index === "number" ? info.index : -1;
+  const invocation = typeof info.invocation === "number" ? info.invocation : 1;
   const parent = run.dagRun.graph.nodes.find((candidate) => candidate.node_id === parentId);
   const state = parent ? _fanoutState(parent) : undefined;
-  if (!parent || !state || index < 0 || state.results.some((result) => result.node_id === child.node_id)) return;
+  if (!parent || !state || invocation !== state.invocation || index < 0 || state.results.some((result) => result.node_id === child.node_id)) return;
   state.active = state.active.filter((id) => id !== child.node_id);
   const config = parent.gateway_config;
   const selected = _fieldValue(content, config?.success_field);
@@ -4089,7 +4324,11 @@ function _recordFanoutChild(run: ActiveRun, child: DAGGraphNode, port: string, c
   const impossible = successes + (total - completed) < threshold;
   const finished = completion === "all" ? completed === total : passed || impossible || completed === total;
   if (!finished) {
-    _spawnFanoutChildren(run, parent, state);
+    try {
+      _spawnFanoutChildren(run, parent, state);
+    } catch (error) {
+      abortActiveRun(run.runId, error instanceof Error ? error.message : String(error), parent.node_id);
+    }
     return;
   }
   if (config?.cancel_remaining) {
@@ -4565,14 +4804,17 @@ function _buildDispatchEnvelope(run: ActiveRun, nodeId: string): DispatchEnvelop
   const actorSurfaceView = getDagActorSurfaceView(run.runId, actorId);
   const correctionOnly = Array.isArray(inputs.correction) && inputs.correction.length > 0;
   const requestedCheckpointVersion = actor.checkpoint_ref?.match(/^portable:(\d+)$/)?.[1];
-  const actorCheckpointRecord = requestedCheckpointVersion
+  const freshDispatchContext = _nodeSessionScope(node) === "dispatch";
+  const actorCheckpointRecord = freshDispatchContext
+    ? undefined
+    : requestedCheckpointVersion
     ? getDagActorCheckpoint({
         run_id: run.runId,
         actor_id: actorId,
         checkpoint_version: Number(requestedCheckpointVersion),
       })
     : getLatestDagActorCheckpoint({ run_id: run.runId, actor_id: actorId });
-  if (requestedCheckpointVersion && !actorCheckpointRecord) {
+  if (!freshDispatchContext && requestedCheckpointVersion && !actorCheckpointRecord) {
     return { ok: false, reason: `portable checkpoint ${requestedCheckpointVersion} is unavailable for actor ${actorId}` };
   }
   const actorCheckpoint = actorCheckpointRecord?.checkpoint;
@@ -4689,6 +4931,8 @@ export function dispatchReadyNodes(
       continue;
     }
 
+    _prepareNodeSessionForDispatch(run, node);
+
     const built = _buildDispatchEnvelope(run, nodeId);
     if (!built.ok) {
       failActiveRun(runId, nodeId, built.reason);
@@ -4759,6 +5003,7 @@ export function markNodeDispatched(
   if (!node) return false;
 
   const before = _snapshotNodeStates(run);
+  _prepareNodeSessionForDispatch(run, node);
   startNode(run.dagRun, nodeId);
   const nodeSession = _ensureNodeSession(run, nodeId);
   _markNodeSessionStatus(run, nodeId, "running");

--- a/homerail_manager/src/runtime/active-runs.ts
+++ b/homerail_manager/src/runtime/active-runs.ts
@@ -2028,6 +2028,7 @@ function _correctionPrompt(
   successPorts: string[],
   failurePorts: string[],
   outputContracts: Record<string, { contract: string; schema: unknown }>,
+  brokerRequirements: BrokerActionRequirement[],
 ): string {
   const declaredPorts = outputPorts.length > 0 ? outputPorts.join(", ") : "done";
   const contractGuidance = Object.keys(outputContracts).length > 0
@@ -2036,6 +2037,13 @@ function _correctionPrompt(
         `Exact output contracts by port (JSON Schema): ${JSON.stringify(outputContracts)}`,
       ]
     : [];
+  const brokerGuidance = brokerRequirements.length > 0
+    ? [
+        "Correction mode permits only declared credential_broker_call verification actions and the final handoff tool call. Do not use any built-in tools or other DAG tools.",
+        `Broker verification actions available when required by the corrected output: ${brokerRequirements.map((requirement) => `${requirement.credential_ref}/${requirement.broker}/${requirement.action}`).join(", ")}.`,
+        "If the corrected output triggers one of those requirements and no valid receipt exists, call that declared broker action before the handoff. Otherwise call handoff directly.",
+      ]
+    : ["Correction mode permits only the handoff tool. Do not repeat investigation, file changes, or other side effects."];
   return [
     `Correction attempt ${attempt}/${maxAttempts} for DAG node ${nodeId}.`,
     `Previous attempt ended without a valid DAG handoff: ${reason}`,
@@ -2047,7 +2055,7 @@ function _correctionPrompt(
     "Use a failure port only when the original task itself cannot complete; never use it merely to report this correction error.",
     "Treat that error as authoritative. Preserve required field names and JSON array/object/number types exactly.",
     "Reuse completed evidence when it is available in the original inputs or current workspace.",
-    "Correction mode permits only the handoff tool. Do not repeat investigation, file changes, or other side effects.",
+    ...brokerGuidance,
     "Never print a pseudo-tool call as prose, XML, or JSON. Invoke the SDK tool itself.",
     "Finish by calling the handoff tool exactly once with one declared output port and contract-valid content. Do not end with prose.",
   ].join("\n");
@@ -2099,14 +2107,18 @@ export function requestNodeCorrection(
       successPorts,
       failurePorts,
       outputContracts,
+      _outputBrokerActionRequirements(run, nodeId),
     ));
     mailbox.set("correction", values);
   }
   resetSkippedSuccessDescendants(run.dagRun, nodeId);
   run.dagRun.nodeStates.set(nodeId, "READY");
   run.dagRun.handoffedNodes.delete(nodeId);
-  const node = run.dagRun.graph.nodes.find((candidate) => candidate.node_id === nodeId);
-  if (_nodeSessionScope(node) === "dispatch") _markNodeSessionStatus(run, nodeId, "completed");
+  // A correction retries the same logical dispatch after a rejected handoff; it
+  // is not a new review round. Keep the provider session (and any broker action
+  // receipts fenced to it) active. A successful handoff still marks the session
+  // completed, so the next real re-entry of a dispatch-scoped node gets a fresh
+  // context through _prepareNodeSessionForDispatch.
   writeRunMetadata(runId, serializeRunMetadata(run));
   _emitNodeStateChanges(run, before);
   emit("dag:node_correction_requested", { runId, nodeId, reason, attempt, maxAttempts });
@@ -4265,6 +4277,7 @@ function _fanoutWorkerRuntime(
     "{{fanout_invocation}}": String(state.invocation),
     "{{fanout_index}}": String(index + 1),
     "{{fanout_child}}": childId,
+    ...(workspacePath ? { "{{fanout_workspace}}": workspacePath } : {}),
   };
   const replacePath = (value: unknown): unknown => {
     if (typeof value !== "string") return value;
@@ -4275,6 +4288,12 @@ function _fanoutWorkerRuntime(
     ? structuredClone(rawAccess as Record<string, unknown>)
     : {};
   if (workspacePath) {
+    const declaredWritablePaths = Array.isArray(access.writable_paths)
+      ? access.writable_paths.filter((entry): entry is string => typeof entry === "string")
+      : [];
+    if (declaredWritablePaths.length !== 1 || declaredWritablePaths[0] !== "{{fanout_workspace}}") {
+      throw new Error("isolated git worktree fanout must explicitly declare {{fanout_workspace}} as its writable path");
+    }
     access.writable_paths = [workspacePath];
   } else {
     access.writable_paths = Array.isArray(access.writable_paths) ? access.writable_paths.map(replacePath) : [];
@@ -4956,6 +4975,19 @@ function _buildDispatchEnvelope(run: ActiveRun, nodeId: string): DispatchEnvelop
   const surfaceId = actor.surface_id;
   const actorSurfaceView = getDagActorSurfaceView(run.runId, actorId);
   const correctionOnly = Array.isArray(inputs.correction) && inputs.correction.length > 0;
+  const effectiveCredentialProjections = correctionOnly
+    ? credentialProjections.flatMap((projection) => {
+        if (projection.mode !== "manager_broker") return [];
+        const requiredActions = new Set(_outputBrokerActionRequirements(run, nodeId)
+          .filter((requirement) => (
+            requirement.credential_ref === projection.credential_ref
+            && requirement.broker === projection.broker
+          ))
+          .map((requirement) => requirement.action));
+        const allowedActions = projection.allowed_actions.filter((action) => requiredActions.has(action));
+        return allowedActions.length > 0 ? [{ ...projection, allowed_actions: allowedActions }] : [];
+      })
+    : credentialProjections;
   const requestedCheckpointVersion = actor.checkpoint_ref?.match(/^portable:(\d+)$/)?.[1];
   const freshDispatchContext = _nodeSessionScope(node) === "dispatch";
   const actorCheckpointRecord = freshDispatchContext
@@ -5018,7 +5050,9 @@ function _buildDispatchEnvelope(run: ActiveRun, nodeId: string): DispatchEnvelop
       allowedBuiltinTools: _allowedBuiltinTools(node),
       maxBuiltinToolCalls: _maxBuiltinToolCalls(run, node),
       allowedDagTools: _allowedDagTools(node),
-      ...(credentialProjections.length > 0 ? { credentialProjections } : {}),
+      ...(effectiveCredentialProjections.length > 0
+        ? { credentialProjections: effectiveCredentialProjections }
+        : {}),
       activity: {
         roundId: run.currentRound.round_id,
         actorId,

--- a/homerail_manager/src/runtime/active-runs.ts
+++ b/homerail_manager/src/runtime/active-runs.ts
@@ -1311,6 +1311,135 @@ export function getActiveRun(runId: string): ActiveRun | undefined {
   return store.get(runId);
 }
 
+interface BrokerActionRequirement {
+  credential_ref: string;
+  broker: string;
+  action: string;
+  when?: {
+    field: string;
+    equals: unknown;
+  };
+}
+
+interface BrokerActionReceipt extends BrokerActionRequirement {
+  node_id: string;
+  session_id: string;
+  recorded_at: number;
+}
+
+const BROKER_ACTION_RECEIPTS_KEY = "broker_action_receipts";
+const BROKER_ACTION_NAME = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+
+function _outputBrokerActionRequirements(
+  run: ActiveRun,
+  nodeId: string,
+  port?: string,
+  content?: unknown,
+  evaluateConditions = false,
+): BrokerActionRequirement[] {
+  const node = run.dagRun.graph.nodes.find((candidate) => candidate.node_id === nodeId);
+  const workflowSpec = node?.extra?.workflow_spec_v1;
+  if (!workflowSpec || typeof workflowSpec !== "object" || Array.isArray(workflowSpec)) return [];
+  const rawByPort = (workflowSpec as Record<string, unknown>).output_broker_requirements;
+  if (!rawByPort || typeof rawByPort !== "object" || Array.isArray(rawByPort)) return [];
+  const selected = port === undefined
+    ? Object.values(rawByPort as Record<string, unknown>).flatMap((value) => Array.isArray(value) ? value : [])
+    : (rawByPort as Record<string, unknown>)[port];
+  if (!Array.isArray(selected)) return [];
+  return selected.flatMap((value) => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return [];
+    const entry = value as Record<string, unknown>;
+    if (![entry.credential_ref, entry.broker, entry.action].every((field) => (
+      typeof field === "string" && BROKER_ACTION_NAME.test(field)
+    ))) return [];
+    let when: BrokerActionRequirement["when"];
+    if (entry.when !== undefined) {
+      if (!entry.when || typeof entry.when !== "object" || Array.isArray(entry.when)) return [];
+      const rawWhen = entry.when as Record<string, unknown>;
+      if (typeof rawWhen.field !== "string"
+        || !/^[A-Za-z_][A-Za-z0-9_-]*(?:\.[A-Za-z_][A-Za-z0-9_-]*)*$/.test(rawWhen.field)
+        || !("equals" in rawWhen)) return [];
+      when = { field: rawWhen.field, equals: rawWhen.equals };
+    }
+    if (evaluateConditions && when) {
+      let actual = content;
+      for (const segment of when.field.split(".")) {
+        if (!actual || typeof actual !== "object" || Array.isArray(actual)) {
+          actual = undefined;
+          break;
+        }
+        actual = (actual as Record<string, unknown>)[segment];
+      }
+      if (!isDeepStrictEqual(actual, when.equals)) return [];
+    }
+    return [{
+      credential_ref: String(entry.credential_ref),
+      broker: String(entry.broker),
+      action: String(entry.action),
+      ...(when ? { when } : {}),
+    }];
+  });
+}
+
+function _brokerActionReceipts(run: ActiveRun): BrokerActionReceipt[] {
+  const raw = run.brokerState[BROKER_ACTION_RECEIPTS_KEY];
+  if (!Array.isArray(raw)) return [];
+  return raw.flatMap((value) => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return [];
+    const entry = value as Record<string, unknown>;
+    if (![entry.credential_ref, entry.broker, entry.action, entry.node_id, entry.session_id].every((field) => (
+      typeof field === "string" && BROKER_ACTION_NAME.test(field)
+    )) || typeof entry.recorded_at !== "number" || !Number.isFinite(entry.recorded_at)) return [];
+    return [{
+      credential_ref: String(entry.credential_ref),
+      broker: String(entry.broker),
+      action: String(entry.action),
+      node_id: String(entry.node_id),
+      session_id: String(entry.session_id),
+      recorded_at: entry.recorded_at,
+    }];
+  });
+}
+
+export function recordActiveRunBrokerActionSuccess(input: {
+  run_id: string;
+  node_id: string;
+  session_id: string;
+  credential_ref: string;
+  broker: string;
+  action: string;
+}): void {
+  const run = store.get(input.run_id);
+  if (!run || run.status !== "active") throw new Error("Broker action receipt run is not active");
+  const required = _outputBrokerActionRequirements(run, input.node_id).some((requirement) => (
+    requirement.credential_ref === input.credential_ref
+    && requirement.broker === input.broker
+    && requirement.action === input.action
+  ));
+  if (!required) return;
+  const session = run.nodeSessions.get(input.node_id);
+  if (!session || session.sessionId !== input.session_id) {
+    throw new Error("Broker action receipt session is stale");
+  }
+  const receipt: BrokerActionReceipt = {
+    credential_ref: input.credential_ref,
+    broker: input.broker,
+    action: input.action,
+    node_id: input.node_id,
+    session_id: input.session_id,
+    recorded_at: Date.now(),
+  };
+  const receipts = _brokerActionReceipts(run).filter((entry) => !(
+    entry.node_id === receipt.node_id
+    && entry.session_id === receipt.session_id
+    && entry.credential_ref === receipt.credential_ref
+    && entry.broker === receipt.broker
+    && entry.action === receipt.action
+  ));
+  run.brokerState[BROKER_ACTION_RECEIPTS_KEY] = [...receipts, receipt].slice(-64);
+  writeRunMetadata(input.run_id, serializeRunMetadata(run));
+}
+
 export function getActiveRunBrokerState(runId: string, key: string): unknown {
   const run = store.get(runId);
   if (!run || !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(key)) return undefined;
@@ -2357,6 +2486,8 @@ function _assertHandoffPreconditions(
   if (surfaceViolation) throw new Error(surfaceViolation);
   const contractViolation = _handoffContractViolation(run, fromNode, port, content);
   if (contractViolation) throw new Error(contractViolation);
+  const brokerRequirementViolation = _handoffBrokerRequirementViolation(run, fromNode, port, content);
+  if (brokerRequirementViolation) throw new Error(brokerRequirementViolation);
   if (run.counters.handoffs >= run.limits.max_handoffs) {
     if (abortOnLimit) abortActiveRun(run.runId, `max_handoffs (${run.limits.max_handoffs}) exceeded`, fromNode);
     throw new Error(`max_handoffs (${run.limits.max_handoffs}) exceeded`);
@@ -2372,6 +2503,28 @@ function _assertHandoffPreconditions(
       throw new Error(`edge retry limit (${edgeLimit}) exceeded for ${key}`);
     }
   }
+}
+
+function _handoffBrokerRequirementViolation(
+  run: ActiveRun,
+  fromNode: string,
+  port: string,
+  content: unknown,
+): string | undefined {
+  const requirements = _outputBrokerActionRequirements(run, fromNode, port, content, true);
+  if (requirements.length === 0) return undefined;
+  const sessionId = run.nodeSessions.get(fromNode)?.sessionId;
+  if (!sessionId) return `DAG_HANDOFF_BROKER_REQUIREMENT_MISSING ${fromNode}.${port}: node has no active session`;
+  const receipts = _brokerActionReceipts(run);
+  const missing = requirements.find((requirement) => !receipts.some((receipt) => (
+    receipt.node_id === fromNode
+    && receipt.session_id === sessionId
+    && receipt.credential_ref === requirement.credential_ref
+    && receipt.broker === requirement.broker
+    && receipt.action === requirement.action
+  )));
+  if (!missing) return undefined;
+  return `DAG_HANDOFF_BROKER_REQUIREMENT_MISSING ${fromNode}.${port}: ${missing.credential_ref}/${missing.broker}/${missing.action}`;
 }
 
 function _requiredSurfaceFinalViolation(

--- a/homerail_manager/src/runtime/credential-broker.ts
+++ b/homerail_manager/src/runtime/credential-broker.ts
@@ -7,11 +7,15 @@ import {
   recordCredentialUseFailure,
   type CredentialRecord,
 } from "../persistence/credentials.js";
-import { getActiveRun } from "./active-runs.js";
+import {
+  getActiveRun,
+  recordActiveRunBrokerActionSuccess,
+} from "./active-runs.js";
 import {
   githubChecksSnapshot,
   githubCommitFiles,
   githubPullRequestSnapshot,
+  githubRequiredChecks,
 } from "./github-pr-broker.js";
 
 export interface CredentialBrokerContext {
@@ -178,6 +182,14 @@ export async function executeCredentialBrokerCall(
         ...(request.generation === undefined ? {} : { generation: request.generation }),
       },
     });
+    recordActiveRunBrokerActionSuccess({
+      run_id: request.run_id,
+      node_id: request.node_id,
+      session_id: request.session_id,
+      credential_ref: request.credential_ref,
+      broker: request.broker,
+      action: request.action,
+    });
     return { request_id: request.request_id, ok: true, result };
   } catch (error) {
     const rawMessage = error instanceof Error ? error.message : String(error);
@@ -243,4 +255,5 @@ registerCredentialBroker("lark_bot", "bot_info", async ({ credential, secret }) 
 
 registerCredentialBroker("github_pr", "pull_request_snapshot", githubPullRequestSnapshot);
 registerCredentialBroker("github_pr", "checks_snapshot", githubChecksSnapshot);
+registerCredentialBroker("github_pr", "required_checks", githubRequiredChecks);
 registerCredentialBroker("github_pr", "commit_files", githubCommitFiles);

--- a/homerail_manager/src/runtime/credential-broker.ts
+++ b/homerail_manager/src/runtime/credential-broker.ts
@@ -8,11 +8,24 @@ import {
   type CredentialRecord,
 } from "../persistence/credentials.js";
 import { getActiveRun } from "./active-runs.js";
+import {
+  githubChecksSnapshot,
+  githubCommitFiles,
+  githubPullRequestSnapshot,
+} from "./github-pr-broker.js";
 
 export interface CredentialBrokerContext {
   credential: CredentialRecord;
   secret: Readonly<Record<string, string>>;
   input: Readonly<Record<string, unknown>>;
+  transport?: Readonly<{
+    run_id: string;
+    node_id: string;
+    session_id: string;
+    round_id?: string;
+    actor_id?: string;
+    generation?: number;
+  }>;
 }
 
 export type CredentialBrokerHandler = (
@@ -156,6 +169,14 @@ export async function executeCredentialBrokerCall(
       credential: materialized.record,
       secret: materialized.secret,
       input: request.input,
+      transport: {
+        run_id: request.run_id,
+        node_id: request.node_id,
+        session_id: request.session_id,
+        ...(request.round_id ? { round_id: request.round_id } : {}),
+        ...(request.actor_id ? { actor_id: request.actor_id } : {}),
+        ...(request.generation === undefined ? {} : { generation: request.generation }),
+      },
     });
     return { request_id: request.request_id, ok: true, result };
   } catch (error) {
@@ -219,3 +240,7 @@ registerCredentialBroker("lark_bot", "bot_info", async ({ credential, secret }) 
     activate_status: infoBody.bot.activate_status ?? 0,
   };
 });
+
+registerCredentialBroker("github_pr", "pull_request_snapshot", githubPullRequestSnapshot);
+registerCredentialBroker("github_pr", "checks_snapshot", githubChecksSnapshot);
+registerCredentialBroker("github_pr", "commit_files", githubCommitFiles);

--- a/homerail_manager/src/runtime/credential-broker.ts
+++ b/homerail_manager/src/runtime/credential-broker.ts
@@ -36,11 +36,21 @@ export type CredentialBrokerHandler = (
   context: CredentialBrokerContext,
 ) => Promise<unknown>;
 
+export interface CredentialBrokerRegistrationOptions {
+  maxInputBytes?: number;
+}
+
+interface RegisteredCredentialBrokerHandler {
+  handler: CredentialBrokerHandler;
+  maxInputBytes: number;
+}
+
 const BROKER_NAME = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
 const ACTION_NAME = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
 const MAX_INPUT_BYTES = 64 * 1024;
+const MAX_CONFIGURED_INPUT_BYTES = 2 * 1024 * 1024;
 const MAX_RESULT_BYTES = 256 * 1024;
-const handlers = new Map<string, Map<string, CredentialBrokerHandler>>();
+const handlers = new Map<string, Map<string, RegisteredCredentialBrokerHandler>>();
 
 function safeJsonSize(value: unknown): number {
   const encoded = JSON.stringify(value);
@@ -74,11 +84,16 @@ export function registerCredentialBroker(
   broker: string,
   action: string,
   handler: CredentialBrokerHandler,
+  options: CredentialBrokerRegistrationOptions = {},
 ): void {
   if (!BROKER_NAME.test(broker)) throw new Error("Invalid credential broker name");
   if (!ACTION_NAME.test(action)) throw new Error("Invalid credential broker action");
-  const actions = handlers.get(broker) ?? new Map<string, CredentialBrokerHandler>();
-  actions.set(action, handler);
+  const maxInputBytes = options.maxInputBytes ?? MAX_INPUT_BYTES;
+  if (!Number.isSafeInteger(maxInputBytes) || maxInputBytes < 1 || maxInputBytes > MAX_CONFIGURED_INPUT_BYTES) {
+    throw new Error(`Credential broker input limit must be 1-${MAX_CONFIGURED_INPUT_BYTES} bytes`);
+  }
+  const actions = handlers.get(broker) ?? new Map<string, RegisteredCredentialBrokerHandler>();
+  actions.set(action, { handler, maxInputBytes });
   handlers.set(broker, actions);
 }
 
@@ -87,12 +102,12 @@ export async function invokeCredentialBroker(
   action: string,
   context: CredentialBrokerContext,
 ): Promise<unknown> {
-  const handler = handlers.get(broker)?.get(action);
-  if (!handler) throw new Error(`Unsupported credential broker action: ${broker}/${action}`);
-  if (safeJsonSize(context.input) > MAX_INPUT_BYTES) {
-    throw new Error("Credential broker input exceeds 64 KiB");
+  const registered = handlers.get(broker)?.get(action);
+  if (!registered) throw new Error(`Unsupported credential broker action: ${broker}/${action}`);
+  if (safeJsonSize(context.input) > registered.maxInputBytes) {
+    throw new Error(`Credential broker input exceeds ${registered.maxInputBytes} bytes`);
   }
-  const result = await handler(context);
+  const result = await registered.handler(context);
   assertResultDoesNotRevealSecrets(result, context.secret);
   if (safeJsonSize(result) > MAX_RESULT_BYTES) {
     throw new Error("Credential broker result exceeds 256 KiB");
@@ -256,4 +271,8 @@ registerCredentialBroker("lark_bot", "bot_info", async ({ credential, secret }) 
 registerCredentialBroker("github_pr", "pull_request_snapshot", githubPullRequestSnapshot);
 registerCredentialBroker("github_pr", "checks_snapshot", githubChecksSnapshot);
 registerCredentialBroker("github_pr", "required_checks", githubRequiredChecks);
-registerCredentialBroker("github_pr", "commit_files", githubCommitFiles);
+registerCredentialBroker("github_pr", "commit_files", githubCommitFiles, {
+  // A 1 MiB decoded commit expands to roughly 1.4 MiB as base64 plus bounded
+  // JSON/path overhead. Other broker actions retain the 64 KiB default.
+  maxInputBytes: MAX_CONFIGURED_INPUT_BYTES,
+});

--- a/homerail_manager/src/runtime/github-pr-broker.ts
+++ b/homerail_manager/src/runtime/github-pr-broker.ts
@@ -24,6 +24,7 @@ interface GithubPullRequestContext {
   task_document_sha256: string;
   require_draft: boolean;
   writable_paths: string[];
+  required_checks: string[];
 }
 
 interface GithubPullRequestState {
@@ -60,8 +61,7 @@ function jsonRecord(value: unknown, label: string): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
-function safeRelativePath(raw: unknown, label: string, allowDot = false): string {
-  if (allowDot && raw === ".") return ".";
+function safeRelativePath(raw: unknown, label: string): string {
   if (typeof raw !== "string" || !raw || raw.includes("\\") || raw.startsWith("/") || raw.includes("\0")) {
     throw new Error(`${label} is not a safe repository path`);
   }
@@ -112,8 +112,22 @@ function parsePullRequestContext(runId: string): GithubPullRequestContext {
     throw new Error("pr_context writable_paths must be a non-empty bounded allowlist");
   }
   const writablePaths = raw.writable_paths.map((entry, index) => (
-    safeRelativePath(entry, `pr_context writable_paths[${index}]`, true)
+    safeRelativePath(entry, `pr_context writable_paths[${index}]`)
   ));
+  if (!Array.isArray(raw.required_checks) || raw.required_checks.length < 1 || raw.required_checks.length > 32) {
+    throw new Error("pr_context required_checks must be a non-empty bounded list");
+  }
+  const requiredChecks = raw.required_checks.map((entry, index) => {
+    if (typeof entry !== "string") throw new Error(`pr_context required_checks[${index}] is invalid`);
+    const name = entry.trim();
+    if (!name || name.length > 256 || /[\u0000-\u001f\u007f]/.test(name)) {
+      throw new Error(`pr_context required_checks[${index}] is invalid`);
+    }
+    return name;
+  });
+  if (new Set(requiredChecks).size !== requiredChecks.length) {
+    throw new Error("pr_context required_checks must be unique");
+  }
   return {
     version: 1,
     owner,
@@ -127,6 +141,7 @@ function parsePullRequestContext(runId: string): GithubPullRequestContext {
     task_document_sha256: taskDocumentSha256,
     require_draft: raw.require_draft !== false,
     writable_paths: Array.from(new Set(writablePaths)).sort(),
+    required_checks: [...requiredChecks].sort(),
   };
 }
 
@@ -308,13 +323,44 @@ export async function githubChecksSnapshot(context: CredentialBrokerContext): Pr
   };
 }
 
+export async function githubRequiredChecks(context: CredentialBrokerContext): Promise<unknown> {
+  const { token, binding, state } = await boundPull(context);
+  const body = await githubApi<{ check_runs?: Array<Record<string, unknown>> }>(
+    token,
+    `${repoPath(binding)}/commits/${state.current_head_sha}/check-runs?per_page=100`,
+  );
+  const checks = body.check_runs ?? [];
+  const required = binding.required_checks.map((name) => {
+    const latest = checks
+      .filter((check) => String(check.name ?? "") === name)
+      .sort((left, right) => Number(right.id ?? 0) - Number(left.id ?? 0))[0];
+    return {
+      name,
+      id: Number(latest?.id ?? 0),
+      status: String(latest?.status ?? "missing"),
+      conclusion: latest?.conclusion === null || latest === undefined
+        ? null
+        : String(latest.conclusion ?? ""),
+    };
+  });
+  const failed = required.filter((check) => check.status !== "completed" || check.conclusion !== "success");
+  if (failed.length > 0) {
+    throw new Error(`Required GitHub checks are not successful: ${failed.map((check) => check.name).join(", ")}`);
+  }
+  return {
+    passed: true,
+    head_sha: state.current_head_sha,
+    required_checks: required,
+  };
+}
+
 function pathAllowed(pathname: string, prefixes: string[]): boolean {
   if (
     pathname === ".git" || pathname.startsWith(".git/")
-    || pathname === ".github/workflows" || pathname.startsWith(".github/workflows/")
+    || pathname === ".github" || pathname.startsWith(".github/")
     || pathname === "input" || pathname.startsWith("input/")
   ) return false;
-  return prefixes.some((prefix) => prefix === "." || pathname === prefix || pathname.startsWith(`${prefix}/`));
+  return prefixes.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
 }
 
 function commitFilesInput(input: Readonly<Record<string, unknown>>, binding: GithubPullRequestContext): {

--- a/homerail_manager/src/runtime/github-pr-broker.ts
+++ b/homerail_manager/src/runtime/github-pr-broker.ts
@@ -1,0 +1,421 @@
+import { sign } from "node:crypto";
+import * as fs from "node:fs";
+
+import {
+  dagRunInputPath,
+  listDagRunInputs,
+} from "../persistence/run-input-artifacts.js";
+import {
+  getActiveRunBrokerState,
+  setActiveRunBrokerState,
+} from "./active-runs.js";
+import type { CredentialBrokerContext } from "./credential-broker.js";
+
+interface GithubPullRequestContext {
+  version: 1;
+  owner: string;
+  repo: string;
+  pull_number: number;
+  clone_url: string;
+  head_ref: string;
+  base_ref: string;
+  initial_head_sha: string;
+  base_sha: string;
+  task_document_sha256: string;
+  require_draft: boolean;
+  writable_paths: string[];
+}
+
+interface GithubPullRequestState {
+  version: 1;
+  identity: string;
+  current_head_sha: string;
+  pending_head_sha?: string;
+}
+
+interface PullResponse {
+  number?: number;
+  title?: string;
+  body?: string | null;
+  draft?: boolean;
+  state?: string;
+  html_url?: string;
+  head?: { sha?: string; ref?: string; label?: string; repo?: { full_name?: string } | null };
+  base?: { sha?: string; ref?: string; label?: string; repo?: { full_name?: string } | null };
+}
+
+const SHA = /^[0-9a-f]{40}(?:[0-9a-f]{24})?$/;
+const OWNER_REPO = /^[A-Za-z0-9](?:[A-Za-z0-9_.-]{0,98}[A-Za-z0-9])?$/;
+const SAFE_PATH_SEGMENT = /^[A-Za-z0-9._-]+$/;
+const MAX_COMMIT_FILES = 64;
+const MAX_COMMIT_BYTES = 1024 * 1024;
+const MAX_PATCH_CHARS = 8_000;
+
+function base64Url(value: string | Buffer): string {
+  return Buffer.from(value).toString("base64url");
+}
+
+function jsonRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`${label} is invalid`);
+  return value as Record<string, unknown>;
+}
+
+function safeRelativePath(raw: unknown, label: string, allowDot = false): string {
+  if (allowDot && raw === ".") return ".";
+  if (typeof raw !== "string" || !raw || raw.includes("\\") || raw.startsWith("/") || raw.includes("\0")) {
+    throw new Error(`${label} is not a safe repository path`);
+  }
+  const segments = raw.split("/");
+  if (segments.some((segment) => !segment || segment === "." || segment === ".." || !SAFE_PATH_SEGMENT.test(segment))) {
+    throw new Error(`${label} is not a safe repository path`);
+  }
+  return segments.join("/");
+}
+
+function parsePullRequestContext(runId: string): GithubPullRequestContext {
+  let value: unknown;
+  try {
+    value = JSON.parse(fs.readFileSync(dagRunInputPath(runId, "pr_context"), "utf8")) as unknown;
+  } catch {
+    throw new Error("The run has no valid immutable pr_context input");
+  }
+  const raw = jsonRecord(value, "pr_context");
+  const owner = String(raw.owner ?? "");
+  const repo = String(raw.repo ?? "");
+  const pullNumber = Number(raw.pull_number);
+  const cloneUrl = String(raw.clone_url ?? "");
+  const headRef = String(raw.head_ref ?? "");
+  const baseRef = String(raw.base_ref ?? raw.base_branch ?? "");
+  const initialHeadSha = String(raw.initial_head_sha ?? raw.head_sha ?? "").toLowerCase();
+  const baseSha = String(raw.base_sha ?? "").toLowerCase();
+  const taskDocumentSha256 = String(raw.task_document_sha256 ?? "").toLowerCase();
+  if (raw.version !== 1 || !OWNER_REPO.test(owner) || !OWNER_REPO.test(repo)) {
+    throw new Error("pr_context repository identity is invalid");
+  }
+  if (!Number.isSafeInteger(pullNumber) || pullNumber < 1) throw new Error("pr_context pull_number is invalid");
+  if (cloneUrl !== `https://github.com/${owner}/${repo}.git`) {
+    throw new Error("pr_context clone_url must match the bound GitHub repository");
+  }
+  if (!headRef || headRef.length > 255 || headRef.startsWith("-") || headRef.includes("..") || headRef.includes("\\")) {
+    throw new Error("pr_context head_ref is invalid");
+  }
+  if (!baseRef || baseRef.length > 255 || baseRef.startsWith("-") || baseRef.includes("..") || baseRef.includes("\\")) {
+    throw new Error("pr_context base_ref is invalid");
+  }
+  if (!SHA.test(initialHeadSha) || !SHA.test(baseSha)) throw new Error("pr_context commit SHA is invalid");
+  if (!/^[0-9a-f]{64}$/.test(taskDocumentSha256)) throw new Error("pr_context task_document_sha256 is invalid");
+  const taskDocument = listDagRunInputs(runId).find((entry) => entry.logical_name === "task_document");
+  if (!taskDocument || taskDocument.sha256 !== taskDocumentSha256) {
+    throw new Error("pr_context task_document_sha256 does not match the immutable task_document input");
+  }
+  if (!Array.isArray(raw.writable_paths) || raw.writable_paths.length < 1 || raw.writable_paths.length > 128) {
+    throw new Error("pr_context writable_paths must be a non-empty bounded allowlist");
+  }
+  const writablePaths = raw.writable_paths.map((entry, index) => (
+    safeRelativePath(entry, `pr_context writable_paths[${index}]`, true)
+  ));
+  return {
+    version: 1,
+    owner,
+    repo,
+    pull_number: pullNumber,
+    clone_url: cloneUrl,
+    head_ref: headRef,
+    base_ref: baseRef,
+    initial_head_sha: initialHeadSha,
+    base_sha: baseSha,
+    task_document_sha256: taskDocumentSha256,
+    require_draft: raw.require_draft !== false,
+    writable_paths: Array.from(new Set(writablePaths)).sort(),
+  };
+}
+
+async function githubToken(context: CredentialBrokerContext): Promise<string> {
+  const direct = context.secret.token ?? context.secret.access_token ?? context.secret.value;
+  if (direct) return direct;
+  const appId = context.secret.app_id;
+  const installationId = context.secret.installation_id;
+  const privateKey = context.secret.private_key;
+  if (!appId || !installationId || !privateKey) {
+    throw new Error("github_pr requires a token or GitHub App installation credential");
+  }
+  const now = Math.floor(Date.now() / 1000);
+  const header = base64Url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const payload = base64Url(JSON.stringify({ iat: now - 60, exp: now + 540, iss: appId }));
+  const unsigned = `${header}.${payload}`;
+  const jwt = `${unsigned}.${sign("RSA-SHA256", Buffer.from(unsigned), privateKey).toString("base64url")}`;
+  const response = await fetch(`https://api.github.com/app/installations/${encodeURIComponent(installationId)}/access_tokens`, {
+    method: "POST",
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${jwt}`,
+      "user-agent": "HomeRail-Autofix-Broker",
+      "x-github-api-version": "2022-11-28",
+    },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!response.ok) throw new Error(`GitHub App installation authentication failed (${response.status})`);
+  const body = jsonRecord(await response.json(), "GitHub App token response");
+  if (typeof body.token !== "string" || !body.token) throw new Error("GitHub App installation token is missing");
+  return body.token;
+}
+
+async function githubApi<T>(token: string, pathname: string, init: RequestInit = {}): Promise<T> {
+  const response = await fetch(`https://api.github.com${pathname}`, {
+    ...init,
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+      "user-agent": "HomeRail-Autofix-Broker",
+      "x-github-api-version": "2022-11-28",
+      ...(init.headers ?? {}),
+    },
+    signal: init.signal ?? AbortSignal.timeout(20_000),
+  });
+  if (!response.ok) throw new Error(`GitHub API request failed (${response.status})`);
+  return await response.json() as T;
+}
+
+function repoPath(context: GithubPullRequestContext): string {
+  return `/repos/${encodeURIComponent(context.owner)}/${encodeURIComponent(context.repo)}`;
+}
+
+function stateIdentity(context: GithubPullRequestContext): string {
+  return `${context.owner}/${context.repo}#${context.pull_number}:${context.head_ref}`;
+}
+
+function pullHead(pull: PullResponse, context: GithubPullRequestContext): string {
+  const head = String(pull.head?.sha ?? "").toLowerCase();
+  if (!SHA.test(head)) throw new Error("GitHub pull request has no valid head SHA");
+  const repository = `${context.owner}/${context.repo}`;
+  if (
+    pull.number !== context.pull_number
+    || pull.state !== "open"
+    || pull.head?.ref !== context.head_ref
+    || pull.base?.ref !== context.base_ref
+    || pull.head?.repo?.full_name !== repository
+    || pull.base?.repo?.full_name !== repository
+    || pull.base?.sha?.toLowerCase() !== context.base_sha
+  ) {
+    throw new Error("GitHub pull request identity differs from immutable pr_context");
+  }
+  if (context.require_draft && pull.draft !== true) throw new Error("Autofix requires the bound pull request to remain Draft");
+  return head;
+}
+
+function reconcileState(runId: string, context: GithubPullRequestContext, remoteHead: string): GithubPullRequestState {
+  const identity = stateIdentity(context);
+  const raw = getActiveRunBrokerState(runId, "github_pr");
+  if (raw === undefined) {
+    if (remoteHead !== context.initial_head_sha) throw new Error("Draft PR head changed before the broker was bound");
+    const initialized: GithubPullRequestState = {
+      version: 1,
+      identity,
+      current_head_sha: remoteHead,
+    };
+    setActiveRunBrokerState(runId, "github_pr", initialized);
+    return initialized;
+  }
+  const record = jsonRecord(raw, "github_pr broker state");
+  const state: GithubPullRequestState = {
+    version: 1,
+    identity: String(record.identity ?? ""),
+    current_head_sha: String(record.current_head_sha ?? "").toLowerCase(),
+    ...(typeof record.pending_head_sha === "string" ? { pending_head_sha: record.pending_head_sha.toLowerCase() } : {}),
+  };
+  if (record.version !== 1 || state.identity !== identity || !SHA.test(state.current_head_sha)) {
+    throw new Error("Persisted GitHub broker state is invalid");
+  }
+  if (state.pending_head_sha) {
+    if (!SHA.test(state.pending_head_sha)) throw new Error("Persisted GitHub pending head is invalid");
+    if (remoteHead === state.pending_head_sha) {
+      const finalized = { version: 1 as const, identity, current_head_sha: remoteHead };
+      setActiveRunBrokerState(runId, "github_pr", finalized);
+      return finalized;
+    }
+    if (remoteHead === state.current_head_sha) {
+      const cleared = { version: 1 as const, identity, current_head_sha: remoteHead };
+      setActiveRunBrokerState(runId, "github_pr", cleared);
+      return cleared;
+    }
+    throw new Error("Draft PR head changed while a broker mutation was pending");
+  }
+  if (remoteHead !== state.current_head_sha) throw new Error("Draft PR head changed outside the HomeRail broker");
+  return state;
+}
+
+async function boundPull(context: CredentialBrokerContext): Promise<{
+  token: string;
+  binding: GithubPullRequestContext;
+  pull: PullResponse;
+  state: GithubPullRequestState;
+}> {
+  const runId = context.transport?.run_id;
+  if (!runId) throw new Error("github_pr broker requires a run transport identity");
+  const binding = parsePullRequestContext(runId);
+  const token = await githubToken(context);
+  const pull = await githubApi<PullResponse>(token, `${repoPath(binding)}/pulls/${binding.pull_number}`);
+  const state = reconcileState(runId, binding, pullHead(pull, binding));
+  return { token, binding, pull, state };
+}
+
+export async function githubPullRequestSnapshot(context: CredentialBrokerContext): Promise<unknown> {
+  const { token, binding, pull, state } = await boundPull(context);
+  const files = await githubApi<Array<Record<string, unknown>>>(
+    token,
+    `${repoPath(binding)}/pulls/${binding.pull_number}/files?per_page=100`,
+  );
+  return {
+    repository: `${binding.owner}/${binding.repo}`,
+    pull_number: binding.pull_number,
+    title: String(pull.title ?? ""),
+    body: String(pull.body ?? "").slice(0, 32_000),
+    draft: pull.draft === true,
+    state: String(pull.state ?? ""),
+    url: String(pull.html_url ?? ""),
+    head_ref: binding.head_ref,
+    head_sha: state.current_head_sha,
+    base_sha: binding.base_sha,
+    files: files.slice(0, 100).map((file) => ({
+      filename: String(file.filename ?? ""),
+      status: String(file.status ?? ""),
+      additions: Number(file.additions ?? 0),
+      deletions: Number(file.deletions ?? 0),
+      changes: Number(file.changes ?? 0),
+      patch: typeof file.patch === "string" ? file.patch.slice(0, MAX_PATCH_CHARS) : undefined,
+    })),
+  };
+}
+
+export async function githubChecksSnapshot(context: CredentialBrokerContext): Promise<unknown> {
+  const { token, binding, state } = await boundPull(context);
+  const body = await githubApi<{ check_runs?: Array<Record<string, unknown>> }>(
+    token,
+    `${repoPath(binding)}/commits/${state.current_head_sha}/check-runs?per_page=100`,
+  );
+  return {
+    head_sha: state.current_head_sha,
+    checks: (body.check_runs ?? []).slice(0, 100).map((check) => ({
+      id: Number(check.id ?? 0),
+      name: String(check.name ?? ""),
+      status: String(check.status ?? ""),
+      conclusion: check.conclusion === null ? null : String(check.conclusion ?? ""),
+      details_url: String(check.details_url ?? ""),
+      started_at: String(check.started_at ?? ""),
+      completed_at: check.completed_at === null ? null : String(check.completed_at ?? ""),
+    })),
+  };
+}
+
+function pathAllowed(pathname: string, prefixes: string[]): boolean {
+  if (
+    pathname === ".git" || pathname.startsWith(".git/")
+    || pathname === ".github/workflows" || pathname.startsWith(".github/workflows/")
+    || pathname === "input" || pathname.startsWith("input/")
+  ) return false;
+  return prefixes.some((prefix) => prefix === "." || pathname === prefix || pathname.startsWith(`${prefix}/`));
+}
+
+function commitFilesInput(input: Readonly<Record<string, unknown>>, binding: GithubPullRequestContext): {
+  expectedHead: string;
+  message: string;
+  files: Array<{ path: string; mode: "100644" | "100755"; bytes: Buffer }>;
+} {
+  const expectedHead = String(input.expected_head_sha ?? "").toLowerCase();
+  const message = String(input.message ?? "").trim();
+  if (!SHA.test(expectedHead)) throw new Error("commit_files expected_head_sha is invalid");
+  if (!message || message.length > 512 || /[\r\n]/.test(message)) throw new Error("commit_files message is invalid");
+  if (!Array.isArray(input.files) || input.files.length < 1 || input.files.length > MAX_COMMIT_FILES) {
+    throw new Error(`commit_files requires 1-${MAX_COMMIT_FILES} files`);
+  }
+  const seen = new Set<string>();
+  let totalBytes = 0;
+  const files = input.files.map((entry, index) => {
+    const raw = jsonRecord(entry, `commit_files files[${index}]`);
+    const pathname = safeRelativePath(raw.path, `commit_files files[${index}].path`);
+    if (seen.has(pathname)) throw new Error(`commit_files path is duplicated: ${pathname}`);
+    if (!pathAllowed(pathname, binding.writable_paths)) throw new Error(`commit_files path is outside the PR write allowlist: ${pathname}`);
+    seen.add(pathname);
+    const encoded = String(raw.content_base64 ?? "");
+    if (!encoded || !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(encoded)) {
+      throw new Error(`commit_files content_base64 is invalid for ${pathname}`);
+    }
+    const bytes = Buffer.from(encoded, "base64");
+    if (bytes.toString("base64") !== encoded) throw new Error(`commit_files content_base64 is not canonical for ${pathname}`);
+    totalBytes += bytes.byteLength;
+    const mode: "100644" | "100755" = raw.mode === "100755" ? "100755" : "100644";
+    return { path: pathname, mode, bytes };
+  });
+  if (totalBytes > MAX_COMMIT_BYTES) throw new Error("commit_files content exceeds 1 MiB");
+  return { expectedHead, message, files };
+}
+
+export async function githubCommitFiles(context: CredentialBrokerContext): Promise<unknown> {
+  const runId = context.transport?.run_id;
+  if (!runId) throw new Error("github_pr broker requires a run transport identity");
+  const { token, binding, state } = await boundPull(context);
+  const request = commitFilesInput(context.input, binding);
+  if (request.expectedHead !== state.current_head_sha) throw new Error("commit_files expected head is stale");
+  const repository = repoPath(binding);
+  const commit = await githubApi<{ tree?: { sha?: string } }>(token, `${repository}/git/commits/${state.current_head_sha}`);
+  const baseTree = String(commit.tree?.sha ?? "").toLowerCase();
+  if (!SHA.test(baseTree)) throw new Error("GitHub base tree SHA is invalid");
+  const treeEntries = [];
+  for (const file of request.files) {
+    const blob = await githubApi<{ sha?: string }>(token, `${repository}/git/blobs`, {
+      method: "POST",
+      body: JSON.stringify({ content: file.bytes.toString("base64"), encoding: "base64" }),
+    });
+    const blobSha = String(blob.sha ?? "").toLowerCase();
+    if (!SHA.test(blobSha)) throw new Error("GitHub blob SHA is invalid");
+    treeEntries.push({ path: file.path, mode: file.mode, type: "blob", sha: blobSha });
+  }
+  const tree = await githubApi<{ sha?: string }>(token, `${repository}/git/trees`, {
+    method: "POST",
+    body: JSON.stringify({ base_tree: baseTree, tree: treeEntries }),
+  });
+  const treeSha = String(tree.sha ?? "").toLowerCase();
+  if (!SHA.test(treeSha)) throw new Error("GitHub tree SHA is invalid");
+  const nextCommit = await githubApi<{ sha?: string }>(token, `${repository}/git/commits`, {
+    method: "POST",
+    body: JSON.stringify({
+      message: request.message,
+      tree: treeSha,
+      parents: [state.current_head_sha],
+    }),
+  });
+  const nextHead = String(nextCommit.sha ?? "").toLowerCase();
+  if (!SHA.test(nextHead)) throw new Error("GitHub commit SHA is invalid");
+  setActiveRunBrokerState(runId, "github_pr", {
+    ...state,
+    pending_head_sha: nextHead,
+  } satisfies GithubPullRequestState);
+  const refPath = binding.head_ref.split("/").map(encodeURIComponent).join("/");
+  try {
+    await githubApi(token, `${repository}/git/refs/heads/${refPath}`, {
+      method: "PATCH",
+      body: JSON.stringify({ sha: nextHead, force: false }),
+    });
+  } catch (error) {
+    const pull = await githubApi<PullResponse>(token, `${repository}/pulls/${binding.pull_number}`);
+    const observedHead = pullHead(pull, binding);
+    if (observedHead !== nextHead) {
+      if (observedHead === state.current_head_sha) setActiveRunBrokerState(runId, "github_pr", state);
+      throw error;
+    }
+  }
+  const finalized: GithubPullRequestState = {
+    version: 1,
+    identity: state.identity,
+    current_head_sha: nextHead,
+  };
+  setActiveRunBrokerState(runId, "github_pr", finalized);
+  return {
+    repository: `${binding.owner}/${binding.repo}`,
+    pull_number: binding.pull_number,
+    previous_head_sha: state.current_head_sha,
+    head_sha: nextHead,
+    committed_files: request.files.map((file) => file.path),
+  };
+}

--- a/homerail_manager/src/runtime/workspace-retention.ts
+++ b/homerail_manager/src/runtime/workspace-retention.ts
@@ -150,6 +150,25 @@ async function inspectWorkspace(target: string): Promise<WorkspaceEntry | undefi
 }
 
 async function removeWorkspace(target: string, entry: WorkspaceEntry): Promise<void> {
+  if (entry.isDirectory && !entry.isSymbolicLink) {
+    const inputRoot = path.join(target, "input");
+    const unlockInputDirectories = async (directory: string): Promise<void> => {
+      let stat;
+      try {
+        stat = await fs.lstat(directory);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+        throw error;
+      }
+      if (!stat.isDirectory() || stat.isSymbolicLink()) return;
+      await fs.chmod(directory, 0o700);
+      const children = await fs.readdir(directory, { withFileTypes: true });
+      await Promise.all(children
+        .filter((child) => child.isDirectory() && !child.isSymbolicLink())
+        .map((child) => unlockInputDirectories(path.join(directory, child.name))));
+    };
+    await unlockInputDirectories(inputRoot);
+  }
   await fs.rm(target, {
     recursive: entry.isDirectory && !entry.isSymbolicLink,
     force: true,

--- a/homerail_manager/src/server/host-codex-manager-agent.ts
+++ b/homerail_manager/src/server/host-codex-manager-agent.ts
@@ -1385,25 +1385,26 @@ export function createManagerTools(
       },
     },
     {
-      name: "create_and_run",
-      description: "Create and immediately invoke a DAG run from a DB workflow_id or repo-local YAML path.",
-      input_schema: {
-        type: "object",
-        properties: {
-          yamlPath: { type: "string" },
-          workflow_id: { type: "string" },
-          workflowId: { type: "string" },
-          profile: { type: "string" },
-          prompt: { type: "string" },
-          runId: { type: "string" },
-        },
-        anyOf: [
-          { required: ["workflow_id"] },
-          { required: ["workflowId"] },
-          { required: ["yamlPath"] },
-        ],
-        additionalProperties: false,
+      ...managerAgentToolSpec("stage_run_input"),
+      async handler(args) {
+        const scopeId = typeof args.scope_id === "string" && args.scope_id.trim()
+          ? args.scope_id.trim()
+          : state.projectId ?? "manager-agent";
+        const body = await requestManager(state.restUrl, "/run-inputs", {
+          method: "POST",
+          body: JSON.stringify({
+            scope_id: scopeId,
+            name: args.name,
+            media_type: args.media_type,
+            content: args.content,
+          }),
+        });
+        state.objectiveToolCalls.push({ name: "stage_run_input", success: true });
+        return { content: [{ type: "text", text: short(body, 12000) }] };
       },
+    },
+    {
+      ...managerAgentToolSpec("create_and_run"),
       async handler(args) {
         try {
           const yamlPath = typeof args.yamlPath === "string" ? args.yamlPath.trim() : "";
@@ -1423,6 +1424,8 @@ export function createManagerTools(
               profile: typeof args.profile === "string" ? args.profile : undefined,
               prompt: typeof args.prompt === "string" ? args.prompt : undefined,
               runId: typeof args.runId === "string" ? args.runId : undefined,
+              input_scope: typeof args.input_scope === "string" ? args.input_scope : undefined,
+              input_artifacts: Array.isArray(args.input_artifacts) ? args.input_artifacts : undefined,
             }),
           }) as Record<string, unknown>;
           const data = body.data as Record<string, unknown> | undefined;
@@ -1459,6 +1462,8 @@ export function createManagerTools(
               profile: typeof args.profile === "string" ? args.profile : undefined,
               prompt: typeof args.prompt === "string" ? args.prompt : undefined,
               runId: typeof args.runId === "string" ? args.runId : undefined,
+              input_scope: typeof args.input_scope === "string" ? args.input_scope : undefined,
+              input_artifacts: Array.isArray(args.input_artifacts) ? args.input_artifacts : undefined,
             }),
           }) as Record<string, unknown>;
           const data = body.data as Record<string, unknown> | undefined;

--- a/homerail_manager/src/server/mutations.ts
+++ b/homerail_manager/src/server/mutations.ts
@@ -35,7 +35,9 @@ import { DagActorLiveCommandRuntimeError } from "../runtime/dag-actor-live-comma
 import { DagActorLiveCommandConflictError } from "../persistence/dag-actor-live-commands.js";
 import {
   canonicalManagerAgentToolCallName,
+  DAG_RUN_INPUT_MEDIA_TYPES,
   normalizeManagerAgentOutcomeCapabilities,
+  type DagRunInputMediaType,
   type DagRunInputBindingRequest,
 } from "homerail-protocol";
 import {
@@ -48,6 +50,11 @@ interface BaseResponse {
   message: string;
   data?: unknown;
   error?: string;
+}
+
+function _isDagRunInputMediaType(value: unknown): value is DagRunInputMediaType {
+  return typeof value === "string"
+    && (DAG_RUN_INPUT_MEDIA_TYPES as readonly string[]).includes(value);
 }
 
 function json(res: http.ServerResponse, status: number, body: BaseResponse) {
@@ -244,11 +251,17 @@ export function mutationRoutesHandler(
       .then((body) => {
         const value = body as Record<string, unknown>;
         try {
+          if (!_isDagRunInputMediaType(value.media_type)) {
+            throw new Error("unsupported run input media_type");
+          }
+          if (typeof value.content !== "string") {
+            throw new Error("run input content must be a string");
+          }
           const artifact = stageDagRunInputArtifact({
             scope_id: typeof value.scope_id === "string" ? value.scope_id : "",
             name: typeof value.name === "string" ? value.name : "",
-            media_type: typeof value.media_type === "string" ? value.media_type as any : "" as any,
-            content: typeof value.content === "string" ? value.content : "" as any,
+            media_type: value.media_type,
+            content: value.content,
           });
           _created(res, "Run input staged", { artifact });
         } catch (error) {

--- a/homerail_manager/src/server/mutations.ts
+++ b/homerail_manager/src/server/mutations.ts
@@ -36,7 +36,12 @@ import { DagActorLiveCommandConflictError } from "../persistence/dag-actor-live-
 import {
   canonicalManagerAgentToolCallName,
   normalizeManagerAgentOutcomeCapabilities,
+  type DagRunInputBindingRequest,
 } from "homerail-protocol";
+import {
+  listDagRunInputs,
+  stageDagRunInputArtifact,
+} from "../persistence/run-input-artifacts.js";
 
 interface BaseResponse {
   success: boolean;
@@ -143,6 +148,7 @@ export function requiresDagMutationAuthorization(pathname: string, method?: stri
   if (/^\/api\/runs\/[^/]+\/node\/[^/]+\/approval$/.test(pathname)) return false;
   return pathname === "/api/runs"
     || pathname.startsWith("/api/runs/")
+    || pathname === "/api/run-inputs"
     || pathname === "/api/dag/workflows/sync"
     || pathname === "/api/dag/profiles/sync"
     || pathname.startsWith("/api/dag/environment/")
@@ -150,11 +156,23 @@ export function requiresDagMutationAuthorization(pathname: string, method?: stri
     || pathname === "/api/settings/workspace-retention";
 }
 
-async function _readJsonBody(req: http.IncomingMessage): Promise<unknown> {
+async function _readJsonBody(req: http.IncomingMessage, maxBytes = Number.POSITIVE_INFINITY): Promise<unknown> {
   return new Promise((resolve, reject) => {
     let data = "";
-    req.on("data", (chunk) => { data += chunk; });
+    let size = 0;
+    let exceeded = false;
+    req.on("data", (chunk) => {
+      if (exceeded) return;
+      size += Buffer.byteLength(chunk);
+      if (size > maxBytes) {
+        exceeded = true;
+        reject(new Error(`JSON request body exceeds ${maxBytes} bytes`));
+        return;
+      }
+      data += chunk;
+    });
     req.on("end", () => {
+      if (exceeded) return;
       try {
         resolve(data ? JSON.parse(data) : {});
       } catch (err) {
@@ -163,6 +181,33 @@ async function _readJsonBody(req: http.IncomingMessage): Promise<unknown> {
     });
     req.on("error", reject);
   });
+}
+
+function _runInputFields(body: Record<string, unknown>): {
+  inputScope?: string;
+  inputArtifacts?: DagRunInputBindingRequest[];
+} {
+  if (body.input_artifacts === undefined) return {};
+  if (!Array.isArray(body.input_artifacts)) throw new Error("input_artifacts must be an array");
+  const inputScope = typeof body.input_scope === "string" ? body.input_scope.trim() : "";
+  if (!inputScope) throw new Error("input_scope is required when input_artifacts are bound");
+  const inputArtifacts = body.input_artifacts.map((value, index) => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      throw new Error(`input_artifacts[${index}] must be an object`);
+    }
+    const entry = value as Record<string, unknown>;
+    for (const field of ["artifact_id", "logical_name", "mount_path"] as const) {
+      if (typeof entry[field] !== "string" || !entry[field].trim()) {
+        throw new Error(`input_artifacts[${index}].${field} is required`);
+      }
+    }
+    return {
+      artifact_id: String(entry.artifact_id).trim(),
+      logical_name: String(entry.logical_name).trim(),
+      mount_path: String(entry.mount_path).trim(),
+    };
+  });
+  return { inputScope, inputArtifacts };
 }
 
 function _appendNodeRequestFromBody(body: Record<string, unknown>): AppendNodeRequest | undefined {
@@ -193,6 +238,37 @@ export function mutationRoutesHandler(
   managerAgentConfigOptions: ManagerAgentConfigRoutesOptions = {},
 ): boolean {
   const pathname = new URL(req.url || "/", "http://localhost").pathname;
+
+  if (pathname === "/api/run-inputs" && req.method === "POST") {
+    _readJsonBody(req, 1_200_000)
+      .then((body) => {
+        const value = body as Record<string, unknown>;
+        try {
+          const artifact = stageDagRunInputArtifact({
+            scope_id: typeof value.scope_id === "string" ? value.scope_id : "",
+            name: typeof value.name === "string" ? value.name : "",
+            media_type: typeof value.media_type === "string" ? value.media_type as any : "" as any,
+            content: typeof value.content === "string" ? value.content : "" as any,
+          });
+          _created(res, "Run input staged", { artifact });
+        } catch (error) {
+          _badRequest(res, error instanceof Error ? error.message : String(error));
+        }
+      })
+      .catch((error) => _badRequest(res, error instanceof Error ? error.message : "Invalid JSON body"));
+    return true;
+  }
+
+  const runInputsMatch = pathname.match(/^\/api\/runs\/([^/]+)\/inputs$/);
+  if (runInputsMatch && req.method === "GET") {
+    try {
+      const runId = decodeURIComponent(runInputsMatch[1]);
+      _ok(res, "Run inputs", { inputs: listDagRunInputs(runId) });
+    } catch (error) {
+      _badRequest(res, error instanceof Error ? error.message : String(error));
+    }
+    return true;
+  }
 
   // POST /api/manager/chat
   if (pathname === "/api/manager/chat" && req.method === "POST") {
@@ -374,7 +450,8 @@ export function mutationRoutesHandler(
         const prompt = typeof b.prompt === "string" ? b.prompt : undefined;
         const llmSettingId = typeof b.llm_setting_id === "string" && b.llm_setting_id.trim() ? b.llm_setting_id.trim() : undefined;
         try {
-          const result = changeOrchestrator.createRun({ yamlPath, workflowId, profile, runId, prompt, llmSettingId });
+          const runInputs = _runInputFields(b);
+          const result = changeOrchestrator.createRun({ yamlPath, workflowId, profile, runId, prompt, llmSettingId, ...runInputs });
           _created(res, "Run created", result);
         } catch (err) {
           _runCreationError(res, err);
@@ -425,6 +502,7 @@ export function mutationRoutesHandler(
           return;
         }
         try {
+          const runInputs = _runInputFields(b);
           const result = changeOrchestrator.createAndRun({
             yamlPath,
             workflowId,
@@ -435,6 +513,7 @@ export function mutationRoutesHandler(
             expectedWorkflowRevision,
             expectedCanonicalHash,
             expectedProfileUpdatedAt,
+            ...runInputs,
           });
           _created(res, "Run created and invoked", result);
         } catch (err) {

--- a/homerail_manager/tests/auto-fix-v2-scenario.test.ts
+++ b/homerail_manager/tests/auto-fix-v2-scenario.test.ts
@@ -1,0 +1,230 @@
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { DAGDispatcher, DispatchEnvelope } from "../src/orchestration/dag-dispatcher.js";
+import { GraphExecutor } from "../src/orchestration/graph-executor.js";
+import { parseWorkflowSource } from "../src/orchestration/workflow-spec-v1.js";
+import { createCredential } from "../src/persistence/credentials.js";
+import { closeDb } from "../src/persistence/db.js";
+import {
+  resolveDagRunInputBindings,
+  stageDagRunInputArtifact,
+} from "../src/persistence/run-input-artifacts.js";
+import {
+  _clearActiveRuns,
+  createActiveRun,
+  getActiveRun,
+  handoffActiveRun,
+  recoverAllActiveRuns,
+} from "../src/runtime/active-runs.js";
+
+const TEMPLATE = path.resolve(import.meta.dirname, "../../assets/orchestrations/auto-fix-v2.yaml.template");
+
+class ReentrantDispatcher implements DAGDispatcher {
+  dispatched: DispatchEnvelope[] = [];
+
+  dispatch(envelope: DispatchEnvelope) {
+    this.dispatched.push(envelope);
+    return { status: "dispatched" as const, targetType: "fake" as const, targetId: "fake" };
+  }
+}
+
+function git(cwd: string, args: string[]): string {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8", shell: false });
+  if (result.status !== 0) throw new Error(String(result.stderr || result.error));
+  return String(result.stdout).trim();
+}
+
+describe("Auto Fix v2 document-first dynamic architecture", () => {
+  let home: string;
+  let previousHome: string | undefined;
+  let head: string;
+
+  beforeEach(() => {
+    previousHome = process.env.HOMERAIL_HOME;
+    home = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-autofix-v2-"));
+    process.env.HOMERAIL_HOME = home;
+    closeDb();
+    _clearActiveRuns();
+
+    createCredential({
+      id: "github-autofix",
+      credential_type: "api_key",
+      name: "Autofix broker token",
+      secret: { value: "fake-github-token" },
+    }, { actor: "test" });
+
+    const repository = path.join(home, "workspace", "autofix-v2-run", "repo");
+    fs.mkdirSync(repository, { recursive: true });
+    git(repository, ["init", "--initial-branch=main"]);
+    git(repository, ["config", "user.name", "HomeRail Test"]);
+    git(repository, ["config", "user.email", "homerail@example.invalid"]);
+    fs.writeFileSync(path.join(repository, "README.md"), "fixture\n");
+    git(repository, ["add", "README.md"]);
+    git(repository, ["commit", "-m", "fixture"]);
+    head = git(repository, ["rev-parse", "HEAD"]);
+  });
+
+  afterEach(() => {
+    _clearActiveRuns();
+    closeDb();
+    if (previousHome === undefined) delete process.env.HOMERAIL_HOME;
+    else process.env.HOMERAIL_HOME = previousHome;
+    const inputRoot = path.join(home, "workspace", "autofix-v2-run", "input");
+    if (fs.existsSync(inputRoot)) fs.chmodSync(inputRoot, 0o700);
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it("parses to a compact graph and completes five fresh review rounds with recovered dynamic fixers", () => {
+    const source = fs.readFileSync(TEMPLATE, "utf8");
+    const parsed = parseWorkflowSource(source);
+    expect(parsed.meta.workflow_id).toBe("auto-fix-v2");
+    expect(parsed.graph.nodes).toHaveLength(8);
+    expect(parsed.graph.edges.length).toBeLessThanOrEqual(28);
+    for (const agent of Object.values(parsed.meta.agents ?? {})) agent.agent_type = "deterministic";
+
+    const task = stageDagRunInputArtifact({
+      scope_id: "pilot",
+      name: "task.md",
+      media_type: "text/markdown",
+      content: "# Issue 172\n\nImplement the durable document-first Auto Fix v2 acceptance criteria.\n",
+    });
+    const pr = stageDagRunInputArtifact({
+      scope_id: "pilot",
+      name: "pr-context.json",
+      media_type: "application/json",
+      content: JSON.stringify({
+        version: 1,
+        owner: "acme",
+        repo: "widget",
+        pull_number: 172,
+        clone_url: "https://github.com/acme/widget.git",
+        head_ref: "autofix/issue-172",
+        base_ref: "main",
+        initial_head_sha: head,
+        base_sha: head,
+        task_document_sha256: task.sha256,
+        require_draft: true,
+        writable_paths: ["src", "tests"],
+      }),
+    });
+    const bindings = resolveDagRunInputBindings("pilot", [
+      { artifact_id: task.artifact_id, logical_name: "task_document", mount_path: "input/task.md" },
+      { artifact_id: pr.artifact_id, logical_name: "pr_context", mount_path: "input/pr-context.json" },
+    ]);
+    createActiveRun("autofix-v2-run", parsed, { initialPrompt: "{}", inputArtifacts: bindings });
+    const dispatcher = new ReentrantDispatcher();
+    const executor = new GraphExecutor(dispatcher);
+
+    handoffActiveRun("autofix-v2-run", "prepare_repository", "ready", {
+      repository_path: "repo",
+      head,
+    });
+    executor.tick("autofix-v2-run");
+    expect(dispatcher.dispatched.at(-1)?.nodeId).toBe("analyze");
+    handoffActiveRun("autofix-v2-run", "analyze", "planned", {
+      tasks: [
+        { id: "runtime", title: "Runtime", description: "Implement runtime", acceptance: ["passes"] },
+        { id: "tests", title: "Tests", description: "Add tests", acceptance: ["passes"] },
+      ],
+      shared: { repository_path: "repo", task_document: "input/task.md", pr_context: "input/pr-context.json" },
+    });
+    executor.tick("autofix-v2-run");
+    expect(dispatcher.dispatched.filter((entry) => entry.nodeId.startsWith("implement__item_"))).toHaveLength(2);
+    for (let index = 1; index <= 2; index++) {
+      const nodeId = `implement__item_${String(index).padStart(4, "0")}`;
+      const workspacePath = `workers/implement/inv_0001/item_${String(index).padStart(4, "0")}`;
+      expect(fs.existsSync(path.join(home, "workspace", "autofix-v2-run", workspacePath, ".git"))).toBe(true);
+      const child = getActiveRun("autofix-v2-run")?.dagRun.graph.nodes.find((node) => node.node_id === nodeId);
+      expect(child?.extra?.agent_runtime).toMatchObject({
+        workspace_access: { writable_paths: [workspacePath], readonly_paths: ["input"] },
+        allowed_dag_tools: ["handoff"],
+        credentials: [],
+      });
+      handoffActiveRun("autofix-v2-run", nodeId, "result", {
+        status: "implemented",
+        task_id: index === 1 ? "runtime" : "tests",
+        commit_sha: head,
+        workspace_path: workspacePath,
+        summary: "implemented",
+        tests: ["fixture"],
+      });
+    }
+    executor.tick("autofix-v2-run");
+    expect(dispatcher.dispatched.at(-1)?.nodeId).toBe("aggregate");
+    expect(dispatcher.dispatched.at(-1)?.credentialProjections).toMatchObject([{
+      broker: "github_pr",
+      allowed_actions: ["pull_request_snapshot", "commit_files"],
+    }]);
+    handoffActiveRun("autofix-v2-run", "aggregate", "candidate", {
+      head_sha: head,
+      review_round: 1,
+      summary: "candidate",
+      tests: ["fixture"],
+    });
+    executor.tick("autofix-v2-run");
+    expect(dispatcher.dispatched.at(-1)?.nodeId).toBe("review_initial");
+    const reviewSessions: string[] = [dispatcher.dispatched.at(-1)?.sessionId ?? ""];
+    handoffActiveRun("autofix-v2-run", "review_initial", "reviewed", {
+      verdict: "changes_requested",
+      head_sha: head,
+      review_round: 1,
+      summary: "round 1",
+      feedback: ["fix round 1"],
+      fix_tasks: [{ id: "round-1", feedback: ["fix round 1"] }],
+    });
+
+    for (let fixRound = 1; fixRound <= 4; fixRound++) {
+      executor.tick("autofix-v2-run");
+      const fixerId = fixRound === 1
+        ? "fix__item_0001"
+        : `fix__inv_${String(fixRound).padStart(4, "0")}__item_0001`;
+      const fixerEnvelope = dispatcher.dispatched.find((entry) => entry.nodeId === fixerId);
+      expect(fixerEnvelope).toBeDefined();
+      expect(fixerEnvelope?.credentialProjections).toMatchObject([{
+        broker: "github_pr",
+        allowed_actions: ["pull_request_snapshot", "commit_files"],
+      }]);
+      handoffActiveRun("autofix-v2-run", fixerId, "result", {
+        status: "fixed",
+        previous_head_sha: head,
+        head_sha: head,
+        summary: `fixed ${fixRound}`,
+        tests: ["fixture"],
+      });
+      executor.tick("autofix-v2-run");
+      const reviewEnvelope = dispatcher.dispatched.at(-1)!;
+      expect(reviewEnvelope.nodeId).toBe("review_revision");
+      reviewSessions.push(reviewEnvelope.sessionId!);
+      const reviewRound = fixRound + 1;
+      handoffActiveRun("autofix-v2-run", "review_revision", "reviewed", {
+        verdict: "changes_requested",
+        head_sha: head,
+        review_round: reviewRound,
+        summary: `round ${reviewRound}`,
+        feedback: [`fix round ${reviewRound}`],
+        fix_tasks: [{ id: `round-${reviewRound}`, feedback: [`fix round ${reviewRound}`] }],
+      });
+
+      if (fixRound === 1) {
+        _clearActiveRuns();
+        closeDb();
+        expect(recoverAllActiveRuns().recovered).toContain("autofix-v2-run");
+      }
+    }
+    executor.tick("autofix-v2-run");
+
+    expect(new Set(reviewSessions).size).toBe(5);
+    expect(getActiveRun("autofix-v2-run")?.status).toBe("cancelled");
+    expect(getActiveRun("autofix-v2-run")?.counters.fanout_invocations).toMatchObject({
+      implement: 1,
+      fix: 4,
+    });
+    expect(getActiveRun("autofix-v2-run")?.dagRun.nodeStates.get("review_gate")).toBe("CANCELLED");
+    expect(getActiveRun("autofix-v2-run")?.dagRun.graph.nodes.some((node) => node.node_id.includes("inv_0005"))).toBe(false);
+    expect(getActiveRun("autofix-v2-run")?.dagRun.graph.nodes).toHaveLength(14);
+  });
+});

--- a/homerail_manager/tests/auto-fix-v2-scenario.test.ts
+++ b/homerail_manager/tests/auto-fix-v2-scenario.test.ts
@@ -19,6 +19,7 @@ import {
   getActiveRun,
   handoffActiveRun,
   recordActiveRunBrokerActionSuccess,
+  requestNodeCorrection,
   recoverAllActiveRuns,
 } from "../src/runtime/active-runs.js";
 
@@ -85,6 +86,14 @@ describe("Auto Fix v2 document-first dynamic architecture", () => {
     expect(parsed.meta.workflow_id).toBe("auto-fix-v2");
     expect(parsed.graph.nodes).toHaveLength(8);
     expect(parsed.graph.edges.length).toBeLessThanOrEqual(28);
+    for (const nodeId of ["implement", "fix"]) {
+      expect(parsed.graph.nodes.find((node) => node.node_id === nodeId)?.gateway_config).toMatchObject({
+        workspace_strategy: "isolated_git_worktree",
+        worker_policy: {
+          workspace_access: { writable_paths: ["{{fanout_workspace}}"], readonly_paths: ["input"] },
+        },
+      });
+    }
     for (const agent of Object.values(parsed.meta.agents ?? {})) agent.agent_type = "deterministic";
 
     const task = stageDagRunInputArtifact({
@@ -223,6 +232,24 @@ describe("Auto Fix v2 document-first dynamic architecture", () => {
         };
         expect(() => handoffActiveRun("autofix-v2-run", "review_revision", "reviewed", approval))
           .toThrow(/DAG_HANDOFF_BROKER_REQUIREMENT_MISSING/);
+        expect(requestNodeCorrection(
+          "autofix-v2-run",
+          "review_revision",
+          "approve handoff omitted required broker verification",
+        ).status).toBe("scheduled");
+        executor.tick("autofix-v2-run");
+        expect(dispatcher.dispatched.at(-1)).toMatchObject({
+          nodeId: "review_revision",
+          sessionId: reviewEnvelope.sessionId,
+        });
+        expect(dispatcher.dispatched.at(-1)?.inputs.correction?.[0]).toContain(
+          "github-autofix/github_pr/required_checks",
+        );
+        expect(dispatcher.dispatched.at(-1)?.credentialProjections).toMatchObject([{
+          credential_ref: "github-autofix",
+          broker: "github_pr",
+          allowed_actions: ["required_checks"],
+        }]);
         recordActiveRunBrokerActionSuccess({
           run_id: "autofix-v2-run",
           node_id: "review_revision",
@@ -230,6 +257,23 @@ describe("Auto Fix v2 document-first dynamic architecture", () => {
           credential_ref: "github-autofix",
           broker: "github_pr",
           action: "required_checks",
+        });
+        expect(() => handoffActiveRun("autofix-v2-run", "review_revision", "reviewed", {
+          verdict: "approve",
+          head_sha: head,
+          review_round: reviewRound,
+          feedback: [],
+          fix_tasks: [],
+        })).toThrow(/DAG_HANDOFF_CONTRACT_VIOLATION/);
+        expect(requestNodeCorrection(
+          "autofix-v2-run",
+          "review_revision",
+          "approve handoff omitted required summary",
+        ).status).toBe("scheduled");
+        executor.tick("autofix-v2-run");
+        expect(dispatcher.dispatched.at(-1)).toMatchObject({
+          nodeId: "review_revision",
+          sessionId: reviewEnvelope.sessionId,
         });
         handoffActiveRun("autofix-v2-run", "review_revision", "reviewed", approval);
       } else {

--- a/homerail_manager/tests/auto-fix-v2-scenario.test.ts
+++ b/homerail_manager/tests/auto-fix-v2-scenario.test.ts
@@ -18,6 +18,7 @@ import {
   createActiveRun,
   getActiveRun,
   handoffActiveRun,
+  recordActiveRunBrokerActionSuccess,
   recoverAllActiveRuns,
 } from "../src/runtime/active-runs.js";
 
@@ -109,6 +110,7 @@ describe("Auto Fix v2 document-first dynamic architecture", () => {
         task_document_sha256: task.sha256,
         require_draft: true,
         writable_paths: ["src", "tests"],
+        required_checks: ["unit"],
       }),
     });
     const bindings = resolveDagRunInputBindings("pilot", [
@@ -200,14 +202,46 @@ describe("Auto Fix v2 document-first dynamic architecture", () => {
       expect(reviewEnvelope.nodeId).toBe("review_revision");
       reviewSessions.push(reviewEnvelope.sessionId!);
       const reviewRound = fixRound + 1;
-      handoffActiveRun("autofix-v2-run", "review_revision", "reviewed", {
-        verdict: "changes_requested",
-        head_sha: head,
-        review_round: reviewRound,
-        summary: `round ${reviewRound}`,
-        feedback: [`fix round ${reviewRound}`],
-        fix_tasks: [{ id: `round-${reviewRound}`, feedback: [`fix round ${reviewRound}`] }],
-      });
+      if (reviewRound === 2) {
+        recordActiveRunBrokerActionSuccess({
+          run_id: "autofix-v2-run",
+          node_id: "review_revision",
+          session_id: reviewEnvelope.sessionId!,
+          credential_ref: "github-autofix",
+          broker: "github_pr",
+          action: "required_checks",
+        });
+      }
+      if (reviewRound === 5) {
+        const approval = {
+          verdict: "approve",
+          head_sha: head,
+          review_round: reviewRound,
+          summary: "approved",
+          feedback: [],
+          fix_tasks: [],
+        };
+        expect(() => handoffActiveRun("autofix-v2-run", "review_revision", "reviewed", approval))
+          .toThrow(/DAG_HANDOFF_BROKER_REQUIREMENT_MISSING/);
+        recordActiveRunBrokerActionSuccess({
+          run_id: "autofix-v2-run",
+          node_id: "review_revision",
+          session_id: reviewEnvelope.sessionId!,
+          credential_ref: "github-autofix",
+          broker: "github_pr",
+          action: "required_checks",
+        });
+        handoffActiveRun("autofix-v2-run", "review_revision", "reviewed", approval);
+      } else {
+        handoffActiveRun("autofix-v2-run", "review_revision", "reviewed", {
+          verdict: "changes_requested",
+          head_sha: head,
+          review_round: reviewRound,
+          summary: `round ${reviewRound}`,
+          feedback: [`fix round ${reviewRound}`],
+          fix_tasks: [{ id: `round-${reviewRound}`, feedback: [`fix round ${reviewRound}`] }],
+        });
+      }
 
       if (fixRound === 1) {
         _clearActiveRuns();
@@ -218,12 +252,12 @@ describe("Auto Fix v2 document-first dynamic architecture", () => {
     executor.tick("autofix-v2-run");
 
     expect(new Set(reviewSessions).size).toBe(5);
-    expect(getActiveRun("autofix-v2-run")?.status).toBe("cancelled");
+    expect(getActiveRun("autofix-v2-run")?.status).toBe("completed");
     expect(getActiveRun("autofix-v2-run")?.counters.fanout_invocations).toMatchObject({
       implement: 1,
       fix: 4,
     });
-    expect(getActiveRun("autofix-v2-run")?.dagRun.nodeStates.get("review_gate")).toBe("CANCELLED");
+    expect(getActiveRun("autofix-v2-run")?.dagRun.nodeStates.get("review_gate")).toBe("COMPLETED");
     expect(getActiveRun("autofix-v2-run")?.dagRun.graph.nodes.some((node) => node.node_id.includes("inv_0005"))).toBe(false);
     expect(getActiveRun("autofix-v2-run")?.dagRun.graph.nodes).toHaveLength(14);
   });

--- a/homerail_manager/tests/dag-runtime-primitives.test.ts
+++ b/homerail_manager/tests/dag-runtime-primitives.test.ts
@@ -31,6 +31,7 @@ import {
   expireActiveRunApprovals,
   failActiveRun,
   getActiveRun,
+  getCurrentNodeSession,
   handoffActiveRun,
   recordAdvisorCall,
   requestNodeCorrection,
@@ -795,6 +796,7 @@ edges:
     for (const pathname of [
       "/api/runs",
       "/api/runs/create-and-run",
+      "/api/run-inputs",
       "/api/runs/emergency-stop",
       "/api/runs/run-1/invoke",
       "/api/runs/run-1/cancel",
@@ -842,6 +844,11 @@ nodes:
       item_field: items
       context_field: shared
       worker_agent: worker
+      worker_policy:
+        workspace_access: { writable_paths: [], readonly_paths: [input] }
+        allowed_builtin_tools: [Read]
+        allowed_dag_tools: [handoff]
+        session_scope: dispatch
       max_items: 5
       max_parallelism: 2
       completion: n_of_m
@@ -874,7 +881,16 @@ edges:
     });
     expect(getActiveRun("fanout-run")?.dagRun.graph.nodes.find(
       (node) => node.node_id === "fan__item_0001",
-    )?.extra?.workflow_spec_v1).toMatchObject({ output_contracts: { result: "WorkerResult" } });
+    )?.extra).toMatchObject({
+      workflow_spec_v1: { output_contracts: { result: "WorkerResult" } },
+      dynamic_fanout: { parent_node: "fan", index: 0, invocation: 1 },
+      agent_runtime: {
+        workspace_access: { writable_paths: [], readonly_paths: ["input"] },
+        allowed_builtin_tools: ["Read"],
+        allowed_dag_tools: ["handoff"],
+        session_scope: "dispatch",
+      },
+    });
     expect(() => handoffActiveRun("fanout-run", "fan__item_0001", "result", { evidence: "missing status" }))
       .toThrow("DAG_HANDOFF_CONTRACT_VIOLATION");
     expect(getActiveRun("fanout-run")?.status).toBe("active");
@@ -893,6 +909,144 @@ edges:
     });
     expect(() => handoffActiveRun("fanout-run", "fan__item_0002", "result", { status: "success", evidence: "late" }))
       .toThrow("not active");
+  });
+
+  it("uses unique child ids and rejects stale children when fanout is entered again", () => {
+    const parsed = parseWorkflowSource(yaml("reentered-fanout", `
+contracts:
+  State: { type: object }
+agents:
+  worker: { system: Process one item. }
+nodes:
+  cycle:
+    kind: while
+    inputs: { state: { contract: State } }
+    outputs: { continue: { contract: State }, done: { contract: State }, exhausted: { contract: State } }
+    config:
+      field: context.stop
+      operator: eq
+      value: true
+      continue_port: continue
+      done_port: done
+      exhausted_port: exhausted
+      max_iterations: 2
+  fan:
+    kind: fanout
+    inputs: { plan: { contract: State } }
+    outputs: { passed: { contract: State }, failed: { contract: State } }
+    config:
+      input: plan
+      item_field: input.context.items
+      context_field: input.context
+      worker_agent: worker
+      max_items: 2
+      max_parallelism: 1
+      completion: all
+      result_port: passed
+      failed_port: failed
+  finished: { kind: terminal, outcome: success, inputs: { result: { contract: State } } }
+  exhausted: { kind: terminal, outcome: success, inputs: { result: { contract: State } } }
+  failed: { kind: terminal, outcome: failure, inputs: { result: { contract: State } } }
+edges:
+  - { from: $run.input, to: cycle.state }
+  - { from: cycle.continue, to: fan.plan }
+  - kind: feedback
+    from: fan.passed
+    to: cycle.state
+    max_traversals: 2
+  - { from: cycle.done, to: finished.result }
+  - { from: cycle.exhausted, to: exhausted.result }
+  - { from: fan.failed, to: failed.result, condition: on_failure }
+`));
+    parsed.meta.agents!.worker.agent_type = "deterministic";
+    const dispatcher = new FakeDAGDispatcher();
+    const executor = new GraphExecutor(dispatcher);
+    executor.createRun("fanout-reentry-run", parsed, JSON.stringify({
+      context: { items: ["only"], stop: false },
+    }));
+
+    executor.tick("fanout-reentry-run");
+    expect(dispatcher.dispatched.map((entry) => entry.nodeId)).toEqual(["fan__item_0001"]);
+    handoffActiveRun("fanout-reentry-run", "fan__item_0001", "result", { status: "success" });
+    executor.tick("fanout-reentry-run");
+    expect(dispatcher.dispatched.map((entry) => entry.nodeId)).toEqual([
+      "fan__item_0001",
+      "fan__inv_0002__item_0001",
+    ]);
+    const run = getActiveRun("fanout-reentry-run");
+    expect(run?.counters.fanout_invocations.fan).toBe(2);
+    expect(run?.dagRun.graph.nodes.find((node) => node.node_id === "fan__inv_0002__item_0001")?.extra)
+      .toMatchObject({
+        dynamic_fanout: { parent_node: "fan", index: 0, invocation: 2 },
+        agent_runtime: {
+          allowed_builtin_tools: [],
+          allowed_dag_tools: ["handoff"],
+          workspace_access: { writable_paths: [], readonly_paths: ["input"] },
+        },
+      });
+  });
+
+  it("creates a fresh provider session whenever a dispatch-scoped reviewer is re-entered", () => {
+    const parsed = parseWorkflowSource(yaml("fresh-review-context", `
+contracts:
+  State:
+    type: object
+    properties: { approved: { type: boolean } }
+agents:
+  reviewer: { system: Review only the supplied candidate. }
+nodes:
+  cycle:
+    kind: while
+    inputs: { state: { contract: State } }
+    outputs: { continue: { contract: State }, done: { contract: State }, exhausted: { contract: State } }
+    config:
+      field: approved
+      operator: eq
+      value: true
+      continue_port: continue
+      done_port: done
+      exhausted_port: exhausted
+      max_iterations: 3
+  review:
+    kind: agent
+    agent: reviewer
+    session_scope: dispatch
+    inputs: { candidate: { contract: State } }
+    outputs: { reviewed: { contract: State } }
+  finished: { kind: terminal, outcome: success, inputs: { result: { contract: State } } }
+  exhausted: { kind: terminal, outcome: failure, inputs: { result: { contract: State } } }
+edges:
+  - { from: $run.input, to: cycle.state }
+  - { from: cycle.continue, to: review.candidate }
+  - kind: feedback
+    from: review.reviewed
+    to: cycle.state
+    max_traversals: 3
+  - { from: cycle.done, to: finished.result }
+  - { from: cycle.exhausted, to: exhausted.result, condition: on_failure }
+`));
+    parsed.meta.agents!.reviewer.agent_type = "deterministic";
+    const dispatcher = new FakeDAGDispatcher();
+    const executor = new GraphExecutor(dispatcher);
+    executor.createRun("fresh-review-run", parsed, JSON.stringify({ approved: false }));
+
+    executor.tick("fresh-review-run");
+    const firstSession = dispatcher.dispatched.at(-1)?.sessionId;
+    dispatcher.reset();
+    handoffActiveRun("fresh-review-run", "review", "reviewed", { approved: false });
+    expect(getCurrentNodeSession("fresh-review-run", "review")?.status).toBe("completed");
+    executor.tick("fresh-review-run");
+    expect(dispatcher.dispatched).toHaveLength(1);
+    const secondSession = dispatcher.dispatched.at(-1)?.sessionId;
+
+    expect(firstSession).toEqual(expect.any(String));
+    expect(secondSession).toEqual(expect.any(String));
+    expect(secondSession).not.toBe(firstSession);
+    expect(getCurrentNodeSession("fresh-review-run", "review")).toMatchObject({
+      sessionId: secondSession,
+      attempt: 2,
+      status: "running",
+    });
   });
 
   it("enforces max_nodes when a running DAG appends dynamic nodes", () => {

--- a/homerail_manager/tests/dispatch-capabilities.test.ts
+++ b/homerail_manager/tests/dispatch-capabilities.test.ts
@@ -518,7 +518,7 @@ nodes:
     });
   });
 
-  it("provisions a run-scoped worker instead of reusing generic workers for isolated workspaces", async () => {
+  it("provisions an isolated run-scoped worker without sending empty workspace inputs", async () => {
     const genericSocket = makeSocket();
     const nodeSocket = makeSocket();
     const created: Array<{
@@ -527,6 +527,7 @@ nodes:
       image?: string;
       workspace?: Record<string, unknown>;
       workspaceReadOnly?: boolean;
+      workspaceInputs?: unknown[];
     }> = [];
     registerWorker({
       worker_id: "generic-worker",
@@ -558,6 +559,7 @@ nodes:
             image: opts.image,
             workspace: opts.workspace,
             workspaceReadOnly: opts.workspaceReadOnly,
+            workspaceInputs: opts.workspaceInputs,
           });
           return { status: "success", resource_data: { id: "container-1" } };
         },
@@ -587,6 +589,7 @@ nodes:
           image: "custom-worker:v2",
           workspace: { mode: "isolated" },
           workspaceReadOnly: true,
+          workspaceInputs: undefined,
         },
       ]);
     });

--- a/homerail_manager/tests/github-pr-broker.test.ts
+++ b/homerail_manager/tests/github-pr-broker.test.ts
@@ -336,6 +336,23 @@ describe("bounded GitHub Draft PR credential broker", () => {
     expect(stale).toMatchObject({ ok: false, error: expect.stringContaining("expected head is stale") });
   });
 
+  it("accepts commit payloads above the generic broker input limit within the 1 MiB file bound", async () => {
+    const content = Buffer.alloc(100 * 1024, "a");
+    const committed = await call("aggregate", "commit_files", {
+      expected_head_sha: INITIAL_HEAD,
+      message: "fix: larger bounded change",
+      files: [{ path: "src/fix.ts", content_base64: content.toString("base64") }],
+    });
+    expect(committed).toMatchObject({
+      ok: true,
+      result: {
+        previous_head_sha: INITIAL_HEAD,
+        head_sha: NEXT_HEAD,
+        committed_files: ["src/fix.ts"],
+      },
+    });
+  });
+
   it("fails closed when the Draft PR head changes outside the broker", async () => {
     await call("reviewer", "pull_request_snapshot");
     remoteHead = "9".repeat(40);

--- a/homerail_manager/tests/github-pr-broker.test.ts
+++ b/homerail_manager/tests/github-pr-broker.test.ts
@@ -1,0 +1,277 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { parseWorkflowSource } from "../src/orchestration/workflow-spec-v1.js";
+import { closeDb } from "../src/persistence/db.js";
+import { createCredential } from "../src/persistence/credentials.js";
+import {
+  resolveDagRunInputBindings,
+  stageDagRunInputArtifact,
+} from "../src/persistence/run-input-artifacts.js";
+import {
+  _clearActiveRuns,
+  createActiveRun,
+  recoverAllActiveRuns,
+} from "../src/runtime/active-runs.js";
+import { executeCredentialBrokerCall } from "../src/runtime/credential-broker.js";
+
+const INITIAL_HEAD = "a".repeat(40);
+const BASE_HEAD = "b".repeat(40);
+const BASE_TREE = "c".repeat(40);
+const BLOB = "d".repeat(40);
+const NEXT_HEAD = "e".repeat(40);
+const NEXT_TREE = "f".repeat(40);
+
+function workflow(): string {
+  const binding = (actions: string) => `
+        - credential_ref: github-autofix
+          purpose: bounded Draft PR access
+          inject:
+            mode: manager_broker
+            broker: github_pr
+            allowed_actions: [${actions}]`;
+  return `
+api_version: homerail.ai/v1
+kind: Workflow
+metadata: { id: github-broker-test, name: GitHub broker test }
+spec:
+  contracts:
+    Task: { type: object }
+  agents:
+    actor: { system: Use only the declared GitHub broker actions. }
+  nodes:
+    aggregate:
+      kind: agent
+      agent: actor
+      allowed_dag_tools: [handoff, credential_broker_call]
+      credentials:${binding("pull_request_snapshot, commit_files")}
+      inputs: { task: { contract: Task } }
+      outputs: { done: {} }
+    reviewer:
+      kind: agent
+      agent: actor
+      allowed_dag_tools: [handoff, credential_broker_call]
+      credentials:${binding("pull_request_snapshot, checks_snapshot")}
+      inputs: { task: {} }
+      outputs: { done: {} }
+    implementer:
+      kind: agent
+      agent: actor
+      inputs: { task: {} }
+      outputs: { done: {} }
+    done: { kind: terminal, outcome: success, inputs: { result: {} } }
+  edges:
+    - { from: $run.input, to: aggregate.task }
+    - { from: aggregate.done, to: reviewer.task }
+    - { from: reviewer.done, to: implementer.task }
+    - { from: implementer.done, to: done.result }
+`;
+}
+
+describe("bounded GitHub Draft PR credential broker", () => {
+  let home: string;
+  let previousHome: string | undefined;
+  let remoteHead: string;
+  let pullState: string;
+  let headRepository: string;
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    previousHome = process.env.HOMERAIL_HOME;
+    home = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-github-broker-"));
+    process.env.HOMERAIL_HOME = home;
+    closeDb();
+    _clearActiveRuns();
+    remoteHead = INITIAL_HEAD;
+    pullState = "open";
+    headRepository = "acme/widget";
+    fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = new URL(String(input));
+      const method = String(init?.method ?? "GET").toUpperCase();
+      const json = (body: unknown, status = 200) => new Response(JSON.stringify(body), {
+        status,
+        headers: { "content-type": "application/json" },
+      });
+      if (method === "GET" && url.pathname === "/repos/acme/widget/pulls/7") {
+        return json({
+          number: 7,
+          title: "WIP autofix",
+          body: "Bound task",
+          draft: true,
+          state: pullState,
+          html_url: "https://github.example/acme/widget/pull/7",
+          head: { sha: remoteHead, ref: "autofix/issue-172", repo: { full_name: headRepository } },
+          base: { sha: BASE_HEAD, ref: "main", repo: { full_name: "acme/widget" } },
+        });
+      }
+      if (method === "GET" && url.pathname === "/repos/acme/widget/pulls/7/files") {
+        return json([{ filename: "src/fix.ts", status: "modified", additions: 2, deletions: 1, changes: 3, patch: "@@ fake" }]);
+      }
+      if (method === "GET" && url.pathname.endsWith("/check-runs")) {
+        return json({ check_runs: [{ id: 1, name: "unit", status: "completed", conclusion: "success" }] });
+      }
+      if (method === "GET" && url.pathname === `/repos/acme/widget/git/commits/${INITIAL_HEAD}`) {
+        return json({ tree: { sha: BASE_TREE } });
+      }
+      if (method === "POST" && url.pathname === "/repos/acme/widget/git/blobs") return json({ sha: BLOB }, 201);
+      if (method === "POST" && url.pathname === "/repos/acme/widget/git/trees") return json({ sha: NEXT_TREE }, 201);
+      if (method === "POST" && url.pathname === "/repos/acme/widget/git/commits") return json({ sha: NEXT_HEAD }, 201);
+      if (method === "PATCH" && url.pathname === "/repos/acme/widget/git/refs/heads/autofix/issue-172") {
+        remoteHead = NEXT_HEAD;
+        return json({ object: { sha: NEXT_HEAD } });
+      }
+      return json({ message: `unhandled ${method} ${url.pathname}` }, 404);
+    });
+
+    createCredential({
+      id: "github-autofix",
+      credential_type: "api_key",
+      name: "GitHub Autofix App token",
+      secret: { value: "github-secret-token-value" },
+    }, { actor: "test" });
+    const taskArtifact = stageDagRunInputArtifact({
+      scope_id: "project-one",
+      name: "task.md",
+      media_type: "text/markdown",
+      content: "# Bounded task\n",
+    });
+    const prArtifact = stageDagRunInputArtifact({
+      scope_id: "project-one",
+      name: "pr-context.json",
+      media_type: "application/json",
+      content: JSON.stringify({
+        version: 1,
+        owner: "acme",
+        repo: "widget",
+        pull_number: 7,
+        clone_url: "https://github.com/acme/widget.git",
+        head_ref: "autofix/issue-172",
+        base_ref: "main",
+        initial_head_sha: INITIAL_HEAD,
+        base_sha: BASE_HEAD,
+        task_document_sha256: taskArtifact.sha256,
+        require_draft: true,
+        writable_paths: ["src", "tests"],
+      }),
+    });
+    const bindings = resolveDagRunInputBindings("project-one", [
+      {
+        artifact_id: taskArtifact.artifact_id,
+        logical_name: "task_document",
+        mount_path: "input/task.md",
+      },
+      {
+        artifact_id: prArtifact.artifact_id,
+        logical_name: "pr_context",
+        mount_path: "input/pr-context.json",
+      },
+    ]);
+    const parsed = parseWorkflowSource(workflow());
+    parsed.meta.agents!.actor.agent_type = "deterministic";
+    createActiveRun("github-broker-run", parsed, { initialPrompt: "{}", inputArtifacts: bindings });
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    _clearActiveRuns();
+    closeDb();
+    if (previousHome === undefined) delete process.env.HOMERAIL_HOME;
+    else process.env.HOMERAIL_HOME = previousHome;
+    const inputRoot = path.join(home, "workspace", "github-broker-run", "input");
+    if (fs.existsSync(inputRoot)) fs.chmodSync(inputRoot, 0o700);
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  function call(nodeId: string, action: string, input: Record<string, unknown> = {}) {
+    return executeCredentialBrokerCall("worker-one", {
+      request_id: `${nodeId}-${action}`,
+      run_id: "github-broker-run",
+      node_id: nodeId,
+      session_id: `session-${nodeId}`,
+      credential_ref: "github-autofix",
+      broker: "github_pr",
+      action,
+      input,
+    });
+  }
+
+  it("keeps the token host-side and enforces per-node action and path allowlists", async () => {
+    const snapshot = await call("reviewer", "pull_request_snapshot");
+    expect(snapshot).toMatchObject({
+      ok: true,
+      result: { repository: "acme/widget", pull_number: 7, draft: true, head_sha: INITIAL_HEAD },
+    });
+    expect(JSON.stringify(snapshot)).not.toContain("github-secret-token-value");
+
+    await expect(call("reviewer", "commit_files", {})).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining("not permitted"),
+    });
+    await expect(call("implementer", "pull_request_snapshot")).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining("not declared"),
+    });
+    const deniedPath = await call("aggregate", "commit_files", {
+      expected_head_sha: INITIAL_HEAD,
+      message: "attempt workflow change",
+      files: [{ path: ".github/workflows/pwn.yml", content_base64: Buffer.from("bad").toString("base64") }],
+    });
+    expect(deniedPath).toMatchObject({ ok: false, error: expect.stringContaining("outside the PR write allowlist") });
+  });
+
+  it("commits through a non-force expected-head fence and restores the advanced head", async () => {
+    const committed = await call("aggregate", "commit_files", {
+      expected_head_sha: INITIAL_HEAD,
+      message: "fix: bounded change",
+      files: [{ path: "src/fix.ts", content_base64: Buffer.from("export const fixed = true;\n").toString("base64") }],
+    });
+    expect(committed).toMatchObject({
+      ok: true,
+      result: {
+        previous_head_sha: INITIAL_HEAD,
+        head_sha: NEXT_HEAD,
+        committed_files: ["src/fix.ts"],
+      },
+    });
+    expect(remoteHead).toBe(NEXT_HEAD);
+    expect(fetchSpy.mock.calls.find(([, init]) => init?.method === "PATCH")?.[1]?.body)
+      .toContain('"force":false');
+
+    _clearActiveRuns();
+    closeDb();
+    expect(recoverAllActiveRuns().recovered).toContain("github-broker-run");
+    const recovered = await call("reviewer", "pull_request_snapshot");
+    expect(recovered).toMatchObject({ ok: true, result: { head_sha: NEXT_HEAD } });
+
+    const stale = await call("aggregate", "commit_files", {
+      expected_head_sha: INITIAL_HEAD,
+      message: "stale write",
+      files: [{ path: "src/fix.ts", content_base64: Buffer.from("stale\n").toString("base64") }],
+    });
+    expect(stale).toMatchObject({ ok: false, error: expect.stringContaining("expected head is stale") });
+  });
+
+  it("fails closed when the Draft PR head changes outside the broker", async () => {
+    await call("reviewer", "pull_request_snapshot");
+    remoteHead = "9".repeat(40);
+    const drifted = await call("reviewer", "checks_snapshot");
+    expect(drifted).toMatchObject({ ok: false, error: expect.stringContaining("outside the HomeRail broker") });
+  });
+
+  it("rejects a closed or cross-repository pull request", async () => {
+    pullState = "closed";
+    await expect(call("reviewer", "pull_request_snapshot")).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining("identity differs"),
+    });
+
+    pullState = "open";
+    headRepository = "someone-else/widget";
+    await expect(call("reviewer", "pull_request_snapshot")).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining("identity differs"),
+    });
+  });
+});

--- a/homerail_manager/tests/github-pr-broker.test.ts
+++ b/homerail_manager/tests/github-pr-broker.test.ts
@@ -13,6 +13,9 @@ import {
 import {
   _clearActiveRuns,
   createActiveRun,
+  getCurrentNodeSession,
+  handoffActiveRun,
+  markNodeDispatched,
   recoverAllActiveRuns,
 } from "../src/runtime/active-runs.js";
 import { executeCredentialBrokerCall } from "../src/runtime/credential-broker.js";
@@ -53,9 +56,15 @@ spec:
       kind: agent
       agent: actor
       allowed_dag_tools: [handoff, credential_broker_call]
-      credentials:${binding("pull_request_snapshot, checks_snapshot")}
+      credentials:${binding("pull_request_snapshot, checks_snapshot, required_checks")}
       inputs: { task: {} }
-      outputs: { done: {} }
+      outputs:
+        reviewed:
+          required_broker_actions:
+            - credential_ref: github-autofix
+              broker: github_pr
+              action: required_checks
+              when: { field: verdict, equals: approve }
     implementer:
       kind: agent
       agent: actor
@@ -65,7 +74,7 @@ spec:
   edges:
     - { from: $run.input, to: aggregate.task }
     - { from: aggregate.done, to: reviewer.task }
-    - { from: reviewer.done, to: implementer.task }
+    - { from: reviewer.reviewed, to: implementer.task }
     - { from: implementer.done, to: done.result }
 `;
 }
@@ -76,7 +85,56 @@ describe("bounded GitHub Draft PR credential broker", () => {
   let remoteHead: string;
   let pullState: string;
   let headRepository: string;
+  let checkName: string;
+  let checkConclusion: string;
   let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  function createBoundRun(
+    runId: string,
+    writablePaths: string[] = ["src", "tests", ".github"],
+  ): void {
+    const taskArtifact = stageDagRunInputArtifact({
+      scope_id: runId,
+      name: "task.md",
+      media_type: "text/markdown",
+      content: "# Bounded task\n",
+    });
+    const prArtifact = stageDagRunInputArtifact({
+      scope_id: runId,
+      name: "pr-context.json",
+      media_type: "application/json",
+      content: JSON.stringify({
+        version: 1,
+        owner: "acme",
+        repo: "widget",
+        pull_number: 7,
+        clone_url: "https://github.com/acme/widget.git",
+        head_ref: "autofix/issue-172",
+        base_ref: "main",
+        initial_head_sha: INITIAL_HEAD,
+        base_sha: BASE_HEAD,
+        task_document_sha256: taskArtifact.sha256,
+        require_draft: true,
+        writable_paths: writablePaths,
+        required_checks: ["unit"],
+      }),
+    });
+    const bindings = resolveDagRunInputBindings(runId, [
+      {
+        artifact_id: taskArtifact.artifact_id,
+        logical_name: "task_document",
+        mount_path: "input/task.md",
+      },
+      {
+        artifact_id: prArtifact.artifact_id,
+        logical_name: "pr_context",
+        mount_path: "input/pr-context.json",
+      },
+    ]);
+    const parsed = parseWorkflowSource(workflow());
+    parsed.meta.agents!.actor.agent_type = "deterministic";
+    createActiveRun(runId, parsed, { initialPrompt: "{}", inputArtifacts: bindings });
+  }
 
   beforeEach(() => {
     previousHome = process.env.HOMERAIL_HOME;
@@ -87,6 +145,8 @@ describe("bounded GitHub Draft PR credential broker", () => {
     remoteHead = INITIAL_HEAD;
     pullState = "open";
     headRepository = "acme/widget";
+    checkName = "unit";
+    checkConclusion = "success";
     fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
       const url = new URL(String(input));
       const method = String(init?.method ?? "GET").toUpperCase();
@@ -110,7 +170,7 @@ describe("bounded GitHub Draft PR credential broker", () => {
         return json([{ filename: "src/fix.ts", status: "modified", additions: 2, deletions: 1, changes: 3, patch: "@@ fake" }]);
       }
       if (method === "GET" && url.pathname.endsWith("/check-runs")) {
-        return json({ check_runs: [{ id: 1, name: "unit", status: "completed", conclusion: "success" }] });
+        return json({ check_runs: [{ id: 1, name: checkName, status: "completed", conclusion: checkConclusion }] });
       }
       if (method === "GET" && url.pathname === `/repos/acme/widget/git/commits/${INITIAL_HEAD}`) {
         return json({ tree: { sha: BASE_TREE } });
@@ -131,46 +191,7 @@ describe("bounded GitHub Draft PR credential broker", () => {
       name: "GitHub Autofix App token",
       secret: { value: "github-secret-token-value" },
     }, { actor: "test" });
-    const taskArtifact = stageDagRunInputArtifact({
-      scope_id: "project-one",
-      name: "task.md",
-      media_type: "text/markdown",
-      content: "# Bounded task\n",
-    });
-    const prArtifact = stageDagRunInputArtifact({
-      scope_id: "project-one",
-      name: "pr-context.json",
-      media_type: "application/json",
-      content: JSON.stringify({
-        version: 1,
-        owner: "acme",
-        repo: "widget",
-        pull_number: 7,
-        clone_url: "https://github.com/acme/widget.git",
-        head_ref: "autofix/issue-172",
-        base_ref: "main",
-        initial_head_sha: INITIAL_HEAD,
-        base_sha: BASE_HEAD,
-        task_document_sha256: taskArtifact.sha256,
-        require_draft: true,
-        writable_paths: ["src", "tests"],
-      }),
-    });
-    const bindings = resolveDagRunInputBindings("project-one", [
-      {
-        artifact_id: taskArtifact.artifact_id,
-        logical_name: "task_document",
-        mount_path: "input/task.md",
-      },
-      {
-        artifact_id: prArtifact.artifact_id,
-        logical_name: "pr_context",
-        mount_path: "input/pr-context.json",
-      },
-    ]);
-    const parsed = parseWorkflowSource(workflow());
-    parsed.meta.agents!.actor.agent_type = "deterministic";
-    createActiveRun("github-broker-run", parsed, { initialPrompt: "{}", inputArtifacts: bindings });
+    createBoundRun("github-broker-run");
   });
 
   afterEach(() => {
@@ -179,17 +200,28 @@ describe("bounded GitHub Draft PR credential broker", () => {
     closeDb();
     if (previousHome === undefined) delete process.env.HOMERAIL_HOME;
     else process.env.HOMERAIL_HOME = previousHome;
-    const inputRoot = path.join(home, "workspace", "github-broker-run", "input");
-    if (fs.existsSync(inputRoot)) fs.chmodSync(inputRoot, 0o700);
+    const workspaceRoot = path.join(home, "workspace");
+    if (fs.existsSync(workspaceRoot)) {
+      for (const runId of fs.readdirSync(workspaceRoot)) {
+        const inputRoot = path.join(workspaceRoot, runId, "input");
+        if (fs.existsSync(inputRoot)) fs.chmodSync(inputRoot, 0o700);
+      }
+    }
     fs.rmSync(home, { recursive: true, force: true });
   });
 
-  function call(nodeId: string, action: string, input: Record<string, unknown> = {}) {
+  function call(
+    nodeId: string,
+    action: string,
+    input: Record<string, unknown> = {},
+    runId = "github-broker-run",
+    sessionId = `session-${nodeId}`,
+  ) {
     return executeCredentialBrokerCall("worker-one", {
       request_id: `${nodeId}-${action}`,
-      run_id: "github-broker-run",
+      run_id: runId,
       node_id: nodeId,
-      session_id: `session-${nodeId}`,
+      session_id: sessionId,
       credential_ref: "github-autofix",
       broker: "github_pr",
       action,
@@ -213,12 +245,63 @@ describe("bounded GitHub Draft PR credential broker", () => {
       ok: false,
       error: expect.stringContaining("not declared"),
     });
-    const deniedPath = await call("aggregate", "commit_files", {
+    const deniedWorkflow = await call("aggregate", "commit_files", {
       expected_head_sha: INITIAL_HEAD,
       message: "attempt workflow change",
       files: [{ path: ".github/workflows/pwn.yml", content_base64: Buffer.from("bad").toString("base64") }],
     });
-    expect(deniedPath).toMatchObject({ ok: false, error: expect.stringContaining("outside the PR write allowlist") });
+    expect(deniedWorkflow).toMatchObject({ ok: false, error: expect.stringContaining("outside the PR write allowlist") });
+    const deniedAction = await call("aggregate", "commit_files", {
+      expected_head_sha: INITIAL_HEAD,
+      message: "attempt local action change",
+      files: [{ path: ".github/actions/pwn/action.yml", content_base64: Buffer.from("bad").toString("base64") }],
+    });
+    expect(deniedAction).toMatchObject({ ok: false, error: expect.stringContaining("outside the PR write allowlist") });
+  });
+
+  it("rejects repository-wide writable paths instead of treating dot as an allow-all prefix", async () => {
+    createBoundRun("github-broker-dot-run", ["."]);
+    const snapshot = await call(
+      "reviewer",
+      "pull_request_snapshot",
+      {},
+      "github-broker-dot-run",
+    );
+    expect(snapshot).toMatchObject({ ok: false, error: expect.stringContaining("not a safe repository path") });
+  });
+
+  it("requires successful immutable checks in the current reviewer dispatch before approval", async () => {
+    expect(markNodeDispatched("github-broker-run", "aggregate")).toBe(true);
+    handoffActiveRun("github-broker-run", "aggregate", "done", {});
+    expect(markNodeDispatched("github-broker-run", "reviewer")).toBe(true);
+    const sessionId = getCurrentNodeSession("github-broker-run", "reviewer")?.sessionId;
+    if (!sessionId) throw new Error("reviewer session was not created");
+
+    const approval = { verdict: "approve" };
+    expect(() => handoffActiveRun("github-broker-run", "reviewer", "reviewed", approval))
+      .toThrow(/DAG_HANDOFF_BROKER_REQUIREMENT_MISSING/);
+
+    checkName = "unrelated";
+    await expect(call("reviewer", "required_checks", {}, "github-broker-run", sessionId))
+      .resolves.toMatchObject({ ok: false, error: expect.stringContaining("unit") });
+    checkName = "unit";
+    checkConclusion = "failure";
+    await expect(call("reviewer", "required_checks", {}, "github-broker-run", sessionId))
+      .resolves.toMatchObject({ ok: false, error: expect.stringContaining("unit") });
+    expect(() => handoffActiveRun("github-broker-run", "reviewer", "reviewed", approval))
+      .toThrow(/DAG_HANDOFF_BROKER_REQUIREMENT_MISSING/);
+
+    checkConclusion = "success";
+    await expect(call("reviewer", "required_checks", {}, "github-broker-run", sessionId))
+      .resolves.toMatchObject({
+        ok: true,
+        result: {
+          passed: true,
+          head_sha: INITIAL_HEAD,
+          required_checks: [{ name: "unit", status: "completed", conclusion: "success" }],
+        },
+      });
+    expect(() => handoffActiveRun("github-broker-run", "reviewer", "reviewed", approval)).not.toThrow();
   });
 
   it("commits through a non-force expected-head fence and restores the advanced head", async () => {

--- a/homerail_manager/tests/persistence-contracts.test.ts
+++ b/homerail_manager/tests/persistence-contracts.test.ts
@@ -183,7 +183,7 @@ describe("SQLite persistence contracts", () => {
   it("installs indexes for status filtering and updated-time run ordering", () => {
     const db = getDb();
     expect(db.prepare("SELECT MAX(version) AS version FROM schema_migrations").get())
-      .toEqual({ version: 33 });
+      .toEqual({ version: 34 });
     expect(db.prepare("PRAGMA index_info(idx_dag_runs_updated)").all())
       .toEqual([
         expect.objectContaining({ seqno: 0, name: "updated_at" }),

--- a/homerail_manager/tests/run-input-artifacts.test.ts
+++ b/homerail_manager/tests/run-input-artifacts.test.ts
@@ -1,0 +1,177 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { FakeDAGDispatcher } from "../src/orchestration/dag-dispatcher.js";
+import { GraphExecutor } from "../src/orchestration/graph-executor.js";
+import { parseWorkflowSource } from "../src/orchestration/workflow-spec-v1.js";
+import { closeDb } from "../src/persistence/db.js";
+import {
+  dagRunInputPath,
+  listDagRunInputs,
+  resolveDagRunInputBindings,
+  stageDagRunInputArtifact,
+} from "../src/persistence/run-input-artifacts.js";
+import { loadRunMetadata, loadRunSnapshot } from "../src/persistence/store.js";
+import {
+  _clearActiveRuns,
+  createActiveRun,
+  recoverAllActiveRuns,
+} from "../src/runtime/active-runs.js";
+
+function commandWorkflow() {
+  return parseWorkflowSource(`
+api_version: homerail.ai/v1
+kind: Workflow
+metadata: { id: run-input-reader, name: Run input reader }
+spec:
+  agents: {}
+  nodes:
+    read:
+      kind: command
+      outputs: { done: {}, failed: {} }
+      config:
+        command:
+          - node
+          - -e
+          - "const fs=require('fs');process.stdout.write(JSON.stringify({task:fs.readFileSync(process.argv[1],'utf8')}))"
+          - $run_input/task_document
+        cwd: $run_workspace
+        timeout_ms: 5000
+        parse_stdout: json
+        result_payload: value
+        success_port: done
+        failure_port: failed
+    done: { kind: terminal, outcome: success, inputs: { result: {} } }
+    failed: { kind: terminal, outcome: failure, inputs: { result: {} } }
+  edges:
+    - { from: read.done, to: done.result }
+    - { from: read.failed, to: failed.result, condition: on_failure }
+`);
+}
+
+describe("immutable DAG run inputs", () => {
+  let tempHome: string;
+  let previousHome: string | undefined;
+  let previousAllowlist: string | undefined;
+
+  beforeEach(() => {
+    previousHome = process.env.HOMERAIL_HOME;
+    previousAllowlist = process.env.HOMERAIL_DAG_COMMAND_ALLOWLIST;
+    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-run-inputs-"));
+    process.env.HOMERAIL_HOME = tempHome;
+    process.env.HOMERAIL_DAG_COMMAND_ALLOWLIST = "node";
+    closeDb();
+    _clearActiveRuns();
+  });
+
+  afterEach(() => {
+    _clearActiveRuns();
+    closeDb();
+    if (previousHome === undefined) delete process.env.HOMERAIL_HOME;
+    else process.env.HOMERAIL_HOME = previousHome;
+    if (previousAllowlist === undefined) delete process.env.HOMERAIL_DAG_COMMAND_ALLOWLIST;
+    else process.env.HOMERAIL_DAG_COMMAND_ALLOWLIST = previousAllowlist;
+    for (const runId of ["run-input-command", "run-input-recovery"]) {
+      const inputRoot = path.join(tempHome, "workspace", runId, "input");
+      if (fs.existsSync(inputRoot)) fs.chmodSync(inputRoot, 0o700);
+    }
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  it("stages content idempotently and rejects invalid content or cross-scope binding", () => {
+    const first = stageDagRunInputArtifact({
+      scope_id: "project-one",
+      name: "task.md",
+      media_type: "text/markdown",
+      content: "# Immutable task\n",
+    });
+    const repeated = stageDagRunInputArtifact({
+      scope_id: "project-one",
+      name: "task.md",
+      media_type: "text/markdown",
+      content: "# Immutable task\n",
+    });
+    expect(repeated).toEqual(first);
+    expect(first.sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(() => stageDagRunInputArtifact({
+      scope_id: "project-one",
+      name: "task.json",
+      media_type: "application/json",
+      content: "not-json",
+    })).toThrow("valid JSON");
+    expect(() => resolveDagRunInputBindings("project-two", [{
+      artifact_id: first.artifact_id,
+      logical_name: "task_document",
+      mount_path: "input/task.md",
+    }])).toThrow("different scope");
+    expect(() => resolveDagRunInputBindings("project-one", [{
+      artifact_id: first.artifact_id,
+      logical_name: "task_document",
+      mount_path: "../task.md",
+    }])).toThrow("below input/");
+  });
+
+  it("binds provenance atomically, projects it read-only, and resolves it for a trusted command", () => {
+    const artifact = stageDagRunInputArtifact({
+      scope_id: "project-one",
+      name: "task.md",
+      media_type: "text/markdown",
+      content: "# Durable plan\nAcceptance: exact input\n",
+    });
+    const bindings = resolveDagRunInputBindings("project-one", [{
+      artifact_id: artifact.artifact_id,
+      logical_name: "task_document",
+      mount_path: "input/task.md",
+    }]);
+    const executor = new GraphExecutor(new FakeDAGDispatcher());
+    createActiveRun("run-input-command", commandWorkflow(), { inputArtifacts: bindings });
+
+    const bound = listDagRunInputs("run-input-command");
+    expect(bound).toHaveLength(1);
+    expect(loadRunMetadata("run-input-command")?.inputArtifacts).toEqual(bound);
+    const projected = dagRunInputPath("run-input-command", "task_document");
+    expect(fs.readFileSync(projected, "utf8")).toContain("# Durable plan");
+    if (process.platform !== "win32") expect(fs.statSync(projected).mode & 0o222).toBe(0);
+
+    executor.tick("run-input-command");
+    expect(loadRunSnapshot("run-input-command")?.handoffs).toContainEqual(expect.objectContaining({
+      fromNode: "read",
+      port: "done",
+      content: { task: "# Durable plan\nAcceptance: exact input\n" },
+    }));
+  });
+
+  it("refuses cold recovery when content-addressed bytes were modified", () => {
+    const artifact = stageDagRunInputArtifact({
+      scope_id: "project-one",
+      name: "task.md",
+      media_type: "text/markdown",
+      content: "original",
+    });
+    const bindings = resolveDagRunInputBindings("project-one", [{
+      artifact_id: artifact.artifact_id,
+      logical_name: "task_document",
+      mount_path: "input/task.md",
+    }]);
+    createActiveRun("run-input-recovery", commandWorkflow(), { inputArtifacts: bindings });
+    const blob = path.join(
+      tempHome,
+      "manager",
+      "run-inputs",
+      "blobs",
+      artifact.sha256.slice(0, 2),
+      artifact.sha256,
+      "blob",
+    );
+    fs.chmodSync(blob, 0o600);
+    fs.writeFileSync(blob, "tampered");
+    _clearActiveRuns();
+    closeDb();
+
+    const recovery = recoverAllActiveRuns();
+    expect(recovery.recovered).not.toContain("run-input-recovery");
+    expect(recovery.skipped).toContain("run-input-recovery");
+  });
+});

--- a/homerail_manager/tests/voice-artifacts.test.ts
+++ b/homerail_manager/tests/voice-artifacts.test.ts
@@ -149,7 +149,7 @@ describe("voice artifact publishing", () => {
     const artifact = publishVoiceArtifact({ session_id: "session-schema", source_path: "schema.html" });
 
     const db = getDb();
-    expect(db.prepare("SELECT MAX(version) AS version FROM schema_migrations").get()).toEqual({ version: 33 });
+    expect(db.prepare("SELECT MAX(version) AS version FROM schema_migrations").get()).toEqual({ version: 34 });
     expect(() => db.prepare(`
       UPDATE voice_artifact_revisions SET title = 'changed'
       WHERE session_id = ? AND artifact_id = ? AND revision = 1

--- a/homerail_manager/tests/workflow-spec-runtime.test.ts
+++ b/homerail_manager/tests/workflow-spec-runtime.test.ts
@@ -226,6 +226,24 @@ describe("WorkflowSpec v1 runtime projection", () => {
     })).toThrow("DAG_RUN_INPUT_CONTRACT_VIOLATION execute.task");
   });
 
+  it("rejects artifact bindings without a non-empty scope at the orchestrator boundary", () => {
+    upsertDagWorkflowFromYaml({ yaml_text: workflowSource() });
+    syncDeterministicProfile("v1-runtime-success");
+    const orchestrator = new ChangeOrchestrator(new GraphExecutor(new FakeDAGDispatcher()));
+
+    expect(() => orchestrator.createRun({
+      workflowId: "v1-runtime-success",
+      runId: "v1-missing-input-scope",
+      prompt: "hello",
+      profile: "deterministic",
+      inputArtifacts: [{
+        artifact_id: `input-${"a".repeat(64)}`,
+        logical_name: "task_document",
+        mount_path: "input/task.md",
+      }],
+    })).toThrow("input_scope is required when input_artifacts are bound");
+  });
+
   it("cold-recovers v1 provenance, contracts, and reserved run input", () => {
     const synced = upsertDagWorkflowFromYaml({ yaml_text: workflowSource() });
     syncDeterministicProfile("v1-runtime-success");

--- a/homerail_manager/tests/workflow-spec-v1.test.ts
+++ b/homerail_manager/tests/workflow-spec-v1.test.ts
@@ -174,6 +174,50 @@ describe("WorkflowSpec v1", () => {
     }));
   });
 
+  it("canonicalizes conditional Manager-broker handoff requirements and rejects undeclared actions", () => {
+    const workflow = structuredClone(MINIMAL_WORKFLOW) as any;
+    workflow.spec.nodes.execute.allowed_dag_tools = ["handoff", "credential_broker_call"];
+    workflow.spec.nodes.execute.credentials = [{
+      credential_ref: "github-autofix",
+      purpose: "verify the bound pull request",
+      inject: {
+        mode: "manager_broker",
+        broker: "github_pr",
+        allowed_actions: ["required_checks"],
+      },
+    }];
+    workflow.spec.nodes.execute.outputs.result.required_broker_actions = [{
+      credential_ref: "github-autofix",
+      broker: "github_pr",
+      action: "required_checks",
+      when: { field: "status", equals: "success" },
+    }];
+
+    const result = compileWorkflowSource(YAML.stringify(workflow));
+    expect(result.valid, result.diagnostics.map((item) => item.message).join("\n")).toBe(true);
+    const requirement = [{
+      credential_ref: "github-autofix",
+      broker: "github_pr",
+      action: "required_checks",
+      when: { field: "status", equals: "success" },
+    }];
+    expect(result.canonical?.nodes.find((node) => node.id === "execute")?.outputs)
+      .toContainEqual(expect.objectContaining({ name: "result", required_broker_actions: requirement }));
+    expect(projectCanonicalWorkflowToParsedDAG(result.canonical!).graph.nodes
+      .find((node) => node.node_id === "execute")?.extra?.workflow_spec_v1)
+      .toMatchObject({ output_broker_requirements: { result: requirement } });
+    expect((canonicalWorkflowToV1Document(result.canonical!) as any).spec.nodes.execute.outputs.result)
+      .toMatchObject({ required_broker_actions: requirement });
+
+    workflow.spec.nodes.execute.outputs.result.required_broker_actions[0].action = "commit_files";
+    const invalid = compileWorkflowSource(YAML.stringify(workflow));
+    expect(invalid.valid).toBe(false);
+    expect(invalid.diagnostics).toContainEqual(expect.objectContaining({
+      code: "DAG_SEMANTIC_UNDECLARED_BROKER_REQUIREMENT",
+      path: "/spec/nodes/execute/outputs/result/required_broker_actions/0",
+    }));
+  });
+
   it("accepts bounded conditional contract invariants", () => {
     const workflow = structuredClone(MINIMAL_WORKFLOW) as any;
     workflow.spec.contracts.Result = {

--- a/homerail_manager/tests/workflow-spec-v1.test.ts
+++ b/homerail_manager/tests/workflow-spec-v1.test.ts
@@ -513,6 +513,53 @@ spec:
     ]));
   });
 
+  it("requires isolated fanout workers to declare their injected writable worktree", () => {
+    const source = `
+api_version: homerail.ai/v1
+kind: Workflow
+metadata: { id: isolated-fanout, name: Isolated Fanout }
+spec:
+  contracts: { Items: { type: array } }
+  agents: { worker: { system: Work. } }
+  nodes:
+    fan:
+      kind: fanout
+      inputs: { items: { contract: Items } }
+      outputs: { passed: {}, failed: {} }
+      config:
+        input: items
+        worker_agent: worker
+        worker_policy:
+          allowed_dag_tools: [handoff]
+          workspace_access: { writable_paths: [], readonly_paths: [input] }
+        workspace_strategy: isolated_git_worktree
+        repository_path: repo
+        max_items: 2
+        max_parallelism: 1
+        completion: all
+        result_port: passed
+        failed_port: failed
+    done: { kind: terminal, outcome: success, inputs: { result: {} } }
+    failed: { kind: terminal, outcome: failure, inputs: { result: {} } }
+  edges:
+    - { from: $run.input, to: fan.items }
+    - { from: fan.passed, to: done.result }
+    - { from: fan.failed, to: failed.result, condition: on_failure }
+`;
+    const missing = compileWorkflowSource(source);
+    expect(missing.valid).toBe(false);
+    expect(missing.diagnostics).toContainEqual(expect.objectContaining({
+      code: "DAG_SEMANTIC_FANOUT_WORKSPACE_REQUIRED",
+      path: "/spec/nodes/fan/config/worker_policy/workspace_access/writable_paths",
+    }));
+
+    const declared = compileWorkflowSource(source.replace(
+      "writable_paths: []",
+      "writable_paths: ['{{fanout_workspace}}']",
+    ));
+    expect(declared.valid, declared.diagnostics.map((item) => item.message).join("\n")).toBe(true);
+  });
+
   it("rejects an approval workflow that authorizes its proposer", () => {
     const result = compileWorkflowSource(`
 api_version: homerail.ai/v1

--- a/homerail_node/src/control-plane/lifecycle-handler.ts
+++ b/homerail_node/src/control-plane/lifecycle-handler.ts
@@ -1,6 +1,7 @@
 import type { ExecutionProvider, ContainerConfig } from "../providers/types.js";
 import { createContainer, createWorkerContainer } from "../lifecycle/create.js";
 import { prepareWorkerWorkspace } from "../storage/workspace-prepare.js";
+import { materializeWorkspaceInputs } from "../storage/workspace-inputs.js";
 import type { MountPolicyOptions } from "../storage/mount-policy.js";
 import type {
   WorkspaceArtifactUploadResult,
@@ -140,11 +141,13 @@ async function dispatchOperation(
           name: (spec.name as string) || undefined,
         };
         await prepareWorkerWorkspace(workspaceId, spec.workspace);
+        const inputCount = materializeWorkspaceInputs(workspaceId, spec.workspace_inputs);
         const info = await createWorkerContainer({
           config,
           provider,
           workspaceId,
           workspaceReadOnly: spec.workspace_read_only === true,
+          workspaceInputsReadOnly: inputCount > 0,
         });
         return info as unknown as Record<string, unknown>;
       }

--- a/homerail_node/src/lifecycle/create.ts
+++ b/homerail_node/src/lifecycle/create.ts
@@ -43,13 +43,21 @@ export interface CreateWorkerOptions {
   provider: ExecutionProvider;
   workspaceId: string;
   workspaceReadOnly?: boolean;
+  workspaceInputsReadOnly?: boolean;
   mountPolicy?: MountPolicyOptions;
 }
 
 const DEFAULT_WORKER_IMAGE = "homerail-worker:latest";
 
 export async function createWorkerContainer(opts: CreateWorkerOptions): Promise<ContainerInfo> {
-  const { config, provider, workspaceId, workspaceReadOnly = false, mountPolicy } = opts;
+  const {
+    config,
+    provider,
+    workspaceId,
+    workspaceReadOnly = false,
+    workspaceInputsReadOnly = false,
+    mountPolicy,
+  } = opts;
 
   const image = config.image || DEFAULT_WORKER_IMAGE;
 
@@ -59,7 +67,7 @@ export async function createWorkerContainer(opts: CreateWorkerOptions): Promise<
 
   const mounts: NonNullable<ContainerConfig["mounts"]> = [];
 
-  const defaultMounts = workerAllowedMounts(workspaceId, workspaceReadOnly);
+  const defaultMounts = workerAllowedMounts(workspaceId, workspaceReadOnly, workspaceInputsReadOnly);
   for (const dm of defaultMounts) {
     if (!mounts.some((m) => m.container === dm.container)) {
       mounts.push({ host: dm.host, container: dm.container, mode: dm.mode });

--- a/homerail_node/src/storage/__tests__/workspace-inputs.test.ts
+++ b/homerail_node/src/storage/__tests__/workspace-inputs.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { workerAllowedMounts } from "../mount-policy.js";
 import { materializeWorkspaceInputs } from "../workspace-inputs.js";
+import { normalizePath } from "../../platform/paths.js";
 
 describe("trusted workspace input projection", () => {
   let home: string;
@@ -43,8 +44,8 @@ describe("trusted workspace input projection", () => {
     expect(fs.readFileSync(target, "utf8")).toBe("# task\n");
     if (process.platform !== "win32") expect(fs.statSync(target).mode & 0o222).toBe(0);
     expect(workerAllowedMounts("run-one", false, true)).toEqual([
-      { host: path.join(home, "workspace", "run-one"), container: "/workspace", mode: "rw" },
-      { host: path.join(home, "workspace", "run-one", "input"), container: "/workspace/input", mode: "ro" },
+      { host: normalizePath(path.join(home, "workspace", "run-one")), container: "/workspace", mode: "rw" },
+      { host: normalizePath(path.join(home, "workspace", "run-one", "input")), container: "/workspace/input", mode: "ro" },
     ]);
   });
 

--- a/homerail_node/src/storage/__tests__/workspace-inputs.test.ts
+++ b/homerail_node/src/storage/__tests__/workspace-inputs.test.ts
@@ -1,0 +1,71 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createHash } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { workerAllowedMounts } from "../mount-policy.js";
+import { materializeWorkspaceInputs } from "../workspace-inputs.js";
+
+describe("trusted workspace input projection", () => {
+  let home: string;
+  let previousHome: string | undefined;
+
+  beforeEach(() => {
+    previousHome = process.env.HOMERAIL_HOME;
+    home = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-node-inputs-"));
+    process.env.HOMERAIL_HOME = home;
+  });
+
+  afterEach(() => {
+    if (previousHome === undefined) delete process.env.HOMERAIL_HOME;
+    else process.env.HOMERAIL_HOME = previousHome;
+    const inputRoot = path.join(home, "workspace", "run-one", "input");
+    if (fs.existsSync(inputRoot)) fs.chmodSync(inputRoot, 0o700);
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  function projection(content = "# task\n") {
+    const bytes = Buffer.from(content);
+    return {
+      logical_name: "task_document",
+      mount_path: "input/task.md",
+      media_type: "text/markdown",
+      sha256: createHash("sha256").update(bytes).digest("hex"),
+      size_bytes: bytes.byteLength,
+      content_base64: bytes.toString("base64"),
+    };
+  }
+
+  it("materializes verified bytes and adds a nested read-only container mount", () => {
+    expect(materializeWorkspaceInputs("run-one", [projection()])).toBe(1);
+    const target = path.join(home, "workspace", "run-one", "input", "task.md");
+    expect(fs.readFileSync(target, "utf8")).toBe("# task\n");
+    if (process.platform !== "win32") expect(fs.statSync(target).mode & 0o222).toBe(0);
+    expect(workerAllowedMounts("run-one", false, true)).toEqual([
+      { host: path.join(home, "workspace", "run-one"), container: "/workspace", mode: "rw" },
+      { host: path.join(home, "workspace", "run-one", "input"), container: "/workspace/input", mode: "ro" },
+    ]);
+  });
+
+  it("rejects digest mismatch, traversal, symlinks, and unstaged files", () => {
+    expect(() => materializeWorkspaceInputs("run-digest", [{
+      ...projection(),
+      sha256: "0".repeat(64),
+    }])).toThrow("does not match");
+    expect(() => materializeWorkspaceInputs("run-traversal", [{
+      ...projection(),
+      mount_path: "input/../task.md",
+    }])).toThrow("below input/");
+
+    const symlinkRoot = path.join(home, "workspace", "run-symlink");
+    fs.mkdirSync(symlinkRoot, { recursive: true });
+    fs.symlinkSync(home, path.join(symlinkRoot, "input"));
+    expect(() => materializeWorkspaceInputs("run-symlink", [projection()])).toThrow("symlink");
+
+    const extraRoot = path.join(home, "workspace", "run-extra", "input");
+    fs.mkdirSync(extraRoot, { recursive: true });
+    fs.writeFileSync(path.join(extraRoot, "unstaged.txt"), "secret");
+    expect(() => materializeWorkspaceInputs("run-extra", [projection()])).toThrow("unstaged file");
+  });
+});

--- a/homerail_node/src/storage/mount-policy.ts
+++ b/homerail_node/src/storage/mount-policy.ts
@@ -74,12 +74,24 @@ export function allowedMounts(volumeId: string): MountEntry[] {
   ];
 }
 
-export function workerAllowedMounts(workspaceId: string, readOnly = false): MountEntry[] {
-  return [
+export function workerAllowedMounts(
+  workspaceId: string,
+  readOnly = false,
+  readOnlyInputs = false,
+): MountEntry[] {
+  const mounts: MountEntry[] = [
     {
       host: homerailWorkerWorkspacePath(workspaceId),
       container: "/workspace",
       mode: readOnly ? "ro" : "rw",
     },
   ];
+  if (readOnlyInputs) {
+    mounts.push({
+      host: `${homerailWorkerWorkspacePath(workspaceId)}/input`,
+      container: "/workspace/input",
+      mode: "ro",
+    });
+  }
+  return mounts;
 }

--- a/homerail_node/src/storage/workspace-inputs.ts
+++ b/homerail_node/src/storage/workspace-inputs.ts
@@ -1,0 +1,158 @@
+import { createHash, randomUUID } from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type {
+  DagWorkspaceInputProjection,
+} from "homerail-protocol";
+import { homerailWorkerWorkspacePath } from "./homerail-home.js";
+
+const MAX_INPUTS = 16;
+const MAX_BYTES = 1024 * 1024;
+const MEDIA_TYPES = new Set<string>(["text/markdown", "text/plain", "application/json"]);
+
+function segmentsFor(value: string): string[] {
+  const normalized = value.replace(/\\/g, "/").trim();
+  const segments = normalized.split("/");
+  if (
+    normalized.length > 512
+    || segments.length < 2
+    || segments[0] !== "input"
+    || segments.some((segment) => (
+      !segment || segment === "." || segment === ".." || !/^[A-Za-z0-9._-]+$/.test(segment)
+    ))
+  ) {
+    throw new Error("workspace input mount_path must be a safe path below input/");
+  }
+  return segments;
+}
+
+function decodeProjection(value: unknown): DagWorkspaceInputProjection & { bytes: Buffer; segments: string[] } {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("workspace input projection must be an object");
+  }
+  const raw = value as Record<string, unknown>;
+  const logicalName = typeof raw.logical_name === "string" ? raw.logical_name.trim() : "";
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(logicalName)) {
+    throw new Error("workspace input logical_name is invalid");
+  }
+  const mountPath = typeof raw.mount_path === "string" ? raw.mount_path : "";
+  const segments = segmentsFor(mountPath);
+  const mediaType = typeof raw.media_type === "string" ? raw.media_type : "";
+  if (!MEDIA_TYPES.has(mediaType)) throw new Error("workspace input media_type is invalid");
+  const sha256 = typeof raw.sha256 === "string" ? raw.sha256 : "";
+  if (!/^[0-9a-f]{64}$/.test(sha256)) throw new Error("workspace input sha256 is invalid");
+  const sizeBytes = Number(raw.size_bytes);
+  if (!Number.isInteger(sizeBytes) || sizeBytes < 1 || sizeBytes > MAX_BYTES) {
+    throw new Error("workspace input size_bytes is invalid");
+  }
+  const encoded = typeof raw.content_base64 === "string" ? raw.content_base64 : "";
+  if (!encoded || encoded.length > Math.ceil(MAX_BYTES / 3) * 4 + 8) {
+    throw new Error("workspace input content_base64 is invalid");
+  }
+  const bytes = Buffer.from(encoded, "base64");
+  if (bytes.byteLength !== sizeBytes || createHash("sha256").update(bytes).digest("hex") !== sha256) {
+    throw new Error("workspace input content does not match its descriptor");
+  }
+  return {
+    logical_name: logicalName,
+    mount_path: segments.join("/"),
+    media_type: mediaType as DagWorkspaceInputProjection["media_type"],
+    sha256,
+    size_bytes: sizeBytes,
+    content_base64: encoded,
+    bytes,
+    segments,
+  };
+}
+
+function assertPathHasNoSymlink(root: string, segments: string[]): void {
+  let current = root;
+  for (const segment of segments) {
+    current = path.join(current, segment);
+    if (fs.existsSync(current) && fs.lstatSync(current).isSymbolicLink()) {
+      throw new Error("workspace input projection cannot traverse a symlink");
+    }
+  }
+}
+
+function listFiles(root: string): string[] {
+  if (!fs.existsSync(root)) return [];
+  const files: string[] = [];
+  const visit = (directory: string): void => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const target = path.join(directory, entry.name);
+      if (entry.isSymbolicLink()) throw new Error("workspace input projection contains a symlink");
+      if (entry.isDirectory()) visit(target);
+      else if (entry.isFile()) files.push(path.relative(root, target).replace(/\\/g, "/"));
+      else throw new Error("workspace input projection contains an unsupported file type");
+    }
+  };
+  visit(root);
+  return files.sort();
+}
+
+export function materializeWorkspaceInputs(workspaceId: string, rawInputs: unknown): number {
+  if (rawInputs === undefined) return 0;
+  if (!Array.isArray(rawInputs) || rawInputs.length < 1 || rawInputs.length > MAX_INPUTS) {
+    throw new Error(`workspace_inputs must contain 1-${MAX_INPUTS} projections`);
+  }
+  const projections = rawInputs.map(decodeProjection);
+  const logicalNames = new Set<string>();
+  const mountPaths = new Set<string>();
+  for (const projection of projections) {
+    if (logicalNames.has(projection.logical_name)) throw new Error("workspace input logical_name is duplicated");
+    if (mountPaths.has(projection.mount_path)) throw new Error("workspace input mount_path is duplicated");
+    logicalNames.add(projection.logical_name);
+    mountPaths.add(projection.mount_path);
+  }
+
+  const workspace = path.resolve(homerailWorkerWorkspacePath(workspaceId));
+  const inputRoot = path.resolve(workspace, "input");
+  fs.mkdirSync(inputRoot, { recursive: true, mode: 0o700 });
+  try { fs.chmodSync(inputRoot, 0o700); } catch { /* Best effort before read-only mount. */ }
+  const directories = new Set<string>([inputRoot]);
+  for (const projection of projections) {
+    assertPathHasNoSymlink(workspace, projection.segments);
+    const target = path.resolve(workspace, ...projection.segments);
+    const relative = path.relative(inputRoot, target);
+    if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+      throw new Error("workspace input projection escaped input root");
+    }
+    const parent = path.dirname(target);
+    fs.mkdirSync(parent, { recursive: true, mode: 0o700 });
+    let cursor = parent;
+    while (cursor === inputRoot || cursor.startsWith(`${inputRoot}${path.sep}`)) {
+      directories.add(cursor);
+      if (cursor === inputRoot) break;
+      cursor = path.dirname(cursor);
+    }
+    if (fs.existsSync(target)) {
+      if (!fs.lstatSync(target).isFile()) throw new Error("workspace input target is not a regular file");
+      const existing = fs.readFileSync(target);
+      if (
+        existing.byteLength !== projection.size_bytes
+        || createHash("sha256").update(existing).digest("hex") !== projection.sha256
+      ) {
+        throw new Error("workspace input target conflicts with its immutable descriptor");
+      }
+    } else {
+      const temporary = path.join(parent, `.input-${randomUUID()}.tmp`);
+      fs.writeFileSync(temporary, projection.bytes, { flag: "wx", mode: 0o400 });
+      fs.renameSync(temporary, target);
+    }
+    try { fs.chmodSync(target, 0o444); } catch { /* The nested read-only mount is authoritative. */ }
+  }
+
+  const expectedFiles = projections
+    .map((projection) => projection.segments.slice(1).join("/"))
+    .sort();
+  const actualFiles = listFiles(inputRoot);
+  if (actualFiles.length !== expectedFiles.length
+    || actualFiles.some((file, index) => file !== expectedFiles[index])) {
+    throw new Error("workspace input directory contains an unstaged file");
+  }
+  for (const directory of Array.from(directories).sort((left, right) => right.length - left.length)) {
+    try { fs.chmodSync(directory, 0o555); } catch { /* Best effort on non-POSIX filesystems. */ }
+  }
+  return projections.length;
+}

--- a/homerail_protocol/src/dag-run-inputs.ts
+++ b/homerail_protocol/src/dag-run-inputs.ts
@@ -1,0 +1,52 @@
+/**
+ * Immutable DAG run input contracts.
+ * @version 0.1.0
+ */
+
+export const DAG_RUN_INPUT_MEDIA_TYPES = [
+  "text/markdown",
+  "text/plain",
+  "application/json",
+] as const;
+
+export type DagRunInputMediaType = (typeof DAG_RUN_INPUT_MEDIA_TYPES)[number];
+
+export interface StageDagRunInputRequest {
+  scope_id: string;
+  name: string;
+  media_type: DagRunInputMediaType;
+  content: string;
+}
+
+export interface DagRunInputArtifactDescriptor {
+  artifact_id: string;
+  scope_id: string;
+  name: string;
+  media_type: DagRunInputMediaType;
+  sha256: string;
+  size_bytes: number;
+  created_at: number;
+}
+
+export interface DagRunInputBindingRequest {
+  artifact_id: string;
+  logical_name: string;
+  mount_path: string;
+}
+
+export interface DagRunInputBinding extends DagRunInputArtifactDescriptor {
+  run_id: string;
+  logical_name: string;
+  mount_path: string;
+  bound_at: number;
+}
+
+/** Trusted Manager-to-Node projection; never exposed to a model prompt. */
+export interface DagWorkspaceInputProjection {
+  logical_name: string;
+  mount_path: string;
+  media_type: DagRunInputMediaType;
+  sha256: string;
+  size_bytes: number;
+  content_base64: string;
+}

--- a/homerail_protocol/src/index.ts
+++ b/homerail_protocol/src/index.ts
@@ -19,6 +19,7 @@ export * from "./dag-activity.js";
 export * from "./dag-observability.js";
 export * from "./dag-worker-skill-context.js";
 export * from "./dag-credentials.js";
+export * from "./dag-run-inputs.js";
 export * from "./dag-actor-surface-patch.js";
 export * from "./dag-actor-surface-media.js";
 export * from "./codec.js";

--- a/homerail_protocol/src/manager-agent-tools.ts
+++ b/homerail_protocol/src/manager-agent-tools.ts
@@ -92,6 +92,7 @@ export const MANAGER_AGENT_COMMON_TOOL_NAMES = [
   "create_change",
   "run_pr_review",
   "run_pr_closeout",
+  "stage_run_input",
   "create_and_run",
   "start_supervised_dag",
   "list_dag_actors",
@@ -987,6 +988,21 @@ export const MANAGER_AGENT_TOOL_SPECS: Record<ManagerAgentToolName, AgentToolDef
       additionalProperties: false,
     },
   },
+  stage_run_input: {
+    name: "stage_run_input",
+    description: "Stage an immutable, content-addressed local task document or structured input before starting a DAG. The returned artifact_id must be bound through create_and_run input_artifacts.",
+    input_schema: {
+      type: "object",
+      properties: {
+        scope_id: { type: "string", minLength: 1, maxLength: 128 },
+        name: { type: "string", minLength: 1, maxLength: 128 },
+        media_type: { type: "string", enum: ["text/markdown", "text/plain", "application/json"] },
+        content: { type: "string", minLength: 1, maxLength: 1048576 },
+      },
+      required: ["name", "media_type", "content"],
+      additionalProperties: false,
+    },
+  },
   create_and_run: {
     name: "create_and_run",
     description: "Create and immediately invoke a DAG run from a DB workflow_id or repo-local YAML path.",
@@ -999,6 +1015,22 @@ export const MANAGER_AGENT_TOOL_SPECS: Record<ManagerAgentToolName, AgentToolDef
         profile: { type: "string" },
         prompt: { type: "string" },
         runId: { type: "string" },
+        input_scope: { type: "string", minLength: 1, maxLength: 128 },
+        input_artifacts: {
+          type: "array",
+          minItems: 1,
+          maxItems: 16,
+          items: {
+            type: "object",
+            properties: {
+              artifact_id: { type: "string" },
+              logical_name: { type: "string" },
+              mount_path: { type: "string" },
+            },
+            required: ["artifact_id", "logical_name", "mount_path"],
+            additionalProperties: false,
+          },
+        },
       },
       anyOf: [
         { required: ["workflow_id"] },
@@ -1020,6 +1052,22 @@ export const MANAGER_AGENT_TOOL_SPECS: Record<ManagerAgentToolName, AgentToolDef
         profile: { type: "string" },
         prompt: { type: "string" },
         runId: { type: "string" },
+        input_scope: { type: "string", minLength: 1, maxLength: 128 },
+        input_artifacts: {
+          type: "array",
+          minItems: 1,
+          maxItems: 16,
+          items: {
+            type: "object",
+            properties: {
+              artifact_id: { type: "string" },
+              logical_name: { type: "string" },
+              mount_path: { type: "string" },
+            },
+            required: ["artifact_id", "logical_name", "mount_path"],
+            additionalProperties: false,
+          },
+        },
       },
       anyOf: [
         { required: ["workflow_id"] },

--- a/homerail_protocol/tests/manager-agent.test.ts
+++ b/homerail_protocol/tests/manager-agent.test.ts
@@ -234,6 +234,7 @@ describe("Manager Agent harness contract", () => {
     const chatNames = managerAgentCommonToolCatalog("chat").map((tool) => tool.name);
     const voiceNames = managerAgentCommonToolCatalog("voice").map((tool) => tool.name);
     expect(chatNames).toContain("create_and_run");
+    expect(chatNames).toContain("stage_run_input");
     expect(chatNames).not.toContain("run_shell_command");
     expect(chatNames).toEqual(expect.arrayContaining([
       "list_skills",
@@ -308,6 +309,22 @@ describe("Manager Agent harness contract", () => {
           profile: { type: "string" },
           prompt: { type: "string" },
           runId: { type: "string" },
+          input_scope: { type: "string", minLength: 1, maxLength: 128 },
+          input_artifacts: {
+            type: "array",
+            minItems: 1,
+            maxItems: 16,
+            items: {
+              type: "object",
+              properties: {
+                artifact_id: { type: "string" },
+                logical_name: { type: "string" },
+                mount_path: { type: "string" },
+              },
+              required: ["artifact_id", "logical_name", "mount_path"],
+              additionalProperties: false,
+            },
+          },
         },
         anyOf: [
           { required: ["workflow_id"] },

--- a/homerail_worker/src/__tests__/prompt-runner.test.ts
+++ b/homerail_worker/src/__tests__/prompt-runner.test.ts
@@ -237,6 +237,52 @@ describe("prompt runner", () => {
     }));
   });
 
+  it("allows only declared broker verification plus handoff during correction", async () => {
+    let observedTools: string[] = [];
+    let observedContext: AgentRunContext | undefined;
+    const mockAgent: AgentClient = {
+      run(_prompt, tools, context) {
+        observedTools = tools.map((tool) => tool.name);
+        observedContext = context;
+        return (async function* () {
+          await tools.find((tool) => tool.name === "handoff")!.handler({ port: "done", content: "corrected" });
+          yield { type: "done" as const };
+        })();
+      },
+    };
+    registerAgentBackend("test-correction-broker", () => mockAgent);
+
+    await runPrompt(
+      {
+        task: "## input:context\n{}\n\n## input:correction\nVerify checks, then use the exact contract",
+        sender: "test",
+        runId: "run-correction-broker",
+        dagConfig: makeConfigWith({
+          session_id: "review-session",
+          allowed_dag_tools: ["handoff", "credential_broker_call"],
+        }),
+        credentialBrokerBindings: [{
+          credential_ref: "github-autofix",
+          purpose: "verify required checks",
+          mode: "manager_broker",
+          broker: "github_pr",
+          allowed_actions: ["required_checks"],
+        }],
+      },
+      {
+        wsSend: () => {},
+        agentBackend: "test-correction-broker",
+        credentialBrokerCall: async (request) => ({ request_id: request.request_id, ok: true, result: {} }),
+      },
+    );
+
+    expect(observedTools).toEqual(["handoff", "credential_broker_call"]);
+    expect(observedContext?.handoffOnly).toBe(true);
+    expect(observedContext?.systemPrompt).toContain(
+      "declared credential broker verification calls followed by exactly one handoff",
+    );
+  });
+
   it("keeps the Claude Code preset for ordinary DAG work", async () => {
     let observedContext: AgentRunContext | undefined;
     const mockAgent: AgentClient = {

--- a/homerail_worker/src/manager-agent/server.ts
+++ b/homerail_worker/src/manager-agent/server.ts
@@ -1019,25 +1019,26 @@ export function createManagerTools(state: {
       },
     },
     {
-      name: "create_and_run",
-      description: "Create and immediately invoke a DAG run from a DB workflow_id or repo-local YAML path.",
-      input_schema: {
-        type: "object",
-        properties: {
-          yamlPath: { type: "string" },
-          workflow_id: { type: "string" },
-          workflowId: { type: "string" },
-          profile: { type: "string" },
-          prompt: { type: "string" },
-          runId: { type: "string" },
-        },
-        anyOf: [
-          { required: ["workflow_id"] },
-          { required: ["workflowId"] },
-          { required: ["yamlPath"] },
-        ],
-        additionalProperties: false,
+      ...managerAgentToolSpec("stage_run_input"),
+      async handler(args) {
+        const scopeId = typeof args.scope_id === "string" && args.scope_id.trim()
+          ? args.scope_id.trim()
+          : state.projectId ?? "manager-agent";
+        const body = await requestManager("/run-inputs", {
+          method: "POST",
+          body: JSON.stringify({
+            scope_id: scopeId,
+            name: args.name,
+            media_type: args.media_type,
+            content: args.content,
+          }),
+        });
+        state.objectiveToolCalls.push({ name: "stage_run_input", success: true });
+        return { content: [{ type: "text", text: short(body, 12000) }] };
       },
+    },
+    {
+      ...managerAgentToolSpec("create_and_run"),
       async handler(args) {
         try {
           const yamlPath = typeof args.yamlPath === "string" ? args.yamlPath.trim() : "";
@@ -1057,6 +1058,8 @@ export function createManagerTools(state: {
               profile: typeof args.profile === "string" ? args.profile : undefined,
               prompt: typeof args.prompt === "string" ? args.prompt : undefined,
               runId: typeof args.runId === "string" ? args.runId : undefined,
+              input_scope: typeof args.input_scope === "string" ? args.input_scope : undefined,
+              input_artifacts: Array.isArray(args.input_artifacts) ? args.input_artifacts : undefined,
             }),
           }) as Record<string, unknown>;
           const data = body.data as Record<string, unknown> | undefined;
@@ -1095,6 +1098,8 @@ export function createManagerTools(state: {
               profile: typeof args.profile === "string" ? args.profile : undefined,
               prompt: typeof args.prompt === "string" ? args.prompt : undefined,
               runId: typeof args.runId === "string" ? args.runId : undefined,
+              input_scope: typeof args.input_scope === "string" ? args.input_scope : undefined,
+              input_artifacts: Array.isArray(args.input_artifacts) ? args.input_artifacts : undefined,
             }),
           }) as Record<string, unknown>;
           const data = body.data as Record<string, unknown> | undefined;

--- a/homerail_worker/src/prompt-runner.ts
+++ b/homerail_worker/src/prompt-runner.ts
@@ -308,8 +308,13 @@ export async function runPrompt(
   const selectedDagTools = allowedDagTools === undefined
     ? allDagTools
     : allDagTools.filter((tool) => allowedDagTools.has(tool.name));
+  const correctionAllowsBrokerVerification = allowedDagTools?.has("credential_broker_call") === true
+    && selectedDagTools.some((tool) => tool.name === "credential_broker_call");
   const dagTools = correctionOnly
-    ? allDagTools.filter((tool) => tool.name === "handoff")
+    ? selectedDagTools.filter((tool) => (
+        tool.name === "handoff"
+        || (correctionAllowsBrokerVerification && tool.name === "credential_broker_call")
+      ))
     : selectedDagTools;
   const ordinarySystemPrompt = surfacePatchAllowed
     ? [job.systemPrompt?.trim(), REPORT_SURFACE_STATE_PROMPT].filter(Boolean).join("\n\n")
@@ -319,8 +324,10 @@ export async function runPrompt(
         "DAG CONTRACT CORRECTION MODE.",
         "The previous turn did not produce a contract-valid handoff.",
         `The active DAG run_id is ${job.runId}. Copy it exactly when the output contract requires it.`,
-        "Your only permitted action is one call to the handoff tool.",
-        "Do not emit prose or tool-like markup. Do not call, describe, or simulate any other tool.",
+        correctionAllowsBrokerVerification
+          ? "Your only permitted actions are declared credential broker verification calls followed by exactly one handoff tool call."
+          : "Your only permitted action is one call to the handoff tool.",
+        "Do not emit prose or tool-like markup. Do not call, describe, or simulate any non-permitted tool.",
         "Use the correction message and original inputs to preserve completed work and satisfy the exact output schema.",
         "The original node instructions follow only for output schema and evidence context:",
         job.systemPrompt ?? "",

--- a/scripts/auto-fix-v2-runtime-profile.test.mjs
+++ b/scripts/auto-fix-v2-runtime-profile.test.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import {
+  autoFixV2RuntimeProfileYaml,
+  selectAutoFixV2Setting,
+} from "./configure-auto-fix-v2-runtime-profile.mjs";
+
+const setting = (id, model, endpoint) => ({
+  id,
+  display_name: model,
+  model_name: model,
+  is_active: 1,
+  supports_llm: 1,
+  ...endpoint,
+});
+
+const settings = [
+  setting("k3", "Kimi K3", { base_url: "https://kimi.example/v1" }),
+  setting("deepseek-v4-flash", "DeepSeek V4 Flash", { anthropic_base_url: "https://models.example/v1" }),
+  setting("glm-5-2", "GLM-5.2", { anthropic_base_url: "https://models.example/v1" }),
+];
+const analyzer = selectAutoFixV2Setting(settings, "k3", "analyzer");
+const implementation = selectAutoFixV2Setting(settings, "deepseek-v4-flash", "implementation");
+const review = selectAutoFixV2Setting(settings, "glm-5-2", "review");
+const yaml = autoFixV2RuntimeProfileYaml({ profileId: "pilot", analyzer, implementation, review });
+
+assert.match(yaml, /workflow_id: auto-fix-v2/);
+assert.match(yaml, /analyzer:\n    llm_setting_id: "k3"\n    agent_type: kimi_code/);
+for (const id of ["implementer", "aggregator", "fixer"]) {
+  assert.match(yaml, new RegExp(`${id}:\\n    llm_setting_id: "deepseek-v4-flash"`));
+}
+assert.match(yaml, /reviewer:\n    llm_setting_id: "glm-5-2"/);
+assert.throws(() => selectAutoFixV2Setting(settings, "glm-5-2", "analyzer"), /required model family/);
+
+process.stdout.write("auto-fix-v2 runtime profile tests passed\n");

--- a/scripts/configure-auto-fix-v2-runtime-profile.mjs
+++ b/scripts/configure-auto-fix-v2-runtime-profile.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from "node:url";
+
+const ROLE_PATTERNS = Object.freeze({
+  analyzer: /(?:^|[-_. /])k3(?:$|[-_. /])/i,
+  implementation: /deepseek.*v4.*flash|v4.*flash.*deepseek/i,
+  review: /glm[-_. /]*5(?:[-_. /]*2|\.2)/i,
+});
+
+function text(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function enabled(value) {
+  return value === true || value === 1;
+}
+
+function yamlString(value) {
+  return JSON.stringify(String(value));
+}
+
+export function selectAutoFixV2Setting(settings, selector, role) {
+  const wanted = text(selector);
+  if (!wanted) throw new Error(`HOMERAIL_AUTO_FIX_V2_${role.toUpperCase()}_MODEL is required`);
+  const matches = settings.filter((setting) => (
+    setting?.id === wanted || setting?.display_name === wanted || setting?.model_name === wanted
+  ));
+  if (matches.length !== 1) {
+    throw new Error(matches.length === 0
+      ? `Auto Fix v2 ${role} model was not found: ${wanted}`
+      : `Auto Fix v2 ${role} model selector is ambiguous: ${wanted}`);
+  }
+  const setting = matches[0];
+  const identity = [setting.id, setting.display_name, setting.model_name].filter(Boolean).join(" ");
+  if (!ROLE_PATTERNS[role]?.test(identity)) {
+    throw new Error(`Auto Fix v2 ${role} selector does not identify the required model family: ${identity}`);
+  }
+  if (!enabled(setting.is_active) || !enabled(setting.supports_llm)) {
+    throw new Error(`Auto Fix v2 ${role} model is not an active LLM setting: ${wanted}`);
+  }
+  const hasKimiCodeEndpoint = Boolean(
+    text(setting.base_url)
+    || text(setting.provider_base_url)
+    || text(setting.chat_completions_base_url),
+  );
+  if (role === "analyzer" && !hasKimiCodeEndpoint) {
+    throw new Error(`Auto Fix v2 analyzer model has no Kimi Code-compatible endpoint: ${wanted}`);
+  }
+  if (role !== "analyzer" && !text(setting.anthropic_base_url)) {
+    throw new Error(`Auto Fix v2 ${role} model has no Anthropic-compatible endpoint: ${wanted}`);
+  }
+  return setting;
+}
+
+function agentEntry(id, setting, agentType) {
+  return [
+    `  ${id}:`,
+    `    llm_setting_id: ${yamlString(setting.id)}`,
+    `    agent_type: ${agentType}`,
+  ];
+}
+
+export function autoFixV2RuntimeProfileYaml({ profileId, analyzer, implementation, review }) {
+  return [
+    `profile_id: ${yamlString(profileId)}`,
+    "workflow_id: auto-fix-v2",
+    "description: K3 analysis, DeepSeek V4 Flash implementation/fix/aggregation, and fresh GLM-5.2 review.",
+    "agents:",
+    ...agentEntry("analyzer", analyzer, "kimi_code"),
+    ...agentEntry("implementer", implementation, "claude-sdk"),
+    ...agentEntry("aggregator", implementation, "claude-sdk"),
+    ...agentEntry("fixer", implementation, "claude-sdk"),
+    ...agentEntry("reviewer", review, "claude-sdk"),
+    "",
+  ].join("\n");
+}
+
+async function request(managerUrl, pathname, init) {
+  const response = await fetch(`${managerUrl}${pathname}`, {
+    ...init,
+    headers: {
+      ...(init?.headers ?? {}),
+      ...(init?.method && init.method !== "GET" && process.env.HOMERAIL_DAG_MUTATION_TOKEN
+        ? { "x-homerail-dag-token": process.env.HOMERAIL_DAG_MUTATION_TOKEN }
+        : {}),
+    },
+  });
+  const body = await response.json();
+  if (!response.ok || body.success === false) {
+    throw new Error(`${init?.method ?? "GET"} ${pathname}: ${body.error ?? body.message ?? `HTTP ${response.status}`}`);
+  }
+  return body.data;
+}
+
+export async function configureAutoFixV2RuntimeProfile({
+  managerUrl = process.env.HOMERAIL_MANAGER_URL ?? "http://127.0.0.1:19191",
+  profileId = process.env.HOMERAIL_AUTO_FIX_V2_PROFILE_ID ?? "auto-fix-v2-mixed",
+  analyzerSelector = process.env.HOMERAIL_AUTO_FIX_V2_ANALYZER_MODEL,
+  implementationSelector = process.env.HOMERAIL_AUTO_FIX_V2_IMPLEMENTATION_MODEL,
+  reviewSelector = process.env.HOMERAIL_AUTO_FIX_V2_REVIEW_MODEL,
+} = {}) {
+  const root = managerUrl.replace(/\/+$/, "");
+  const listed = await request(root, "/api/llm/settings");
+  const settings = Array.isArray(listed?.settings) ? listed.settings : [];
+  const analyzer = selectAutoFixV2Setting(settings, analyzerSelector, "analyzer");
+  const implementation = selectAutoFixV2Setting(settings, implementationSelector, "implementation");
+  const review = selectAutoFixV2Setting(settings, reviewSelector, "review");
+  const yamlText = autoFixV2RuntimeProfileYaml({ profileId, analyzer, implementation, review });
+  const synced = await request(root, "/api/dag/profiles/sync", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      yaml_text: yamlText,
+      workflow_id: "auto-fix-v2",
+      source_path: "stable-runner:auto-fix-v2-mixed",
+    }),
+  });
+  if (synced?.profile?.profile_id !== profileId || synced?.profile?.workflow_id !== "auto-fix-v2") {
+    throw new Error("Manager synced an unexpected Auto Fix v2 runtime profile");
+  }
+  return { profileId, analyzer, implementation, review, yamlText };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const configured = await configureAutoFixV2RuntimeProfile();
+    process.stdout.write(configured.profileId);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary

Adds an opt-in, document-first `auto-fix-v2` workflow without replacing the existing `auto-fix` path.

- stages task and PR context as immutable, content-addressed Manager inputs projected read-only into Workers
- lets K3 split work into bounded dynamic fan-out tasks
- provisions isolated, credential-free Git worktrees for DeepSeek V4 Flash implementers
- uses DeepSeek V4 Flash for aggregation and fresh dynamic fixers
- resets GLM-5.2 review context on every dispatch and limits the loop to five review rounds
- keeps GitHub credentials in a Manager-only broker with Draft-PR identity, expected-head, path, file-count, byte-count, and non-force fences
- requires exact immutable GitHub checks to pass on the current head before a `verdict: approve` handoff can complete
- binds the approval receipt to the current fresh reviewer dispatch, so recovery or later review rounds cannot reuse it
- adds the mixed-model profile configurator, operator runbook, architecture document, and deterministic fake-remote coverage

## Review hardening

- rejects all `.github/**` mutations even when a caller includes `.github` in `writable_paths`
- rejects `writable_paths: ["."]` instead of permitting repository-wide writes
- adds a generic conditional WorkflowSpec output requirement backed by Manager-broker action receipts
- registers `github_pr/required_checks` and fails closed for missing, pending, cancelled, or unsuccessful checks
- removes the new run-input route's `as any` media/content coercions with explicit runtime narrowing
- documents Git Data API partial-object/rate-limit behavior and the repository's Draft-PR CI dispatch requirement

## Why

The current Auto Fix DAG carries too much task state through conversation history and a large static graph. This makes recovery fragile and makes task loss difficult to diagnose. V2 establishes an immutable document and Draft PR as the durable source of truth, then generates implementation and repair workers only when the runtime needs them.

## Impact and rollout

- `auto-fix-v2` is opt-in and does not change the existing `auto-fix` workflow or trigger.
- No GitHub token or provider credential is stored in this repository.
- Production activation still requires deployment of this code, an encrypted `github-autofix` Manager credential, workflow/profile sync, trusted checks configured in immutable `pr-context.json`, and a dedicated Draft PR.
- Issue #172 is documented only as a possible first pilot task; this PR does not close it.
- A real Draft-PR pilot remains required before production adoption.

## Validation

- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run typecheck`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run build:packages`
- focused WorkflowSpec, broker, recovery, five-round scenario, credential, and run-input tests: 93 passed
- Auto Fix v2 mixed-model runtime-profile test passed
- full `npm run test:packages` with an isolated temporary `HOMERAIL_HOME`
  - Protocol: 306 passed
  - Plugin SDK: 35 passed
  - Manager: 1209 passed, 2 skipped
  - Node: 189 passed, 2 skipped
  - Worker: 331 passed, 1 skipped
  - CLI: 259 passed
  - Agent UI: 528 passed
  - live validator: 86 passed, 2 skipped
- `git diff --cached --check`

The repository currently has no `npm run scan` script; the full live-validator suite, including tracked credential and deployment configuration checks, passed.
