### PR TITLE
test(worker): normalize Codex cwd expectation on Windows

### DIFF
--- a/homerail_worker/src/__tests__/codex-appserver.test.ts
+++ b/homerail_worker/src/__tests__/codex-appserver.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { EventEmitter } from "node:events";
+import * as path from "node:path";
 import { PassThrough, Writable } from "node:stream";
 import type { AgentEvent, AgentRunContext, DagToolDefinition } from "../agent/types.js";
 import { WORKER_RUNTIME_VERSION } from "../runtime-version.js";
@@ -839,7 +840,7 @@ describe("CodexAppServerAdapter", () => {
     expect(reqs2[1].params).toMatchObject({
       baseInstructions: null,
       developerInstructions: "You are a helpful assistant.",
-      cwd: "/test/workspace",
+      cwd: path.resolve("/test/workspace"),
       model: "gpt-4.1",
       approvalPolicy: "never",
       sandbox: "workspace-write",


### PR DESCRIPTION
## What changed

- Resolve the expected Codex app-server workspace path with `node:path` in the test.
- Keep the production adapter behavior unchanged.

## Why

The merge commit from PR #170 succeeded, but the post-merge `Core (Windows, Node 24)` check failed because the test expected the Unix literal `/test/workspace`. The adapter correctly normalizes that path to `D:\test\workspace` on Windows, so the assertion was platform-specific.

## Impact

The Codex app-server test now validates the normalized working directory on Linux, macOS, and Windows. This restores the Windows CI signal without changing runtime behavior.

## Validation

- `npm --prefix homerail_worker test -- src/__tests__/codex-appserver.test.ts` — 19 passed
- `npm --prefix homerail_worker run typecheck` — passed
- `npm --prefix homerail_worker test` — 335 passed, 1 skipped
- [Manual full CI](https://github.com/xiaotianfotos/homerail/actions/runs/30711615101) — Windows Node 24, Linux Node 20/24, Agent UI coverage, and Docker smoke passed
