### PR TITLE
Harden Auto Fix v2 fan-out result integrity

### DIFF
--- a/assets/orchestrations/auto-fix-v2.yaml.template
+++ b/assets/orchestrations/auto-fix-v2.yaml.template
@@ -58,10 +58,6 @@ spec:
           minItems: 1
           maxItems: 30
           items: { type: string, minLength: 1, maxLength: 2000 }
-        dependencies:
-          type: array
-          maxItems: 3
-          items: { type: string, pattern: '^[a-z][a-z0-9_-]{0,63}$' }
 
     TaskPlan:
       type: object
@@ -89,10 +85,6 @@ spec:
                 minItems: 1
                 maxItems: 30
                 items: { type: string, minLength: 1, maxLength: 2000 }
-              dependencies:
-                type: array
-                maxItems: 3
-                items: { type: string, pattern: '^[a-z][a-z0-9_-]{0,63}$' }
         shared:
           type: object
           additionalProperties: false
@@ -202,19 +194,26 @@ spec:
       system: |
         Read /workspace/input/task.md as the immutable authoritative task and
         /workspace/input/pr-context.json as immutable PR identity. Inspect the
-        read-only repository at /workspace/repo. Produce a minimal independent
-        task list. Do not edit files and do not access GitHub. Finish only with
-        handoff(planned) matching TaskPlan. Set shared paths exactly to repo,
-        input/task.md, and input/pr-context.json.
+        read-only repository at /workspace/repo. Produce only implementation
+        tasks that are independently executable in isolated Git worktrees. Do
+        not emit dependency-only verification, coordination, or follow-up tasks;
+        combine coupled changes into one task. Do not edit files or access
+        GitHub. Finish only with handoff(planned), passing content as an object
+        matching exactly:
+        {"tasks":[{"id":"implementation","title":"...","description":"...","files":["..."],"acceptance":["..."]}],"shared":{"repository_path":"repo","task_document":"input/task.md","pr_context":"input/pr-context.json"}}
+        Never use work_items, findings, task, or a JSON-encoded string as the
+        handoff content. Set the three shared paths exactly as shown.
 
     implementer:
       description: DeepSeek V4 Flash isolated implementation worker
       system: |
         Implement only input.item inside input.workspace_path. Read the mounted
         task document for authoritative acceptance criteria. Never access the
-        PR or credentials. Run focused tests, commit the changes in the detached
-        Git worktree, and hand off result with the exact commit SHA and workspace
-        path. Do not modify another worker's directory.
+        PR or credentials. input.workspace_path is a real Git worktree even
+        though .git is a file. Run focused tests and commit from that exact
+        worktree. Never copy changes into /workspace/repo or another worker's
+        directory. Verify git cat-file -e HEAD^{commit} and a clean git status,
+        then hand off result with the exact HEAD SHA and workspace path.
 
     aggregator:
       description: DeepSeek V4 Flash candidate integrator
@@ -314,6 +313,10 @@ spec:
         workspace_strategy: isolated_git_worktree
         workspace_root: workers
         repository_path: repo
+        result_git_commit:
+          commit_field: commit_sha
+          workspace_field: workspace_path
+          require_clean: true
         max_items: 3
         max_parallelism: 3
         completion: all

--- a/docs/architecture/autofix-v2.md
+++ b/docs/architecture/autofix-v2.md
@@ -280,6 +280,10 @@ config:
   workspace_strategy: isolated_git_worktree
   workspace_root: workers
   repository_path: repo
+  result_git_commit:
+    commit_field: commit_sha
+    workspace_field: workspace_path
+    require_clean: true
 ```
 
 Its semantics are:
@@ -300,6 +304,10 @@ Its semantics are:
 - only `handoff` is available unless DAG tools are declared explicitly;
 - each child has a unique logical actor, provider session, and isolated
   worktree based on the same immutable source SHA;
+- successful child handoffs are accepted only when the reported workspace is
+  that child's exact worktree, the reported commit exists and equals its HEAD,
+  and the worktree is clean; a syntactically valid but fabricated SHA is
+  rejected before aggregation;
 - child corrections retain the same policy and cannot broaden it;
 - runtime events expose the effective policy digest for audit.
 
@@ -505,7 +513,7 @@ strict v1 template.
    automation, and security-sensitive infrastructure from the first pilot.
 7. Run one real Draft-PR pilot with no auto-ready or merge behavior.
 8. Expand only after at least four of five eligible pilots produce a validated
-   Draft PR within the agreed runtime budget and no capability boundary is
+   Draft PR within the agreed operational time window and no capability boundary is
    violated.
 
 The current Auto Fix workflow can be deprecated only after the pilot evidence

--- a/docs/scenarios/auto-fix-v2.md
+++ b/docs/scenarios/auto-fix-v2.md
@@ -143,6 +143,12 @@ Auto Fix v2 Agent node.
 Auto Fix v2 intentionally does not configure any node-level or workflow-level
 tool-call budget. Do not add a fixed tool-call budget to this workflow.
 
+The analyzer may emit only parallel-safe implementation items. It must combine
+coupled work instead of generating a separate verification/dependency worker.
+For every successful worker result, Manager verifies that `workspace_path` is
+the assigned isolated worktree, `commit_sha` exists and is that worktree's
+current HEAD, and the worktree is clean before aggregation can start.
+
 ## Start a local or stable run
 
 ```bash

