### PR TITLE
Honor Worker Vitest timeout settings

### DIFF
--- a/homerail_worker/src/__tests__/vitest-config.test.ts
+++ b/homerail_worker/src/__tests__/vitest-config.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+type WorkerVitestConfigModule = {
+  default: {
+    test?: { testTimeout?: number; hookTimeout?: number };
+  };
+  timeoutFromEnv: (name: string) => number | undefined;
+};
+
+async function loadWorkerVitestConfig(): Promise<WorkerVitestConfigModule> {
+  return import(new URL("../../vitest.config.js", import.meta.url).href) as Promise<WorkerVitestConfigModule>;
+}
+
+const originalTestTimeout = process.env.VITEST_TEST_TIMEOUT;
+const originalHookTimeout = process.env.VITEST_HOOK_TIMEOUT;
+
+afterEach(() => {
+  if (originalTestTimeout === undefined) delete process.env.VITEST_TEST_TIMEOUT;
+  else process.env.VITEST_TEST_TIMEOUT = originalTestTimeout;
+  if (originalHookTimeout === undefined) delete process.env.VITEST_HOOK_TIMEOUT;
+  else process.env.VITEST_HOOK_TIMEOUT = originalHookTimeout;
+});
+
+describe("Worker Vitest timeout configuration", () => {
+  it("binds the CI timeout environment variables into the default config", async () => {
+    const { default: config, timeoutFromEnv } = await loadWorkerVitestConfig();
+    expect(config.test?.testTimeout).toBe(timeoutFromEnv("VITEST_TEST_TIMEOUT"));
+    expect(config.test?.hookTimeout).toBe(timeoutFromEnv("VITEST_HOOK_TIMEOUT"));
+  });
+
+  it("accepts only positive safe integer timeout values", async () => {
+    const { timeoutFromEnv } = await loadWorkerVitestConfig();
+    process.env.VITEST_TEST_TIMEOUT = "15000";
+    expect(timeoutFromEnv("VITEST_TEST_TIMEOUT")).toBe(15_000);
+
+    for (const invalid of ["", "0", "-1", "1.5", "not-a-number", String(Number.MAX_SAFE_INTEGER + 1)]) {
+      process.env.VITEST_TEST_TIMEOUT = invalid;
+      expect(timeoutFromEnv("VITEST_TEST_TIMEOUT")).toBeUndefined();
+    }
+  });
+});

--- a/homerail_worker/vitest.config.ts
+++ b/homerail_worker/vitest.config.ts
@@ -1,9 +1,21 @@
 import { defineConfig } from "vitest/config";
 
-export default defineConfig({
+export function timeoutFromEnv(name: string): number | undefined {
+  const value = process.env[name];
+  if (value === undefined) return undefined;
+
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+export const workerVitestConfig = defineConfig({
   test: {
     environment: "node",
     include: ["src/**/*.test.ts"],
     setupFiles: ["src/__tests__/setup.ts"],
+    testTimeout: timeoutFromEnv("VITEST_TEST_TIMEOUT"),
+    hookTimeout: timeoutFromEnv("VITEST_HOOK_TIMEOUT"),
   },
 });
+
+export default workerVitestConfig;


### PR DESCRIPTION
## Summary

- make the Worker Vitest config honor the CI-provided `VITEST_TEST_TIMEOUT` and `VITEST_HOOK_TIMEOUT` values
- reject empty, non-integer, non-positive, and unsafe timeout values instead of passing them to Vitest
- add regression coverage for the config wiring and timeout parsing

## Root cause

After PR #189 merged, the Windows Node 24 CI job timed out in `workspace-dependencies.test.ts` at Vitest's default 5-second test limit. The Windows workflow already supplies a 15-second test timeout and a 30-second hook timeout, but only the Manager Vitest config consumed those environment variables. The Worker config silently kept the 5-second default.

The same test passed on Linux and in the previous Windows run, so the merged Auto Fix behavior was not the cause; hosted-runner timing exposed the pre-existing Worker configuration gap.

Failed run: https://github.com/xiaotianfotos/homerail/actions/runs/30920701632

## Local validation

- `npm --prefix homerail_worker run typecheck`
- `npm --prefix homerail_worker run build`
- `VITEST_TEST_TIMEOUT=15000 VITEST_HOOK_TIMEOUT=30000 npm --prefix homerail_worker test`
  - 33 test files passed
  - 364 tests passed, 1 skipped

The new PR's Windows job is the authoritative platform validation.
