### PR TITLE
Harden Auto Fix v2 pilot runtime configuration

### DIFF
--- a/assets/orchestrations/auto-fix-v2.yaml.template
+++ b/assets/orchestrations/auto-fix-v2.yaml.template
@@ -310,7 +310,6 @@ spec:
           session_scope: dispatch
           allowed_builtin_tools: [Bash, Edit, Glob, Grep, LS, Read, Write]
           allowed_dag_tools: [handoff]
-          max_builtin_tool_calls: 80
           workspace_access: { writable_paths: ["{{fanout_workspace}}"], readonly_paths: [input] }
         workspace_strategy: isolated_git_worktree
         workspace_root: workers
@@ -331,7 +330,6 @@ spec:
       workspace_access: { writable_paths: [repo], readonly_paths: [input, workers] }
       allowed_builtin_tools: [Bash, Edit, Glob, Grep, LS, Read, Write]
       allowed_dag_tools: [handoff, credential_broker_call]
-      max_builtin_tool_calls: 120
       credentials:
         - credential_ref: github-autofix
           purpose: integrate the candidate into the bound Draft PR
@@ -349,7 +347,6 @@ spec:
       workspace_access: { writable_paths: [], readonly_paths: [input, repo, workers] }
       allowed_builtin_tools: [Glob, Grep, LS, Read]
       allowed_dag_tools: [handoff, credential_broker_call]
-      max_builtin_tool_calls: 60
       credentials:
         - credential_ref: github-autofix
           purpose: review the bound Draft PR without mutation
@@ -394,7 +391,6 @@ spec:
           session_scope: dispatch
           allowed_builtin_tools: [Bash, Edit, Glob, Grep, LS, Read, Write]
           allowed_dag_tools: [handoff, credential_broker_call]
-          max_builtin_tool_calls: 100
           workspace_access: { writable_paths: ["{{fanout_workspace}}"], readonly_paths: [input] }
           credentials:
             - credential_ref: github-autofix
@@ -424,7 +420,6 @@ spec:
       workspace_access: { writable_paths: [], readonly_paths: [input, repo, fixers] }
       allowed_builtin_tools: [Glob, Grep, LS, Read]
       allowed_dag_tools: [handoff, credential_broker_call]
-      max_builtin_tool_calls: 60
       credentials:
         - credential_ref: github-autofix
           purpose: re-review the bound Draft PR without mutation
@@ -484,4 +479,3 @@ spec:
     max_handoffs: 48
     max_corrections_per_node: 2
     max_edge_traversals: 4
-    max_tool_calls_per_node: 120

--- a/docs/architecture/autofix-v2.md
+++ b/docs/architecture/autofix-v2.md
@@ -273,7 +273,6 @@ config:
     session_scope: dispatch
     allowed_builtin_tools: [Bash, Read, Write, Edit, Grep, Glob]
     allowed_dag_tools: [handoff]
-    max_builtin_tool_calls: 50
     workspace_access:
       writable_paths: ["{{fanout_workspace}}"]
       readonly_paths: [input, evidence]
@@ -287,6 +286,10 @@ Its semantics are:
 
 - the compiler validates the complete template;
 - every child receives a canonical copy of it;
+- Auto Fix v2 deliberately leaves both node-level and workflow-level tool-call
+  budget fields unset; completion is governed by handoff contracts,
+  model/runtime limits, and operator cancellation rather than a fixed
+  tool-call budget;
 - omitted tool allowlists are empty for dynamic children;
 - omitted credentials mean no credentials;
 - omitted workspace access means no writable paths;

--- a/docs/scenarios/auto-fix-v2.md
+++ b/docs/scenarios/auto-fix-v2.md
@@ -135,8 +135,10 @@ export HOMERAIL_AUTO_FIX_V2_REVIEW_MODEL='<GLM-5.2 setting id>'
 node scripts/configure-auto-fix-v2-runtime-profile.mjs
 ```
 
-The analyzer uses the `kimi-code` harness. DeepSeek and GLM use the
-Claude-compatible harness; no coding role uses direct chat-completions.
+K3, DeepSeek, and GLM all use the Claude Agent SDK harness against their
+Anthropic-compatible endpoints; no coding role uses Kimi Code or direct
+chat-completions. This keeps `allowed_builtin_tools` enforceable for every
+Auto Fix v2 Agent node.
 
 ## Start a local or stable run
 

--- a/docs/scenarios/auto-fix-v2.md
+++ b/docs/scenarios/auto-fix-v2.md
@@ -140,6 +140,9 @@ Anthropic-compatible endpoints; no coding role uses Kimi Code or direct
 chat-completions. This keeps `allowed_builtin_tools` enforceable for every
 Auto Fix v2 Agent node.
 
+Auto Fix v2 intentionally does not configure any node-level or workflow-level
+tool-call budget. Do not add a fixed tool-call budget to this workflow.
+
 ## Start a local or stable run
 
 ```bash

