### PR TITLE
feat(agent-ui): add dynamic appearance themes

### DIFF
--- a/agent-ui/index.html
+++ b/agent-ui/index.html
@@ -24,13 +24,13 @@
           const legacyTheme = storage.getItem('omni_theme')
           const systemLight = legacyTheme === 'system'
             && window.matchMedia?.('(prefers-color-scheme: light)').matches
-          const stored = current
+          const stored = current === 'dream' ? 'skin-09' : current
             || (legacySkin === 'paper' || legacySkin === 'cockpit' ? legacySkin : '')
             || (legacyTheme === 'light' || systemLight ? 'paper' : 'cockpit')
           const storedScheme = storage.getItem('homerail.appearance-color-scheme')
-          const scheme = stored === 'paper'
+          const scheme = stored === 'paper' || (stored.startsWith('skin-') && stored !== 'skin-08' && stored !== 'skin-09')
             ? 'light'
-            : stored === 'cockpit'
+            : stored === 'cockpit' || stored === 'skin-08' || stored === 'skin-09'
               ? 'dark'
               : storedScheme === 'light' ? 'light' : 'dark'
           document.documentElement.dataset.hrAppearance = stored
@@ -38,7 +38,7 @@
           document.documentElement.style.colorScheme = scheme
           document.querySelector('meta[name="theme-color"]')?.setAttribute(
             'content',
-            scheme === 'light' ? '#f5f6f8' : '#06080d',
+            stored === 'skin-08' ? '#141313' : stored === 'skin-09' ? '#061124' : scheme === 'light' ? '#f5f6f8' : '#06080d',
           )
         } catch {
           document.documentElement.classList.add('dark')

--- a/agent-ui/src/appearance/appearance-registry.test.ts
+++ b/agent-ui/src/appearance/appearance-registry.test.ts
@@ -19,11 +19,12 @@ describe('appearance registry', () => {
     applyAppearanceToDocument('cockpit')
   })
 
-  it('ships the cockpit and paper appearances and normalizes unknown ids', () => {
+  it('ships the built-in appearances and normalizes unknown ids', () => {
     expect(listAppearancePlugins().map(plugin => plugin.id)).toEqual(
-      expect.arrayContaining(['cockpit', 'paper']),
+      expect.arrayContaining(['cockpit', 'paper', 'skin-01', 'skin-02', 'skin-03', 'skin-04', 'skin-05', 'skin-06', 'skin-07', 'skin-08', 'skin-09']),
     )
     expect(getAppearancePlugin('paper').colorScheme).toBe('light')
+    expect(getAppearancePlugin('skin-09').preview.accent).toBe('#6da7ff')
     expect(normalizeAppearanceId('missing')).toBe('cockpit')
   })
 
@@ -111,6 +112,19 @@ describe('appearance registry', () => {
     expect(document.documentElement.style.getPropertyValue('--hr-bg')).toBe('')
     expect(document.documentElement.style.getPropertyValue('--hr-text-1')).toBe('')
     unsubscribe()
+  })
+
+  it('applies a gallery skin tokens and atmospheric document state', () => {
+    applyAppearanceToDocument('skin-09')
+
+    expect(document.documentElement.dataset.hrAppearance).toBe('skin-09')
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+    expect(document.documentElement.style.colorScheme).toBe('dark')
+    expect(document.documentElement.style.getPropertyValue('--hr-accent')).toBe('#6da7ff')
+    expect(document.documentElement.style.getPropertyValue('--hr-speaking')).toBe('#9cbbf6')
+
+    applyAppearanceToDocument('cockpit')
+    expect(document.documentElement.style.getPropertyValue('--hr-accent')).toBe('')
   })
 
   it('rejects token names outside the public appearance contract', () => {

--- a/agent-ui/src/appearance/appearance-registry.ts
+++ b/agent-ui/src/appearance/appearance-registry.ts
@@ -89,6 +89,22 @@ export interface AppearancePlugin {
   tokens?: AppearanceTokens
 }
 
+interface SkinPalette {
+  id: string
+  colorScheme: AppearanceColorScheme
+  themeColor: string
+  background: string
+  panel: string
+  text: string
+  muted: string
+  accent: string
+  accentHover: string
+  secondary: string
+  warning: string
+  danger: string
+  radius?: string
+}
+
 export const APPEARANCE_STORAGE_KEY = 'homerail.appearance'
 export const APPEARANCE_COLOR_SCHEME_STORAGE_KEY = 'homerail.appearance-color-scheme'
 export const LEGACY_SKIN_STORAGE_KEY = 'homerail.skin'
@@ -172,6 +188,148 @@ registerAppearance({
   },
 })
 
+function skinTokens(palette: SkinPalette): AppearanceTokens {
+  const dark = palette.colorScheme === 'dark'
+  const alpha = (color: string, amount: number): string =>
+    `color-mix(in srgb, ${color} ${amount}%, transparent)`
+
+  return {
+    '--hr-bg': palette.background,
+    '--hr-bg-raised': palette.panel,
+    '--hr-surface-1': alpha(palette.accent, dark ? 7 : 5),
+    '--hr-surface-2': alpha(palette.accent, dark ? 12 : 9),
+    '--hr-surface-3': alpha(palette.accent, dark ? 18 : 14),
+    '--hr-panel': palette.panel,
+    '--hr-control': alpha(palette.secondary, dark ? 9 : 7),
+    '--hr-control-hover': alpha(palette.accent, dark ? 15 : 12),
+    '--hr-control-active': alpha(palette.accent, dark ? 22 : 17),
+    '--hr-overlay': dark ? 'rgba(0, 0, 0, 0.78)' : 'rgba(38, 38, 32, 0.24)',
+    '--hr-code-bg': dark ? 'rgba(0, 0, 0, 0.62)' : alpha(palette.background, 82),
+    '--hr-border': alpha(palette.accent, dark ? 22 : 20),
+    '--hr-border-strong': alpha(palette.accent, dark ? 40 : 34),
+    '--hr-text-1': palette.text,
+    '--hr-text-2': dark ? palette.text : palette.muted,
+    '--hr-text-3': palette.muted,
+    '--hr-text-4': alpha(palette.muted, dark ? 68 : 78),
+    '--hr-on-strong': dark ? '#ffffff' : palette.background,
+    '--hr-accent': palette.accent,
+    '--hr-accent-hover': palette.accentHover,
+    '--hr-accent-soft': alpha(palette.accent, dark ? 17 : 14),
+    '--hr-accent-border': alpha(palette.accent, dark ? 48 : 42),
+    '--hr-on-accent': dark ? palette.background : '#ffffff',
+    '--hr-speaking': palette.secondary,
+    '--hr-speaking-soft': alpha(palette.secondary, dark ? 17 : 14),
+    '--hr-speaking-border': alpha(palette.secondary, dark ? 44 : 38),
+    '--hr-success': palette.secondary,
+    '--hr-success-soft': alpha(palette.secondary, dark ? 17 : 14),
+    '--hr-success-border': alpha(palette.secondary, dark ? 44 : 38),
+    '--hr-warning': palette.warning,
+    '--hr-warning-soft': alpha(palette.warning, dark ? 17 : 14),
+    '--hr-warning-border': alpha(palette.warning, dark ? 44 : 38),
+    '--hr-danger': palette.danger,
+    '--hr-danger-soft': alpha(palette.danger, dark ? 17 : 14),
+    '--hr-danger-border': alpha(palette.danger, dark ? 44 : 38),
+    '--hr-info': palette.secondary,
+    '--hr-info-soft': alpha(palette.secondary, dark ? 17 : 14),
+    '--hr-info-border': alpha(palette.secondary, dark ? 44 : 38),
+    '--hr-focus-ring': alpha(palette.accent, dark ? 42 : 34),
+    '--hr-selection': alpha(palette.accent, dark ? 30 : 24),
+    '--hr-scrollbar-track': palette.background,
+    '--hr-scrollbar': palette.accent,
+    '--hr-scrollbar-hover': palette.accentHover,
+    '--hr-ambient-accent': alpha(palette.accent, dark ? 20 : 12),
+    '--hr-ambient-info': alpha(palette.secondary, dark ? 16 : 10),
+    '--hr-canvas-ambient-primary': alpha(palette.accent, dark ? 15 : 10),
+    '--hr-canvas-ambient-secondary': alpha(palette.secondary, dark ? 10 : 7),
+    '--hr-decorative-accent-soft': alpha(palette.accent, dark ? 17 : 14),
+    '--hr-decorative-accent-border': alpha(palette.accent, dark ? 42 : 36),
+    '--hr-decorative-speaking-soft': alpha(palette.secondary, dark ? 17 : 14),
+    '--hr-decorative-speaking-border': alpha(palette.secondary, dark ? 42 : 36),
+    '--hr-settings-sidebar': alpha(palette.secondary, dark ? 8 : 6),
+    '--hr-settings-card': alpha(palette.panel, dark ? 92 : 100),
+    '--hr-settings-card-hover': alpha(palette.accent, dark ? 14 : 10),
+    '--hr-settings-divider': alpha(palette.accent, dark ? 24 : 22),
+    '--hr-settings-active': alpha(palette.accent, dark ? 17 : 14),
+    '--hr-settings-active-border': alpha(palette.accent, dark ? 50 : 44),
+    '--hr-radius-lg': palette.radius ?? (dark ? '18px' : '14px'),
+    '--hr-radius-md': dark ? '13px' : '10px',
+    '--hr-radius-sm': '9px',
+    '--hr-shadow-panel': dark
+      ? `0 22px 64px rgba(0, 0, 0, 0.38), 0 0 28px ${alpha(palette.accent, 8)}`
+      : `0 12px 34px rgba(37, 50, 58, 0.08), 0 0 22px ${alpha(palette.accent, 8)}`,
+    '--hr-shadow-floating': dark
+      ? `0 28px 90px rgba(0, 0, 0, 0.58), 0 0 34px ${alpha(palette.accent, 12)}`
+      : `0 20px 54px rgba(37, 50, 58, 0.14), 0 0 28px ${alpha(palette.accent, 10)}`,
+    '--hr-shadow-accent': `0 0 28px ${alpha(palette.accent, 22)}`,
+  }
+}
+
+function registerSkinTheme(palette: SkinPalette): void {
+  registerAppearance({
+    id: palette.id,
+    colorScheme: palette.colorScheme,
+    labelKey: `settings.general.appearance.options.${palette.id}.label`,
+    descriptionKey: `settings.general.appearance.options.${palette.id}.description`,
+    themeColor: palette.themeColor,
+    preview: {
+      background: palette.background,
+      panel: palette.panel,
+      accent: palette.accent,
+      text: palette.text,
+    },
+    tokens: skinTokens(palette),
+  })
+}
+
+// These nine palettes translate the reference gallery into Homerail's live
+// semantic-token contract. The source gallery files are composite screenshots,
+// so they are used as visual references rather than injected as fake UI images.
+registerSkinTheme({
+  id: 'skin-01', colorScheme: 'light', themeColor: '#fbf1f2', background: '#fbf1f2',
+  panel: '#fffafa', text: '#50363a', muted: '#96777d', accent: '#d86c80',
+  accentHover: '#bd4f66', secondary: '#e7a0ad', warning: '#c8974b', danger: '#c84e63',
+})
+registerSkinTheme({
+  id: 'skin-02', colorScheme: 'light', themeColor: '#fbf3d9', background: '#fbf3d9',
+  panel: '#fffdf1', text: '#513b1e', muted: '#92744a', accent: '#c98c25',
+  accentHover: '#a96d13', secondary: '#4f8b65', warning: '#d08b28', danger: '#bd4a32',
+})
+registerSkinTheme({
+  id: 'skin-03', colorScheme: 'light', themeColor: '#fff4f2', background: '#fff4f2',
+  panel: '#fffdfc', text: '#302327', muted: '#896f75', accent: '#d93632',
+  accentHover: '#b92525', secondary: '#e97771', warning: '#d28a34', danger: '#b8202a',
+})
+registerSkinTheme({
+  id: 'skin-04', colorScheme: 'light', themeColor: '#f5f5e9', background: '#f5f5e9',
+  panel: '#fffef6', text: '#3c4435', muted: '#7e866f', accent: '#87976a',
+  accentHover: '#6d7e53', secondary: '#b5b98b', warning: '#b48a42', danger: '#a35f55',
+})
+registerSkinTheme({
+  id: 'skin-05', colorScheme: 'light', themeColor: '#fff8dc', background: '#fff8dc',
+  panel: '#fffef8', text: '#30342b', muted: '#72796c', accent: '#16a594',
+  accentHover: '#0c8478', secondary: '#ef7a66', warning: '#e0b52c', danger: '#d95f58',
+})
+registerSkinTheme({
+  id: 'skin-06', colorScheme: 'light', themeColor: '#f1f0ff', background: '#f1f0ff',
+  panel: '#fbfaff', text: '#292b58', muted: '#6f719d', accent: '#7359db',
+  accentHover: '#5b40c3', secondary: '#39a9e8', warning: '#d49d38', danger: '#c9527c',
+})
+registerSkinTheme({
+  id: 'skin-07', colorScheme: 'light', themeColor: '#edfaff', background: '#edfaff',
+  panel: '#fbffff', text: '#24435b', muted: '#64859a', accent: '#18b9d0',
+  accentHover: '#0a92ad', secondary: '#e85ea8', warning: '#e4ac39', danger: '#d8586d',
+})
+registerSkinTheme({
+  id: 'skin-08', colorScheme: 'dark', themeColor: '#141313', background: '#141313',
+  panel: '#211e1c', text: '#f3e8d5', muted: '#b4a58e', accent: '#d9b56e',
+  accentHover: '#f0d18c', secondary: '#b88972', warning: '#e5b84c', danger: '#d77a72',
+})
+registerSkinTheme({
+  id: 'skin-09', colorScheme: 'dark', themeColor: '#061124', background: '#061124',
+  panel: '#0b1b35', text: '#e8f1ff', muted: '#91a8c8', accent: '#6da7ff',
+  accentHover: '#9bc4ff', secondary: '#9cbbf6', warning: '#efbd62', danger: '#ee8c9e',
+})
+
 export function listAppearancePlugins(): readonly AppearancePlugin[] {
   return [...registry.values()]
 }
@@ -196,6 +354,7 @@ export function resolveStoredAppearance(
   if (!storage) return DEFAULT_APPEARANCE_ID
 
   const current = storage.getItem(APPEARANCE_STORAGE_KEY)
+  if (current === 'dream') return 'skin-09'
   if (current && registry.has(current)) return current
 
   const legacySkin = storage.getItem(LEGACY_SKIN_STORAGE_KEY)

--- a/agent-ui/src/components/agent/settings/GeneralSettings.test.ts
+++ b/agent-ui/src/components/agent/settings/GeneralSettings.test.ts
@@ -97,4 +97,26 @@ describe('GeneralSettings', () => {
     expect(document.documentElement.classList.contains('dark')).toBe(false)
     expect(document.documentElement.style.colorScheme).toBe('light')
   })
+
+  it('switches to a gallery skin without reloading', async () => {
+    const pinia = createPinia()
+    root = document.createElement('div')
+    document.body.appendChild(root)
+    app = createApp(GeneralSettings)
+    app.use(pinia)
+    app.use(i18n)
+    app.mount(root)
+
+    const uiStore = useUiStore(pinia)
+    root
+      .querySelector<HTMLButtonElement>('[data-testid="agent-settings-appearance-skin-09"]')
+      ?.click()
+    await nextTick()
+
+    expect(uiStore.appearanceId).toBe('skin-09')
+    expect(localStorage.getItem(APPEARANCE_STORAGE_KEY)).toBe('skin-09')
+    expect(document.documentElement.dataset.hrAppearance).toBe('skin-09')
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+    expect(document.documentElement.style.colorScheme).toBe('dark')
+  })
 })

--- a/agent-ui/src/locales/en-US/settings.json
+++ b/agent-ui/src/locales/en-US/settings.json
@@ -40,6 +40,42 @@
         "paper": {
           "label": "Soft Paper",
           "description": "A low-glare workspace with misty slate tones and soft surfaces."
+        },
+        "skin-01": {
+          "label": "Rose Garden",
+          "description": "A light rose theme with soft pink surfaces."
+        },
+        "skin-02": {
+          "label": "Golden Fortune",
+          "description": "A festive palette of warm gold, red, and jade."
+        },
+        "skin-03": {
+          "label": "Red Future",
+          "description": "A bright red-and-white interface with a sci-fi edge."
+        },
+        "skin-04": {
+          "label": "Paper Crane",
+          "description": "A calm ivory theme with olive and paper-like tones."
+        },
+        "skin-05": {
+          "label": "Inspiration",
+          "description": "An energetic palette of teal, coral, and yellow signals."
+        },
+        "skin-06": {
+          "label": "Violet Night",
+          "description": "A dreamy layered theme of violet, blue, and soft light."
+        },
+        "skin-07": {
+          "label": "Future Notes",
+          "description": "A neon music theme with cyan and pink-violet accents."
+        },
+        "skin-08": {
+          "label": "Black Gold Stage",
+          "description": "An immersive dark theme with warm gold highlights."
+        },
+        "skin-09": {
+          "label": "Astronaut",
+          "description": "An exploration theme of deep space blue and cool starlight."
         }
       }
     },

--- a/agent-ui/src/locales/zh-Hans/settings.json
+++ b/agent-ui/src/locales/zh-Hans/settings.json
@@ -40,6 +40,42 @@
         "paper": {
           "label": "柔雾浅色",
           "description": "以低亮度青灰和柔和表面构成的耐看工作区。"
+        },
+        "skin-01": {
+          "label": "樱粉花园",
+          "description": "柔粉玫瑰与低对比表面的轻盈主题。"
+        },
+        "skin-02": {
+          "label": "财神金",
+          "description": "暖金、朱红与玉绿构成的喜庆主题。"
+        },
+        "skin-03": {
+          "label": "红白未来",
+          "description": "高亮红白与未来感界面的明快主题。"
+        },
+        "skin-04": {
+          "label": "千纸鹤",
+          "description": "米白、橄榄绿与纸张质感的清新主题。"
+        },
+        "skin-05": {
+          "label": "灵感彩虹",
+          "description": "青绿、珊瑚与黄色信号组成的活力主题。"
+        },
+        "skin-06": {
+          "label": "紫夜星光",
+          "description": "紫色、蓝色与柔光层叠的梦幻主题。"
+        },
+        "skin-07": {
+          "label": "未来音符",
+          "description": "青蓝、粉紫和霓虹光感的音乐主题。"
+        },
+        "skin-08": {
+          "label": "黑金舞台",
+          "description": "深黑背景与金色高光构成的沉浸主题。"
+        },
+        "skin-09": {
+          "label": "星航员",
+          "description": "深空蓝、星光与冷色高光构成的探索主题。"
         }
       }
     },

