### PR TITLE
fix(ui): support secure external origins behind reverse proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,36 @@ hr start --ui --public \
   --ui-public-url https://homerail-ui.example.com
 ```
 
+`--ui-public-url` (or `HOMERAIL_UI_PUBLIC_URL`) must be an exact `http(s)`
+Origin — no wildcard, path, query, fragment, or credentials. HomeRail rejects
+anything else at startup instead of silently trusting a truncated Origin. The
+same canonical Origin is shared with the Manager admin allowlist
+(`HOMERAIL_MANAGER_ADMIN_ORIGINS`) and with the static Agent UI proxy, which
+authorizes protected UI mutations from either the request-derived self Origin
+(direct local/LAN access) or the explicitly configured public Origin. With no
+explicit public URL, mutation authorization stays strictly request-derived.
+`Forwarded` and `X-Forwarded-*` headers are never trusted for this decision.
+
+FN Connect (fnOS) rewrites the Host it forwards to HomeRail, so the browser
+Origin no longer matches the internal Host. Configure the exact public Origin
+the proxy presents:
+
+```bash
+# Browser loads https://homerail.fn.example; FN Connect forwards the request
+# to HomeRail with an internal Host such as 127.0.0.1:19192.
+hr start --ui \
+  --ui-public-url https://homerail.fn.example
+```
+
+Generic Tailscale Serve / nginx / Caddy setups work the same way: terminate
+TLS in the proxy, forward to the local Agent UI port, and configure the public
+Origin:
+
+```bash
+hr start --ui --public \
+  --ui-public-url https://homerail.tail1234.ts.net
+```
+
 Worker containers connect back to the Manager through the URL Manager passes to
 Node. On Docker Desktop the default `host.docker.internal` mapping is usually
 enough; on Linux use Docker `host-gateway` support or set

--- a/homerail_cli/src/commands/runtime.ts
+++ b/homerail_cli/src/commands/runtime.ts
@@ -142,6 +142,13 @@ interface UiServiceState {
   mode?: "dev" | "static";
   managerUrl?: string;
   publicUrl?: string;
+  /**
+   * Canonical explicit external Origin the child was launched with
+   * (`HOMERAIL_UI_PUBLIC_URL`), or `undefined` when the child runs with
+   * strict request-derived authorization. Drives the restart decision when
+   * the requested effective Origin changes.
+   */
+  explicitPublicUrl?: string;
   textModeEnabled?: boolean;
   startedAt: number;
 }
@@ -728,6 +735,30 @@ function explicitUiPublicUrl(
   return undefined;
 }
 
+/**
+ * Resolve the operator-configured explicit public UI Origin from the CLI
+ * flag, `HOMERAIL_UI_PUBLIC_URL`, or stored `ui.publicUrl` (in that
+ * precedence order) into one canonical value shared by both static listeners.
+ * The same exact http(s) Origin rule the static UI mutation proxy applies is
+ * enforced here, so the runtime fails fast before any listener is launched
+ * with an ambiguous trust boundary. Returns `undefined` when no explicit
+ * Origin is configured so both listeners stay strictly request-derived.
+ */
+export function resolveExplicitUiPublicOrigin(
+  config: ReturnType<typeof loadLocalConfig>,
+  override?: string,
+): string | undefined {
+  const raw = explicitUiPublicUrl(config, override);
+  if (raw === undefined) return undefined;
+  const normalized = normalizeExactHttpOrigin(raw);
+  if (normalized === undefined) {
+    throw new Error(
+      `Agent UI public URL must be an exact http(s) Origin without wildcard, path, query, fragment, or credentials: ${raw}`,
+    );
+  }
+  return normalized;
+}
+
 async function startUiServer(globalOpts: GlobalOpts, opts: UiStartOpts = {}): Promise<UiStatus> {
   ensureHomerailHome();
   const cfg = loadLocalConfig();
@@ -740,17 +771,16 @@ async function startUiServer(globalOpts: GlobalOpts, opts: UiStartOpts = {}): Pr
   }
 
   ensureAgentUiRuntime();
-  const explicitPublicUrl = explicitUiPublicUrl(cfg, opts.publicUrl);
-  if (explicitPublicUrl !== undefined && normalizeExactHttpOrigin(explicitPublicUrl) === undefined) {
-    throw new Error(
-      `Agent UI public URL must be an exact http(s) Origin without wildcard, path, query, fragment, or credentials: ${explicitPublicUrl}`,
-    );
-  }
+  // One normalized explicit external Origin drives both static listener
+  // environments, the persisted service state, and the restart decisions
+  // below, no matter whether it came from the CLI flag, the environment, or
+  // stored config.
+  const explicitPublicUrl = resolveExplicitUiPublicOrigin(cfg, opts.publicUrl);
   const managerUrl = opts.managerUrl !== undefined || globalOpts.baseUrl
     ? configuredManagerAccessUrl(cfg, opts.managerUrl || globalOpts.baseUrl)
     : undefined;
   const httpsPublicUrl = explicitPublicUrl ?? configuredUiPublicUrl(cfg, host, httpsPort);
-  const httpPublicUrl = configuredUiHttpPublicUrl(cfg, host, httpPort);
+  const httpPublicUrl = explicitPublicUrl ?? configuredUiHttpPublicUrl(cfg, host, httpPort);
   const managerPort = String(configuredManagerPort(managerUrl ? { ...cfg, manager: { ...cfg.manager, url: managerUrl } } : cfg));
   const textModeEnabled = resolveTextModeEnabled(opts.enableTextMode);
   const serveStatic = shouldServeStaticAgentUi(path.join(resolveRepoRoot(), "agent-ui"));
@@ -758,6 +788,8 @@ async function startUiServer(globalOpts: GlobalOpts, opts: UiStartOpts = {}): Pr
   restartUiIfTextModeChanged("ui", textModeEnabled);
   restartUiIfServingModeChanged("ui-https", serveStatic);
   restartUiIfServingModeChanged("ui", serveStatic);
+  restartUiIfPublicOriginChanged("ui-https", explicitPublicUrl);
+  restartUiIfPublicOriginChanged("ui", explicitPublicUrl);
   const existing = getUiStatus(host, httpsPort, httpsPublicUrl, httpPort, httpPublicUrl);
   let httpsError: string | undefined;
   let httpError: string | undefined;
@@ -795,6 +827,7 @@ async function startUiServer(globalOpts: GlobalOpts, opts: UiStartOpts = {}): Pr
         managerUrl,
         managerPort,
         publicUrl: httpPublicUrl,
+        explicitPublicUrl,
         textModeEnabled,
       });
       await waitForHttp(uiProbeUrl(host, httpPort, "http"));
@@ -827,7 +860,10 @@ interface StartUiProcessOpts {
    * Operator-configured public UI URL (--ui-public-url /
    * HOMERAIL_UI_PUBLIC_URL / ui.publicUrl), only when explicitly set. Derived
    * URLs stay out of the static server so no-config behavior remains strictly
-   * request-derived.
+   * request-derived. Both the HTTPS and the HTTP static listeners receive the
+   * same canonical Origin; the listener transport never rewrites it, so an
+   * HTTPS browser Origin stays HTTPS behind a TLS-terminating proxy that
+   * forwards plain HTTP to the fallback listener.
    */
   explicitPublicUrl?: string;
   textModeEnabled: boolean;
@@ -962,6 +998,7 @@ function startUiProcess(opts: StartUiProcessOpts): number {
     mode: serveStatic ? "static" : "dev",
     managerUrl: opts.managerUrl,
     publicUrl: opts.publicUrl,
+    explicitPublicUrl: opts.explicitPublicUrl,
     textModeEnabled: opts.textModeEnabled,
     startedAt: Date.now(),
   });
@@ -1044,6 +1081,29 @@ function restartUiIfServingModeChanged(name: "ui" | "ui-https", serveStatic: boo
   if (pid === undefined || !pidIsRunning(pid)) return;
   const desiredMode = serveStatic ? "static" : "dev";
   if (state?.mode !== desiredMode && (state?.mode !== undefined || serveStatic)) {
+    stopService(name);
+  }
+}
+
+/**
+ * Compare the explicit external Origin a running UI child was launched with
+ * against the newly requested one. Adding (`undefined -> value`), changing
+ * (`value -> different value`), and removing (`value -> undefined`) the
+ * Origin all invalidate the live child so the new authorization policy is
+ * actually applied; an unchanged effective Origin never restarts.
+ */
+export function explicitPublicUrlChanged(
+  runningExplicitPublicUrl: string | undefined,
+  requestedExplicitPublicUrl: string | undefined,
+): boolean {
+  return (runningExplicitPublicUrl ?? undefined) !== (requestedExplicitPublicUrl ?? undefined);
+}
+
+function restartUiIfPublicOriginChanged(name: "ui" | "ui-https", explicitPublicUrl: string | undefined): void {
+  const state = readUiState(name);
+  const pid = readPid(name) ?? state?.pid;
+  if (pid === undefined || !pidIsRunning(pid)) return;
+  if (explicitPublicUrlChanged(state?.explicitPublicUrl, explicitPublicUrl)) {
     stopService(name);
   }
 }
@@ -1313,6 +1373,9 @@ function readUiState(name: "ui" | "ui-https" = "ui"): UiServiceState | undefined
         mode: parsed.mode === "static" ? "static" : parsed.mode === "dev" ? "dev" : undefined,
         managerUrl: typeof parsed.managerUrl === "string" ? parsed.managerUrl : DEFAULT_MANAGER_URL,
         publicUrl: typeof parsed.publicUrl === "string" ? parsed.publicUrl : undefined,
+        explicitPublicUrl: typeof parsed.explicitPublicUrl === "string" && parsed.explicitPublicUrl
+          ? parsed.explicitPublicUrl
+          : undefined,
         textModeEnabled: parsed.textModeEnabled === true,
         startedAt: typeof parsed.startedAt === "number" ? parsed.startedAt : 0,
       };

--- a/homerail_cli/src/commands/runtime.ts
+++ b/homerail_cli/src/commands/runtime.ts
@@ -36,6 +36,7 @@ import {
   type LocalRuntimeServiceStatus,
   type RuntimeServiceControlStatus,
 } from "../local-service-lifecycle.js";
+import { normalizeExactHttpOrigin } from "../ui-admin-proxy.js";
 
 interface GlobalOpts {
   json?: boolean;
@@ -158,33 +159,32 @@ type RuntimeServiceName = "manager" | "node" | "worker" | "ui" | "ui-https";
 
 const MANAGER_ADMIN_ORIGINS_ENV = "HOMERAIL_MANAGER_ADMIN_ORIGINS";
 
-/** Merge operator-provided exact Origins with the two UI proxy origins. */
+/**
+ * Merge operator-provided exact Origins with the two UI proxy origins.
+ * Both inputs are validated with the same canonical exact HTTP(S) Origin rule
+ * the static UI mutation proxy applies, so the Manager allowlist and the UI
+ * proxy never diverge on what counts as an exact Origin.
+ */
 export function mergeManagerAdminOrigins(
   configured: string | undefined,
   uiUrls: readonly string[],
 ): string {
   const origins = new Set<string>();
   for (const value of (configured ?? "").split(",").map((entry) => entry.trim()).filter(Boolean)) {
-    let parsed: URL;
-    try { parsed = new URL(value); } catch { throw new Error(`${MANAGER_ADMIN_ORIGINS_ENV} contains an invalid Origin`); }
-    if (
-      (parsed.protocol !== "http:" && parsed.protocol !== "https:")
-      || parsed.username
-      || parsed.password
-      || parsed.pathname !== "/"
-      || parsed.search
-      || parsed.hash
-      || parsed.origin !== value
-    ) throw new Error(`${MANAGER_ADMIN_ORIGINS_ENV} must contain exact http(s) Origins without paths`);
-    origins.add(value);
+    const normalized = normalizeExactHttpOrigin(value);
+    if (!normalized) {
+      throw new Error(`${MANAGER_ADMIN_ORIGINS_ENV} must contain exact http(s) Origins without paths`);
+    }
+    origins.add(normalized);
   }
   for (const value of uiUrls) {
-    let parsed: URL;
-    try { parsed = new URL(value); } catch { throw new Error(`Agent UI public URL is invalid: ${value}`); }
-    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-      throw new Error(`Agent UI public URL must use http(s): ${value}`);
+    const normalized = normalizeExactHttpOrigin(value);
+    if (!normalized) {
+      throw new Error(
+        `Agent UI public URL must be an exact http(s) Origin without wildcard, path, query, fragment, or credentials: ${value}`,
+      );
     }
-    origins.add(parsed.origin);
+    origins.add(normalized);
   }
   return [...origins].sort().join(",");
 }
@@ -711,6 +711,23 @@ function startService(name: RuntimeServiceName, relativeScript: string, env: Rec
   return child.pid;
 }
 
+/**
+ * Explicit operator-configured public UI URL, mirroring the explicit sources
+ * of configuredUiPublicUrl (--public-url flag, HOMERAIL_UI_PUBLIC_URL, then
+ * ui.publicUrl). Returns undefined when the URL would be derived from the
+ * bind host/port, so callers can keep no-config behavior strictly
+ * request-derived.
+ */
+function explicitUiPublicUrl(
+  config: ReturnType<typeof loadLocalConfig>,
+  override?: string,
+): string | undefined {
+  if (override?.trim()) return override.trim().replace(/\/+$/, "");
+  if (process.env.HOMERAIL_UI_PUBLIC_URL?.trim()) return process.env.HOMERAIL_UI_PUBLIC_URL.trim().replace(/\/+$/, "");
+  if (config.ui?.publicUrl?.trim()) return config.ui.publicUrl.trim().replace(/\/+$/, "");
+  return undefined;
+}
+
 async function startUiServer(globalOpts: GlobalOpts, opts: UiStartOpts = {}): Promise<UiStatus> {
   ensureHomerailHome();
   const cfg = loadLocalConfig();
@@ -723,10 +740,16 @@ async function startUiServer(globalOpts: GlobalOpts, opts: UiStartOpts = {}): Pr
   }
 
   ensureAgentUiRuntime();
+  const explicitPublicUrl = explicitUiPublicUrl(cfg, opts.publicUrl);
+  if (explicitPublicUrl !== undefined && normalizeExactHttpOrigin(explicitPublicUrl) === undefined) {
+    throw new Error(
+      `Agent UI public URL must be an exact http(s) Origin without wildcard, path, query, fragment, or credentials: ${explicitPublicUrl}`,
+    );
+  }
   const managerUrl = opts.managerUrl !== undefined || globalOpts.baseUrl
     ? configuredManagerAccessUrl(cfg, opts.managerUrl || globalOpts.baseUrl)
     : undefined;
-  const httpsPublicUrl = configuredUiPublicUrl(cfg, host, httpsPort, opts.publicUrl);
+  const httpsPublicUrl = explicitPublicUrl ?? configuredUiPublicUrl(cfg, host, httpsPort);
   const httpPublicUrl = configuredUiHttpPublicUrl(cfg, host, httpPort);
   const managerPort = String(configuredManagerPort(managerUrl ? { ...cfg, manager: { ...cfg.manager, url: managerUrl } } : cfg));
   const textModeEnabled = resolveTextModeEnabled(opts.enableTextMode);
@@ -750,6 +773,7 @@ async function startUiServer(globalOpts: GlobalOpts, opts: UiStartOpts = {}): Pr
         managerUrl,
         managerPort,
         publicUrl: httpsPublicUrl,
+        explicitPublicUrl,
         textModeEnabled,
         certificate,
       });
@@ -799,6 +823,13 @@ interface StartUiProcessOpts {
   managerUrl?: string;
   managerPort: string;
   publicUrl: string;
+  /**
+   * Operator-configured public UI URL (--ui-public-url /
+   * HOMERAIL_UI_PUBLIC_URL / ui.publicUrl), only when explicitly set. Derived
+   * URLs stay out of the static server so no-config behavior remains strictly
+   * request-derived.
+   */
+  explicitPublicUrl?: string;
   textModeEnabled: boolean;
   certificate?: UiCertificate;
 }
@@ -812,6 +843,39 @@ export function agentUiDevServerCommand(agentUiDir: string): { command: string; 
   return {
     command: process.execPath,
     args: [path.join(agentUiDir, "node_modules", "vite", "bin", "vite.js")],
+  };
+}
+
+/**
+ * Environment for the zero-dependency static UI server. `HOMERAIL_UI_PUBLIC_URL`
+ * is only present when the operator explicitly configured a public UI URL, so
+ * the proxy's mutation authorization stays strictly request-derived otherwise.
+ */
+export function staticUiServerEnv(opts: {
+  homerailHome: string;
+  staticUiDir: string;
+  host: string;
+  port: number;
+  protocol: "http" | "https";
+  managerHttp: string;
+  explicitPublicUrl?: string;
+  certificate?: UiCertificate;
+}): Record<string, string> {
+  return {
+    HOMERAIL_HOME: opts.homerailHome,
+    HOMERAIL_STATIC_UI_DIR: opts.staticUiDir,
+    HOMERAIL_UI_HOST: opts.host,
+    HOMERAIL_UI_PORT: String(opts.port),
+    HOMERAIL_MANAGER_HTTP: opts.managerHttp,
+    HOMERAIL_MANAGER_WS: opts.managerHttp.replace(/^http/, "ws"),
+    ...(opts.protocol === "https"
+      ? {
+        HOMERAIL_UI_HTTPS: "1",
+        HOMERAIL_UI_HTTPS_KEY: opts.certificate?.keyPath || "",
+        HOMERAIL_UI_HTTPS_CERT: opts.certificate?.certPath || "",
+      }
+      : {}),
+    ...(opts.explicitPublicUrl ? { HOMERAIL_UI_PUBLIC_URL: opts.explicitPublicUrl } : {}),
   };
 }
 
@@ -829,25 +893,21 @@ function startUiProcess(opts: StartUiProcessOpts): number {
   let child: import("child_process").ChildProcess;
   if (serveStatic) {
     const serverScript = path.join(resolveRepoRoot(), "homerail_cli", "dist", "static-ui-server.js");
-    const managerWs = managerHttp.replace(/^http/, "ws");
     child = spawn(process.execPath, [serverScript], {
       cwd: agentUiDir,
       env: {
         ...loadLocalSecrets(),
         ...process.env,
-        HOMERAIL_HOME: getHomerailHome(),
-        HOMERAIL_STATIC_UI_DIR: path.join(agentUiDir, "dist"),
-        HOMERAIL_UI_HOST: opts.host,
-        HOMERAIL_UI_PORT: String(opts.port),
-        HOMERAIL_MANAGER_HTTP: managerHttp,
-        HOMERAIL_MANAGER_WS: managerWs,
-        ...(opts.protocol === "https"
-          ? {
-            HOMERAIL_UI_HTTPS: "1",
-            HOMERAIL_UI_HTTPS_KEY: opts.certificate?.keyPath || "",
-            HOMERAIL_UI_HTTPS_CERT: opts.certificate?.certPath || "",
-          }
-          : {}),
+        ...staticUiServerEnv({
+          homerailHome: getHomerailHome(),
+          staticUiDir: path.join(agentUiDir, "dist"),
+          host: opts.host,
+          port: opts.port,
+          protocol: opts.protocol,
+          managerHttp,
+          explicitPublicUrl: opts.explicitPublicUrl,
+          certificate: opts.certificate,
+        }),
       },
       detached: true,
       shell: false,

--- a/homerail_cli/src/static-ui-server.ts
+++ b/homerail_cli/src/static-ui-server.ts
@@ -14,6 +14,10 @@
 //   HOMERAIL_UI_HTTPS_CERT      PEM cert path (HTTPS only)
 //   HOMERAIL_MANAGER_HTTP       manager HTTP origin, e.g. http://localhost:19191
 //   HOMERAIL_MANAGER_WS         manager WS origin, e.g. ws://localhost:19191
+//   HOMERAIL_UI_PUBLIC_URL      explicit public UI URL (exact http(s) Origin) additionally
+//                               accepted for protected mutations when a reverse proxy
+//                               rewrites the Host header; unset keeps strict
+//                               request-derived same-origin behavior
 //   HOMERAIL_DAG_MUTATION_TOKEN internal token added to trusted same-origin mutations
 import http from "node:http";
 import https from "node:https";
@@ -24,6 +28,7 @@ import { URL } from "node:url";
 import {
   authorizeUiAdminProxyMutation,
   isProtectedApiMutation,
+  normalizeExactHttpOrigin,
 } from "./ui-admin-proxy.js";
 
 const ROOT = path.resolve(process.env.HOMERAIL_STATIC_UI_DIR || "");
@@ -34,6 +39,27 @@ const MANAGER_WS = process.env.HOMERAIL_MANAGER_WS || "ws://localhost:19191";
 const DAG_MUTATION_TOKEN = process.env.HOMERAIL_DAG_MUTATION_TOKEN?.trim();
 const USE_HTTPS = process.env.HOMERAIL_UI_HTTPS === "1";
 const BUILD_MANIFEST = "homerail-build.json";
+
+// Explicit operator-configured public Origin (shared name with the CLI's
+// --ui-public-url / HOMERAIL_UI_PUBLIC_URL). Validated with the same exact
+// HTTP(S) Origin rule the Manager admin allowlist uses; anything ambiguous
+// fails the startup instead of silently widening the mutation trust boundary.
+const CONFIGURED_PUBLIC_ORIGIN = resolveConfiguredPublicOrigin();
+
+function resolveConfiguredPublicOrigin(): string | undefined {
+  const configured = process.env.HOMERAIL_UI_PUBLIC_URL?.trim();
+  if (!configured) return undefined;
+  const normalized = normalizeExactHttpOrigin(configured);
+  if (!normalized) {
+    // eslint-disable-next-line no-console
+    console.error(
+      "static-ui-server fatal: HOMERAIL_UI_PUBLIC_URL must be an exact http(s) Origin " +
+      `without wildcard, path, query, fragment, or credentials: ${configured}`,
+    );
+    process.exit(1);
+  }
+  return normalized;
+}
 
 // WebSocket upgrade allowlist. Manager-published routes that the Agent UI must
 // reach same-origin are listed here; everything else is destroyed. Keep these in
@@ -182,7 +208,7 @@ function proxyHttp(req: http.IncomingMessage, res: http.ServerResponse): void {
       host: req.headers.host,
       origin: req.headers.origin,
       secFetchSite: req.headers["sec-fetch-site"],
-    });
+    }, CONFIGURED_PUBLIC_ORIGIN);
     if (!authorization.allowed) {
       req.resume();
       res.writeHead(403, {

--- a/homerail_cli/src/ui-admin-proxy.ts
+++ b/homerail_cli/src/ui-admin-proxy.ts
@@ -19,12 +19,40 @@ export function isProtectedApiMutation(methodValue: string | undefined, urlValue
 }
 
 /**
+ * Canonical exact HTTP(S) Origin normalization shared by the Manager admin
+ * Origin allowlist and the static UI mutation proxy. Accepts only `http:` or
+ * `https:` URLs without wildcard hosts, username, password, path other than
+ * `/`, query, or fragment, and returns the canonical serialized Origin
+ * (lowercased scheme/host, default ports omitted). Returns `undefined` for
+ * anything else so every caller fails closed on the same rule.
+ */
+export function normalizeExactHttpOrigin(value: string): string | undefined {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return undefined;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return undefined;
+  if (parsed.hostname.includes("*")) return undefined;
+  if (parsed.username || parsed.password) return undefined;
+  if (parsed.pathname !== "/" || parsed.search || parsed.hash) return undefined;
+  return parsed.origin;
+}
+
+/**
  * Keep the UI proxy zero-config by deriving its self Origin from the request
- * that reached the server. Manager performs the canonical authorization after
+ * that reached the server. When the operator explicitly configures the public
+ * UI URL (`--ui-public-url` / `HOMERAIL_UI_PUBLIC_URL`), its exact canonical
+ * Origin is additionally accepted so reverse proxies that rewrite the Host
+ * header keep working; the request-derived self Origin remains accepted for
+ * direct local/LAN access. Manager performs the canonical authorization after
  * this hop; this check only rejects obvious browser cross-origin mutations.
+ * `Forwarded`/`X-Forwarded-*` headers are never consulted here.
  */
 export function authorizeUiAdminProxyMutation(
   request: UiMutationRequestTrust,
+  configuredPublicOrigin?: string,
 ): { allowed: true } | { allowed: false; reason: string } {
   const host = singleHeader(request.host);
   const origin = singleHeader(request.origin);
@@ -38,7 +66,15 @@ export function authorizeUiAdminProxyMutation(
   } catch {
     return { allowed: false, reason: "UI request Host is invalid" };
   }
-  if (origin !== selfOrigin) {
+
+  const requestOrigin = normalizeExactHttpOrigin(origin);
+  if (!requestOrigin) {
+    return { allowed: false, reason: "UI mutation Origin is invalid" };
+  }
+  const publicOrigin = configuredPublicOrigin
+    ? normalizeExactHttpOrigin(configuredPublicOrigin)
+    : undefined;
+  if (requestOrigin !== selfOrigin && requestOrigin !== publicOrigin) {
     return { allowed: false, reason: "Cross-origin UI mutation requests are forbidden" };
   }
 

--- a/homerail_cli/tests/commands.test.ts
+++ b/homerail_cli/tests/commands.test.ts
@@ -8,8 +8,10 @@ import { createProgram } from "../src/index.js";
 import { readLineFromStdin, redactSecret } from "../src/commands/llm-settings.js";
 import {
   agentUiDevServerCommand,
+  explicitPublicUrlChanged,
   isMissingModelCredential,
   mergeManagerAdminOrigins,
+  resolveExplicitUiPublicOrigin,
   shouldAbortStartForModelConfig,
   shouldServeStaticAgentUi,
   staticUiServerEnv,
@@ -37,6 +39,7 @@ let previousManagerUrl: string | undefined;
 let previousPublicHost: string | undefined;
 let previousAssetDir: string | undefined;
 let previousUiServeStatic: string | undefined;
+let previousUiPublicUrl: string | undefined;
 
 function restoreEnv(key: string, value: string | undefined): void {
   if (value === undefined) delete process.env[key];
@@ -54,6 +57,7 @@ beforeEach(() => {
   previousPublicHost = process.env.HOMERAIL_PUBLIC_HOST;
   previousAssetDir = process.env.HOMERAIL_ASSET_DIR;
   previousUiServeStatic = process.env.HOMERAIL_UI_SERVE_STATIC;
+  previousUiPublicUrl = process.env.HOMERAIL_UI_PUBLIC_URL;
   process.env.HOMERAIL_HOME = tempHome;
   delete process.env.HOMERAIL_CONFIG_PATH;
   delete process.env.HOMERAIL_SECRETS_PATH;
@@ -61,6 +65,7 @@ beforeEach(() => {
   delete process.env.HOMERAIL_PUBLIC_HOST;
   delete process.env.HOMERAIL_ASSET_DIR;
   delete process.env.HOMERAIL_UI_SERVE_STATIC;
+  delete process.env.HOMERAIL_UI_PUBLIC_URL;
 });
 
 describe("credential command", () => {
@@ -96,6 +101,7 @@ afterEach(() => {
   restoreEnv("HOMERAIL_PUBLIC_HOST", previousPublicHost);
   restoreEnv("HOMERAIL_ASSET_DIR", previousAssetDir);
   restoreEnv("HOMERAIL_UI_SERVE_STATIC", previousUiServeStatic);
+  restoreEnv("HOMERAIL_UI_PUBLIC_URL", previousUiPublicUrl);
   rmSync(tempHome, { recursive: true, force: true });
 });
 
@@ -2131,6 +2137,61 @@ describe("runtime command", () => {
     expect(staticUiServerEnv(base)).not.toHaveProperty("HOMERAIL_UI_PUBLIC_URL");
     expect(staticUiServerEnv({ ...base, protocol: "http" as const }))
       .not.toHaveProperty("HOMERAIL_UI_HTTPS");
+    // The HTTP fallback listener receives the same explicit external Origin,
+    // unchanged by the listener transport, for TLS-terminating proxies.
+    expect(staticUiServerEnv({ ...base, protocol: "http" as const, explicitPublicUrl: "https://external.example" }))
+      .toMatchObject({
+        HOMERAIL_UI_PORT: "19192",
+        HOMERAIL_UI_PUBLIC_URL: "https://external.example",
+      });
+  });
+
+  it("resolves one normalized explicit UI Origin across flag, environment, and stored config sources", () => {
+    const storedConfig = { ui: { publicUrl: "https://Stored.Example.test:443/" } };
+
+    // Stored config alone resolves to the canonical exact Origin.
+    expect(resolveExplicitUiPublicOrigin(storedConfig)).toBe("https://stored.example.test");
+
+    // HOMERAIL_UI_PUBLIC_URL takes precedence over stored config.
+    process.env.HOMERAIL_UI_PUBLIC_URL = " https://Env.Example.test/ ";
+    expect(resolveExplicitUiPublicOrigin(storedConfig)).toBe("https://env.example.test");
+
+    // The CLI flag takes precedence over both, with default ports omitted.
+    expect(resolveExplicitUiPublicOrigin(storedConfig, "https://Flag.Example.test:443/"))
+      .toBe("https://flag.example.test");
+    expect(resolveExplicitUiPublicOrigin(storedConfig, "https://flag.example.test:8443"))
+      .toBe("https://flag.example.test:8443");
+
+    // No source configured means no explicit Origin on either listener.
+    delete process.env.HOMERAIL_UI_PUBLIC_URL;
+    expect(resolveExplicitUiPublicOrigin({})).toBeUndefined();
+  });
+
+  it("rejects ambiguous explicit UI Origins from every configuration source", () => {
+    for (const invalid of [
+      "https://ui.example.test/app",
+      "https://*.example.test",
+      "https://user:pass@ui.example.test",
+      "ftp://ui.example.test",
+      "not-a-url",
+    ]) {
+      expect(() => resolveExplicitUiPublicOrigin({}, invalid), invalid)
+        .toThrow(/exact http\(s\) Origin/);
+      process.env.HOMERAIL_UI_PUBLIC_URL = invalid;
+      expect(() => resolveExplicitUiPublicOrigin({}), invalid)
+        .toThrow(/exact http\(s\) Origin/);
+      expect(() => resolveExplicitUiPublicOrigin({ ui: { publicUrl: invalid } }), invalid)
+        .toThrow(/exact http\(s\) Origin/);
+      delete process.env.HOMERAIL_UI_PUBLIC_URL;
+    }
+  });
+
+  it("treats adding, changing, and removing the explicit Origin as a restart; unchanged as stable", () => {
+    expect(explicitPublicUrlChanged(undefined, "https://a.example.test")).toBe(true);
+    expect(explicitPublicUrlChanged("https://a.example.test", "https://b.example.test")).toBe(true);
+    expect(explicitPublicUrlChanged("https://a.example.test", undefined)).toBe(true);
+    expect(explicitPublicUrlChanged("https://a.example.test", "https://a.example.test")).toBe(false);
+    expect(explicitPublicUrlChanged(undefined, undefined)).toBe(false);
   });
 
   it("launches the Agent UI dev server directly through Node", () => {

--- a/homerail_cli/tests/commands.test.ts
+++ b/homerail_cli/tests/commands.test.ts
@@ -12,6 +12,7 @@ import {
   mergeManagerAdminOrigins,
   shouldAbortStartForModelConfig,
   shouldServeStaticAgentUi,
+  staticUiServerEnv,
 } from "../src/commands/runtime.js";
 import { createLaunchAgentPlist, installRuntimeService, uninstallRuntimeService } from "../src/local-service-lifecycle.js";
 
@@ -2081,10 +2082,55 @@ describe("runtime command", () => {
   it("derives exact UI proxy Origins while preserving explicit trusted Origins", () => {
     expect(mergeManagerAdminOrigins(
       "https://admin.example.test",
-      ["https://ui.example.test/app", "http://localhost:19193"],
+      ["https://ui.example.test", "http://localhost:19193"],
     )).toBe("http://localhost:19193,https://admin.example.test,https://ui.example.test");
     expect(() => mergeManagerAdminOrigins("https://bad.example.test/path", []))
       .toThrow(/without paths/);
+  });
+
+  it("applies one canonical exact Origin rule to Manager allowlist entries and UI public URLs", () => {
+    expect(mergeManagerAdminOrigins(undefined, ["https://UI.Example.test:443", "http://localhost:80"]))
+      .toBe("http://localhost,https://ui.example.test");
+    expect(mergeManagerAdminOrigins("https://Admin.Example.test:443", []))
+      .toBe("https://admin.example.test");
+    for (const invalid of [
+      "https://ui.example.test/app",
+      "https://*.example.test",
+      "https://user:pass@ui.example.test",
+      "ftp://ui.example.test",
+      "not-a-url",
+    ]) {
+      expect(() => mergeManagerAdminOrigins(undefined, [invalid]), invalid)
+        .toThrow(/exact http\(s\) Origin/);
+      expect(() => mergeManagerAdminOrigins(invalid, []), invalid)
+        .toThrow(/exact http\(s\) Origins without paths/);
+    }
+  });
+
+  it("propagates only an explicit UI public URL into the static UI server environment", () => {
+    const base = {
+      homerailHome: tempHome,
+      staticUiDir: join(tempHome, "agent-ui", "dist"),
+      host: "127.0.0.1",
+      port: 19192,
+      protocol: "https" as const,
+      managerHttp: "http://localhost:19191",
+    };
+
+    expect(staticUiServerEnv({ ...base, explicitPublicUrl: "https://external.example" }))
+      .toMatchObject({
+        HOMERAIL_HOME: tempHome,
+        HOMERAIL_STATIC_UI_DIR: base.staticUiDir,
+        HOMERAIL_UI_HOST: "127.0.0.1",
+        HOMERAIL_UI_PORT: "19192",
+        HOMERAIL_MANAGER_HTTP: "http://localhost:19191",
+        HOMERAIL_MANAGER_WS: "ws://localhost:19191",
+        HOMERAIL_UI_HTTPS: "1",
+        HOMERAIL_UI_PUBLIC_URL: "https://external.example",
+      });
+    expect(staticUiServerEnv(base)).not.toHaveProperty("HOMERAIL_UI_PUBLIC_URL");
+    expect(staticUiServerEnv({ ...base, protocol: "http" as const }))
+      .not.toHaveProperty("HOMERAIL_UI_HTTPS");
   });
 
   it("launches the Agent UI dev server directly through Node", () => {

--- a/homerail_cli/tests/static-ui-admin-proxy.integration.test.ts
+++ b/homerail_cli/tests/static-ui-admin-proxy.integration.test.ts
@@ -315,6 +315,225 @@ describe("static Agent UI mutation proxy", () => {
     expect(received[1]?.mutationToken).toBeUndefined();
   }, 15_000);
 
+  it("accepts the configured external Origin through an FN Connect-style Host rewrite", async () => {
+    const received: Array<{ authorization?: string; origin?: string; method?: string; mutationToken?: string }> = [];
+    const manager = http.createServer((req, res) => {
+      received.push({
+        authorization: req.headers.authorization,
+        origin: req.headers.origin,
+        method: req.method,
+        mutationToken: typeof req.headers["x-homerail-dag-token"] === "string"
+          ? req.headers["x-homerail-dag-token"]
+          : undefined,
+      });
+      req.resume();
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ success: true }));
+    });
+    servers.push(manager);
+    const managerUrl = await listen(manager, "127.0.0.1");
+    const uiPort = await reservePort();
+    const uiOrigin = `http://127.0.0.1:${uiPort}`;
+    await startStaticUi({
+      port: uiPort,
+      host: "127.0.0.1",
+      origin: uiOrigin,
+      managerUrl,
+      mutationToken: "internal-mutation-token",
+      publicUrl: "https://external.example",
+    });
+
+    // The reverse proxy presents the external browser Origin while forwarding
+    // with the internal Host (127.0.0.1:<port>) it bound to.
+    const response = await fetch(`${uiOrigin}/api/runs`, {
+      method: "POST",
+      headers: {
+        Origin: "https://external.example",
+        "Sec-Fetch-Site": "same-origin",
+        Authorization: "Bearer browser-supplied",
+        "x-homerail-dag-token": "browser-supplied-token",
+      },
+    });
+    expect(response.status).toBe(200);
+    expect(received[0]).toEqual({
+      authorization: undefined,
+      origin: "https://external.example",
+      method: "POST",
+      mutationToken: "internal-mutation-token",
+    });
+
+    // Direct local access keeps working through the request-derived Origin.
+    expect((await fetch(`${uiOrigin}/api/runs`, {
+      method: "POST",
+      headers: { Origin: uiOrigin, "Sec-Fetch-Site": "same-origin" },
+    })).status).toBe(200);
+    expect(received[1]?.origin).toBe(uiOrigin);
+
+    // Read-only API requests stay unaffected by the Origin policy.
+    expect((await fetch(`${uiOrigin}/api/read`)).status).toBe(200);
+    expect(received[2]?.mutationToken).toBeUndefined();
+  }, 15_000);
+
+  it("keeps rejecting missing, malformed, unrelated, and cross-site mutations with a configured external Origin", async () => {
+    let managerHits = 0;
+    const manager = http.createServer((req, res) => {
+      managerHits++;
+      req.resume();
+      res.writeHead(200).end();
+    });
+    servers.push(manager);
+    const managerUrl = await listen(manager, "127.0.0.1");
+    const uiPort = await reservePort();
+    const uiOrigin = `http://127.0.0.1:${uiPort}`;
+    await startStaticUi({
+      port: uiPort,
+      host: "127.0.0.1",
+      origin: uiOrigin,
+      managerUrl,
+      mutationToken: "internal-mutation-token",
+      publicUrl: "https://external.example",
+    });
+
+    expect((await fetch(`${uiOrigin}/api/runs`, { method: "POST" })).status).toBe(403);
+    expect((await fetch(`${uiOrigin}/api/runs`, {
+      method: "POST",
+      headers: { Origin: "null", "Sec-Fetch-Site": "same-origin" },
+    })).status).toBe(403);
+    expect((await fetch(`${uiOrigin}/api/runs`, {
+      method: "POST",
+      headers: { Origin: "not-a-url", "Sec-Fetch-Site": "same-origin" },
+    })).status).toBe(403);
+    expect((await fetch(`${uiOrigin}/api/runs`, {
+      method: "POST",
+      headers: { Origin: "https://evil.example", "Sec-Fetch-Site": "same-origin" },
+    })).status).toBe(403);
+    expect((await fetch(`${uiOrigin}/api/runs`, {
+      method: "POST",
+      headers: { Origin: "https://external.example", "Sec-Fetch-Site": "cross-site" },
+    })).status).toBe(403);
+    expect(managerHits).toBe(0);
+  }, 15_000);
+
+  it("preserves strict request-derived behavior without a configured public Origin", async () => {
+    let managerHits = 0;
+    const manager = http.createServer((req, res) => {
+      managerHits++;
+      req.resume();
+      res.writeHead(200).end();
+    });
+    servers.push(manager);
+    const managerUrl = await listen(manager, "127.0.0.1");
+    const uiPort = await reservePort();
+    const uiOrigin = `http://127.0.0.1:${uiPort}`;
+    await startStaticUi({ port: uiPort, host: "127.0.0.1", origin: uiOrigin, managerUrl });
+
+    expect((await fetch(`${uiOrigin}/api/runs`, {
+      method: "POST",
+      headers: { Origin: "https://external.example", "Sec-Fetch-Site": "same-origin" },
+    })).status).toBe(403);
+    expect(managerHits).toBe(0);
+
+    expect((await fetch(`${uiOrigin}/api/runs`, {
+      method: "POST",
+      headers: { Origin: uiOrigin, "Sec-Fetch-Site": "same-origin" },
+    })).status).toBe(200);
+    expect(managerHits).toBe(1);
+  }, 15_000);
+
+  it("does not trust forged Forwarded or X-Forwarded-Host headers", async () => {
+    let managerHits = 0;
+    const manager = http.createServer((req, res) => {
+      managerHits++;
+      req.resume();
+      res.writeHead(200).end();
+    });
+    servers.push(manager);
+    const managerUrl = await listen(manager, "127.0.0.1");
+    const uiPort = await reservePort();
+    const uiOrigin = `http://127.0.0.1:${uiPort}`;
+    await startStaticUi({
+      port: uiPort,
+      host: "127.0.0.1",
+      origin: uiOrigin,
+      managerUrl,
+      mutationToken: "internal-mutation-token",
+      publicUrl: "https://external.example",
+    });
+
+    // Forged forwarding headers alone cannot make an unrelated Origin pass,
+    // with or without a configured public Origin.
+    expect((await fetch(`${uiOrigin}/api/runs`, {
+      method: "POST",
+      headers: {
+        Origin: "https://evil.example",
+        "Sec-Fetch-Site": "same-origin",
+        Forwarded: "for=192.0.2.1;host=external.example;proto=https",
+        "X-Forwarded-Host": "external.example",
+        "X-Forwarded-Proto": "https",
+      },
+    })).status).toBe(403);
+    expect((await fetch(`${uiOrigin}/api/runs`, {
+      method: "POST",
+      headers: {
+        Origin: "https://external.example",
+        "Sec-Fetch-Site": "cross-site",
+        Forwarded: "host=external.example;proto=https",
+        "X-Forwarded-Host": "external.example",
+      },
+    })).status).toBe(403);
+    expect(managerHits).toBe(0);
+
+    // Positive control: the same proxy headers do not break a legitimate
+    // configured-Origin mutation.
+    expect((await fetch(`${uiOrigin}/api/runs`, {
+      method: "POST",
+      headers: {
+        Origin: "https://external.example",
+        "Sec-Fetch-Site": "same-origin",
+        Forwarded: "host=external.example;proto=https",
+        "X-Forwarded-Host": "external.example",
+      },
+    })).status).toBe(200);
+    expect(managerHits).toBe(1);
+  }, 15_000);
+
+  it("fails closed when HOMERAIL_UI_PUBLIC_URL is not an exact http(s) Origin", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-static-ui-invalid-"));
+    tempDirs.push(root);
+    fs.writeFileSync(path.join(root, "index.html"), "<!doctype html><title>test</title>");
+    const uiPort = await reservePort();
+    const child = spawn(process.execPath, [
+      path.resolve("node_modules/tsx/dist/cli.mjs"),
+      path.resolve("src/static-ui-server.ts"),
+    ], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        HOMERAIL_STATIC_UI_DIR: root,
+        HOMERAIL_UI_PORT: String(uiPort),
+        HOMERAIL_UI_HOST: "127.0.0.1",
+        HOMERAIL_UI_HTTPS: "0",
+        HOMERAIL_MANAGER_HTTP: "http://127.0.0.1:1",
+        HOMERAIL_MANAGER_WS: "ws://127.0.0.1:1",
+        HOMERAIL_UI_PUBLIC_URL: "https://external.example/ui",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    children.push(child);
+    let stderr = "";
+    child.stdout?.resume();
+    child.stderr?.on("data", (chunk) => { stderr += chunk.toString(); });
+    const exitCode = await new Promise<number | null>((resolve) => {
+      const timer = setTimeout(() => resolve(null), 10_000);
+      child.once("close", (code) => {
+        clearTimeout(timer);
+        resolve(code);
+      });
+    });
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("HOMERAIL_UI_PUBLIC_URL must be an exact http(s) Origin");
+  }, 15_000);
+
   it("derives the self Origin for a publicly bound development server", async () => {
     let managerHits = 0;
     let receivedMutationToken: string | undefined;
@@ -396,6 +615,7 @@ async function startStaticUi(options: {
   managerUrl: string;
   root?: string;
   mutationToken?: string;
+  publicUrl?: string;
   entry?: "source" | "dist";
 }): Promise<void> {
   const root = options.root ?? fs.mkdtempSync(path.join(os.tmpdir(), "homerail-static-ui-trust-"));
@@ -420,6 +640,7 @@ async function startStaticUi(options: {
       HOMERAIL_MANAGER_HTTP: options.managerUrl,
       HOMERAIL_MANAGER_WS: options.managerUrl.replace(/^http/, "ws"),
       ...(options.mutationToken ? { HOMERAIL_DAG_MUTATION_TOKEN: options.mutationToken } : {}),
+      ...(options.publicUrl ? { HOMERAIL_UI_PUBLIC_URL: options.publicUrl } : {}),
     },
     stdio: ["ignore", "pipe", "pipe"],
   });

--- a/homerail_cli/tests/static-ui-admin-proxy.integration.test.ts
+++ b/homerail_cli/tests/static-ui-admin-proxy.integration.test.ts
@@ -1,10 +1,12 @@
 import { execFileSync, spawn, type ChildProcess } from "node:child_process";
 import * as fs from "node:fs";
 import * as http from "node:http";
+import * as https from "node:https";
 import * as net from "node:net";
 import * as os from "node:os";
 import * as path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { createProgram } from "../src/index.js";
 
 const children: ChildProcess[] = [];
 const servers: http.Server[] = [];
@@ -813,4 +815,510 @@ async function waitUntil(check: () => Promise<boolean>): Promise<void> {
     await new Promise((resolve) => setTimeout(resolve, 25));
   }
   throw new Error("static UI did not become ready");
+}
+
+describe("runtime UI Origin propagation through hr ui start", () => {
+  afterAll(() => {
+    if (sharedRuntimeRepoRoot) {
+      fs.rmSync(sharedRuntimeRepoRoot, { recursive: true, force: true });
+      sharedRuntimeRepoRoot = undefined;
+    }
+  });
+
+  afterEach(() => {
+    for (const harness of runtimeHarnesses.splice(0)) {
+      for (const name of ["ui-https", "ui"] as const) {
+        const pid = runtimePidFile(harness.home, name);
+        if (pid === undefined) continue;
+        try {
+          process.kill(-pid, "SIGTERM");
+        } catch {
+          try {
+            process.kill(pid, "SIGTERM");
+          } catch {
+            // Already exited.
+          }
+        }
+      }
+    }
+  });
+
+  it("propagates the explicit external Origin from flag, environment, and stored config into both static listeners", async () => {
+    const harness = await createRuntimeHarness();
+    fs.mkdirSync(path.join(harness.home, "secrets"), { recursive: true, mode: 0o700 });
+    fs.writeFileSync(
+      path.join(harness.home, "secrets", "env"),
+      "HOMERAIL_DAG_MUTATION_TOKEN=internal-mutation-token\n",
+      { mode: 0o600 },
+    );
+
+    // Source 1: the CLI flag, deliberately non-canonical.
+    const flag = await runUiStart(harness, ["--public-url", "https://UI.Example.test:443/"]);
+    expect(flag.errors).toEqual([]);
+    expect(flag.status.uiHttpsPidRunning).toBe(true);
+    expect(flag.status.uiHttpPidRunning).toBe(true);
+
+    // Both children are launched from one normalized Origin and the persisted
+    // state records the effective authorization configuration.
+    expect(runtimeStateFile(harness.home, "ui-https")?.explicitPublicUrl).toBe("https://ui.example.test");
+    expect(runtimeStateFile(harness.home, "ui")?.explicitPublicUrl).toBe("https://ui.example.test");
+    expect(flag.status.uiHttpsPublicUrl).toBe("https://ui.example.test");
+    expect(flag.status.uiHttpPublicUrl).toBe("https://ui.example.test");
+
+    for (const protocol of ["https", "http"] as const) {
+      const port = protocol === "https" ? harness.httpsPort : harness.httpPort;
+      // The external HTTPS Origin is accepted by both listeners; the HTTP
+      // fallback covers TLS-terminating reverse proxies.
+      expect((await mutationRequest({
+        protocol,
+        port,
+        headers: {
+          Origin: "https://ui.example.test",
+          "Sec-Fetch-Site": "same-origin",
+          Authorization: "Bearer browser-supplied",
+          "x-homerail-dag-token": "browser-supplied-token",
+        },
+      })).status).toBe(200);
+      // Unrelated Origins and cross-site submissions stay rejected.
+      expect((await mutationRequest({
+        protocol,
+        port,
+        headers: { Origin: "https://evil.example.test", "Sec-Fetch-Site": "same-origin" },
+      })).status).toBe(403);
+      expect((await mutationRequest({
+        protocol,
+        port,
+        headers: { Origin: "https://ui.example.test", "Sec-Fetch-Site": "cross-site" },
+      })).status).toBe(403);
+    }
+
+    // Browser credentials are stripped and the internal mutation token is
+    // injected on the proxied hop for both listeners.
+    expect(harness.received[0]).toMatchObject({
+      origin: "https://ui.example.test",
+      authorization: undefined,
+      mutationToken: "internal-mutation-token",
+    });
+    expect(harness.received[1]).toMatchObject({
+      origin: "https://ui.example.test",
+      authorization: undefined,
+      mutationToken: "internal-mutation-token",
+    });
+
+    // Direct local access keeps working through the request-derived Origin,
+    // and read-only requests stay unaffected.
+    const httpSelfOrigin = `http://127.0.0.1:${harness.httpPort}`;
+    expect((await mutationRequest({
+      protocol: "http",
+      port: harness.httpPort,
+      headers: { Origin: httpSelfOrigin, "Sec-Fetch-Site": "same-origin" },
+    })).status).toBe(200);
+    expect((await mutationRequest({
+      protocol: "http",
+      port: harness.httpPort,
+      method: "GET",
+      path: "/api/read",
+    })).status).toBe(200);
+
+    // Source 2: HOMERAIL_UI_PUBLIC_URL. A changed effective Origin restarts
+    // both live listeners and the new Origin is the one enforced.
+    const flagPids = runtimePids(harness.home);
+    const fromEnv = await runUiStart(harness, [], { HOMERAIL_UI_PUBLIC_URL: "https://env-origin.example.test" });
+    expect(fromEnv.errors).toEqual([]);
+    const envPids = runtimePids(harness.home);
+    expect(envPids.https).not.toBe(flagPids.https);
+    expect(envPids.http).not.toBe(flagPids.http);
+    await waitForRuntimePidExit(flagPids.https);
+    await waitForRuntimePidExit(flagPids.http);
+    for (const protocol of ["https", "http"] as const) {
+      const port = protocol === "https" ? harness.httpsPort : harness.httpPort;
+      expect((await mutationRequest({
+        protocol,
+        port,
+        headers: { Origin: "https://env-origin.example.test", "Sec-Fetch-Site": "same-origin" },
+      })).status).toBe(200);
+      expect((await mutationRequest({
+        protocol,
+        port,
+        headers: { Origin: "https://ui.example.test", "Sec-Fetch-Site": "same-origin" },
+      })).status).toBe(403);
+    }
+
+    // Source 3: stored ui.publicUrl. Same restart-and-apply behavior.
+    fs.writeFileSync(
+      path.join(harness.home, "config.json"),
+      `${JSON.stringify({ ui: { publicUrl: "https://stored.example.test" } }, null, 2)}\n`,
+    );
+    const fromConfig = await runUiStart(harness, []);
+    expect(fromConfig.errors).toEqual([]);
+    const configPids = runtimePids(harness.home);
+    expect(configPids.https).not.toBe(envPids.https);
+    expect(configPids.http).not.toBe(envPids.http);
+    await waitForRuntimePidExit(envPids.https);
+    await waitForRuntimePidExit(envPids.http);
+    expect(runtimeStateFile(harness.home, "ui-https")?.explicitPublicUrl).toBe("https://stored.example.test");
+    expect(runtimeStateFile(harness.home, "ui")?.explicitPublicUrl).toBe("https://stored.example.test");
+    for (const protocol of ["https", "http"] as const) {
+      const port = protocol === "https" ? harness.httpsPort : harness.httpPort;
+      expect((await mutationRequest({
+        protocol,
+        port,
+        headers: { Origin: "https://stored.example.test", "Sec-Fetch-Site": "same-origin" },
+      })).status).toBe(200);
+      expect((await mutationRequest({
+        protocol,
+        port,
+        headers: { Origin: "https://env-origin.example.test", "Sec-Fetch-Site": "same-origin" },
+      })).status).toBe(403);
+    }
+  }, 120_000);
+
+  it("restarts stale live UI processes when the explicit Origin is added, changed, or removed; keeps unchanged Origins stable", async () => {
+    const harness = await createRuntimeHarness();
+    const originA = "https://origin-a.example.test";
+    const originB = "https://origin-b.example.test";
+    const httpSelfOrigin = `http://127.0.0.1:${harness.httpPort}`;
+    const httpsSelfOrigin = `https://127.0.0.1:${harness.httpsPort}`;
+
+    // Baseline: no explicit Origin anywhere -> strict request-derived
+    // authorization on both listeners.
+    const baseline = await runUiStart(harness, []);
+    expect(baseline.errors).toEqual([]);
+    expect(baseline.status.uiHttpsPidRunning).toBe(true);
+    expect(baseline.status.uiHttpPidRunning).toBe(true);
+    expect(runtimeStateFile(harness.home, "ui-https")?.explicitPublicUrl).toBeUndefined();
+    expect(runtimeStateFile(harness.home, "ui")?.explicitPublicUrl).toBeUndefined();
+    const baselinePids = runtimePids(harness.home);
+    expect((await mutationRequest({
+      protocol: "http",
+      port: harness.httpPort,
+      headers: { Origin: originA, "Sec-Fetch-Site": "same-origin" },
+    })).status).toBe(403);
+    expect((await mutationRequest({
+      protocol: "http",
+      port: harness.httpPort,
+      headers: { Origin: httpSelfOrigin, "Sec-Fetch-Site": "same-origin" },
+    })).status).toBe(200);
+
+    // undefined -> value: both stale listeners are restarted and the new
+    // Origin is enforced; status reports the processes actually running.
+    const added = await runUiStart(harness, ["--public-url", originA]);
+    expect(added.errors).toEqual([]);
+    const addedPids = runtimePids(harness.home);
+    expect(addedPids.https).not.toBe(baselinePids.https);
+    expect(addedPids.http).not.toBe(baselinePids.http);
+    await waitForRuntimePidExit(baselinePids.https);
+    await waitForRuntimePidExit(baselinePids.http);
+    expect(pidAlive(addedPids.https)).toBe(true);
+    expect(pidAlive(addedPids.http)).toBe(true);
+    expect(added.status.uiHttpsPid).toBe(addedPids.https);
+    expect(added.status.uiHttpPid).toBe(addedPids.http);
+    expect(runtimeStateFile(harness.home, "ui-https")?.explicitPublicUrl).toBe(originA);
+    expect(runtimeStateFile(harness.home, "ui")?.explicitPublicUrl).toBe(originA);
+    for (const protocol of ["https", "http"] as const) {
+      const port = protocol === "https" ? harness.httpsPort : harness.httpPort;
+      expect((await mutationRequest({
+        protocol,
+        port,
+        headers: { Origin: originA, "Sec-Fetch-Site": "same-origin" },
+      })).status).toBe(200);
+    }
+
+    // value -> identical value: healthy processes are not restarted.
+    const unchanged = await runUiStart(harness, ["--public-url", originA]);
+    expect(unchanged.errors).toEqual([]);
+    const unchangedPids = runtimePids(harness.home);
+    expect(unchangedPids).toEqual(addedPids);
+    expect(unchanged.status.uiHttpsPid).toBe(addedPids.https);
+    expect(unchanged.status.uiHttpPid).toBe(addedPids.http);
+
+    // value -> different value: both listeners restart; the old Origin is
+    // rejected after relaunch.
+    const changed = await runUiStart(harness, ["--public-url", originB]);
+    expect(changed.errors).toEqual([]);
+    const changedPids = runtimePids(harness.home);
+    expect(changedPids.https).not.toBe(addedPids.https);
+    expect(changedPids.http).not.toBe(addedPids.http);
+    await waitForRuntimePidExit(addedPids.https);
+    await waitForRuntimePidExit(addedPids.http);
+    expect(runtimeStateFile(harness.home, "ui-https")?.explicitPublicUrl).toBe(originB);
+    expect(runtimeStateFile(harness.home, "ui")?.explicitPublicUrl).toBe(originB);
+    for (const protocol of ["https", "http"] as const) {
+      const port = protocol === "https" ? harness.httpsPort : harness.httpPort;
+      expect((await mutationRequest({
+        protocol,
+        port,
+        headers: { Origin: originA, "Sec-Fetch-Site": "same-origin" },
+      })).status).toBe(403);
+      expect((await mutationRequest({
+        protocol,
+        port,
+        headers: { Origin: originB, "Sec-Fetch-Site": "same-origin" },
+      })).status).toBe(200);
+    }
+
+    // value -> undefined: both listeners restart and strict request-derived
+    // authorization is restored.
+    const removed = await runUiStart(harness, []);
+    expect(removed.errors).toEqual([]);
+    const removedPids = runtimePids(harness.home);
+    expect(removedPids.https).not.toBe(changedPids.https);
+    expect(removedPids.http).not.toBe(changedPids.http);
+    await waitForRuntimePidExit(changedPids.https);
+    await waitForRuntimePidExit(changedPids.http);
+    expect(runtimeStateFile(harness.home, "ui-https")?.explicitPublicUrl).toBeUndefined();
+    expect(runtimeStateFile(harness.home, "ui")?.explicitPublicUrl).toBeUndefined();
+    for (const protocol of ["https", "http"] as const) {
+      const port = protocol === "https" ? harness.httpsPort : harness.httpPort;
+      expect((await mutationRequest({
+        protocol,
+        port,
+        headers: { Origin: originB, "Sec-Fetch-Site": "same-origin" },
+      })).status).toBe(403);
+    }
+    expect((await mutationRequest({
+      protocol: "http",
+      port: harness.httpPort,
+      headers: { Origin: httpSelfOrigin, "Sec-Fetch-Site": "same-origin" },
+    })).status).toBe(200);
+    expect((await mutationRequest({
+      protocol: "https",
+      port: harness.httpsPort,
+      headers: { Origin: httpsSelfOrigin, "Sec-Fetch-Site": "same-origin" },
+    })).status).toBe(200);
+  }, 120_000);
+});
+
+interface RuntimeHarness {
+  home: string;
+  repoRoot: string;
+  managerUrl: string;
+  httpsPort: number;
+  httpPort: number;
+  received: Array<{
+    origin?: string;
+    authorization?: string;
+    mutationToken?: string;
+    method?: string;
+    path?: string;
+  }>;
+}
+
+interface RuntimeUiStartStatus {
+  uiPid?: number;
+  uiHttpsPid?: number;
+  uiHttpPid?: number;
+  uiPidRunning: boolean;
+  uiHttpsPidRunning: boolean;
+  uiHttpPidRunning: boolean;
+  uiHttpsPublicUrl?: string;
+  uiHttpPublicUrl?: string;
+}
+
+const runtimeHarnesses: RuntimeHarness[] = [];
+let sharedRuntimeRepoRoot: string | undefined;
+
+const runtimeEnvKeys = [
+  "HOMERAIL_HOME",
+  "HOMERAIL_REPO_ROOT",
+  "HOMERAIL_CONFIG_PATH",
+  "HOMERAIL_SECRETS_PATH",
+  "HOMERAIL_MANAGER_URL",
+  "HOMERAIL_MANAGER_PUBLIC_URL",
+  "HOMERAIL_UI_PORT",
+  "HOMERAIL_UI_HTTP_PORT",
+  "HOMERAIL_UI_PUBLIC_URL",
+  "HOMERAIL_UI_SERVE_STATIC",
+] as const;
+
+/**
+ * Hermetic repository root standing in for the real workspace: a prebuilt
+ * static UI server (bundled from the real `src/static-ui-server.ts`) plus the
+ * minimal agent-ui dist layout `startUiServer` expects. This lets the tests
+ * drive the actual `hr ui start` runtime lifecycle — flag parsing, Origin
+ * normalization, child environment propagation, persisted state, and restart
+ * decisions — instead of launching `static-ui-server.ts` with hand-injected
+ * environment variables.
+ */
+function runtimeRepoRoot(): string {
+  if (sharedRuntimeRepoRoot) return sharedRuntimeRepoRoot;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-runtime-origin-repo-"));
+  fs.mkdirSync(path.join(root, "agent-ui", "dist"), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, "agent-ui", "package.json"),
+    `${JSON.stringify({ name: "agent-ui", private: true }, null, 2)}\n`,
+  );
+  fs.writeFileSync(
+    path.join(root, "agent-ui", "dist", "index.html"),
+    "<!doctype html><title>runtime-origin-test</title>",
+  );
+  fs.mkdirSync(path.join(root, "homerail_cli", "dist"), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, "homerail_cli", "package.json"),
+    `${JSON.stringify({ name: "homerail-cli-runtime-test", private: true, type: "module" }, null, 2)}\n`,
+  );
+  execFileSync(path.resolve("node_modules/esbuild/bin/esbuild"), [
+    path.resolve("src/static-ui-server.ts"),
+    "--bundle",
+    "--platform=node",
+    "--format=esm",
+    "--target=node20",
+    `--outfile=${path.join(root, "homerail_cli", "dist", "static-ui-server.js")}`,
+  ], { stdio: "pipe", timeout: 60_000 });
+  sharedRuntimeRepoRoot = root;
+  return root;
+}
+
+async function createRuntimeHarness(): Promise<RuntimeHarness> {
+  const repoRoot = runtimeRepoRoot();
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-runtime-origin-home-"));
+  tempDirs.push(home);
+  const received: RuntimeHarness["received"] = [];
+  const manager = http.createServer((req, res) => {
+    received.push({
+      origin: typeof req.headers.origin === "string" ? req.headers.origin : undefined,
+      authorization: typeof req.headers.authorization === "string" ? req.headers.authorization : undefined,
+      mutationToken: typeof req.headers["x-homerail-dag-token"] === "string"
+        ? req.headers["x-homerail-dag-token"]
+        : undefined,
+      method: req.method,
+      path: req.url,
+    });
+    req.resume();
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ success: true }));
+  });
+  servers.push(manager);
+  const managerUrl = await listen(manager, "127.0.0.1");
+  const httpsPort = await reservePort();
+  const httpPort = await reservePort();
+  return { home, repoRoot, managerUrl, httpsPort, httpPort, received };
+}
+
+async function runUiStart(
+  harness: RuntimeHarness,
+  extraArgs: string[],
+  env: Record<string, string> = {},
+): Promise<{ status: RuntimeUiStartStatus; errors: string[] }> {
+  const savedEnv: Record<string, string | undefined> = {};
+  for (const key of runtimeEnvKeys) savedEnv[key] = process.env[key];
+  for (const key of runtimeEnvKeys) delete process.env[key];
+  process.env.HOMERAIL_HOME = harness.home;
+  process.env.HOMERAIL_REPO_ROOT = harness.repoRoot;
+  process.env.HOMERAIL_UI_HTTP_PORT = String(harness.httpPort);
+  for (const [key, value] of Object.entries(env)) process.env[key] = value;
+
+  const logs: string[] = [];
+  const errors: string[] = [];
+  const logSpy = vi.spyOn(console, "log").mockImplementation((message) => {
+    logs.push(String(message));
+  });
+  const errorSpy = vi.spyOn(console, "error").mockImplementation((message) => {
+    errors.push(String(message));
+  });
+  const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  const previousExitCode = process.exitCode;
+  process.exitCode = undefined;
+  try {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "homerail",
+      "--json",
+      "--base-url",
+      harness.managerUrl,
+      "ui",
+      "start",
+      "--port",
+      String(harness.httpsPort),
+      ...extraArgs,
+    ]);
+  } finally {
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+    for (const key of runtimeEnvKeys) {
+      if (savedEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedEnv[key];
+    }
+    process.exitCode = previousExitCode;
+  }
+  const statusLine = logs.find((line) => line.startsWith("{"));
+  if (!statusLine) {
+    throw new Error(`hr ui start did not report status: ${errors.join("; ") || "unknown error"}`);
+  }
+  return { status: JSON.parse(statusLine) as RuntimeUiStartStatus, errors };
+}
+
+function runtimePidFile(home: string, name: "ui" | "ui-https"): number | undefined {
+  try {
+    const pid = Number(fs.readFileSync(path.join(home, "pids", `${name}.pid`), "utf-8").trim());
+    return Number.isInteger(pid) && pid > 0 ? pid : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function runtimeStateFile(
+  home: string,
+  name: "ui" | "ui-https",
+): { pid?: number; explicitPublicUrl?: string } | undefined {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(home, "pids", `${name}.json`), "utf-8")) as {
+      pid?: number;
+      explicitPublicUrl?: string;
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function runtimePids(home: string): { https?: number; http?: number } {
+  return { https: runtimePidFile(home, "ui-https"), http: runtimePidFile(home, "ui") };
+}
+
+function pidAlive(pid: number | undefined): boolean {
+  if (pid === undefined) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForRuntimePidExit(pid: number | undefined, timeoutMs = 10_000): Promise<void> {
+  if (pid === undefined) return;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!pidAlive(pid)) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`Agent UI pid ${pid} did not exit within ${timeoutMs}ms`);
+}
+
+function mutationRequest(options: {
+  protocol: "http" | "https";
+  port: number;
+  method?: string;
+  path?: string;
+  headers?: Record<string, string>;
+}): Promise<{ status: number }> {
+  return new Promise((resolve, reject) => {
+    const request = options.protocol === "https" ? https.request : http.request;
+    const req = request({
+      hostname: "127.0.0.1",
+      port: options.port,
+      method: options.method ?? "POST",
+      path: options.path ?? "/api/runs",
+      headers: options.headers,
+      rejectUnauthorized: false,
+    }, (res) => {
+      res.resume();
+      res.on("end", () => resolve({ status: res.statusCode ?? 0 }));
+    });
+    req.setTimeout(10_000, () => req.destroy(new Error("mutation request timed out")));
+    req.on("error", reject);
+    req.end();
+  });
 }

--- a/homerail_cli/tests/ui-admin-proxy.test.ts
+++ b/homerail_cli/tests/ui-admin-proxy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   authorizeUiAdminProxyMutation,
   isProtectedApiMutation,
+  normalizeExactHttpOrigin,
 } from "../src/ui-admin-proxy.js";
 
 describe("Agent UI mutation proxy trust", () => {
@@ -46,5 +47,105 @@ describe("Agent UI mutation proxy trust", () => {
     expect(isProtectedApiMutation("DELETE", "/api/plugins/demo")).toBe(true);
     expect(isProtectedApiMutation("GET", "/api/plugins")).toBe(false);
     expect(isProtectedApiMutation("POST", "/health")).toBe(false);
+  });
+});
+
+describe("exact HTTP(S) Origin normalization", () => {
+  it("accepts exact http(s) Origins and canonicalizes case and default ports", () => {
+    expect(normalizeExactHttpOrigin("https://external.example")).toBe("https://external.example");
+    expect(normalizeExactHttpOrigin("http://192.168.1.10:19193")).toBe("http://192.168.1.10:19193");
+    expect(normalizeExactHttpOrigin("https://[::1]:19192")).toBe("https://[::1]:19192");
+    expect(normalizeExactHttpOrigin("https://External.Example:443")).toBe("https://external.example");
+    expect(normalizeExactHttpOrigin("http://localhost:80")).toBe("http://localhost");
+    expect(normalizeExactHttpOrigin("https://external.example/")).toBe("https://external.example");
+  });
+
+  it("rejects wildcards, paths, queries, fragments, credentials, and non-http(s) values", () => {
+    for (const value of [
+      "",
+      "not-a-url",
+      "null",
+      "https://*.example.com",
+      "https://external.example/ui",
+      "https://external.example?token=1",
+      "https://external.example#fragment",
+      "https://user:pass@external.example",
+      "ftp://external.example",
+      "ws://external.example",
+    ]) {
+      expect(normalizeExactHttpOrigin(value), value).toBeUndefined();
+    }
+  });
+});
+
+describe("configured external UI Origin", () => {
+  const publicOrigin = "https://external.example";
+  const rewrittenHost = { protocol: "http" as const, host: "127.0.0.1:19192" };
+
+  it("accepts the configured public Origin despite an internally rewritten Host", () => {
+    expect(authorizeUiAdminProxyMutation({
+      ...rewrittenHost,
+      origin: publicOrigin,
+      secFetchSite: "same-origin",
+    }, publicOrigin)).toEqual({ allowed: true });
+  });
+
+  it("still accepts the request-derived self Origin for direct local access", () => {
+    expect(authorizeUiAdminProxyMutation({
+      ...rewrittenHost,
+      origin: "http://127.0.0.1:19192",
+      secFetchSite: "same-origin",
+    }, publicOrigin)).toEqual({ allowed: true });
+  });
+
+  it("compares canonical Origins for case and default ports", () => {
+    expect(authorizeUiAdminProxyMutation({
+      ...rewrittenHost,
+      origin: "https://External.Example:443",
+      secFetchSite: "same-origin",
+    }, publicOrigin)).toEqual({ allowed: true });
+    expect(authorizeUiAdminProxyMutation({
+      ...rewrittenHost,
+      origin: publicOrigin,
+      secFetchSite: "same-origin",
+    }, "https://External.Example:443")).toEqual({ allowed: true });
+  });
+
+  it("rejects missing, malformed, and unrelated Origins even with a configured Origin", () => {
+    for (const origin of [
+      undefined,
+      "null",
+      "not-a-url",
+      "https://external.example.evil",
+      "https://evil.example",
+      "https://user:pass@external.example",
+      "http://external.example",
+    ]) {
+      expect(authorizeUiAdminProxyMutation({
+        ...rewrittenHost,
+        origin,
+        secFetchSite: "same-origin",
+      }, publicOrigin), String(origin)).toMatchObject({ allowed: false });
+    }
+  });
+
+  it("rejects a present non-same-origin Sec-Fetch-Site even when the Origin matches", () => {
+    for (const secFetchSite of ["cross-site", "same-site", "none"]) {
+      expect(authorizeUiAdminProxyMutation({
+        ...rewrittenHost,
+        origin: publicOrigin,
+        secFetchSite,
+      }, publicOrigin), secFetchSite).toMatchObject({ allowed: false });
+    }
+  });
+
+  it("ignores configured values that are not exact http(s) Origins", () => {
+    for (const configured of ["https://evil.example/path", "https://*.example.com", "null"]) {
+      expect(authorizeUiAdminProxyMutation({
+        ...rewrittenHost,
+        origin: "https://evil.example",
+        secFetchSite: "same-origin",
+      }, configured), configured).toMatchObject({ allowed: false });
+    }
   });
 });


### PR DESCRIPTION
## Summary

This Draft PR is the bounded write target for an Auto Fix v2 pilot addressing #194.

The implementation should make the static Agent UI mutation proxy accept the explicitly configured external UI origin behind FN Connect and similar reverse proxies, while preserving the default strict same-origin boundary and `Sec-Fetch-Site` checks.

## Scope

- reuse the normalized `--ui-public-url` / `HOMERAIL_UI_PUBLIC_URL` origin;
- keep request-derived same-origin behavior when no public URL is configured;
- reject missing, malformed, cross-site, and forged forwarded-header requests;
- add focused unit and integration coverage plus operator documentation.

## Validation

The Auto Fix v2 run will execute the caller-authored local tests and two fresh-context reviews before this Draft is considered ready for CI.

Fixes #194
