### PR TITLE
feat(voice): adapt transcription deadlines for emulated ASR

### DIFF
--- a/agent-ui/src/components/agent/AgentVoiceCockpit.vue
+++ b/agent-ui/src/components/agent/AgentVoiceCockpit.vue
@@ -64,7 +64,8 @@ import {
 import {
   ASR_CONNECTION_TIMEOUT_MS,
   AsrTranscriptionDeadlineController,
-  isBatchAsrStrategy
+  isBatchAsrStrategy,
+  type AsrTranscriptionAttempt
 } from '@/components/agent/asr-transcription-deadline'
 import { voiceWs } from '@/api/clients/events-ws'
 import { useOnboardingStatus } from '@/composables/useOnboardingStatus'
@@ -431,6 +432,7 @@ let nativeGamepadAnalogAt = 0
 let asrSocket: WebSocket | null = null
 let asrSocketGeneration = 0
 let asrTranscriptRaw = ''
+let asrPendingTranscription: AsrTranscriptionAttempt | null = null
 const asrDeadlineController = new AsrTranscriptionDeadlineController()
 let lastSubmittedVoiceTranscriptKey = ''
 let lastSubmittedVoiceTranscriptAt = 0
@@ -4933,8 +4935,17 @@ function finishAsrUtterance(): Promise<string> {
   const transcription = asrDeadlineController.finish({
     timeoutMessage: t('voice.errors.asrTranscriptionTimeout')
   })
-  asrSocket?.send(JSON.stringify({ type: 'finish' }))
-  return transcription
+  asrPendingTranscription = transcription
+  try {
+    asrSocket.send(JSON.stringify({ type: 'finish' }))
+  } catch (sendError) {
+    transcription.reject(
+      sendError instanceof Error ? sendError : new Error(t('voice.errors.asrResponse'))
+    )
+  }
+  return transcription.promise.finally(() => {
+    if (asrPendingTranscription === transcription) asrPendingTranscription = null
+  })
 }
 
 function handleAsrRealtimeMessage(payload: unknown): void {
@@ -4980,12 +4991,12 @@ function handleAsrRealtimeMessage(payload: unknown): void {
 
 function resolveAsrFinal(text: string): void {
   asrTranscriptRaw = ''
-  asrDeadlineController.resolve(text)
+  asrPendingTranscription?.resolve(text)
 }
 
 function rejectAsrFinal(error: Error): void {
   asrTranscriptRaw = ''
-  asrDeadlineController.reject(error)
+  asrPendingTranscription?.reject(error)
 }
 
 function cleanAsrTranscript(text: string): string {

--- a/agent-ui/src/components/agent/AgentVoiceCockpit.vue
+++ b/agent-ui/src/components/agent/AgentVoiceCockpit.vue
@@ -63,7 +63,8 @@ import {
 } from '@/components/agent/codex-model-selection'
 import {
   ASR_CONNECTION_TIMEOUT_MS,
-  AsrTranscriptionDeadlineController
+  AsrTranscriptionDeadlineController,
+  isBatchAsrStrategy
 } from '@/components/agent/asr-transcription-deadline'
 import { voiceWs } from '@/api/clients/events-ws'
 import { useOnboardingStatus } from '@/composables/useOnboardingStatus'
@@ -428,9 +429,9 @@ let immersiveExitTimer = 0
 let immersiveReturnTimer = 0
 let nativeGamepadAnalogAt = 0
 let asrSocket: WebSocket | null = null
+let asrSocketGeneration = 0
 let asrTranscriptRaw = ''
 const asrDeadlineController = new AsrTranscriptionDeadlineController()
-let asrClosing = false
 let lastSubmittedVoiceTranscriptKey = ''
 let lastSubmittedVoiceTranscriptAt = 0
 let managerStatusTimer = 0
@@ -4653,7 +4654,7 @@ function handleNativeVoiceSamples(samples: Float32Array, sampleRate: number): vo
       liveTranscript.value = ''
       spokenText.value = ''
       asrTranscriptRaw = ''
-      asrDeadlineController.beginUtterance()
+      if (recognitionMode.value === 'asr') beginAsrUtterance()
       liveTranscript.value = t('voice.state.listening')
     }
   }
@@ -4767,7 +4768,7 @@ function updateVoiceWaveform(now: number): void {
       liveTranscript.value = ''
       spokenText.value = ''
       asrTranscriptRaw = ''
-      asrDeadlineController.beginUtterance()
+      if (recognitionMode.value === 'asr') beginAsrUtterance()
       liveTranscript.value = t('voice.state.listening')
     }
   } else if (speechActive && now - lastVoiceAt > voiceVadSilenceMs.value) {
@@ -4794,6 +4795,7 @@ async function finishUtterance(): Promise<void> {
       if (token !== voiceSessionToken) return
       error.value = err?.message || t('voice.errors.asrFailed')
       liveTranscript.value = ''
+      await recoverAsrRealtimeAfterFailure(token)
     } finally {
       if (token === voiceSessionToken) voiceBusy.value = false
     }
@@ -4843,8 +4845,8 @@ async function finishUtterance(): Promise<void> {
 
 async function connectAsrRealtime(): Promise<void> {
   disconnectAsrRealtime()
+  const socketGeneration = asrSocketGeneration
   await new Promise<void>((resolve, reject) => {
-    asrClosing = false
     const socket = createAsrRealtimeSocket()
     const timer = window.setTimeout(() => {
       socket.close()
@@ -4853,6 +4855,11 @@ async function connectAsrRealtime(): Promise<void> {
     socket.binaryType = 'arraybuffer'
     socket.onopen = () => {
       window.clearTimeout(timer)
+      if (socketGeneration !== asrSocketGeneration) {
+        socket.close()
+        reject(new Error(t('voice.errors.asrDisconnected')))
+        return
+      }
       asrSocket = socket
       resolve()
     }
@@ -4861,22 +4868,47 @@ async function connectAsrRealtime(): Promise<void> {
       reject(new Error(t('voice.errors.asrConnectionFailed')))
     }
     socket.onclose = () => {
+      if (socketGeneration !== asrSocketGeneration) return
       const wasActiveSocket = asrSocket === socket
       if (wasActiveSocket) asrSocket = null
-      if (wasActiveSocket && !asrClosing && listening.value) {
-        rejectAsrFinal(new Error(t('voice.errors.asrDisconnected')))
-        error.value = t('voice.errors.asrDisconnected')
+      if (wasActiveSocket && listening.value) {
+        const disconnectError = new Error(t('voice.errors.asrDisconnected'))
+        asrTranscriptRaw = ''
+        asrDeadlineController.resetSession(disconnectError)
+        error.value = disconnectError.message
       }
     }
-    socket.onmessage = event => handleAsrRealtimeMessage(event.data)
+    socket.onmessage = event => {
+      if (socketGeneration !== asrSocketGeneration || asrSocket !== socket) return
+      handleAsrRealtimeMessage(event.data)
+    }
   })
 }
 
 function disconnectAsrRealtime(): void {
-  asrClosing = true
+  asrSocketGeneration += 1
   asrDeadlineController.resetSession(new Error(t('voice.errors.asrDisconnected')))
   if (asrSocket) asrSocket.close()
   asrSocket = null
+}
+
+async function recoverAsrRealtimeAfterFailure(token: number): Promise<void> {
+  if (token !== voiceSessionToken || !listening.value || recognitionMode.value !== 'asr') return
+  try {
+    await connectAsrRealtime()
+    if (token !== voiceSessionToken) disconnectAsrRealtime()
+  } catch (reconnectError: any) {
+    if (token !== voiceSessionToken) return
+    error.value = reconnectError?.message || t('voice.errors.asrConnectionFailed')
+    closeVoiceInputAfterSubmit()
+  }
+}
+
+function beginAsrUtterance(): void {
+  asrDeadlineController.beginUtterance()
+  if (!isBatchAsrStrategy(asrDeadlineController.getSessionStrategy())) return
+  if (!asrSocket || asrSocket.readyState !== WebSocket.OPEN) return
+  asrSocket.send(JSON.stringify({ type: 'start' }))
 }
 
 function sendAsrAudio(samples: Float32Array, sampleRate: number): void {

--- a/agent-ui/src/components/agent/AgentVoiceCockpit.vue
+++ b/agent-ui/src/components/agent/AgentVoiceCockpit.vue
@@ -63,10 +63,14 @@ import {
 } from '@/components/agent/codex-model-selection'
 import {
   ASR_CONNECTION_TIMEOUT_MS,
-  AsrTranscriptionDeadlineController,
-  isBatchAsrStrategy,
-  type AsrTranscriptionAttempt
+  AsrTranscriptionDeadlineController
 } from '@/components/agent/asr-transcription-deadline'
+import {
+  AsrSocketGenerationFence,
+  AsrTranscriptionAttemptRegistry,
+  beginAsrRealtimeUtterance,
+  recoverAsrRealtimeSession
+} from '@/components/agent/asr-realtime-lifecycle'
 import { voiceWs } from '@/api/clients/events-ws'
 import { useOnboardingStatus } from '@/composables/useOnboardingStatus'
 import {
@@ -430,10 +434,10 @@ let immersiveExitTimer = 0
 let immersiveReturnTimer = 0
 let nativeGamepadAnalogAt = 0
 let asrSocket: WebSocket | null = null
-let asrSocketGeneration = 0
 let asrTranscriptRaw = ''
-let asrPendingTranscription: AsrTranscriptionAttempt | null = null
 const asrDeadlineController = new AsrTranscriptionDeadlineController()
+const asrSocketGeneration = new AsrSocketGenerationFence()
+const asrTranscriptionAttempts = new AsrTranscriptionAttemptRegistry()
 let lastSubmittedVoiceTranscriptKey = ''
 let lastSubmittedVoiceTranscriptAt = 0
 let managerStatusTimer = 0
@@ -4851,7 +4855,7 @@ async function finishUtterance(): Promise<void> {
 
 async function connectAsrRealtime(): Promise<void> {
   disconnectAsrRealtime()
-  const socketGeneration = asrSocketGeneration
+  const socketGeneration = asrSocketGeneration.current()
   await new Promise<void>((resolve, reject) => {
     const socket = createAsrRealtimeSocket()
     const timer = window.setTimeout(() => {
@@ -4861,7 +4865,7 @@ async function connectAsrRealtime(): Promise<void> {
     socket.binaryType = 'arraybuffer'
     socket.onopen = () => {
       window.clearTimeout(timer)
-      if (socketGeneration !== asrSocketGeneration) {
+      if (!asrSocketGeneration.isCurrent(socketGeneration)) {
         socket.close()
         reject(new Error(t('voice.errors.asrDisconnected')))
         return
@@ -4874,7 +4878,7 @@ async function connectAsrRealtime(): Promise<void> {
       reject(new Error(t('voice.errors.asrConnectionFailed')))
     }
     socket.onclose = () => {
-      if (socketGeneration !== asrSocketGeneration) return
+      if (!asrSocketGeneration.isCurrent(socketGeneration)) return
       const wasActiveSocket = asrSocket === socket
       if (wasActiveSocket) asrSocket = null
       if (wasActiveSocket && listening.value) {
@@ -4885,36 +4889,47 @@ async function connectAsrRealtime(): Promise<void> {
       }
     }
     socket.onmessage = event => {
-      if (socketGeneration !== asrSocketGeneration || asrSocket !== socket) return
+      if (!asrSocketGeneration.isCurrent(socketGeneration) || asrSocket !== socket) return
       handleAsrRealtimeMessage(event.data)
     }
   })
 }
 
 function disconnectAsrRealtime(): void {
-  asrSocketGeneration += 1
+  asrSocketGeneration.invalidate()
   asrDeadlineController.resetSession(new Error(t('voice.errors.asrDisconnected')))
   if (asrSocket) asrSocket.close()
   asrSocket = null
 }
 
 async function recoverAsrRealtimeAfterFailure(token: number): Promise<void> {
-  if (token !== voiceSessionToken || !listening.value || recognitionMode.value !== 'asr') return
-  try {
-    await connectAsrRealtime()
-    if (token !== voiceSessionToken) disconnectAsrRealtime()
-  } catch (reconnectError: any) {
-    if (token !== voiceSessionToken) return
-    error.value = reconnectError?.message || t('voice.errors.asrConnectionFailed')
-    closeVoiceInputAfterSubmit()
-  }
+  await recoverAsrRealtimeSession({
+    shouldContinue: () =>
+      token === voiceSessionToken && listening.value && recognitionMode.value === 'asr',
+    connect: connectAsrRealtime,
+    disconnect: disconnectAsrRealtime,
+    clearError: () => {
+      error.value = ''
+    },
+    reportError: reconnectError => {
+      error.value =
+        reconnectError instanceof Error && reconnectError.message
+          ? reconnectError.message
+          : t('voice.errors.asrConnectionFailed')
+    },
+    closeInput: closeVoiceInputAfterSubmit
+  })
 }
 
 function beginAsrUtterance(): void {
-  asrDeadlineController.beginUtterance()
-  if (!isBatchAsrStrategy(asrDeadlineController.getSessionStrategy())) return
-  if (!asrSocket || asrSocket.readyState !== WebSocket.OPEN) return
-  asrSocket.send(JSON.stringify({ type: 'start' }))
+  beginAsrRealtimeUtterance({
+    controller: asrDeadlineController,
+    socket: asrSocket,
+    openReadyState: WebSocket.OPEN,
+    onBegin: () => {
+      error.value = ''
+    }
+  })
 }
 
 function sendAsrAudio(samples: Float32Array, sampleRate: number): void {
@@ -4935,7 +4950,7 @@ function finishAsrUtterance(): Promise<string> {
   const transcription = asrDeadlineController.finish({
     timeoutMessage: t('voice.errors.asrTranscriptionTimeout')
   })
-  asrPendingTranscription = transcription
+  const promise = asrTranscriptionAttempts.track(transcription)
   try {
     asrSocket.send(JSON.stringify({ type: 'finish' }))
   } catch (sendError) {
@@ -4943,9 +4958,7 @@ function finishAsrUtterance(): Promise<string> {
       sendError instanceof Error ? sendError : new Error(t('voice.errors.asrResponse'))
     )
   }
-  return transcription.promise.finally(() => {
-    if (asrPendingTranscription === transcription) asrPendingTranscription = null
-  })
+  return promise
 }
 
 function handleAsrRealtimeMessage(payload: unknown): void {
@@ -4991,12 +5004,12 @@ function handleAsrRealtimeMessage(payload: unknown): void {
 
 function resolveAsrFinal(text: string): void {
   asrTranscriptRaw = ''
-  asrPendingTranscription?.resolve(text)
+  asrTranscriptionAttempts.resolve(text)
 }
 
 function rejectAsrFinal(error: Error): void {
   asrTranscriptRaw = ''
-  asrPendingTranscription?.reject(error)
+  asrTranscriptionAttempts.reject(error)
 }
 
 function cleanAsrTranscript(text: string): string {

--- a/agent-ui/src/components/agent/AgentVoiceCockpit.vue
+++ b/agent-ui/src/components/agent/AgentVoiceCockpit.vue
@@ -4787,7 +4787,11 @@ async function finishUtterance(): Promise<void> {
     try {
       const text = (await finishAsrUtterance()).trim()
       if (token !== voiceSessionToken) return
-      if (!text) throw new Error(t('voice.errors.noTranscript'))
+      if (!text) {
+        error.value = t('voice.errors.noTranscript')
+        liveTranscript.value = ''
+        return
+      }
       liveTranscript.value = text
       voiceBusy.value = false
       await handleFinalTranscript(text)

--- a/agent-ui/src/components/agent/AgentVoiceCockpit.vue
+++ b/agent-ui/src/components/agent/AgentVoiceCockpit.vue
@@ -66,6 +66,7 @@ import {
   AsrTranscriptionDeadlineController
 } from '@/components/agent/asr-transcription-deadline'
 import {
+  AsrProtocolError,
   AsrSocketGenerationFence,
   AsrTranscriptionAttemptRegistry,
   beginAsrRealtimeUtterance,
@@ -4805,7 +4806,7 @@ async function finishUtterance(): Promise<void> {
       if (token !== voiceSessionToken) return
       error.value = err?.message || t('voice.errors.asrFailed')
       liveTranscript.value = ''
-      await recoverAsrRealtimeAfterFailure(token)
+      await recoverAsrRealtimeAfterFailure(token, err instanceof AsrProtocolError)
     } finally {
       if (token === voiceSessionToken) voiceBusy.value = false
     }
@@ -4902,7 +4903,10 @@ function disconnectAsrRealtime(): void {
   asrSocket = null
 }
 
-async function recoverAsrRealtimeAfterFailure(token: number): Promise<void> {
+async function recoverAsrRealtimeAfterFailure(
+  token: number,
+  preserveErrorAfterReconnect: boolean
+): Promise<void> {
   await recoverAsrRealtimeSession({
     shouldContinue: () =>
       token === voiceSessionToken && listening.value && recognitionMode.value === 'asr',
@@ -4911,6 +4915,7 @@ async function recoverAsrRealtimeAfterFailure(token: number): Promise<void> {
     clearError: () => {
       error.value = ''
     },
+    clearErrorAfterReconnect: !preserveErrorAfterReconnect,
     reportError: reconnectError => {
       error.value =
         reconnectError instanceof Error && reconnectError.message
@@ -4979,7 +4984,7 @@ function handleAsrRealtimeMessage(payload: unknown): void {
   }
   if (event.type === 'error') {
     const message = asrTextField(event, ['error', 'message']) || t('voice.errors.asrResponse')
-    rejectAsrFinal(new Error(message))
+    rejectAsrFinal(new AsrProtocolError(message))
     error.value = message
     return
   }

--- a/agent-ui/src/components/agent/AgentVoiceCockpit.vue
+++ b/agent-ui/src/components/agent/AgentVoiceCockpit.vue
@@ -61,6 +61,10 @@ import {
   resolveCodexServiceTierForModel,
   resolveCodexServiceTierOptions
 } from '@/components/agent/codex-model-selection'
+import {
+  ASR_CONNECTION_TIMEOUT_MS,
+  AsrTranscriptionDeadlineController
+} from '@/components/agent/asr-transcription-deadline'
 import { voiceWs } from '@/api/clients/events-ws'
 import { useOnboardingStatus } from '@/composables/useOnboardingStatus'
 import {
@@ -425,9 +429,7 @@ let immersiveReturnTimer = 0
 let nativeGamepadAnalogAt = 0
 let asrSocket: WebSocket | null = null
 let asrTranscriptRaw = ''
-let asrFinalResolve: ((text: string) => void) | null = null
-let asrFinalReject: ((error: Error) => void) | null = null
-let asrFinalTimer = 0
+const asrDeadlineController = new AsrTranscriptionDeadlineController()
 let asrClosing = false
 let lastSubmittedVoiceTranscriptKey = ''
 let lastSubmittedVoiceTranscriptAt = 0
@@ -4651,6 +4653,7 @@ function handleNativeVoiceSamples(samples: Float32Array, sampleRate: number): vo
       liveTranscript.value = ''
       spokenText.value = ''
       asrTranscriptRaw = ''
+      asrDeadlineController.beginUtterance()
       liveTranscript.value = t('voice.state.listening')
     }
   }
@@ -4764,6 +4767,7 @@ function updateVoiceWaveform(now: number): void {
       liveTranscript.value = ''
       spokenText.value = ''
       asrTranscriptRaw = ''
+      asrDeadlineController.beginUtterance()
       liveTranscript.value = t('voice.state.listening')
     }
   } else if (speechActive && now - lastVoiceAt > voiceVadSilenceMs.value) {
@@ -4845,7 +4849,7 @@ async function connectAsrRealtime(): Promise<void> {
     const timer = window.setTimeout(() => {
       socket.close()
       reject(new Error(t('voice.errors.asrTimeout')))
-    }, 5000)
+    }, ASR_CONNECTION_TIMEOUT_MS)
     socket.binaryType = 'arraybuffer'
     socket.onopen = () => {
       window.clearTimeout(timer)
@@ -4870,10 +4874,7 @@ async function connectAsrRealtime(): Promise<void> {
 
 function disconnectAsrRealtime(): void {
   asrClosing = true
-  if (asrFinalTimer) window.clearTimeout(asrFinalTimer)
-  asrFinalTimer = 0
-  asrFinalResolve = null
-  asrFinalReject = null
+  asrDeadlineController.resetSession(new Error(t('voice.errors.asrDisconnected')))
   if (asrSocket) asrSocket.close()
   asrSocket = null
 }
@@ -4884,19 +4885,20 @@ function sendAsrAudio(samples: Float32Array, sampleRate: number): void {
     return
   }
   const pcm = encodePcm16(samples, sampleRate, 16000)
-  if (pcm.byteLength) asrSocket.send(pcm)
+  if (!pcm.byteLength) return
+  asrSocket.send(pcm)
+  asrDeadlineController.recordSentAudio(samples.length, sampleRate)
 }
 
 function finishAsrUtterance(): Promise<string> {
   if (!asrSocket || asrSocket.readyState !== WebSocket.OPEN) {
     throw new Error(t('voice.errors.asrNotConnected'))
   }
-  return new Promise((resolve, reject) => {
-    asrFinalResolve = resolve
-    asrFinalReject = reject
-    asrFinalTimer = window.setTimeout(() => rejectAsrFinal(new Error(t('voice.errors.asrTranscriptionTimeout'))), 9000)
-    asrSocket?.send(JSON.stringify({ type: 'finish' }))
+  const transcription = asrDeadlineController.finish({
+    timeoutMessage: t('voice.errors.asrTranscriptionTimeout')
   })
+  asrSocket?.send(JSON.stringify({ type: 'finish' }))
+  return transcription
 }
 
 function handleAsrRealtimeMessage(payload: unknown): void {
@@ -4905,6 +4907,14 @@ function handleAsrRealtimeMessage(payload: unknown): void {
   try {
     event = JSON.parse(payload)
   } catch {
+    return
+  }
+  if (event.type === 'session.ready') {
+    asrDeadlineController.handleSessionReady(event.strategy)
+    return
+  }
+  if (event.type === 'transcription.processing') {
+    asrDeadlineController.handleTranscriptionProcessing(event.strategy)
     return
   }
   if (event.type === 'error') {
@@ -4933,23 +4943,13 @@ function handleAsrRealtimeMessage(payload: unknown): void {
 }
 
 function resolveAsrFinal(text: string): void {
-  if (asrFinalTimer) window.clearTimeout(asrFinalTimer)
-  asrFinalTimer = 0
-  const resolve = asrFinalResolve
-  asrFinalResolve = null
-  asrFinalReject = null
   asrTranscriptRaw = ''
-  resolve?.(text)
+  asrDeadlineController.resolve(text)
 }
 
 function rejectAsrFinal(error: Error): void {
-  if (asrFinalTimer) window.clearTimeout(asrFinalTimer)
-  asrFinalTimer = 0
-  const reject = asrFinalReject
-  asrFinalResolve = null
-  asrFinalReject = null
   asrTranscriptRaw = ''
-  reject?.(error)
+  asrDeadlineController.reject(error)
 }
 
 function cleanAsrTranscript(text: string): string {

--- a/agent-ui/src/components/agent/AgentVoiceCockpitAsrLifecycle.test.ts
+++ b/agent-ui/src/components/agent/AgentVoiceCockpitAsrLifecycle.test.ts
@@ -38,7 +38,7 @@ class FakeAsrSocket implements AsrControlSocket {
 }
 
 describe('Agent Voice Cockpit ASR lifecycle helpers', () => {
-  it('clears the prior utterance error and sends start only for an open batch session', () => {
+  it('clears the prior utterance error and sends start only for an open session', () => {
     const controller = new AsrTranscriptionDeadlineController({
       scheduler: new FakeDeadlineScheduler()
     })
@@ -61,13 +61,27 @@ describe('Agent Voice Cockpit ASR lifecycle helpers', () => {
     expect(socket.sent).toEqual([JSON.stringify({ type: 'start' })])
 
     const closedSocket = new FakeAsrSocket(3)
+    error = 'ASR disconnected'
     beginAsrRealtimeUtterance({
       controller,
       socket: closedSocket,
       openReadyState: 1,
-      onBegin: () => {}
+      onBegin: () => {
+        error = ''
+      }
     })
+    expect(error).toBe('ASR disconnected')
     expect(closedSocket.sent).toEqual([])
+
+    beginAsrRealtimeUtterance({
+      controller,
+      socket: null,
+      openReadyState: 1,
+      onBegin: () => {
+        error = ''
+      }
+    })
+    expect(error).toBe('ASR disconnected')
   })
 
   it('invalidates events from earlier socket generations', () => {

--- a/agent-ui/src/components/agent/AgentVoiceCockpitAsrLifecycle.test.ts
+++ b/agent-ui/src/components/agent/AgentVoiceCockpitAsrLifecycle.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  AsrProtocolError,
   AsrSocketGenerationFence,
   AsrTranscriptionAttemptRegistry,
   beginAsrRealtimeUtterance,
@@ -165,6 +166,28 @@ describe('Agent Voice Cockpit ASR lifecycle helpers', () => {
     })
     expect(disconnected).toBe(1)
     expect(closed).toBe(0)
+  })
+
+  it('preserves an upstream protocol error after reconnecting', async () => {
+    const protocolError = new AsrProtocolError('invalid upstream API key')
+    let error = protocolError.message
+    let cleared = 0
+
+    await recoverAsrRealtimeSession({
+      shouldContinue: () => true,
+      connect: async () => {},
+      disconnect: () => {},
+      clearError: () => {
+        cleared += 1
+        error = ''
+      },
+      clearErrorAfterReconnect: false,
+      reportError: () => {},
+      closeInput: () => {}
+    })
+
+    expect(error).toBe('invalid upstream API key')
+    expect(cleared).toBe(0)
   })
 
   it('reports a reconnect failure and closes only the still-active input', async () => {

--- a/agent-ui/src/components/agent/AgentVoiceCockpitAsrLifecycle.test.ts
+++ b/agent-ui/src/components/agent/AgentVoiceCockpitAsrLifecycle.test.ts
@@ -38,7 +38,7 @@ class FakeAsrSocket implements AsrControlSocket {
 }
 
 describe('Agent Voice Cockpit ASR lifecycle helpers', () => {
-  it('clears the prior utterance error and sends start only for an open session', () => {
+  it('keeps a late batch strategy on the initial server buffer and resets later utterances', async () => {
     const controller = new AsrTranscriptionDeadlineController({
       scheduler: new FakeDeadlineScheduler()
     })
@@ -56,7 +56,13 @@ describe('Agent Voice Cockpit ASR lifecycle helpers', () => {
     expect(error).toBe('')
     expect(socket.sent).toEqual([])
 
+    controller.recordSentAudio(16_000, 16_000)
     controller.handleSessionReady('emulated_batch')
+    expect(socket.sent).toEqual([])
+    const firstAttempt = controller.finish()
+    firstAttempt.resolve('first transcript')
+    await expect(firstAttempt.promise).resolves.toBe('first transcript')
+
     beginAsrRealtimeUtterance({ controller, socket, openReadyState: 1, onBegin: () => {} })
     expect(socket.sent).toEqual([JSON.stringify({ type: 'start' })])
 

--- a/agent-ui/src/components/agent/AgentVoiceCockpitAsrLifecycle.test.ts
+++ b/agent-ui/src/components/agent/AgentVoiceCockpitAsrLifecycle.test.ts
@@ -96,4 +96,24 @@ describe('AgentVoiceCockpit ASR session lifecycle', () => {
     expect(emptyTranscriptBranch).not.toContain('recoverAsrRealtimeAfterFailure')
     expect(failureCatch).toContain('await recoverAsrRealtimeAfterFailure(token)')
   })
+
+  it('routes terminal events through the utterance-scoped transcription attempt', () => {
+    const finish = sourceBetween(
+      cockpitSource,
+      'function finishAsrUtterance(): Promise<string>',
+      'function handleAsrRealtimeMessage('
+    )
+    const settle = sourceBetween(
+      cockpitSource,
+      'function resolveAsrFinal(text: string): void',
+      'function cleanAsrTranscript('
+    )
+
+    expect(finish).toContain('asrPendingTranscription = transcription')
+    expect(finish).toContain('asrPendingTranscription === transcription')
+    expect(settle).toContain('asrPendingTranscription?.resolve(text)')
+    expect(settle).toContain('asrPendingTranscription?.reject(error)')
+    expect(settle).not.toContain('asrDeadlineController.resolve(')
+    expect(settle).not.toContain('asrDeadlineController.reject(')
+  })
 })

--- a/agent-ui/src/components/agent/AgentVoiceCockpitAsrLifecycle.test.ts
+++ b/agent-ui/src/components/agent/AgentVoiceCockpitAsrLifecycle.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+
+import cockpitSource from './AgentVoiceCockpit.vue?raw'
+
+function sourceBetween(start: string, end: string): string {
+  return cockpitSource.slice(cockpitSource.indexOf(start), cockpitSource.indexOf(end))
+}
+
+describe('AgentVoiceCockpit ASR session lifecycle', () => {
+  it('starts each utterance with a protocol reset for emulated sessions', () => {
+    const beginUtterance = sourceBetween(
+      'function beginAsrUtterance(): void',
+      'function sendAsrAudio('
+    )
+
+    expect(beginUtterance).toContain('asrDeadlineController.beginUtterance()')
+    expect(beginUtterance).toContain(
+      'isBatchAsrStrategy(asrDeadlineController.getSessionStrategy())'
+    )
+    expect(beginUtterance).toContain("asrSocket.send(JSON.stringify({ type: 'start' }))")
+    expect(cockpitSource.match(/beginAsrUtterance\(\)/g)).toHaveLength(3)
+  })
+
+  it('drops events from sockets invalidated by timeout recovery or disconnect', () => {
+    const connect = sourceBetween(
+      'async function connectAsrRealtime(): Promise<void>',
+      'function disconnectAsrRealtime(): void'
+    )
+
+    expect(connect).toContain('const socketGeneration = asrSocketGeneration')
+    expect(connect).toContain(
+      'if (socketGeneration !== asrSocketGeneration || asrSocket !== socket) return'
+    )
+    expect(connect).toContain('asrDeadlineController.resetSession(disconnectError)')
+  })
+
+  it('reconnects after a failed transcription before accepting another utterance', () => {
+    const finish = sourceBetween(
+      'async function finishUtterance(): Promise<void>',
+      'async function connectAsrRealtime(): Promise<void>'
+    )
+    const recover = sourceBetween(
+      'async function recoverAsrRealtimeAfterFailure(token: number): Promise<void>',
+      'function beginAsrUtterance(): void'
+    )
+
+    expect(finish).toContain('await recoverAsrRealtimeAfterFailure(token)')
+    expect(recover).toContain('await connectAsrRealtime()')
+    expect(recover).toContain('closeVoiceInputAfterSubmit()')
+  })
+})

--- a/agent-ui/src/components/agent/AgentVoiceCockpitAsrLifecycle.test.ts
+++ b/agent-ui/src/components/agent/AgentVoiceCockpitAsrLifecycle.test.ts
@@ -2,15 +2,31 @@ import { describe, expect, it } from 'vitest'
 
 import cockpitSource from './AgentVoiceCockpit.vue?raw'
 
-function sourceBetween(start: string, end: string): string {
-  return cockpitSource.slice(cockpitSource.indexOf(start), cockpitSource.indexOf(end))
+function sourceBetween(source: string, start: string, end: string): string {
+  const startIndex = source.indexOf(start)
+  const endIndex = source.indexOf(end, startIndex + start.length)
+  if (startIndex < 0 || endIndex < 0 || endIndex <= startIndex) {
+    throw new Error(`Could not find ordered lifecycle anchors: ${start} -> ${end}`)
+  }
+  return source.slice(startIndex, endIndex)
 }
 
 describe('AgentVoiceCockpit ASR session lifecycle', () => {
   it('starts each utterance with a protocol reset for emulated sessions', () => {
     const beginUtterance = sourceBetween(
+      cockpitSource,
       'function beginAsrUtterance(): void',
       'function sendAsrAudio('
+    )
+    const nativeCapture = sourceBetween(
+      cockpitSource,
+      'function handleNativeVoiceSamples(',
+      'function updateNativeVoiceWaveform('
+    )
+    const browserCapture = sourceBetween(
+      cockpitSource,
+      'function updateVoiceWaveform(',
+      'async function finishUtterance('
     )
 
     expect(beginUtterance).toContain('asrDeadlineController.beginUtterance()')
@@ -18,11 +34,17 @@ describe('AgentVoiceCockpit ASR session lifecycle', () => {
       'isBatchAsrStrategy(asrDeadlineController.getSessionStrategy())'
     )
     expect(beginUtterance).toContain("asrSocket.send(JSON.stringify({ type: 'start' }))")
-    expect(cockpitSource.match(/beginAsrUtterance\(\)/g)).toHaveLength(3)
+    expect(nativeCapture).toContain(
+      "if (recognitionMode.value === 'asr') beginAsrUtterance()"
+    )
+    expect(browserCapture).toContain(
+      "if (recognitionMode.value === 'asr') beginAsrUtterance()"
+    )
   })
 
   it('drops events from sockets invalidated by timeout recovery or disconnect', () => {
     const connect = sourceBetween(
+      cockpitSource,
       'async function connectAsrRealtime(): Promise<void>',
       'function disconnectAsrRealtime(): void'
     )
@@ -36,10 +58,12 @@ describe('AgentVoiceCockpit ASR session lifecycle', () => {
 
   it('reconnects after a failed transcription before accepting another utterance', () => {
     const finish = sourceBetween(
+      cockpitSource,
       'async function finishUtterance(): Promise<void>',
       'async function connectAsrRealtime(): Promise<void>'
     )
     const recover = sourceBetween(
+      cockpitSource,
       'async function recoverAsrRealtimeAfterFailure(token: number): Promise<void>',
       'function beginAsrUtterance(): void'
     )
@@ -47,5 +71,29 @@ describe('AgentVoiceCockpit ASR session lifecycle', () => {
     expect(finish).toContain('await recoverAsrRealtimeAfterFailure(token)')
     expect(recover).toContain('await connectAsrRealtime()')
     expect(recover).toContain('closeVoiceInputAfterSubmit()')
+  })
+
+  it('keeps a healthy ASR socket when a completed transcription is empty', () => {
+    const finish = sourceBetween(
+      cockpitSource,
+      'async function finishUtterance(): Promise<void>',
+      'async function connectAsrRealtime(): Promise<void>'
+    )
+    const asrBranch = sourceBetween(
+      finish,
+      "if (recognitionMode.value === 'asr') {",
+      '\n  const chunks = pcmChunks'
+    )
+    const emptyTranscriptBranch = sourceBetween(
+      asrBranch,
+      'if (!text) {',
+      '\n      liveTranscript.value = text'
+    )
+    const failureCatch = sourceBetween(asrBranch, '} catch (err: any) {', '} finally {')
+
+    expect(emptyTranscriptBranch).toContain("error.value = t('voice.errors.noTranscript')")
+    expect(emptyTranscriptBranch).toContain('return')
+    expect(emptyTranscriptBranch).not.toContain('recoverAsrRealtimeAfterFailure')
+    expect(failureCatch).toContain('await recoverAsrRealtimeAfterFailure(token)')
   })
 })

--- a/agent-ui/src/components/agent/AgentVoiceCockpitAsrLifecycle.test.ts
+++ b/agent-ui/src/components/agent/AgentVoiceCockpitAsrLifecycle.test.ts
@@ -1,119 +1,172 @@
 import { describe, expect, it } from 'vitest'
 
-import cockpitSource from './AgentVoiceCockpit.vue?raw'
+import {
+  AsrSocketGenerationFence,
+  AsrTranscriptionAttemptRegistry,
+  beginAsrRealtimeUtterance,
+  recoverAsrRealtimeSession,
+  type AsrControlSocket
+} from './asr-realtime-lifecycle'
+import {
+  ASR_UTTERANCE_SUPERSEDED_MESSAGE,
+  AsrTranscriptionDeadlineController,
+  type AsrDeadlineScheduler
+} from './asr-transcription-deadline'
 
-function sourceBetween(source: string, start: string, end: string): string {
-  const startIndex = source.indexOf(start)
-  const endIndex = source.indexOf(end, startIndex + start.length)
-  if (startIndex < 0 || endIndex < 0 || endIndex <= startIndex) {
-    throw new Error(`Could not find ordered lifecycle anchors: ${start} -> ${end}`)
+class FakeDeadlineScheduler implements AsrDeadlineScheduler {
+  private nextHandle = 1
+
+  now(): number {
+    return 0
   }
-  return source.slice(startIndex, endIndex)
+
+  setTimeout(): number {
+    return this.nextHandle++
+  }
+
+  clearTimeout(): void {}
 }
 
-describe('AgentVoiceCockpit ASR session lifecycle', () => {
-  it('starts each utterance with a protocol reset for emulated sessions', () => {
-    const beginUtterance = sourceBetween(
-      cockpitSource,
-      'function beginAsrUtterance(): void',
-      'function sendAsrAudio('
-    )
-    const nativeCapture = sourceBetween(
-      cockpitSource,
-      'function handleNativeVoiceSamples(',
-      'function updateNativeVoiceWaveform('
-    )
-    const browserCapture = sourceBetween(
-      cockpitSource,
-      'function updateVoiceWaveform(',
-      'async function finishUtterance('
-    )
+class FakeAsrSocket implements AsrControlSocket {
+  readonly sent: string[] = []
 
-    expect(beginUtterance).toContain('asrDeadlineController.beginUtterance()')
-    expect(beginUtterance).toContain(
-      'isBatchAsrStrategy(asrDeadlineController.getSessionStrategy())'
-    )
-    expect(beginUtterance).toContain("asrSocket.send(JSON.stringify({ type: 'start' }))")
-    expect(nativeCapture).toContain(
-      "if (recognitionMode.value === 'asr') beginAsrUtterance()"
-    )
-    expect(browserCapture).toContain(
-      "if (recognitionMode.value === 'asr') beginAsrUtterance()"
-    )
+  constructor(readonly readyState: number) {}
+
+  send(data: string): void {
+    this.sent.push(data)
+  }
+}
+
+describe('Agent Voice Cockpit ASR lifecycle helpers', () => {
+  it('clears the prior utterance error and sends start only for an open batch session', () => {
+    const controller = new AsrTranscriptionDeadlineController({
+      scheduler: new FakeDeadlineScheduler()
+    })
+    const socket = new FakeAsrSocket(1)
+    let error = 'No transcript'
+
+    beginAsrRealtimeUtterance({
+      controller,
+      socket,
+      openReadyState: 1,
+      onBegin: () => {
+        error = ''
+      }
+    })
+    expect(error).toBe('')
+    expect(socket.sent).toEqual([])
+
+    controller.handleSessionReady('emulated_batch')
+    beginAsrRealtimeUtterance({ controller, socket, openReadyState: 1, onBegin: () => {} })
+    expect(socket.sent).toEqual([JSON.stringify({ type: 'start' })])
+
+    const closedSocket = new FakeAsrSocket(3)
+    beginAsrRealtimeUtterance({
+      controller,
+      socket: closedSocket,
+      openReadyState: 1,
+      onBegin: () => {}
+    })
+    expect(closedSocket.sent).toEqual([])
   })
 
-  it('drops events from sockets invalidated by timeout recovery or disconnect', () => {
-    const connect = sourceBetween(
-      cockpitSource,
-      'async function connectAsrRealtime(): Promise<void>',
-      'function disconnectAsrRealtime(): void'
-    )
+  it('invalidates events from earlier socket generations', () => {
+    const fence = new AsrSocketGenerationFence()
+    const firstGeneration = fence.current()
+    expect(fence.isCurrent(firstGeneration)).toBe(true)
 
-    expect(connect).toContain('const socketGeneration = asrSocketGeneration')
-    expect(connect).toContain(
-      'if (socketGeneration !== asrSocketGeneration || asrSocket !== socket) return'
-    )
-    expect(connect).toContain('asrDeadlineController.resetSession(disconnectError)')
+    fence.invalidate()
+    expect(fence.isCurrent(firstGeneration)).toBe(false)
+    expect(fence.isCurrent(fence.current())).toBe(true)
   })
 
-  it('reconnects after a failed transcription before accepting another utterance', () => {
-    const finish = sourceBetween(
-      cockpitSource,
-      'async function finishUtterance(): Promise<void>',
-      'async function connectAsrRealtime(): Promise<void>'
-    )
-    const recover = sourceBetween(
-      cockpitSource,
-      'async function recoverAsrRealtimeAfterFailure(token: number): Promise<void>',
-      'function beginAsrUtterance(): void'
-    )
+  it('keeps a newer transcription registered when an older attempt settles', async () => {
+    const controller = new AsrTranscriptionDeadlineController({
+      scheduler: new FakeDeadlineScheduler()
+    })
+    const registry = new AsrTranscriptionAttemptRegistry()
+    const firstAttempt = controller.finish()
+    const firstPromise = registry.track(firstAttempt)
+    const secondAttempt = controller.finish()
+    const secondPromise = registry.track(secondAttempt)
 
-    expect(finish).toContain('await recoverAsrRealtimeAfterFailure(token)')
-    expect(recover).toContain('await connectAsrRealtime()')
-    expect(recover).toContain('closeVoiceInputAfterSubmit()')
+    await expect(firstPromise).rejects.toThrow(ASR_UTTERANCE_SUPERSEDED_MESSAGE)
+    expect(registry.hasPending()).toBe(true)
+
+    firstAttempt.resolve('stale transcript')
+    registry.resolve('current transcript')
+    await expect(secondPromise).resolves.toBe('current transcript')
+    expect(registry.hasPending()).toBe(false)
   })
 
-  it('keeps a healthy ASR socket when a completed transcription is empty', () => {
-    const finish = sourceBetween(
-      cockpitSource,
-      'async function finishUtterance(): Promise<void>',
-      'async function connectAsrRealtime(): Promise<void>'
-    )
-    const asrBranch = sourceBetween(
-      finish,
-      "if (recognitionMode.value === 'asr') {",
-      '\n  const chunks = pcmChunks'
-    )
-    const emptyTranscriptBranch = sourceBetween(
-      asrBranch,
-      'if (!text) {',
-      '\n      liveTranscript.value = text'
-    )
-    const failureCatch = sourceBetween(asrBranch, '} catch (err: any) {', '} finally {')
+  it('clears a stale error after reconnecting the active voice session', async () => {
+    let active = true
+    let error = 'ASR disconnected'
+    let disconnected = 0
+    let closed = 0
 
-    expect(emptyTranscriptBranch).toContain("error.value = t('voice.errors.noTranscript')")
-    expect(emptyTranscriptBranch).toContain('return')
-    expect(emptyTranscriptBranch).not.toContain('recoverAsrRealtimeAfterFailure')
-    expect(failureCatch).toContain('await recoverAsrRealtimeAfterFailure(token)')
+    await recoverAsrRealtimeSession({
+      shouldContinue: () => active,
+      connect: async () => {},
+      disconnect: () => {
+        disconnected += 1
+      },
+      clearError: () => {
+        error = ''
+      },
+      reportError: reconnectError => {
+        error = String(reconnectError)
+      },
+      closeInput: () => {
+        closed += 1
+      }
+    })
+
+    expect(error).toBe('')
+    expect(disconnected).toBe(0)
+    expect(closed).toBe(0)
+
+    active = true
+    await recoverAsrRealtimeSession({
+      shouldContinue: () => active,
+      connect: async () => {
+        active = false
+      },
+      disconnect: () => {
+        disconnected += 1
+      },
+      clearError: () => {
+        error = ''
+      },
+      reportError: () => {},
+      closeInput: () => {
+        closed += 1
+      }
+    })
+    expect(disconnected).toBe(1)
+    expect(closed).toBe(0)
   })
 
-  it('routes terminal events through the utterance-scoped transcription attempt', () => {
-    const finish = sourceBetween(
-      cockpitSource,
-      'function finishAsrUtterance(): Promise<string>',
-      'function handleAsrRealtimeMessage('
-    )
-    const settle = sourceBetween(
-      cockpitSource,
-      'function resolveAsrFinal(text: string): void',
-      'function cleanAsrTranscript('
-    )
+  it('reports a reconnect failure and closes only the still-active input', async () => {
+    let error: unknown = null
+    let closed = 0
 
-    expect(finish).toContain('asrPendingTranscription = transcription')
-    expect(finish).toContain('asrPendingTranscription === transcription')
-    expect(settle).toContain('asrPendingTranscription?.resolve(text)')
-    expect(settle).toContain('asrPendingTranscription?.reject(error)')
-    expect(settle).not.toContain('asrDeadlineController.resolve(')
-    expect(settle).not.toContain('asrDeadlineController.reject(')
+    await recoverAsrRealtimeSession({
+      shouldContinue: () => true,
+      connect: async () => {
+        throw new Error('reconnect failed')
+      },
+      disconnect: () => {},
+      clearError: () => {},
+      reportError: reconnectError => {
+        error = reconnectError
+      },
+      closeInput: () => {
+        closed += 1
+      }
+    })
+
+    expect(error).toEqual(new Error('reconnect failed'))
+    expect(closed).toBe(1)
   })
 })

--- a/agent-ui/src/components/agent/asr-realtime-lifecycle.ts
+++ b/agent-ui/src/components/agent/asr-realtime-lifecycle.ts
@@ -26,6 +26,9 @@ export function beginAsrRealtimeUtterance({
   controller.beginUtterance()
   if (!socket || socket.readyState !== openReadyState) return
   onBegin()
+  // The batch server's initial state already represents the first `start`. If
+  // `session.ready` arrives after audio begins, a retroactive start would discard
+  // that buffered audio. The session-scoped strategy resets every later utterance.
   if (!isBatchAsrStrategy(controller.getSessionStrategy())) return
   socket.send(JSON.stringify({ type: 'start' }))
 }

--- a/agent-ui/src/components/agent/asr-realtime-lifecycle.ts
+++ b/agent-ui/src/components/agent/asr-realtime-lifecycle.ts
@@ -23,10 +23,10 @@ export function beginAsrRealtimeUtterance({
   openReadyState,
   onBegin
 }: BeginAsrRealtimeUtteranceOptions): void {
-  onBegin()
   controller.beginUtterance()
-  if (!isBatchAsrStrategy(controller.getSessionStrategy())) return
   if (!socket || socket.readyState !== openReadyState) return
+  onBegin()
+  if (!isBatchAsrStrategy(controller.getSessionStrategy())) return
   socket.send(JSON.stringify({ type: 'start' }))
 }
 

--- a/agent-ui/src/components/agent/asr-realtime-lifecycle.ts
+++ b/agent-ui/src/components/agent/asr-realtime-lifecycle.ts
@@ -1,0 +1,106 @@
+import {
+  AsrTranscriptionDeadlineController,
+  isBatchAsrStrategy,
+  type AsrTranscriptionAttempt
+} from './asr-transcription-deadline'
+
+export interface AsrControlSocket {
+  readonly readyState: number
+  send(data: string): void
+}
+
+export interface BeginAsrRealtimeUtteranceOptions {
+  controller: AsrTranscriptionDeadlineController
+  socket: AsrControlSocket | null
+  openReadyState: number
+  onBegin: () => void
+}
+
+/** Begins one utterance and resets batch-style servers before audio is sent. */
+export function beginAsrRealtimeUtterance({
+  controller,
+  socket,
+  openReadyState,
+  onBegin
+}: BeginAsrRealtimeUtteranceOptions): void {
+  onBegin()
+  controller.beginUtterance()
+  if (!isBatchAsrStrategy(controller.getSessionStrategy())) return
+  if (!socket || socket.readyState !== openReadyState) return
+  socket.send(JSON.stringify({ type: 'start' }))
+}
+
+/** Monotonic fence used to reject events emitted by invalidated ASR sockets. */
+export class AsrSocketGenerationFence {
+  private generation = 0
+
+  current(): number {
+    return this.generation
+  }
+
+  invalidate(): number {
+    this.generation += 1
+    return this.generation
+  }
+
+  isCurrent(generation: number): boolean {
+    return generation === this.generation
+  }
+}
+
+/** Routes terminal events to the exact attempt currently owned by the cockpit. */
+export class AsrTranscriptionAttemptRegistry {
+  private pending: AsrTranscriptionAttempt | null = null
+
+  track(attempt: AsrTranscriptionAttempt): Promise<string> {
+    this.pending = attempt
+    return attempt.promise.finally(() => {
+      if (this.pending === attempt) this.pending = null
+    })
+  }
+
+  resolve(text: string): void {
+    this.pending?.resolve(text)
+  }
+
+  reject(error: Error): void {
+    this.pending?.reject(error)
+  }
+
+  hasPending(): boolean {
+    return this.pending !== null
+  }
+}
+
+export interface RecoverAsrRealtimeSessionOptions {
+  shouldContinue: () => boolean
+  connect: () => Promise<void>
+  disconnect: () => void
+  clearError: () => void
+  reportError: (error: unknown) => void
+  closeInput: () => void
+}
+
+/** Reconnects only for the active voice session and clears a recovered stale error. */
+export async function recoverAsrRealtimeSession({
+  shouldContinue,
+  connect,
+  disconnect,
+  clearError,
+  reportError,
+  closeInput
+}: RecoverAsrRealtimeSessionOptions): Promise<void> {
+  if (!shouldContinue()) return
+  try {
+    await connect()
+    if (!shouldContinue()) {
+      disconnect()
+      return
+    }
+    clearError()
+  } catch (error) {
+    if (!shouldContinue()) return
+    reportError(error)
+    closeInput()
+  }
+}

--- a/agent-ui/src/components/agent/asr-realtime-lifecycle.ts
+++ b/agent-ui/src/components/agent/asr-realtime-lifecycle.ts
@@ -75,21 +75,28 @@ export class AsrTranscriptionAttemptRegistry {
   }
 }
 
+/** Identifies an upstream protocol response that reconnecting cannot itself resolve. */
+export class AsrProtocolError extends Error {
+  override name = 'AsrProtocolError'
+}
+
 export interface RecoverAsrRealtimeSessionOptions {
   shouldContinue: () => boolean
   connect: () => Promise<void>
   disconnect: () => void
   clearError: () => void
+  clearErrorAfterReconnect?: boolean
   reportError: (error: unknown) => void
   closeInput: () => void
 }
 
-/** Reconnects only for the active voice session and clears a recovered stale error. */
+/** Reconnects only for the active voice session and clears recovered transport errors. */
 export async function recoverAsrRealtimeSession({
   shouldContinue,
   connect,
   disconnect,
   clearError,
+  clearErrorAfterReconnect = true,
   reportError,
   closeInput
 }: RecoverAsrRealtimeSessionOptions): Promise<void> {
@@ -100,7 +107,7 @@ export async function recoverAsrRealtimeSession({
       disconnect()
       return
     }
-    clearError()
+    if (clearErrorAfterReconnect) clearError()
   } catch (error) {
     if (!shouldContinue()) return
     reportError(error)

--- a/agent-ui/src/components/agent/asr-transcription-deadline.test.ts
+++ b/agent-ui/src/components/agent/asr-transcription-deadline.test.ts
@@ -466,6 +466,21 @@ describe('AsrTranscriptionDeadlineController terminal paths', () => {
     expect(rejectedMessage(outcome())).toBe(ASR_SESSION_DISCONNECTED_MESSAGE)
     expect(scheduler.activeTimerCount).toBe(0)
   })
+
+  it('clears strategy and captured audio when the socket closes before finish', () => {
+    const scheduler = new FakeDeadlineScheduler()
+    const controller = new AsrTranscriptionDeadlineController({ scheduler })
+    controller.handleSessionReady('emulated_batch')
+    controller.beginUtterance()
+    controller.recordSentAudio(32000, 16000)
+
+    controller.resetSession(new Error('socket closed'))
+
+    expect(controller.getSessionStrategy()).toBeNull()
+    expect(controller.getCapturedAudioMs()).toBe(0)
+    expect(controller.hasPendingUtterance()).toBe(false)
+    expect(scheduler.activeTimerCount).toBe(0)
+  })
 })
 
 describe('AsrTranscriptionDeadlineController per-utterance isolation', () => {

--- a/agent-ui/src/components/agent/asr-transcription-deadline.test.ts
+++ b/agent-ui/src/components/agent/asr-transcription-deadline.test.ts
@@ -1,0 +1,550 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  ASR_CONNECTION_TIMEOUT_MS,
+  ASR_SESSION_DISCONNECTED_MESSAGE,
+  ASR_UTTERANCE_SUPERSEDED_MESSAGE,
+  AsrTranscriptionDeadlineController,
+  BATCH_ASR_DEADLINE_AUDIO_FACTOR,
+  BATCH_ASR_DEADLINE_BASE_MS,
+  BATCH_ASR_DEADLINE_MAX_MS,
+  BATCH_ASR_DEADLINE_MIN_MS,
+  NATIVE_ASR_TRANSCRIPTION_DEADLINE_MS,
+  computeBatchTranscriptionDeadlineMs,
+  computeTranscriptionDeadlineMs,
+  isAsrTranscriptionStrategy,
+  normalizeAsrStrategy,
+  type AsrDeadlineScheduler
+} from './asr-transcription-deadline'
+
+class FakeDeadlineScheduler implements AsrDeadlineScheduler {
+  nowMs = 0
+  private nextHandle = 1
+  private readonly timers = new Map<number, { at: number; handler: () => void }>()
+
+  now(): number {
+    return this.nowMs
+  }
+
+  setTimeout(handler: () => void, delayMs: number): number {
+    const handle = this.nextHandle
+    this.nextHandle += 1
+    this.timers.set(handle, { at: this.nowMs + Math.max(0, delayMs), handler })
+    return handle
+  }
+
+  clearTimeout(handle: number): void {
+    this.timers.delete(handle)
+  }
+
+  advance(ms: number): void {
+    const target = this.nowMs + ms
+    for (;;) {
+      let dueHandle: number | null = null
+      let dueAt = Number.POSITIVE_INFINITY
+      for (const [handle, timer] of this.timers) {
+        if (timer.at <= target && timer.at < dueAt) {
+          dueAt = timer.at
+          dueHandle = handle
+        }
+      }
+      if (dueHandle === null) break
+      const timer = this.timers.get(dueHandle)
+      this.timers.delete(dueHandle)
+      this.nowMs = dueAt
+      timer?.handler()
+    }
+    this.nowMs = target
+  }
+
+  get activeTimerCount(): number {
+    return this.timers.size
+  }
+}
+
+type TrackedOutcome =
+  | { status: 'pending' }
+  | { status: 'resolved'; text: string }
+  | { status: 'rejected'; error: Error }
+
+function trackTranscription(promise: Promise<string>): () => TrackedOutcome {
+  let outcome: TrackedOutcome = { status: 'pending' }
+  promise.then(
+    text => {
+      outcome = { status: 'resolved', text }
+    },
+    error => {
+      outcome = {
+        status: 'rejected',
+        error: error instanceof Error ? error : new Error(String(error))
+      }
+    }
+  )
+  return () => outcome
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+function rejectedMessage(outcome: TrackedOutcome): string {
+  expect(outcome.status).toBe('rejected')
+  return outcome.status === 'rejected' ? outcome.error.message : ''
+}
+
+describe('ASR transcription deadline constants and formula', () => {
+  it('keeps the documented connection and native transcription budgets', () => {
+    expect(ASR_CONNECTION_TIMEOUT_MS).toBe(5000)
+    expect(NATIVE_ASR_TRANSCRIPTION_DEADLINE_MS).toBe(9000)
+  })
+
+  it('clamps the batch formula to the documented minimum and maximum', () => {
+    expect(BATCH_ASR_DEADLINE_BASE_MS).toBe(15000)
+    expect(BATCH_ASR_DEADLINE_AUDIO_FACTOR).toBe(2)
+    expect(BATCH_ASR_DEADLINE_MIN_MS).toBe(30000)
+    expect(BATCH_ASR_DEADLINE_MAX_MS).toBe(120000)
+    expect(computeBatchTranscriptionDeadlineMs(0)).toBe(30000)
+    expect(computeBatchTranscriptionDeadlineMs(7499)).toBe(30000)
+    expect(computeBatchTranscriptionDeadlineMs(7500)).toBe(30000)
+    expect(computeBatchTranscriptionDeadlineMs(20000)).toBe(55000)
+    expect(computeBatchTranscriptionDeadlineMs(52500)).toBe(120000)
+    expect(computeBatchTranscriptionDeadlineMs(120000)).toBe(120000)
+    expect(computeBatchTranscriptionDeadlineMs(-100)).toBe(30000)
+    expect(computeBatchTranscriptionDeadlineMs(Number.NaN)).toBe(30000)
+  })
+
+  it('keeps native realtime on the 9,000 ms deadline regardless of audio duration', () => {
+    expect(computeTranscriptionDeadlineMs('native_realtime', 0)).toBe(9000)
+    expect(computeTranscriptionDeadlineMs('native_realtime', 999999)).toBe(9000)
+    expect(computeTranscriptionDeadlineMs(null, 20000)).toBe(9000)
+  })
+
+  it('applies the bounded batch formula to emulated_batch and ark_voice', () => {
+    expect(computeTranscriptionDeadlineMs('emulated_batch', 1000)).toBe(30000)
+    expect(computeTranscriptionDeadlineMs('emulated_batch', 20000)).toBe(55000)
+    expect(computeTranscriptionDeadlineMs('emulated_batch', 90000)).toBe(120000)
+    expect(computeTranscriptionDeadlineMs('ark_voice', 10000)).toBe(35000)
+    expect(computeTranscriptionDeadlineMs('ark_voice', 60000)).toBe(120000)
+  })
+
+  it('fails closed for invalid strategy values', () => {
+    const invalidValues: unknown[] = [
+      undefined,
+      null,
+      '',
+      'EMULATED_BATCH',
+      'emulated',
+      'batch',
+      'native',
+      'native_realtime_extra',
+      42,
+      {},
+      ['emulated_batch']
+    ]
+    for (const value of invalidValues) {
+      expect(isAsrTranscriptionStrategy(value)).toBe(false)
+      expect(normalizeAsrStrategy(value)).toBeNull()
+    }
+    expect(normalizeAsrStrategy('native_realtime')).toBe('native_realtime')
+    expect(normalizeAsrStrategy('emulated_batch')).toBe('emulated_batch')
+    expect(normalizeAsrStrategy('ark_voice')).toBe('ark_voice')
+  })
+})
+
+describe('AsrTranscriptionDeadlineController defaults', () => {
+  it('times out native realtime at 9,000 ms even with long audio', async () => {
+    const scheduler = new FakeDeadlineScheduler()
+    const controller = new AsrTranscriptionDeadlineController({ scheduler })
+    controller.handleSessionReady('native_realtime')
+    controller.beginUtterance()
+    controller.recordSentAudio(160000, 16000)
+    const outcome = trackTranscription(controller.finish())
+
+    scheduler.advance(NATIVE_ASR_TRANSCRIPTION_DEADLINE_MS - 1)
+    await flushMicrotasks()
+    expect(outcome().status).toBe('pending')
+
+    scheduler.advance(1)
+    await flushMicrotasks()
+    expect(rejectedMessage(outcome())).toBe('ASR transcription timed out')
+    expect(scheduler.activeTimerCount).toBe(0)
+    expect(controller.hasPendingUtterance()).toBe(false)
+  })
+
+  it('times out an unknown strategy at 9,000 ms when session.ready never arrived', async () => {
+    const scheduler = new FakeDeadlineScheduler()
+    const controller = new AsrTranscriptionDeadlineController({ scheduler })
+    controller.beginUtterance()
+    controller.recordSentAudio(320000, 16000)
+    const outcome = trackTranscription(controller.finish())
+
+    scheduler.advance(8999)
+    await flushMicrotasks()
+    expect(outcome().status).toBe('pending')
+
+    scheduler.advance(1)
+    await flushMicrotasks()
+    expect(rejectedMessage(outcome())).toBe('ASR transcription timed out')
+    expect(controller.getSessionStrategy()).toBeNull()
+  })
+
+  it('fails closed when session.ready carries an invalid strategy', async () => {
+    const scheduler = new FakeDeadlineScheduler()
+    const controller = new AsrTranscriptionDeadlineController({ scheduler })
+    controller.handleSessionReady('quantum_asr')
+    expect(controller.getSessionStrategy()).toBeNull()
+    controller.beginUtterance()
+    controller.recordSentAudio(320000, 16000)
+    const outcome = trackTranscription(controller.finish())
+
+    scheduler.advance(9000)
+    await flushMicrotasks()
+    expect(rejectedMessage(outcome())).toBe('ASR transcription timed out')
+  })
+
+  it('gives short emulated audio the 30,000 ms minimum', async () => {
+    const scheduler = new FakeDeadlineScheduler()
+    const controller = new AsrTranscriptionDeadlineController({ scheduler })
+    controller.handleSessionReady('emulated_batch')
+    controller.beginUtterance()
+    controller.recordSentAudio(16000, 16000)
+    const outcome = trackTranscription(controller.finish())
+
+    scheduler.advance(BATCH_ASR_DEADLINE_MIN_MS - 1)
+    await flushMicrotasks()
+    expect(outcome().status).toBe('pending')
+
+    scheduler.advance(1)
+    await flushMicrotasks()
+    expect(rejectedMessage(outcome())).toBe('ASR transcription timed out')
+  })
+
+  it('scales longer audio with the formula and caps at 120,000 ms', async () => {
+    const scheduler = new FakeDeadlineScheduler()
+    const controller = new AsrTranscriptionDeadlineController({ scheduler })
+    controller.handleSessionReady('emulated_batch')
+    controller.beginUtterance()
+    controller.recordSentAudio(320000, 16000)
+    const scaled = trackTranscription(controller.finish())
+
+    scheduler.advance(54999)
+    await flushMicrotasks()
+    expect(scaled().status).toBe('pending')
+    scheduler.advance(1)
+    await flushMicrotasks()
+    expect(rejectedMessage(scaled())).toBe('ASR transcription timed out')
+
+    controller.handleSessionReady('ark_voice')
+    controller.beginUtterance()
+    controller.recordSentAudio(1920000, 16000)
+    const capped = trackTranscription(controller.finish())
+
+    scheduler.advance(BATCH_ASR_DEADLINE_MAX_MS - 1)
+    await flushMicrotasks()
+    expect(capped().status).toBe('pending')
+    scheduler.advance(1)
+    await flushMicrotasks()
+    expect(rejectedMessage(capped())).toBe('ASR transcription timed out')
+  })
+
+  it('honors a custom timeout message from the cockpit', async () => {
+    const scheduler = new FakeDeadlineScheduler()
+    const controller = new AsrTranscriptionDeadlineController({ scheduler })
+    controller.beginUtterance()
+    const outcome = trackTranscription(controller.finish({ timeoutMessage: 'voice timeout' }))
+    scheduler.advance(9000)
+    await flushMicrotasks()
+    expect(rejectedMessage(outcome())).toBe('voice timeout')
+  })
+})
+
+describe('AsrTranscriptionDeadlineController promotion', () => {
+  it('promotes a pending unknown deadline to the batch deadline from the original finish time', async () => {
+    const scheduler = new FakeDeadlineScheduler()
+    scheduler.nowMs = 100000
+    const controller = new AsrTranscriptionDeadlineController({ scheduler })
+    controller.beginUtterance()
+    controller.recordSentAudio(320000, 16000)
+    const outcome = trackTranscription(controller.finish())
+    const finishedAt = scheduler.nowMs
+
+    scheduler.advance(8000)
+    controller.handleTranscriptionProcessing('emulated_batch')
+    expect(controller.getSessionStrategy()).toBe('emulated_batch')
+
+    scheduler.advance(1000)
+    await flushMicrotasks()
+    expect(outcome().status).toBe('pending')
+
+    scheduler.advance(45999)
+    await flushMicrotasks()
+    expect(outcome().status).toBe('pending')
+
+    scheduler.advance(1)
+    await flushMicrotasks()
+    expect(scheduler.nowMs).toBe(finishedAt + 55000)
+    expect(rejectedMessage(outcome())).toBe('ASR transcription timed out')
+  })
+
+  it('promotes a pending native deadline when the batch strategy arrives late', async () => {
+    const scheduler = new FakeDeadlineScheduler()
+    const controller = new AsrTranscriptionDeadlineController({ scheduler })
+    controller.handleSessionReady('native_realtime')
+    controller.beginUtterance()
+    controller.recordSentAudio(160000, 16000)
+    const outcome = trackTranscription(controller.finish())
+
+    scheduler.advance(4000)
+    controller.handleTranscriptionProcessing('emulated_batch')
+
+    scheduler.advance(5000)
+    await flushMicrotasks()
+    expect(outcome().status).toBe('pending')
+
+    scheduler.advance(35000 - 9000 - 1)
+    await flushMicrotasks()
+    expect(outcome().status).toBe('pending')
+
+    scheduler.advance(1)
+    await flushMicrotasks()
+    expect(scheduler.nowMs).toBe(35000)
+    expect(rejectedMessage(outcome())).toBe('ASR transcription timed out')
+  })
+
+  it('never slides the absolute deadline when processing events repeat', async () => {
+    const scheduler = new FakeDeadlineScheduler()
+    const controller = new AsrTranscriptionDeadlineController({ scheduler })
+    controller.beginUtterance()
+    controller.recordSentAudio(320000, 16000)
+    const outcome = trackTranscription(controller.finish())
+
+    scheduler.advance(1000)
+    controller.handleTranscriptionProcessing('emulated_batch')
+    scheduler.advance(49000)
+    controller.handleTranscriptionProcessing('emulated_batch')
+    controller.handleTranscriptionProcessing('emulated_batch')
+    controller.handleTranscriptionProcessing('ark_voice')
+    await flushMicrotasks()
+    expect(outcome().status).toBe('pending')
+
+    scheduler.advance(4999)
+    await flushMicrotasks()
+    expect(outcome().status).toBe('pending')
+
+    scheduler.advance(1)
+    await flushMicrotasks()
+    expect(scheduler.nowMs).toBe(55000)
+    expect(rejectedMessage(outcome())).toBe('ASR transcription timed out')
+  })
+
+  it('does not shorten a batch deadline when processing confirms a native strategy', async () => {
+    const scheduler = new FakeDeadlineScheduler()
+    const controller = new AsrTranscriptionDeadlineController({ scheduler })
+    controller.handleSessionReady('emulated_batch')
+    controller.beginUtterance()
+    controller.recordSentAudio(320000, 16000)
+    const outcome = trackTranscription(controller.finish())
+
+    scheduler.advance(1000)
+    controller.handleTranscriptionProcessing('native_realtime')
+
+    scheduler.advance(53999)
+    await flushMicrotasks()
+    expect(outcome().status).toBe('pending')
+
+    scheduler.advance(1)
+    await flushMicrotasks()
+    expect(rejectedMessage(outcome())).toBe('ASR transcription timed out')
+  })
+
+  it('does not promote for invalid processing strategies', async () => {
+    const scheduler = new FakeDeadlineScheduler()
+    const controller = new AsrTranscriptionDeadlineController({ scheduler })
+    controller.beginUtterance()
+    controller.recordSentAudio(320000, 16000)
+    const outcome = trackTranscription(controller.finish())
+
+    scheduler.advance(1000)
+    controller.handleTranscriptionProcessing('emulated')
+    expect(controller.getSessionStrategy()).toBeNull()
+
+    scheduler.advance(8000)
+    await flushMicrotasks()
+    expect(rejectedMessage(outcome())).toBe('ASR transcription timed out')
+  })
+
+  it('records a processing strategy that arrives before any pending utterance', () => {
+    const scheduler = new FakeDeadlineScheduler()
+    const controller = new AsrTranscriptionDeadlineController({ scheduler })
+    controller.handleTranscriptionProcessing('emulated_batch')
+    expect(controller.getSessionStrategy()).toBe('emulated_batch')
+    expect(controller.hasPendingUtterance()).toBe(false)
+  })
+})
+
+describe('AsrTranscriptionDeadlineController terminal paths', () => {
+  it('resolves on transcription.done exactly once and clears the timer', async () => {
+    const scheduler = new FakeDeadlineScheduler()
+    const controller = new AsrTranscriptionDeadlineController({ scheduler })
+    controller.handleSessionReady('emulated_batch')
+    controller.beginUtterance()
+    controller.recordSentAudio(320000, 16000)
+    const outcome = trackTranscription(controller.finish())
+
+    scheduler.advance(100)
+    controller.resolve('hello')
+    controller.resolve('second resolve')
+    controller.reject(new Error('late error'))
+    await flushMicrotasks()
+
+    const settled = outcome()
+    expect(settled).toEqual({ status: 'resolved', text: 'hello' })
+    expect(scheduler.activeTimerCount).toBe(0)
+    expect(controller.hasPendingUtterance()).toBe(false)
+
+    scheduler.advance(200000)
+    await flushMicrotasks()
+    expect(outcome()).toEqual({ status: 'resolved', text: 'hello' })
+  })
+
+  it('rejects on protocol error exactly once', async () => {
+    const scheduler = new FakeDeadlineScheduler()
+    const controller = new AsrTranscriptionDeadlineController({ scheduler })
+    controller.beginUtterance()
+    const outcome = trackTranscription(controller.finish())
+
+    scheduler.advance(100)
+    controller.reject(new Error('boom'))
+    controller.resolve('late text')
+    await flushMicrotasks()
+
+    expect(rejectedMessage(outcome())).toBe('boom')
+    expect(scheduler.activeTimerCount).toBe(0)
+
+    scheduler.advance(200000)
+    await flushMicrotasks()
+    expect(rejectedMessage(outcome())).toBe('boom')
+  })
+
+  it('clears timer and state on disconnect via resetSession', async () => {
+    const scheduler = new FakeDeadlineScheduler()
+    const controller = new AsrTranscriptionDeadlineController({ scheduler })
+    controller.handleSessionReady('emulated_batch')
+    controller.beginUtterance()
+    controller.recordSentAudio(320000, 16000)
+    const outcome = trackTranscription(controller.finish())
+
+    controller.resetSession(new Error('ASR disconnected'))
+    await flushMicrotasks()
+
+    expect(rejectedMessage(outcome())).toBe('ASR disconnected')
+    expect(controller.getSessionStrategy()).toBeNull()
+    expect(controller.getCapturedAudioMs()).toBe(0)
+    expect(controller.hasPendingUtterance()).toBe(false)
+    expect(scheduler.activeTimerCount).toBe(0)
+
+    scheduler.advance(200000)
+    await flushMicrotasks()
+    expect(rejectedMessage(outcome())).toBe('ASR disconnected')
+
+    controller.handleSessionReady('native_realtime')
+    controller.beginUtterance()
+    const nextOutcome = trackTranscription(controller.finish())
+    scheduler.advance(9000)
+    await flushMicrotasks()
+    expect(rejectedMessage(nextOutcome())).toBe('ASR transcription timed out')
+  })
+
+  it('uses the default disconnect error when stop provides none', async () => {
+    const scheduler = new FakeDeadlineScheduler()
+    const controller = new AsrTranscriptionDeadlineController({ scheduler })
+    controller.beginUtterance()
+    const outcome = trackTranscription(controller.finish())
+    controller.resetSession()
+    await flushMicrotasks()
+    expect(rejectedMessage(outcome())).toBe(ASR_SESSION_DISCONNECTED_MESSAGE)
+    expect(scheduler.activeTimerCount).toBe(0)
+  })
+})
+
+describe('AsrTranscriptionDeadlineController per-utterance isolation', () => {
+  it('does not let a stale callback from the previous utterance reject the next one', async () => {
+    const scheduler = new FakeDeadlineScheduler()
+    const controller = new AsrTranscriptionDeadlineController({ scheduler })
+    const first = trackTranscription(controller.finish())
+
+    scheduler.advance(1000)
+    controller.beginUtterance()
+    await flushMicrotasks()
+    expect(rejectedMessage(first())).toBe(ASR_UTTERANCE_SUPERSEDED_MESSAGE)
+    expect(scheduler.activeTimerCount).toBe(0)
+
+    controller.recordSentAudio(16000, 16000)
+    const second = trackTranscription(controller.finish())
+
+    scheduler.advance(8999)
+    await flushMicrotasks()
+    expect(second().status).toBe('pending')
+
+    scheduler.advance(1)
+    await flushMicrotasks()
+    expect(rejectedMessage(second())).toBe('ASR transcription timed out')
+  })
+
+  it('settles the earlier promise deterministically when finish is called twice', async () => {
+    const scheduler = new FakeDeadlineScheduler()
+    const controller = new AsrTranscriptionDeadlineController({ scheduler })
+    const first = trackTranscription(controller.finish())
+    const second = trackTranscription(controller.finish())
+    await flushMicrotasks()
+
+    expect(rejectedMessage(first())).toBe(ASR_UTTERANCE_SUPERSEDED_MESSAGE)
+    expect(second().status).toBe('pending')
+
+    scheduler.advance(9000)
+    await flushMicrotasks()
+    expect(rejectedMessage(second())).toBe('ASR transcription timed out')
+    expect(scheduler.activeTimerCount).toBe(0)
+  })
+
+  it('isolates captured audio duration between utterances', async () => {
+    const scheduler = new FakeDeadlineScheduler()
+    const controller = new AsrTranscriptionDeadlineController({ scheduler })
+    controller.handleSessionReady('emulated_batch')
+
+    controller.beginUtterance()
+    controller.recordSentAudio(960000, 16000)
+    const first = trackTranscription(controller.finish())
+    scheduler.advance(100)
+    controller.resolve('done')
+    await flushMicrotasks()
+    expect(first()).toEqual({ status: 'resolved', text: 'done' })
+    expect(controller.getCapturedAudioMs()).toBe(0)
+
+    controller.beginUtterance()
+    const second = trackTranscription(controller.finish())
+    scheduler.advance(BATCH_ASR_DEADLINE_MIN_MS - 1)
+    await flushMicrotasks()
+    expect(second().status).toBe('pending')
+    scheduler.advance(1)
+    await flushMicrotasks()
+    expect(rejectedMessage(second())).toBe('ASR transcription timed out')
+  })
+
+  it('counts only valid sent audio toward the captured duration', () => {
+    const scheduler = new FakeDeadlineScheduler()
+    const controller = new AsrTranscriptionDeadlineController({ scheduler })
+    controller.recordSentAudio(0, 16000)
+    controller.recordSentAudio(-5, 16000)
+    controller.recordSentAudio(16000, 0)
+    controller.recordSentAudio(Number.NaN, 16000)
+    expect(controller.getCapturedAudioMs()).toBe(0)
+
+    controller.recordSentAudio(24000, 48000)
+    expect(controller.getCapturedAudioMs()).toBe(500)
+
+    controller.beginUtterance()
+    expect(controller.getCapturedAudioMs()).toBe(0)
+  })
+})

--- a/agent-ui/src/components/agent/asr-transcription-deadline.test.ts
+++ b/agent-ui/src/components/agent/asr-transcription-deadline.test.ts
@@ -67,7 +67,10 @@ type TrackedOutcome =
   | { status: 'resolved'; text: string }
   | { status: 'rejected'; error: Error }
 
-function trackTranscription(promise: Promise<string>): () => TrackedOutcome {
+function trackTranscription(
+  transcription: Promise<string> | { promise: Promise<string> }
+): () => TrackedOutcome {
+  const promise = 'promise' in transcription ? transcription.promise : transcription
   let outcome: TrackedOutcome = { status: 'pending' }
   promise.then(
     text => {
@@ -287,6 +290,31 @@ describe('AsrTranscriptionDeadlineController promotion', () => {
     expect(rejectedMessage(outcome())).toBe('ASR transcription timed out')
   })
 
+  it('also promotes an in-flight deadline when session.ready arrives late', async () => {
+    const scheduler = new FakeDeadlineScheduler()
+    const controller = new AsrTranscriptionDeadlineController({ scheduler })
+    controller.beginUtterance()
+    controller.recordSentAudio(320000, 16000)
+    const outcome = trackTranscription(controller.finish())
+
+    scheduler.advance(8000)
+    controller.handleSessionReady('emulated_batch')
+    expect(controller.getSessionStrategy()).toBe('emulated_batch')
+
+    scheduler.advance(1000)
+    await flushMicrotasks()
+    expect(outcome().status).toBe('pending')
+
+    scheduler.advance(45999)
+    await flushMicrotasks()
+    expect(outcome().status).toBe('pending')
+
+    scheduler.advance(1)
+    await flushMicrotasks()
+    expect(scheduler.nowMs).toBe(55000)
+    expect(rejectedMessage(outcome())).toBe('ASR transcription timed out')
+  })
+
   it('promotes a pending native deadline when the batch strategy arrives late', async () => {
     const scheduler = new FakeDeadlineScheduler()
     const controller = new AsrTranscriptionDeadlineController({ scheduler })
@@ -390,12 +418,13 @@ describe('AsrTranscriptionDeadlineController terminal paths', () => {
     controller.handleSessionReady('emulated_batch')
     controller.beginUtterance()
     controller.recordSentAudio(320000, 16000)
-    const outcome = trackTranscription(controller.finish())
+    const transcription = controller.finish()
+    const outcome = trackTranscription(transcription)
 
     scheduler.advance(100)
-    controller.resolve('hello')
-    controller.resolve('second resolve')
-    controller.reject(new Error('late error'))
+    transcription.resolve('hello')
+    transcription.resolve('second resolve')
+    transcription.reject(new Error('late error'))
     await flushMicrotasks()
 
     const settled = outcome()
@@ -412,11 +441,12 @@ describe('AsrTranscriptionDeadlineController terminal paths', () => {
     const scheduler = new FakeDeadlineScheduler()
     const controller = new AsrTranscriptionDeadlineController({ scheduler })
     controller.beginUtterance()
-    const outcome = trackTranscription(controller.finish())
+    const transcription = controller.finish()
+    const outcome = trackTranscription(transcription)
 
     scheduler.advance(100)
-    controller.reject(new Error('boom'))
-    controller.resolve('late text')
+    transcription.reject(new Error('boom'))
+    transcription.resolve('late text')
     await flushMicrotasks()
 
     expect(rejectedMessage(outcome())).toBe('boom')
@@ -510,11 +540,18 @@ describe('AsrTranscriptionDeadlineController per-utterance isolation', () => {
   it('settles the earlier promise deterministically when finish is called twice', async () => {
     const scheduler = new FakeDeadlineScheduler()
     const controller = new AsrTranscriptionDeadlineController({ scheduler })
-    const first = trackTranscription(controller.finish())
-    const second = trackTranscription(controller.finish())
+    const firstTranscription = controller.finish()
+    const first = trackTranscription(firstTranscription)
+    const secondTranscription = controller.finish()
+    const second = trackTranscription(secondTranscription)
     await flushMicrotasks()
 
     expect(rejectedMessage(first())).toBe(ASR_UTTERANCE_SUPERSEDED_MESSAGE)
+    expect(second().status).toBe('pending')
+
+    firstTranscription.resolve('stale text')
+    firstTranscription.reject(new Error('stale error'))
+    await flushMicrotasks()
     expect(second().status).toBe('pending')
 
     scheduler.advance(9000)
@@ -530,9 +567,10 @@ describe('AsrTranscriptionDeadlineController per-utterance isolation', () => {
 
     controller.beginUtterance()
     controller.recordSentAudio(960000, 16000)
-    const first = trackTranscription(controller.finish())
+    const firstTranscription = controller.finish()
+    const first = trackTranscription(firstTranscription)
     scheduler.advance(100)
-    controller.resolve('done')
+    firstTranscription.resolve('done')
     await flushMicrotasks()
     expect(first()).toEqual({ status: 'resolved', text: 'done' })
     expect(controller.getCapturedAudioMs()).toBe(0)

--- a/agent-ui/src/components/agent/asr-transcription-deadline.ts
+++ b/agent-ui/src/components/agent/asr-transcription-deadline.ts
@@ -1,0 +1,252 @@
+/**
+ * Deterministic ASR transcription deadline control for the Agent Voice Cockpit.
+ *
+ * The WebSocket connection timeout (5 s) and the transcription wait are separate
+ * clocks. Native realtime and unknown strategies keep the historical 9 s deadline,
+ * while batch-style strategies (`emulated_batch`, `ark_voice`) receive a bounded
+ * adaptive deadline based on the audio duration actually sent:
+ *
+ *   clamp(15000 ms + 2 * capturedAudioMs, 30000 ms, 120000 ms)
+ *
+ * `session.ready` records the strategy for the connection; `transcription.processing`
+ * may confirm or promote the pending utterance to the batch deadline recomputed from
+ * the original finish timestamp. Repeated events are idempotent and can never slide
+ * the absolute deadline past the formula. All per-utterance state (audio duration,
+ * timer, resolver/rejector) is cleared on every terminal lifecycle path.
+ */
+
+export type AsrTranscriptionStrategy = 'native_realtime' | 'emulated_batch' | 'ark_voice'
+
+/** WebSocket connection establishment budget; unrelated to transcription speed. */
+export const ASR_CONNECTION_TIMEOUT_MS = 5000
+
+/** Existing transcription deadline kept for native realtime and unknown strategies. */
+export const NATIVE_ASR_TRANSCRIPTION_DEADLINE_MS = 9000
+
+/** Batch-style deadline formula: clamp(base + factor * audio, min, max). */
+export const BATCH_ASR_DEADLINE_BASE_MS = 15000
+export const BATCH_ASR_DEADLINE_AUDIO_FACTOR = 2
+export const BATCH_ASR_DEADLINE_MIN_MS = 30000
+export const BATCH_ASR_DEADLINE_MAX_MS = 120000
+
+export const ASR_TRANSCRIPTION_TIMEOUT_MESSAGE = 'ASR transcription timed out'
+export const ASR_SESSION_DISCONNECTED_MESSAGE = 'ASR realtime session disconnected'
+export const ASR_UTTERANCE_SUPERSEDED_MESSAGE = 'ASR transcription superseded by next utterance'
+
+const ASR_TRANSCRIPTION_STRATEGIES: readonly AsrTranscriptionStrategy[] = [
+  'native_realtime',
+  'emulated_batch',
+  'ark_voice'
+]
+
+/** True only for the exact protocol strategy literals; anything else fails closed. */
+export function isAsrTranscriptionStrategy(value: unknown): value is AsrTranscriptionStrategy {
+  return (
+    typeof value === 'string' &&
+    (ASR_TRANSCRIPTION_STRATEGIES as readonly string[]).includes(value)
+  )
+}
+
+/** Normalizes an event-carried strategy; invalid, absent, or malformed values yield null. */
+export function normalizeAsrStrategy(value: unknown): AsrTranscriptionStrategy | null {
+  return isAsrTranscriptionStrategy(value) ? value : null
+}
+
+/** Batch-style strategies process the whole recording after `finish`. */
+export function isBatchAsrStrategy(value: unknown): value is AsrTranscriptionStrategy {
+  return value === 'emulated_batch' || value === 'ark_voice'
+}
+
+/** clamp(15000 + 2 * capturedAudioMs, 30000, 120000). */
+export function computeBatchTranscriptionDeadlineMs(capturedAudioMs: number): number {
+  const safeAudioMs =
+    Number.isFinite(capturedAudioMs) && capturedAudioMs > 0 ? capturedAudioMs : 0
+  const rawDeadlineMs =
+    BATCH_ASR_DEADLINE_BASE_MS + BATCH_ASR_DEADLINE_AUDIO_FACTOR * safeAudioMs
+  return Math.min(BATCH_ASR_DEADLINE_MAX_MS, Math.max(BATCH_ASR_DEADLINE_MIN_MS, rawDeadlineMs))
+}
+
+/** Deadline for an utterance: 9 s default, bounded adaptive formula for batch strategies. */
+export function computeTranscriptionDeadlineMs(
+  strategy: AsrTranscriptionStrategy | null,
+  capturedAudioMs: number
+): number {
+  if (!isBatchAsrStrategy(strategy)) return NATIVE_ASR_TRANSCRIPTION_DEADLINE_MS
+  return computeBatchTranscriptionDeadlineMs(capturedAudioMs)
+}
+
+/** Injectable clock/scheduler so tests stay deterministic without real waits. */
+export interface AsrDeadlineScheduler {
+  now(): number
+  setTimeout(handler: () => void, delayMs: number): number
+  clearTimeout(handle: number): void
+}
+
+export function createDefaultAsrDeadlineScheduler(): AsrDeadlineScheduler {
+  return {
+    now: () => Date.now(),
+    setTimeout: (handler, delayMs) => window.setTimeout(handler, delayMs),
+    clearTimeout: handle => window.clearTimeout(handle)
+  }
+}
+
+export interface AsrTranscriptionDeadlineOptions {
+  scheduler?: AsrDeadlineScheduler
+  defaultTimeoutMessage?: string
+}
+
+interface PendingAsrUtterance {
+  id: number
+  resolve: (text: string) => void
+  reject: (error: Error) => void
+  finishedAt: number
+  capturedAudioMs: number
+  deadlineAt: number
+  timer: number
+  timeoutMessage: string
+}
+
+export class AsrTranscriptionDeadlineController {
+  private readonly scheduler: AsrDeadlineScheduler
+  private readonly defaultTimeoutMessage: string
+  /** Session-scoped strategy recorded from session.ready / transcription.processing. */
+  private sessionStrategy: AsrTranscriptionStrategy | null = null
+  /** Audio duration (ms) actually sent to the active ASR socket for this utterance. */
+  private capturedAudioMs = 0
+  private pending: PendingAsrUtterance | null = null
+  private utteranceSequence = 0
+
+  constructor(options: AsrTranscriptionDeadlineOptions = {}) {
+    this.scheduler = options.scheduler ?? createDefaultAsrDeadlineScheduler()
+    this.defaultTimeoutMessage = options.defaultTimeoutMessage ?? ASR_TRANSCRIPTION_TIMEOUT_MESSAGE
+  }
+
+  getSessionStrategy(): AsrTranscriptionStrategy | null {
+    return this.sessionStrategy
+  }
+
+  getCapturedAudioMs(): number {
+    return this.capturedAudioMs
+  }
+
+  hasPendingUtterance(): boolean {
+    return this.pending !== null
+  }
+
+  /** Records a valid strategy announced by `session.ready`; invalid values fail closed. */
+  handleSessionReady(strategy: unknown): void {
+    const normalized = normalizeAsrStrategy(strategy)
+    if (normalized) this.sessionStrategy = normalized
+  }
+
+  /**
+   * Consumes `transcription.processing`. A valid strategy may confirm or promote the
+   * pending utterance to the matching batch deadline, recomputed from the original
+   * finish timestamp so repeated events never slide the absolute deadline.
+   */
+  handleTranscriptionProcessing(strategy: unknown): void {
+    const normalized = normalizeAsrStrategy(strategy)
+    if (!normalized) return
+    this.sessionStrategy = normalized
+    const pending = this.pending
+    if (!pending || !isBatchAsrStrategy(normalized)) return
+    const promotedDeadlineAt =
+      pending.finishedAt + computeBatchTranscriptionDeadlineMs(pending.capturedAudioMs)
+    if (promotedDeadlineAt <= pending.deadlineAt) return
+    pending.deadlineAt = promotedDeadlineAt
+    this.scheduler.clearTimeout(pending.timer)
+    const remainingMs = Math.max(0, promotedDeadlineAt - this.scheduler.now())
+    pending.timer = this.scheduler.setTimeout(() => this.handleTimeout(pending.id), remainingMs)
+  }
+
+  /** Starts a new utterance: settles any pending one and resets per-utterance audio. */
+  beginUtterance(): void {
+    this.supersedePending()
+    this.capturedAudioMs = 0
+  }
+
+  /** Counts audio actually sent to the open ASR socket toward the current utterance. */
+  recordSentAudio(sampleCount: number, sampleRate: number): void {
+    if (!Number.isFinite(sampleCount) || !Number.isFinite(sampleRate)) return
+    if (sampleCount <= 0 || sampleRate <= 0) return
+    this.capturedAudioMs += (sampleCount / sampleRate) * 1000
+  }
+
+  /**
+   * Ends capture and waits for the transcript. Any earlier pending utterance is
+   * rejected deterministically so it is never orphaned.
+   */
+  finish(options: { timeoutMessage?: string } = {}): Promise<string> {
+    const finishedAt = this.scheduler.now()
+    const capturedAudioMs = this.capturedAudioMs
+    this.supersedePending()
+    this.capturedAudioMs = 0
+    const deadlineMs = computeTranscriptionDeadlineMs(this.sessionStrategy, capturedAudioMs)
+    const deadlineAt = finishedAt + deadlineMs
+    const utteranceId = ++this.utteranceSequence
+    const timeoutMessage = options.timeoutMessage ?? this.defaultTimeoutMessage
+    return new Promise<string>((resolve, reject) => {
+      const timer = this.scheduler.setTimeout(() => this.handleTimeout(utteranceId), deadlineMs)
+      this.pending = {
+        id: utteranceId,
+        resolve,
+        reject,
+        finishedAt,
+        capturedAudioMs,
+        deadlineAt,
+        timer,
+        timeoutMessage
+      }
+    })
+  }
+
+  /** Settles the pending utterance with the final transcript, exactly once. */
+  resolve(text: string): void {
+    const pending = this.takePending()
+    if (!pending) return
+    this.capturedAudioMs = 0
+    pending.resolve(text)
+  }
+
+  /** Settles the pending utterance with an error, exactly once. */
+  reject(error: Error): void {
+    const pending = this.takePending()
+    if (!pending) return
+    this.capturedAudioMs = 0
+    pending.reject(error)
+  }
+
+  /**
+   * Terminal session path (disconnect/stop): clears strategy, audio, and timers, and
+   * settles any pending utterance so nothing leaks into the next session.
+   */
+  resetSession(error?: Error): void {
+    const pending = this.takePending()
+    this.sessionStrategy = null
+    this.capturedAudioMs = 0
+    if (pending) pending.reject(error ?? new Error(ASR_SESSION_DISCONNECTED_MESSAGE))
+  }
+
+  private takePending(): PendingAsrUtterance | null {
+    const pending = this.pending
+    if (!pending) return null
+    this.pending = null
+    this.scheduler.clearTimeout(pending.timer)
+    return pending
+  }
+
+  private supersedePending(): void {
+    const pending = this.takePending()
+    if (!pending) return
+    pending.reject(new Error(ASR_UTTERANCE_SUPERSEDED_MESSAGE))
+  }
+
+  private handleTimeout(utteranceId: number): void {
+    const pending = this.pending
+    // Stale callbacks from superseded utterances must not touch the current one.
+    if (!pending || pending.id !== utteranceId) return
+    this.pending = null
+    this.capturedAudioMs = 0
+    pending.reject(new Error(pending.timeoutMessage))
+  }
+}

--- a/agent-ui/src/components/agent/asr-transcription-deadline.ts
+++ b/agent-ui/src/components/agent/asr-transcription-deadline.ts
@@ -95,6 +95,14 @@ export interface AsrTranscriptionDeadlineOptions {
   defaultTimeoutMessage?: string
 }
 
+/** Promise and terminal callbacks scoped to the utterance created by finish(). */
+export interface AsrTranscriptionAttempt {
+  readonly utteranceId: number
+  readonly promise: Promise<string>
+  resolve(text: string): void
+  reject(error: Error): void
+}
+
 interface PendingAsrUtterance {
   id: number
   resolve: (text: string) => void
@@ -135,8 +143,7 @@ export class AsrTranscriptionDeadlineController {
 
   /** Records a valid strategy announced by `session.ready`; invalid values fail closed. */
   handleSessionReady(strategy: unknown): void {
-    const normalized = normalizeAsrStrategy(strategy)
-    if (normalized) this.sessionStrategy = normalized
+    this.applyStrategy(strategy)
   }
 
   /**
@@ -145,6 +152,10 @@ export class AsrTranscriptionDeadlineController {
    * finish timestamp so repeated events never slide the absolute deadline.
    */
   handleTranscriptionProcessing(strategy: unknown): void {
+    this.applyStrategy(strategy)
+  }
+
+  private applyStrategy(strategy: unknown): void {
     const normalized = normalizeAsrStrategy(strategy)
     if (!normalized) return
     this.sessionStrategy = normalized
@@ -176,7 +187,7 @@ export class AsrTranscriptionDeadlineController {
    * Ends capture and waits for the transcript. Any earlier pending utterance is
    * rejected deterministically so it is never orphaned.
    */
-  finish(options: { timeoutMessage?: string } = {}): Promise<string> {
+  finish(options: { timeoutMessage?: string } = {}): AsrTranscriptionAttempt {
     const finishedAt = this.scheduler.now()
     const capturedAudioMs = this.capturedAudioMs
     this.supersedePending()
@@ -185,7 +196,7 @@ export class AsrTranscriptionDeadlineController {
     const deadlineAt = finishedAt + deadlineMs
     const utteranceId = ++this.utteranceSequence
     const timeoutMessage = options.timeoutMessage ?? this.defaultTimeoutMessage
-    return new Promise<string>((resolve, reject) => {
+    const promise = new Promise<string>((resolve, reject) => {
       const timer = this.scheduler.setTimeout(() => this.handleTimeout(utteranceId), deadlineMs)
       this.pending = {
         id: utteranceId,
@@ -198,19 +209,25 @@ export class AsrTranscriptionDeadlineController {
         timeoutMessage
       }
     })
+    return {
+      utteranceId,
+      promise,
+      resolve: (text: string) => this.resolveUtterance(utteranceId, text),
+      reject: (error: Error) => this.rejectUtterance(utteranceId, error)
+    }
   }
 
-  /** Settles the pending utterance with the final transcript, exactly once. */
-  resolve(text: string): void {
-    const pending = this.takePending()
+  /** Settles only the matching pending utterance with the final transcript. */
+  private resolveUtterance(utteranceId: number, text: string): void {
+    const pending = this.takePending(utteranceId)
     if (!pending) return
     this.capturedAudioMs = 0
     pending.resolve(text)
   }
 
-  /** Settles the pending utterance with an error, exactly once. */
-  reject(error: Error): void {
-    const pending = this.takePending()
+  /** Settles only the matching pending utterance with an error. */
+  private rejectUtterance(utteranceId: number, error: Error): void {
+    const pending = this.takePending(utteranceId)
     if (!pending) return
     this.capturedAudioMs = 0
     pending.reject(error)
@@ -227,9 +244,11 @@ export class AsrTranscriptionDeadlineController {
     if (pending) pending.reject(error ?? new Error(ASR_SESSION_DISCONNECTED_MESSAGE))
   }
 
-  private takePending(): PendingAsrUtterance | null {
+  private takePending(expectedUtteranceId?: number): PendingAsrUtterance | null {
     const pending = this.pending
-    if (!pending) return null
+    if (!pending || (expectedUtteranceId !== undefined && pending.id !== expectedUtteranceId)) {
+      return null
+    }
     this.pending = null
     this.scheduler.clearTimeout(pending.timer)
     return pending

--- a/homerail_manager/src/server/voice.ts
+++ b/homerail_manager/src/server/voice.ts
@@ -1168,6 +1168,8 @@ function _resolveAsrRealtimeRuntime(): {
 }
 
 function _setupEmulatedAsrSession(client: WebSocket, runtime: ReturnType<typeof _resolveAsrRealtimeRuntime>): void {
+  // These initial values intentionally match a `start` frame. The first utterance
+  // may begin while `session.ready` is in flight; later `start` frames reset state.
   const audioChunks: Buffer[] = [];
   let finishing = false;
   _sendWsJson(client, { type: "ready" });

--- a/homerail_manager/tests/voice-bootstrap.test.ts
+++ b/homerail_manager/tests/voice-bootstrap.test.ts
@@ -2256,7 +2256,7 @@ describe("voice bootstrap routes", () => {
     }
   });
 
-  it("emulates realtime ASR over the backend WebSocket for a configured MiMo ASR setting", async () => {
+  it("accepts the initial emulated realtime ASR utterance without a start frame", async () => {
     const port = await listen(server);
     const baseUrl = `http://127.0.0.1:${port}`;
     await fetch(`${baseUrl}/api/llm-settings`, {


### PR DESCRIPTION
## Summary

This Draft PR is the bounded write target for an Auto Fix v2 run addressing #195.

The implementation should replace the single fixed ASR transcription timeout with strategy-aware, audio-aware waiting for `emulated_batch`, while preserving the current native realtime and connection-timeout behavior.

## Scope

- consume the existing `session.ready.strategy` and `transcription.processing` protocol events;
- keep the ASR WebSocket connection timeout separate from transcription processing;
- preserve the current deadline for native realtime or unknown strategy;
- give emulated batch transcription a bounded adaptive deadline;
- clean timers and per-utterance state on success, error, disconnect, stop, and the next utterance;
- add deterministic unit tests using fake timers.

This PR must not redesign endpoint capability detection from #193 or introduce fnOS-specific defaults.

## Validation

Auto Fix v2 will run the caller-authored focused Agent UI tests, typecheck, and build, followed by two fresh-context reviews before the Draft is considered ready for CI.

Fixes #195