--- a/homerail_manager/tests/auto-fix-v2-scenario.test.ts
+++ b/homerail_manager/tests/auto-fix-v2-scenario.test.ts
@@ -86,6 +86,7 @@ describe("Auto Fix v2 document-first dynamic architecture", () => {
     expect(parsed.meta.workflow_id).toBe("auto-fix-v2");
     expect(parsed.graph.nodes).toHaveLength(8);
     expect(parsed.graph.edges.length).toBeLessThanOrEqual(28);
+    expect(source).not.toMatch(/\bmax_[a-z_]*tool_calls[a-z_]*:/);
     for (const nodeId of ["implement", "fix"]) {
       expect(parsed.graph.nodes.find((node) => node.node_id === nodeId)?.gateway_config).toMatchObject({
         workspace_strategy: "isolated_git_worktree",

--- a/scripts/auto-fix-v2-runtime-profile.test.mjs
+++ b/scripts/auto-fix-v2-runtime-profile.test.mjs
@@ -16,7 +16,7 @@ const setting = (id, model, endpoint) => ({
 });
 
 const settings = [
-  setting("k3", "Kimi K3", { base_url: "https://kimi.example/v1" }),
+  setting("k3", "Kimi K3", { anthropic_base_url: "https://models.example/v1" }),
   setting("deepseek-v4-flash", "DeepSeek V4 Flash", { anthropic_base_url: "https://models.example/v1" }),
   setting("glm-5-2", "GLM-5.2", { anthropic_base_url: "https://models.example/v1" }),
 ];
@@ -26,11 +26,14 @@ const review = selectAutoFixV2Setting(settings, "glm-5-2", "review");
 const yaml = autoFixV2RuntimeProfileYaml({ profileId: "pilot", analyzer, implementation, review });
 
 assert.match(yaml, /workflow_id: auto-fix-v2/);
-assert.match(yaml, /analyzer:\n    llm_setting_id: "k3"\n    agent_type: kimi_code/);
+assert.match(yaml, /analyzer:\n    llm_setting_id: "k3"\n    agent_type: claude-sdk/);
 for (const id of ["implementer", "aggregator", "fixer"]) {
   assert.match(yaml, new RegExp(`${id}:\\n    llm_setting_id: "deepseek-v4-flash"`));
 }
 assert.match(yaml, /reviewer:\n    llm_setting_id: "glm-5-2"/);
 assert.throws(() => selectAutoFixV2Setting(settings, "glm-5-2", "analyzer"), /required model family/);
+assert.throws(() => selectAutoFixV2Setting([
+  setting("k3-no-anthropic", "Kimi K3", { base_url: "https://kimi.example/v1" }),
+], "k3-no-anthropic", "analyzer"), /no Anthropic-compatible endpoint/);
 
 process.stdout.write("auto-fix-v2 runtime profile tests passed\n");

--- a/scripts/configure-auto-fix-v2-runtime-profile.mjs
+++ b/scripts/configure-auto-fix-v2-runtime-profile.mjs
@@ -39,15 +39,7 @@ export function selectAutoFixV2Setting(settings, selector, role) {
   if (!enabled(setting.is_active) || !enabled(setting.supports_llm)) {
     throw new Error(`Auto Fix v2 ${role} model is not an active LLM setting: ${wanted}`);
   }
-  const hasKimiCodeEndpoint = Boolean(
-    text(setting.base_url)
-    || text(setting.provider_base_url)
-    || text(setting.chat_completions_base_url),
-  );
-  if (role === "analyzer" && !hasKimiCodeEndpoint) {
-    throw new Error(`Auto Fix v2 analyzer model has no Kimi Code-compatible endpoint: ${wanted}`);
-  }
-  if (role !== "analyzer" && !text(setting.anthropic_base_url)) {
+  if (!text(setting.anthropic_base_url)) {
     throw new Error(`Auto Fix v2 ${role} model has no Anthropic-compatible endpoint: ${wanted}`);
   }
   return setting;
@@ -67,7 +59,7 @@ export function autoFixV2RuntimeProfileYaml({ profileId, analyzer, implementatio
     "workflow_id: auto-fix-v2",
     "description: K3 analysis, DeepSeek V4 Flash implementation/fix/aggregation, and fresh GLM-5.2 review.",
     "agents:",
-    ...agentEntry("analyzer", analyzer, "kimi_code"),
+    ...agentEntry("analyzer", analyzer, "claude-sdk"),
     ...agentEntry("implementer", implementation, "claude-sdk"),
     ...agentEntry("aggregator", implementation, "claude-sdk"),
     ...agentEntry("fixer", implementation, "claude-sdk"),


### PR DESCRIPTION
## What changed

- run the Auto Fix v2 K3 analyzer through `claude-sdk`
- require an Anthropic-compatible endpoint for the analyzer setting
- remove every node-level and workflow-level tool-call budget from Auto Fix v2
- add a regression assertion that prevents reintroducing fixed tool budgets
- document the enforced backend boundary and update profile regression coverage

## Why

The first real Issue pilot on 112 failed closed before analysis because `kimi_code` cannot enforce HomeRail's `allowed_builtin_tools` policy. K3 already has an Anthropic-compatible endpoint and works through Claude Agent SDK, which enforces the analyzer's read-only tool allowlist. The next pilot reached dynamic implementation but one worker exhausted the configured 80-call budget while still making progress, so fixed tool-call budgets are now explicitly excluded from this workflow.

## Impact

Model roles remain unchanged: K3 analyzes, DeepSeek V4 Flash implements/aggregates/fixes, and GLM-5.2 reviews. The profile and no-budget workflow revision were applied on 112; a clean pilot rerun is active from the same immutable inputs and unchanged Draft PR head.

## Validation

- `node scripts/auto-fix-v2-runtime-profile.test.mjs`
- live `hr dag validate` accepted the no-budget template with no diagnostics
- live 112 profile inspection confirms `analyzer.agent_type = claude-sdk`
- pilot run `6fd5e4abefe15f593cefc857` passed the previous fail-closed point and generated two dynamic implementation workers; it was cancelled after exposing the fixed-budget problem
- clean no-budget rerun: `b8bd73297a8f1db2c7015b93`