--- a/homerail_manager/src/orchestration/graph.ts
+++ b/homerail_manager/src/orchestration/graph.ts
@@ -111,6 +111,11 @@ export interface DAGGatewayConfig {
   workspace_root?: string;
   repository_path?: string;
   revision_field?: string;
+  result_git_commit?: {
+    commit_field: string;
+    workspace_field: string;
+    require_clean?: boolean;
+  };
   max_parallelism?: number;
   completion?: "all" | "any" | "n_of_m" | string;
   result_contract?: string;

--- a/homerail_manager/src/orchestration/workflow-spec-v1-schema.ts
+++ b/homerail_manager/src/orchestration/workflow-spec-v1-schema.ts
@@ -313,6 +313,11 @@ const FanoutNode = Type.Object({
     workspace_root: Type.Optional(Type.String({ minLength: 1, maxLength: 512 })),
     repository_path: Type.Optional(Type.String({ minLength: 1, maxLength: 512 })),
     revision_field: Type.Optional(Type.String({ minLength: 1, maxLength: 256 })),
+    result_git_commit: Type.Optional(Type.Object({
+      commit_field: Identifier,
+      workspace_field: Identifier,
+      require_clean: Type.Optional(Type.Boolean()),
+    }, { additionalProperties: false })),
     max_items: Type.Integer({ minimum: 1, maximum: 256 }),
     max_parallelism: Type.Integer({ minimum: 1, maximum: 256 }),
     completion: Type.Union([Type.Literal("all"), Type.Literal("any"), Type.Literal("n_of_m")]),

--- a/homerail_manager/src/orchestration/workflow-spec-v1.ts
+++ b/homerail_manager/src/orchestration/workflow-spec-v1.ts
@@ -609,6 +609,13 @@ function semanticDiagnostics(context: SourceContext, workflow: WorkflowSpecV1): 
           "{{fanout_workspace}} is only available with isolated_git_worktree fanout",
         );
       }
+      if (node.config.result_git_commit && node.config.workspace_strategy !== "isolated_git_worktree") {
+        add(
+          `${nodePath}/config/result_git_commit`,
+          "DAG_SEMANTIC_FANOUT_GIT_RESULT_REQUIRES_WORKTREE",
+          "result_git_commit validation requires isolated_git_worktree fanout",
+        );
+      }
     }
     if (node.kind === "await_command") {
       for (let index = 0; index < (node.config.target_actors ?? []).length; index++) {

--- a/homerail_manager/src/runtime/active-runs.ts
+++ b/homerail_manager/src/runtime/active-runs.ts
@@ -4470,6 +4470,85 @@ function _interruptDynamicNode(run: ActiveRun, nodeId: string): void {
   }
 }
 
+function _assertFanoutGitCommitResult(
+  run: ActiveRun,
+  parent: DAGGraphNode,
+  state: FanoutRuntimeState,
+  index: number,
+  content: unknown,
+): void {
+  const validation = parent.gateway_config?.result_git_commit;
+  if (!validation) return;
+  if (parent.gateway_config?.workspace_strategy !== "isolated_git_worktree") {
+    throw new Error("DAG_FANOUT_GIT_RESULT_INVALID result_git_commit requires isolated_git_worktree");
+  }
+  const commitSha = _fieldValue(content, validation.commit_field);
+  const reportedWorkspace = _fieldValue(content, validation.workspace_field);
+  const expectedWorkspace = _fanoutChildWorkspacePath(parent, state, index);
+  if (reportedWorkspace !== expectedWorkspace) {
+    throw new Error(
+      `DAG_FANOUT_GIT_RESULT_INVALID workspace '${String(reportedWorkspace ?? "")}' does not match '${expectedWorkspace}'`,
+    );
+  }
+  if (typeof commitSha !== "string" || !/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i.test(commitSha)) {
+    throw new Error("DAG_FANOUT_GIT_RESULT_INVALID commit SHA is missing or malformed");
+  }
+  const resolved = _commandGatewayCwd(run, RUN_WORKSPACE_CWD);
+  if ("error" in resolved) throw new Error(`DAG_FANOUT_GIT_RESULT_INVALID ${resolved.error}`);
+  const runWorkspace = resolved.cwd;
+  const workspace = path.resolve(runWorkspace, expectedWorkspace);
+  if (!_pathIsWithin(runWorkspace, workspace)) {
+    throw new Error("DAG_FANOUT_GIT_RESULT_INVALID workspace escaped the run workspace");
+  }
+  const repositoryPath = parent.gateway_config?.repository_path === "."
+    ? "."
+    : _fanoutSafeRelativePath(parent.gateway_config?.repository_path, "repo");
+  const repository = path.resolve(runWorkspace, repositoryPath);
+  const git = (args: string[], timeout = 10_000) => spawnSync("git", ["-C", workspace, ...args], {
+    encoding: "utf8",
+    timeout,
+    maxBuffer: 256_000,
+    shell: false,
+  });
+  const topLevel = git(["rev-parse", "--show-toplevel"]);
+  const commonDir = git(["rev-parse", "--path-format=absolute", "--git-common-dir"]);
+  const gitDir = git(["rev-parse", "--path-format=absolute", "--git-dir"]);
+  let resolvedTopLevel: string;
+  let resolvedCommonDir: string;
+  let resolvedGitDir: string;
+  let expectedCommonDir: string;
+  try {
+    resolvedTopLevel = realpathSync(String(topLevel.stdout).trim());
+    resolvedCommonDir = realpathSync(String(commonDir.stdout).trim());
+    resolvedGitDir = realpathSync(String(gitDir.stdout).trim());
+    expectedCommonDir = realpathSync(path.join(repository, ".git"));
+  } catch {
+    throw new Error("DAG_FANOUT_GIT_RESULT_INVALID isolated worktree Git metadata could not be resolved");
+  }
+  if (
+    topLevel.status !== 0 || commonDir.status !== 0 || gitDir.status !== 0
+    || resolvedTopLevel !== realpathSync(workspace)
+    || resolvedCommonDir !== expectedCommonDir
+    || !_pathIsWithin(path.join(expectedCommonDir, "worktrees"), resolvedGitDir)
+  ) {
+    throw new Error("DAG_FANOUT_GIT_RESULT_INVALID isolated worktree Git binding is invalid");
+  }
+  const exists = git(["cat-file", "-e", `${commitSha.toLowerCase()}^{commit}`]);
+  if (exists.status !== 0 || exists.error) {
+    throw new Error("DAG_FANOUT_GIT_RESULT_INVALID commit does not exist in the isolated worktree");
+  }
+  const head = git(["rev-parse", "HEAD"]);
+  if (head.status !== 0 || head.error || String(head.stdout).trim().toLowerCase() !== commitSha.toLowerCase()) {
+    throw new Error("DAG_FANOUT_GIT_RESULT_INVALID commit is not the isolated worktree HEAD");
+  }
+  if (validation.require_clean !== false) {
+    const status = git(["status", "--porcelain"]);
+    if (status.status !== 0 || status.error || String(status.stdout).trim()) {
+      throw new Error("DAG_FANOUT_GIT_RESULT_INVALID isolated worktree has uncommitted changes");
+    }
+  }
+}
+
 function _recordFanoutChild(run: ActiveRun, child: DAGGraphNode, port: string, content: unknown): void {
   const dynamic = child.extra?.dynamic_fanout;
   if (!dynamic || typeof dynamic !== "object" || Array.isArray(dynamic)) return;
@@ -4485,6 +4564,7 @@ function _recordFanoutChild(run: ActiveRun, child: DAGGraphNode, port: string, c
   const selected = _fieldValue(content, config?.success_field);
   const successValues = config?.success_values ?? [true, "pass", "passed", "success", "approved", "yes", "act"];
   const success = port !== "failed" && (!config?.success_field || successValues.some((value) => value === selected));
+  if (success) _assertFanoutGitCommitResult(run, parent, state, index, content);
   state.results.push({ index, node_id: child.node_id, port, content, success });
   state.results.sort((left, right) => left.index - right.index);
   const successes = state.results.filter((result) => result.success).length;

--- a/homerail_manager/tests/auto-fix-v2-scenario.test.ts
+++ b/homerail_manager/tests/auto-fix-v2-scenario.test.ts
@@ -156,6 +156,38 @@ describe("Auto Fix v2 document-first dynamic architecture", () => {
         allowed_dag_tools: ["handoff"],
         credentials: [],
       });
+      if (index === 1) {
+        expect(() => handoffActiveRun("autofix-v2-run", nodeId, "result", {
+          status: "implemented",
+          task_id: "runtime",
+          commit_sha: "f".repeat(40),
+          workspace_path: workspacePath,
+          summary: "fabricated commit",
+          tests: [],
+        })).toThrow("DAG_FANOUT_GIT_RESULT_INVALID commit does not exist");
+        expect(getActiveRun("autofix-v2-run")?.dagRun.nodeStates.get(nodeId)).toBe("RUNNING");
+        expect(() => handoffActiveRun("autofix-v2-run", nodeId, "result", {
+          status: "implemented",
+          task_id: "runtime",
+          commit_sha: head,
+          workspace_path: "workers/implement/inv_0001/item_0002",
+          summary: "wrong workspace",
+          tests: [],
+        })).toThrow("DAG_FANOUT_GIT_RESULT_INVALID workspace");
+        expect(getActiveRun("autofix-v2-run")?.dagRun.nodeStates.get(nodeId)).toBe("RUNNING");
+        const dirtyPath = path.join(home, "workspace", "autofix-v2-run", workspacePath, "dirty.tmp");
+        fs.writeFileSync(dirtyPath, "uncommitted");
+        expect(() => handoffActiveRun("autofix-v2-run", nodeId, "result", {
+          status: "implemented",
+          task_id: "runtime",
+          commit_sha: head,
+          workspace_path: workspacePath,
+          summary: "dirty workspace",
+          tests: [],
+        })).toThrow("DAG_FANOUT_GIT_RESULT_INVALID isolated worktree has uncommitted changes");
+        expect(getActiveRun("autofix-v2-run")?.dagRun.nodeStates.get(nodeId)).toBe("RUNNING");
+        fs.rmSync(dirtyPath);
+      }
       handoffActiveRun("autofix-v2-run", nodeId, "result", {
         status: "implemented",
         task_id: index === 1 ? "runtime" : "tests",

--- a/homerail_manager/tests/workflow-spec-v1.test.ts
+++ b/homerail_manager/tests/workflow-spec-v1.test.ts
@@ -534,6 +534,10 @@ spec:
           workspace_access: { writable_paths: [], readonly_paths: [input] }
         workspace_strategy: isolated_git_worktree
         repository_path: repo
+        result_git_commit:
+          commit_field: commit_sha
+          workspace_field: workspace_path
+          require_clean: true
         max_items: 2
         max_parallelism: 1
         completion: all
@@ -558,6 +562,15 @@ spec:
       "writable_paths: ['{{fanout_workspace}}']",
     ));
     expect(declared.valid, declared.diagnostics.map((item) => item.message).join("\n")).toBe(true);
+
+    const shared = compileWorkflowSource(source
+      .replace("writable_paths: []", "writable_paths: ['{{fanout_workspace}}']")
+      .replace("workspace_strategy: isolated_git_worktree", "workspace_strategy: shared"));
+    expect(shared.valid).toBe(false);
+    expect(shared.diagnostics).toContainEqual(expect.objectContaining({
+      code: "DAG_SEMANTIC_FANOUT_GIT_RESULT_REQUIRES_WORKTREE",
+      path: "/spec/nodes/fan/config/result_git_commit",
+    }));
   });
 
   it("rejects an approval workflow that authorizes its proposer", () => {


### PR DESCRIPTION
## Summary

- constrain K3 analysis to independent implementation items and an exact `TaskPlan` handoff shape
- teach DeepSeek workers to commit only inside their assigned Git worktree
- add Manager-side validation for successful fan-out results: exact assigned workspace, authentic commit at HEAD, valid worktree binding, and clean status
- preserve the Auto Fix v2 invariant that no node-level or workflow-level tool-call budget is configured

## Pilot evidence

The real Issue #172 pilot run `b8bd73297a8f1db2c7015b93` exposed both failure modes:

- a dependency-only verification worker reported a fabricated commit SHA
- an implementation worker copied changes into the shared repository and was correctly rejected by the workspace policy

The Draft PR was not modified because aggregation never started.

## Validation

- `npm run typecheck` in `homerail_manager`
- `vitest run tests/workflow-spec-v1.test.ts tests/auto-fix-v2-scenario.test.ts tests/dag-runtime-primitives.test.ts` (64 passed)
- `node scripts/auto-fix-v2-runtime-profile.test.mjs`
- `git diff --check`
- verified the Auto Fix v2 template contains no `max_*tool_calls` key