--- a/agent-ui/src/locales/zh-Hant/settings.json
+++ b/agent-ui/src/locales/zh-Hant/settings.json
@@ -40,6 +40,42 @@
         "paper": {
           "label": "柔霧淺色",
           "description": "以低亮度青灰和柔和表面構成的耐看工作區。"
+        },
+        "skin-01": {
+          "label": "櫻粉花園",
+          "description": "柔粉玫瑰與低對比表面的輕盈主題。"
+        },
+        "skin-02": {
+          "label": "財神金",
+          "description": "暖金、朱紅與玉綠構成的喜慶主題。"
+        },
+        "skin-03": {
+          "label": "紅白未來",
+          "description": "高亮紅白與未來感介面的明快主題。"
+        },
+        "skin-04": {
+          "label": "千紙鶴",
+          "description": "米白、橄欖綠與紙張質感的清新主題。"
+        },
+        "skin-05": {
+          "label": "靈感彩虹",
+          "description": "青綠、珊瑚與黃色信號組成的活力主題。"
+        },
+        "skin-06": {
+          "label": "紫夜星光",
+          "description": "紫色、藍色與柔光層疊的夢幻主題。"
+        },
+        "skin-07": {
+          "label": "未來音符",
+          "description": "青藍、粉紫和霓虹光感的音樂主題。"
+        },
+        "skin-08": {
+          "label": "黑金舞台",
+          "description": "深黑背景與金色高光構成的沉浸主題。"
+        },
+        "skin-09": {
+          "label": "星航員",
+          "description": "深空藍、星光與冷色高光構成的探索主題。"
         }
       }
     },

--- a/agent-ui/src/styles/hr-theme.css
+++ b/agent-ui/src/styles/hr-theme.css
@@ -159,6 +159,22 @@
   --hr-shadow-accent: 0 8px 22px rgba(37, 50, 58, 0.08);
 }
 
+/* Gallery-derived skins share a live Homerail shell while each appearance
+   supplies its own palette through the semantic token contract. The original
+   reference files are composite screenshots, so the UI stays native here. */
+:root[data-hr-appearance^='skin-'] body {
+  background:
+    radial-gradient(circle at 84% 4%, var(--hr-ambient-accent), transparent 28%),
+    radial-gradient(circle at 18% 10%, var(--hr-ambient-info), transparent 30%),
+    var(--hr-bg);
+}
+
+:root[data-hr-appearance^='skin-'] #app {
+  position: relative;
+  z-index: 1;
+  background: transparent !important;
+}
+
 ::selection {
   background: var(--hr-selection);
   color: var(--hr-text-1);


### PR DESCRIPTION
## Summary
- add 11 peer appearance themes: cockpit, paper, and skin-01 through skin-09
- persist immediate theme switching in Agent UI settings
- translate the codex-skin-skill visual templates into Homerail semantic tokens while preserving native layout

## Validation
- Agent UI: 93 test files / 531 tests
- Typecheck and production build passed
- git diff --check passed

This PR is submitted from ctguxp/homerail to xiaotianfotos/homerail.