### PR TITLE
fix(voice): distinguish batch-only and native realtime ASR

### DIFF
--- a/agent-ui/src/api/services/voice-api.ts
+++ b/agent-ui/src/api/services/voice-api.ts
@@ -70,6 +70,19 @@ export interface VoiceModelsRequest {
 
 export type VoiceEndpointProbeKind = 'http' | 'websocket'
 
+/**
+ * Explicit probe outcome attached by newer Manager builds (issue #193) so
+ * UIs can distinguish verified WebSocket upgrades from
+ * authentication-required, not-found, rejected, or unreachable responses
+ * without interpreting status codes themselves.
+ */
+export type VoiceEndpointProbeCapability =
+  | 'verified'
+  | 'authentication_required'
+  | 'not_found'
+  | 'rejected'
+  | 'unreachable'
+
 export interface VoiceEndpointProbeCandidate {
   id: string
   kind: VoiceEndpointProbeKind
@@ -81,6 +94,8 @@ export interface VoiceEndpointProbeResult extends VoiceEndpointProbeCandidate {
   reachable: boolean
   status_code?: number
   message: string
+  /** Additive explicit outcome; older Manager builds omit it. */
+  capability?: VoiceEndpointProbeCapability
 }
 
 export interface VoiceEndpointProbeResponse {

--- a/agent-ui/src/components/agent/asr-endpoint-capability.test.ts
+++ b/agent-ui/src/components/agent/asr-endpoint-capability.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest'
+import {
+  asrRealtimeCapability,
+  decideAsrRealtimeUrlPersistence,
+  isVerifiedAsrRealtimeProbe,
+  type AsrRealtimeProbeLike
+} from './asr-endpoint-capability'
+
+// Reporter's production case (issue #193): a local SenseVoice-compatible
+// service answers POST /v1/audio/transcriptions but has no native
+// /v1/realtime WebSocket endpoint. Pre-upgrade 401/403/404 responses for
+// the derived ws:// URL must never be treated as realtime support.
+const SENSEVOICE_BATCH_URL = 'http://192.168.100.10:5002/v1/audio/transcriptions'
+const SENSEVOICE_DERIVED_REALTIME_URL = 'ws://192.168.100.10:5002/v1/realtime'
+
+function legacyWebSocketResult(partial: Partial<AsrRealtimeProbeLike>): AsrRealtimeProbeLike {
+  return {
+    url: SENSEVOICE_DERIVED_REALTIME_URL,
+    kind: 'websocket',
+    message: 'probe',
+    ...partial
+  }
+}
+
+describe('asrRealtimeCapability', () => {
+  it('treats a completed WebSocket upgrade as verified (legacy shape)', () => {
+    const result = legacyWebSocketResult({ ok: true, reachable: true, message: 'WebSocket handshake succeeded' })
+    expect(asrRealtimeCapability(result)).toBe('verified')
+    expect(isVerifiedAsrRealtimeProbe(result)).toBe(true)
+  })
+
+  it.each([401, 403])('treats pre-upgrade HTTP %i as authentication-required, not verified', (status) => {
+    // Legacy Manager builds answered ok=true for 401/403; the capability
+    // rule must not trust that signal.
+    const legacyOk = legacyWebSocketResult({ ok: true, reachable: true, status_code: status })
+    expect(asrRealtimeCapability(legacyOk)).toBe('authentication_required')
+    expect(isVerifiedAsrRealtimeProbe(legacyOk)).toBe(false)
+
+    const explicit = legacyWebSocketResult({
+      ok: false,
+      reachable: true,
+      status_code: status,
+      capability: 'authentication_required'
+    })
+    expect(asrRealtimeCapability(explicit)).toBe('authentication_required')
+    expect(isVerifiedAsrRealtimeProbe(explicit)).toBe(false)
+  })
+
+  it.each([404, 405])('treats pre-upgrade HTTP %i as not-found, not verified', (status) => {
+    const result = legacyWebSocketResult({ ok: false, reachable: true, status_code: status })
+    expect(asrRealtimeCapability(result)).toBe('not_found')
+    expect(isVerifiedAsrRealtimeProbe(result)).toBe(false)
+  })
+
+  it.each([400, 418, 500, 503])('treats other pre-upgrade HTTP %i as rejected, not verified', (status) => {
+    const result = legacyWebSocketResult({ ok: status < 500, reachable: true, status_code: status })
+    expect(asrRealtimeCapability(result)).toBe('rejected')
+    expect(isVerifiedAsrRealtimeProbe(result)).toBe(false)
+  })
+
+  it('treats network failures as unreachable', () => {
+    const result = legacyWebSocketResult({ ok: false, reachable: false, message: 'connect ECONNREFUSED' })
+    expect(asrRealtimeCapability(result)).toBe('unreachable')
+    expect(isVerifiedAsrRealtimeProbe(result)).toBe(false)
+  })
+
+  it('treats a socket closed before the handshake as rejected', () => {
+    const result = legacyWebSocketResult({ ok: false, reachable: true, message: 'WebSocket closed before the handshake completed' })
+    expect(asrRealtimeCapability(result)).toBe('rejected')
+  })
+
+  it('trusts an explicit capability outcome over legacy heuristics', () => {
+    expect(asrRealtimeCapability({ capability: 'verified', ok: true, reachable: true })).toBe('verified')
+    expect(asrRealtimeCapability({ capability: 'authentication_required', ok: false, reachable: true, status_code: 401 }))
+      .toBe('authentication_required')
+    expect(asrRealtimeCapability({ outcome: 'not-found', ok: false, reachable: true, status_code: 404 }))
+      .toBe('not_found')
+    expect(asrRealtimeCapability({ capability: 'auth_required', ok: false, reachable: true, status_code: 403 }))
+      .toBe('authentication_required')
+    expect(asrRealtimeCapability({ capability: 'unreachable', ok: false, reachable: false }))
+      .toBe('unreachable')
+  })
+
+  it('never reports verified without a probe result', () => {
+    expect(asrRealtimeCapability(undefined)).toBe('unreachable')
+    expect(asrRealtimeCapability(null)).toBe('unreachable')
+    expect(isVerifiedAsrRealtimeProbe(undefined)).toBe(false)
+  })
+})
+
+describe('decideAsrRealtimeUrlPersistence', () => {
+  const verifiedProbe = legacyWebSocketResult({ ok: true, reachable: true })
+  const authRequiredProbe = legacyWebSocketResult({ ok: true, reachable: true, status_code: 401 })
+
+  it('persists a verified derived candidate automatically', () => {
+    const decision = decideAsrRealtimeUrlPersistence({
+      derivedUrl: SENSEVOICE_DERIVED_REALTIME_URL,
+      probeResult: verifiedProbe
+    })
+    expect(decision).toEqual({ url: SENSEVOICE_DERIVED_REALTIME_URL, reason: 'verified' })
+  })
+
+  it.each([401, 403, 404])(
+    'does not persist the derived candidate when the batch endpoint works but the probe returned %i',
+    (status) => {
+      const decision = decideAsrRealtimeUrlPersistence({
+        derivedUrl: SENSEVOICE_DERIVED_REALTIME_URL,
+        probeResult: legacyWebSocketResult({ ok: status < 404, reachable: true, status_code: status })
+      })
+      expect(decision.url).toBe('')
+      expect(decision.reason).toBe('unverified')
+    }
+  )
+
+  it('does not persist the derived candidate without a probe result', () => {
+    expect(decideAsrRealtimeUrlPersistence({ derivedUrl: SENSEVOICE_DERIVED_REALTIME_URL }).url).toBe('')
+    expect(decideAsrRealtimeUrlPersistence({}).url).toBe('')
+  })
+
+  it('keeps a user-entered URL even when the probe failed or never ran', () => {
+    const explicit = 'ws://speech.example/custom-realtime'
+    expect(decideAsrRealtimeUrlPersistence({ explicitUrl: explicit, derivedUrl: SENSEVOICE_DERIVED_REALTIME_URL }))
+      .toEqual({ url: explicit, reason: 'explicit' })
+    expect(decideAsrRealtimeUrlPersistence({ explicitUrl: explicit, probeResult: authRequiredProbe }))
+      .toEqual({ url: explicit, reason: 'explicit' })
+  })
+
+  it('keeps an explicitly cleared URL empty even when a derived candidate is verified', () => {
+    expect(decideAsrRealtimeUrlPersistence({ explicitUrl: '', derivedUrl: SENSEVOICE_DERIVED_REALTIME_URL }))
+      .toEqual({ url: '', reason: 'cleared' })
+    expect(decideAsrRealtimeUrlPersistence({
+      explicitUrl: '   ',
+      derivedUrl: SENSEVOICE_DERIVED_REALTIME_URL,
+      probeResult: verifiedProbe
+    })).toEqual({ url: '', reason: 'cleared' })
+  })
+
+  it('trims surrounding whitespace from explicit and derived URLs', () => {
+    expect(decideAsrRealtimeUrlPersistence({ explicitUrl: '  ws://a.example/rt  ' }).url)
+      .toBe('ws://a.example/rt')
+    expect(decideAsrRealtimeUrlPersistence({
+      derivedUrl: `  ${SENSEVOICE_DERIVED_REALTIME_URL}  `,
+      probeResult: verifiedProbe
+    }).url).toBe(SENSEVOICE_DERIVED_REALTIME_URL)
+  })
+})
+
+describe('SenseVoice regression: batch HTTP works, derived realtime is not native', () => {
+  it.each([
+    ['legacy ok=true 401', { ok: true, reachable: true, status_code: 401 }],
+    ['explicit authentication_required 401', { ok: false, reachable: true, status_code: 401, capability: 'authentication_required' }],
+    ['legacy ok=true 403', { ok: true, reachable: true, status_code: 403 }],
+    ['explicit authentication_required 403', { ok: false, reachable: true, status_code: 403, capability: 'authentication_required' }],
+    ['legacy 404', { ok: false, reachable: true, status_code: 404 }],
+    ['explicit not_found 404', { ok: false, reachable: true, status_code: 404, capability: 'not_found' }]
+  ])('persists the batch endpoint but not the realtime URL for %s', (_label, realtimeProbe) => {
+    const batchResult = {
+      id: 'asr_http',
+      kind: 'http',
+      url: SENSEVOICE_BATCH_URL,
+      ok: true,
+      reachable: true,
+      status_code: 200,
+      message: 'Endpoint is reachable'
+    }
+    expect(batchResult.ok).toBe(true)
+
+    const decision = decideAsrRealtimeUrlPersistence({
+      derivedUrl: SENSEVOICE_DERIVED_REALTIME_URL,
+      probeResult: legacyWebSocketResult(realtimeProbe)
+    })
+    expect(decision.url).toBe('')
+    expect(decision.reason).toBe('unverified')
+    expect(isVerifiedAsrRealtimeProbe(legacyWebSocketResult(realtimeProbe))).toBe(false)
+  })
+})

--- a/agent-ui/src/components/agent/asr-endpoint-capability.ts
+++ b/agent-ui/src/components/agent/asr-endpoint-capability.ts
@@ -1,0 +1,144 @@
+/**
+ * Shared, pure capability/persistence rule for ASR realtime endpoints.
+ *
+ * Issue #193: a batch-only transcription service (for example a local
+ * SenseVoice-compatible server exposing only POST /v1/audio/transcriptions)
+ * must never be silently configured as native realtime ASR. Both Agent
+ * Onboarding and Custom Provider Settings derive `ws://<host>/v1/realtime`
+ * as a probe candidate, and both must apply exactly the same rule before
+ * persisting it:
+ *
+ *   - Only a probe that completed a real WebSocket upgrade verifies native
+ *     realtime support, and only a verified derived candidate may be saved
+ *     automatically.
+ *   - HTTP 401/403 only proves the endpoint is reachable and requires
+ *     authentication; 404/405 prove it does not exist; network failures and
+ *     any other pre-upgrade response prove nothing. None of them may be
+ *     persisted as a derived realtime URL or labeled as verified support.
+ *   - A URL the user deliberately entered, or an explicit URL loaded from a
+ *     saved configuration, always survives. If the user explicitly clears
+ *     the URL, the empty value survives too: the derived default must not
+ *     be silently restored.
+ *
+ * Newer Manager builds attach an explicit capability outcome to probe
+ * results so the UI never interprets status codes itself; older responses
+ * only carry ok/reachable/status_code, so a conservative fallback keeps the
+ * same semantics there (a WebSocket probe was only answered `ok` without a
+ * pre-upgrade HTTP status when the upgrade really happened).
+ */
+
+/** Explicit probe outcomes a voice endpoint result may carry. */
+export type AsrRealtimeCapability =
+  | 'verified'
+  | 'authentication_required'
+  | 'not_found'
+  | 'rejected'
+  | 'unreachable'
+
+/**
+ * Structural view of one probed endpoint. Accepts the API
+ * `VoiceEndpointProbeResult` shape plus the additive explicit outcome
+ * fields newer Manager builds may include.
+ */
+export interface AsrRealtimeProbeLike {
+  url?: string
+  kind?: string
+  ok?: boolean
+  reachable?: boolean
+  status_code?: number
+  message?: string
+  capability?: string | null
+  outcome?: string | null
+}
+
+const CAPABILITY_ALIASES: Record<string, AsrRealtimeCapability> = {
+  verified: 'verified',
+  websocket_verified: 'verified',
+  authentication_required: 'authentication_required',
+  auth_required: 'authentication_required',
+  requires_authentication: 'authentication_required',
+  not_found: 'not_found',
+  rejected: 'rejected',
+  unreachable: 'unreachable'
+}
+
+function normalizeCapabilityAlias(value: string | null | undefined): AsrRealtimeCapability | undefined {
+  if (typeof value !== 'string') return undefined
+  return CAPABILITY_ALIASES[value.trim().toLowerCase().replace(/-/g, '_')]
+}
+
+/**
+ * Reduce one ASR realtime endpoint probe to an explicit capability state.
+ * Anything other than `verified` means native realtime support is unproven.
+ */
+export function asrRealtimeCapability(
+  result: AsrRealtimeProbeLike | null | undefined
+): AsrRealtimeCapability {
+  if (!result) return 'unreachable'
+  const explicit = normalizeCapabilityAlias(result.capability) ?? normalizeCapabilityAlias(result.outcome)
+  if (explicit) return explicit
+
+  const status = typeof result.status_code === 'number' ? result.status_code : undefined
+  if (status !== undefined) {
+    if (status === 401 || status === 403) return 'authentication_required'
+    if (status === 404 || status === 405) return 'not_found'
+    return 'rejected'
+  }
+  if (result.reachable === false) return 'unreachable'
+  if (result.ok) return 'verified'
+  return result.reachable ? 'rejected' : 'unreachable'
+}
+
+/** True only when the probe completed a real WebSocket upgrade. */
+export function isVerifiedAsrRealtimeProbe(
+  result: AsrRealtimeProbeLike | null | undefined
+): boolean {
+  return asrRealtimeCapability(result) === 'verified'
+}
+
+export interface AsrRealtimeUrlPersistenceInput {
+  /**
+   * The user's own intent for the realtime URL:
+   * - non-empty string: a URL the user typed or an explicit saved value;
+   * - empty/blank string: the user explicitly cleared the field;
+   * - undefined/null: no user intent, only an automatically derived
+   *   candidate exists.
+   */
+  explicitUrl?: string | null
+  /** Candidate automatically derived from the ASR base URL. */
+  derivedUrl?: string | null
+  /**
+   * Probe result for the derived candidate. Callers must pass the result
+   * that matches the current derived URL; both UI flows drop stale probe
+   * results whenever the URL changes.
+   */
+  probeResult?: AsrRealtimeProbeLike | null
+}
+
+export type AsrRealtimeUrlPersistenceReason = 'explicit' | 'cleared' | 'verified' | 'unverified'
+
+export interface AsrRealtimeUrlPersistenceDecision {
+  /** Value to persist; '' keeps the field intentionally empty. */
+  url: string
+  reason: AsrRealtimeUrlPersistenceReason
+}
+
+/**
+ * The one persistence predicate shared by Onboarding and Custom Provider
+ * Settings. Explicit user values always win (including an explicit clear);
+ * a derived candidate is persisted only after a verified WebSocket upgrade.
+ */
+export function decideAsrRealtimeUrlPersistence(
+  input: AsrRealtimeUrlPersistenceInput
+): AsrRealtimeUrlPersistenceDecision {
+  if (typeof input.explicitUrl === 'string') {
+    const explicit = input.explicitUrl.trim()
+    if (!explicit) return { url: '', reason: 'cleared' }
+    return { url: explicit, reason: 'explicit' }
+  }
+  const derived = typeof input.derivedUrl === 'string' ? input.derivedUrl.trim() : ''
+  if (derived && isVerifiedAsrRealtimeProbe(input.probeResult ?? undefined)) {
+    return { url: derived, reason: 'verified' }
+  }
+  return { url: '', reason: 'unverified' }
+}

--- a/agent-ui/src/components/agent/onboarding/OnboardingStepForm.test.ts
+++ b/agent-ui/src/components/agent/onboarding/OnboardingStepForm.test.ts
@@ -135,6 +135,8 @@ beforeEach(() => {
   voiceApiMocks.updateVoiceSettings.mockResolvedValue({ success: true, data: {} })
   // 默认所有候选端点都可达（按请求原样返回 ok 结果）；
   // 需要失败场景时各用例用 mockResolvedValueOnce 覆盖。
+  // WebSocket 候选默认按"真正完成握手升级"返回：派生的 realtime URL
+  // 只有在验证通过后才允许自动持久化（issue #193）。
   voiceApiMocks.testVoiceEndpoints.mockImplementation((endpoints: Array<{ id: string; kind: string; url: string }>) =>
     Promise.resolve({
       success: true,
@@ -144,8 +146,9 @@ beforeEach(() => {
           ...endpoint,
           ok: true,
           reachable: true,
-          status_code: 405,
-          message: endpoint.kind === 'websocket' ? 'WebSocket handshake succeeded' : 'Endpoint is reachable'
+          ...(endpoint.kind === 'websocket'
+            ? { capability: 'verified', message: 'WebSocket handshake succeeded' }
+            : { status_code: 405, message: 'Endpoint is reachable' })
         }))
       }
     })
@@ -492,6 +495,100 @@ describe('OnboardingStepForm ASR endpoint detection', () => {
             reachable: true,
             status_code: 404,
             message: 'WebSocket handshake returned HTTP 404'
+          }
+        ]
+      }
+    })
+    const root = await mountForm({
+      capability: 'supports_asr',
+      providers: [],
+      existingSettings: []
+    })
+    await fillCustomAsr(root)
+
+    root.querySelector<HTMLButtonElement>('.onboarding-step-form__submit')!.click()
+
+    await vi.waitFor(() => expect(apiMocks.createLLMSetting).toHaveBeenCalledTimes(1))
+    expect(apiMocks.createProvider).toHaveBeenCalledWith(expect.objectContaining({
+      asr_async_url: 'http://192.168.100.10:5002/v1/audio/transcriptions',
+      asr_realtime_url: ''
+    }))
+    expect(apiMocks.createLLMSetting).toHaveBeenCalledWith(expect.objectContaining({
+      asr_async_url: 'http://192.168.100.10:5002/v1/audio/transcriptions',
+      asr_realtime_url: ''
+    }))
+  })
+
+  it('persists the derived realtime URL after a verified WebSocket upgrade (legacy response shape)', async () => {
+    voiceApiMocks.testVoiceEndpoints.mockResolvedValueOnce({
+      success: true,
+      data: {
+        ok: true,
+        results: [
+          {
+            id: 'asr_http',
+            kind: 'http',
+            url: 'http://192.168.100.10:5002/v1/audio/transcriptions',
+            ok: true,
+            reachable: true,
+            status_code: 200,
+            message: 'Endpoint is reachable'
+          },
+          {
+            id: 'asr_realtime',
+            kind: 'websocket',
+            url: 'ws://192.168.100.10:5002/v1/realtime',
+            ok: true,
+            reachable: true,
+            message: 'WebSocket handshake succeeded'
+          }
+        ]
+      }
+    })
+    const root = await mountForm({
+      capability: 'supports_asr',
+      providers: [],
+      existingSettings: []
+    })
+    await fillCustomAsr(root)
+
+    root.querySelector<HTMLButtonElement>('.onboarding-step-form__submit')!.click()
+
+    await vi.waitFor(() => expect(apiMocks.createLLMSetting).toHaveBeenCalledTimes(1))
+    expect(apiMocks.createProvider).toHaveBeenCalledWith(expect.objectContaining({
+      asr_realtime_url: 'ws://192.168.100.10:5002/v1/realtime'
+    }))
+  })
+
+  // Reporter's SenseVoice case (issue #193): batch transcription works,
+  // the derived ws://…/v1/realtime candidate answers 401/403 before any
+  // WebSocket upgrade. Legacy Manager builds reported ok=true for those
+  // responses; the derived URL must still not be persisted.
+  it.each([
+    ['401 (legacy ok=true shape)', { ok: true, reachable: true, status_code: 401, message: 'WebSocket endpoint is reachable and requires authentication or handshake parameters' }],
+    ['401 (explicit authentication_required)', { ok: false, reachable: true, status_code: 401, capability: 'authentication_required', message: 'Endpoint requires authentication' }],
+    ['403 (legacy ok=true shape)', { ok: true, reachable: true, status_code: 403, message: 'WebSocket endpoint is reachable and requires authentication or handshake parameters' }],
+    ['403 (explicit authentication_required)', { ok: false, reachable: true, status_code: 403, capability: 'authentication_required', message: 'Endpoint requires authentication' }]
+  ])('does not persist the derived realtime URL when batch works but the probe returns %s', async (_label, realtimeProbe) => {
+    voiceApiMocks.testVoiceEndpoints.mockResolvedValueOnce({
+      success: true,
+      data: {
+        ok: false,
+        results: [
+          {
+            id: 'asr_http',
+            kind: 'http',
+            url: 'http://192.168.100.10:5002/v1/audio/transcriptions',
+            ok: true,
+            reachable: true,
+            status_code: 200,
+            message: 'Endpoint is reachable'
+          },
+          {
+            id: 'asr_realtime',
+            kind: 'websocket',
+            url: 'ws://192.168.100.10:5002/v1/realtime',
+            ...realtimeProbe
           }
         ]
       }

--- a/agent-ui/src/components/agent/onboarding/OnboardingStepForm.vue
+++ b/agent-ui/src/components/agent/onboarding/OnboardingStepForm.vue
@@ -26,6 +26,7 @@ import {
   updateVoiceSettings,
   type VoiceEndpointProbeResult,
 } from '@/api/services/voice-api'
+import { decideAsrRealtimeUrlPersistence } from '@/components/agent/asr-endpoint-capability'
 import {
   BUILTIN_EDGE_TTS_MODEL,
   BUILTIN_EDGE_TTS_OPTION_ID,
@@ -539,11 +540,17 @@ async function detectCustomAsrEndpoints(): Promise<CustomVoiceUrls> {
       realtime: endpointProbeMessage(realtimeResult),
     }))
   }
+  // 派生的 realtime 候选只在 WebSocket 真正握手成功后才自动持久化；
+  // 401/403/404、其他预升级响应或网络失败一律按未验证处理（issue #193）。
+  const realtimePersistence = decideAsrRealtimeUrlPersistence({
+    derivedUrl: realtimeUrl,
+    probeResult: realtimeResult,
+  })
   return {
     // Empty strings deliberately clear stale guessed endpoints on an existing
     // local provider. The Manager normalizes them back to undefined.
     asr_async_url: asyncResult?.ok ? asyncUrl : '',
-    asr_realtime_url: realtimeResult?.ok ? realtimeUrl : '',
+    asr_realtime_url: realtimePersistence.url,
   }
 }
 

--- a/agent-ui/src/components/agent/settings/CustomProviderManager.vue
+++ b/agent-ui/src/components/agent/settings/CustomProviderManager.vue
@@ -9,6 +9,10 @@ import {
   type VoiceEndpointProbeCandidate,
   type VoiceEndpointProbeResult
 } from '@/api/services/voice-api'
+import {
+  decideAsrRealtimeUrlPersistence,
+  isVerifiedAsrRealtimeProbe
+} from '@/components/agent/asr-endpoint-capability'
 import type { Provider } from '@/api/types/orchestration-v2.types'
 import { useToast } from '@/components/controls/useToast'
 import CapabilityToggle from './CapabilityToggle.vue'
@@ -118,9 +122,21 @@ function loadVoiceEndpoint(
   target: typeof ttsHttpUrl,
   automatic: typeof ttsHttpAutomatic
 ): void {
-  const saved = savedValue?.trim() ?? ''
-  automatic.value = !saved || saved === derivedValue
-  target.value = automatic.value ? derivedValue : saved
+  if (savedValue == null) {
+    automatic.value = true
+    target.value = derivedValue
+    return
+  }
+  const saved = savedValue.trim()
+  if (!saved) {
+    // A saved empty string is an intentional clear (issue #193): keep the
+    // field empty instead of silently restoring the derived default.
+    automatic.value = false
+    target.value = ''
+    return
+  }
+  automatic.value = saved === derivedValue
+  target.value = saved
 }
 
 type VoiceEndpointField = 'tts_http' | 'tts_streaming' | 'asr_http' | 'asr_realtime'
@@ -159,6 +175,13 @@ function restoreEndpoint(field: VoiceEndpointField): void {
   const endpoint = voiceEndpointState(field)
   endpoint.automatic.value = true
   endpoint.target.value = endpoint.derived
+}
+
+function voiceEndpointPayloadValue(field: VoiceEndpointField): string {
+  const endpoint = voiceEndpointState(field)
+  // An edited (non-automatic) field keeps exactly what the user left in
+  // it, including an intentional empty value.
+  return endpoint.automatic.value ? endpoint.derived : endpoint.target.value.trim()
 }
 
 function draftSignature(): string {
@@ -314,8 +337,23 @@ const canTestEndpoints = computed(() =>
 )
 
 const endpointTestPassed = computed(() =>
-  endpointTestResults.value.length > 0 && endpointTestResults.value.every(result => result.ok)
+  endpointTestResults.value.length > 0 && endpointTestResults.value.every(endpointProbePassed)
 )
+
+/**
+ * Shared issue #193 semantics: a WebSocket endpoint only passes when the
+ * probe completed a real upgrade (verified native realtime); HTTP
+ * endpoints keep the existing reachable semantics.
+ */
+function endpointProbePassed(result: VoiceEndpointProbeResult): boolean {
+  return result.kind === 'websocket' ? isVerifiedAsrRealtimeProbe(result) : result.ok
+}
+
+function latestAsrRealtimeProbeResult(): VoiceEndpointProbeResult | undefined {
+  // Probe results are cleared whenever any endpoint URL changes, so a
+  // stored result always belongs to the current field values.
+  return endpointTestResults.value.find(result => result.id === 'asr_realtime')
+}
 
 function endpointLabel(id: VoiceEndpointProbeResult['id']): string {
   const labels: Record<string, string> = {
@@ -328,8 +366,13 @@ function endpointLabel(id: VoiceEndpointProbeResult['id']): string {
 }
 
 function endpointResultText(result: VoiceEndpointProbeResult): string {
-  const status = !result.ok && result.status_code ? ` (${result.status_code})` : ''
-  return `${endpointLabel(result.id)}${status} ${result.ok ? '✓' : '✕'}`
+  const passed = endpointProbePassed(result)
+  const status = !passed && result.status_code ? ` (${result.status_code})` : ''
+  // For WebSocket endpoints an authentication-required or otherwise
+  // non-upgrade response is never "verified realtime support"; surface the
+  // Manager's own message so the user sees why (issue #193).
+  const detail = !passed && result.kind === 'websocket' && result.message ? ` ${result.message}` : ''
+  return `${endpointLabel(result.id)}${status} ${passed ? '✓' : '✕'}${detail}`
 }
 
 async function testEndpoints(): Promise<void> {
@@ -352,6 +395,11 @@ async function save(): Promise<void> {
   saving.value = true
   const id = providerId.value.trim()
   normalizeVoiceBaseUrl()
+  const realtimePersistence = decideAsrRealtimeUrlPersistence({
+    explicitUrl: asrRealtimeAutomatic.value ? undefined : asrRealtimeUrl.value,
+    derivedUrl: defaultAsrRealtimeUrl.value,
+    probeResult: latestAsrRealtimeProbeResult()
+  })
   const payload = {
     name: providerName.value.trim(),
     base_url: baseUrl.value.trim(),
@@ -360,18 +408,14 @@ async function save(): Promise<void> {
     anthropic_base_url: anthropicBaseUrl.value.trim() || undefined,
     voice_adapter:
       supportsAsr.value || supportsTts.value ? ('openai_audio' as const) : ('custom' as const),
-    tts_http_url: supportsTts.value
-      ? ttsHttpUrl.value.trim() || defaultTtsHttpUrl.value
-      : undefined,
-    tts_realtime_url: supportsTts.value
-      ? ttsStreamingUrl.value.trim() || defaultTtsStreamingUrl.value
-      : undefined,
-    asr_async_url: supportsAsr.value
-      ? asrHttpUrl.value.trim() || defaultAsrHttpUrl.value
-      : undefined,
-    asr_realtime_url: supportsAsr.value
-      ? asrRealtimeUrl.value.trim() || defaultAsrRealtimeUrl.value
-      : undefined,
+    tts_http_url: supportsTts.value ? voiceEndpointPayloadValue('tts_http') : undefined,
+    tts_realtime_url: supportsTts.value ? voiceEndpointPayloadValue('tts_streaming') : undefined,
+    asr_async_url: supportsAsr.value ? voiceEndpointPayloadValue('asr_http') : undefined,
+    // A derived realtime candidate is only persisted after a verified
+    // WebSocket handshake; explicit user values (including an explicit
+    // clear) always win. The automatic default is never silently restored
+    // on top of a deliberate empty value (issue #193).
+    asr_realtime_url: supportsAsr.value ? realtimePersistence.url : undefined,
     status: 'active' as const,
     supports_llm: supportsLlm.value,
     supports_asr: supportsAsr.value,

--- a/agent-ui/src/components/agent/settings/ModelForms.test.ts
+++ b/agent-ui/src/components/agent/settings/ModelForms.test.ts
@@ -430,6 +430,14 @@ describe('model purpose forms', () => {
     expect(root.querySelector('input[placeholder="Responses URL"]')).toBeNull()
     expect(root.querySelector('input[placeholder="Anthropic URL"]')).toBeNull()
 
+    // A derived realtime candidate is only saved automatically after a
+    // verified WebSocket handshake (issue #193).
+    root.querySelector<HTMLButtonElement>('[data-testid="provider-test-voice-endpoints"]')!.click()
+    await nextTick()
+    await nextTick()
+    expect(root.querySelector('[data-testid="provider-endpoint-test-result"]')?.textContent)
+      .toContain('端点可用')
+
     const save = Array.from(root.querySelectorAll('button')).find(
       button => button.textContent?.trim() === '保存'
     )!
@@ -444,6 +452,263 @@ describe('model purpose forms', () => {
         voice_adapter: 'openai_audio',
         asr_async_url: 'http://192.168.100.10:5002/v1/audio/transcriptions',
         asr_realtime_url: 'ws://192.168.100.10:5002/v1/realtime'
+      })
+    )
+  })
+
+  it('persists a derived realtime URL verified through the explicit capability outcome', async () => {
+    vi.mocked(testVoiceEndpoints).mockResolvedValueOnce({
+      success: true,
+      data: {
+        ok: true,
+        results: [
+          {
+            id: 'asr_http',
+            kind: 'http',
+            url: 'http://192.168.100.10:5002/v1/audio/transcriptions',
+            ok: true,
+            reachable: true,
+            status_code: 200,
+            message: 'Endpoint is reachable'
+          },
+          {
+            id: 'asr_realtime',
+            kind: 'websocket',
+            url: 'ws://192.168.100.10:5002/v1/realtime',
+            ok: true,
+            reachable: true,
+            capability: 'verified',
+            message: 'WebSocket handshake succeeded'
+          }
+        ]
+      }
+    } as never)
+    const root = await mount(CustomProviderManager, {
+      providers: [asrProvider],
+      settings: [asrSetting]
+    })
+
+    root.querySelector<HTMLButtonElement>('[data-testid="provider-test-voice-endpoints"]')!.click()
+    await nextTick()
+    await nextTick()
+    Array.from(root.querySelectorAll<HTMLButtonElement>('button'))
+      .find(button => button.textContent?.trim() === '保存')!
+      .click()
+    await nextTick()
+    await nextTick()
+
+    expect(agentSettingsApi.updateProvider).toHaveBeenCalledWith(
+      asrProvider.id,
+      expect.objectContaining({ asr_realtime_url: 'ws://192.168.100.10:5002/v1/realtime' })
+    )
+  })
+
+  it('does not persist the derived realtime WebSocket URL before it is verified', async () => {
+    const root = await mount(CustomProviderManager, {
+      providers: [asrProvider],
+      settings: [asrSetting]
+    })
+
+    Array.from(root.querySelectorAll<HTMLButtonElement>('button'))
+      .find(button => button.textContent?.trim() === '保存')!
+      .click()
+    await nextTick()
+    await nextTick()
+
+    expect(agentSettingsApi.updateProvider).toHaveBeenCalledWith(
+      asrProvider.id,
+      expect.objectContaining({
+        asr_async_url: 'http://192.168.100.10:5002/v1/audio/transcriptions',
+        asr_realtime_url: ''
+      })
+    )
+  })
+
+  // Reporter's SenseVoice case (issue #193): batch transcription works but
+  // the derived realtime candidate answers 401 before any WebSocket
+  // upgrade. The settings flow must not persist the derived URL and must
+  // not label the endpoint as verified realtime support.
+  it.each([
+    ['401 (legacy ok=true shape)', { ok: true, reachable: true, status_code: 401, message: 'WebSocket endpoint is reachable and requires authentication or handshake parameters' }],
+    ['403 (explicit authentication_required)', { ok: false, reachable: true, status_code: 403, capability: 'authentication_required', message: 'Endpoint requires authentication' }],
+    ['404 (explicit not_found)', { ok: false, reachable: true, status_code: 404, capability: 'not_found', message: 'WebSocket handshake returned HTTP 404' }]
+  ])('does not persist the derived realtime URL when batch works but the probe returns %s', async (_label, realtimeProbe) => {
+    vi.mocked(testVoiceEndpoints).mockResolvedValueOnce({
+      success: true,
+      data: {
+        ok: false,
+        results: [
+          {
+            id: 'asr_http',
+            kind: 'http',
+            url: 'http://192.168.100.10:5002/v1/audio/transcriptions',
+            ok: true,
+            reachable: true,
+            status_code: 200,
+            message: 'Endpoint is reachable'
+          },
+          {
+            id: 'asr_realtime',
+            kind: 'websocket',
+            url: 'ws://192.168.100.10:5002/v1/realtime',
+            ...realtimeProbe
+          }
+        ]
+      }
+    } as never)
+    const root = await mount(CustomProviderManager, {
+      providers: [asrProvider],
+      settings: [asrSetting]
+    })
+
+    root.querySelector<HTMLButtonElement>('[data-testid="provider-test-voice-endpoints"]')!.click()
+    await nextTick()
+    await nextTick()
+
+    const resultText = root.querySelector('[data-testid="provider-endpoint-test-result"]')!
+    expect(resultText.textContent).toContain('部分端点不可用')
+    // The batch HTTP endpoint stays reachable (✓); the realtime WebSocket
+    // endpoint must be marked failed, never verified.
+    expect(resultText.textContent).toMatch(/ASR 实时 WebSocket \(\d+\) ✕/)
+    expect(resultText.textContent).not.toMatch(/ASR 实时 WebSocket[^·]*✓/)
+    expect(resultText.textContent).not.toContain('端点可用')
+
+    Array.from(root.querySelectorAll<HTMLButtonElement>('button'))
+      .find(button => button.textContent?.trim() === '保存')!
+      .click()
+    await nextTick()
+    await nextTick()
+
+    expect(agentSettingsApi.updateProvider).toHaveBeenCalledWith(
+      asrProvider.id,
+      expect.objectContaining({
+        asr_async_url: 'http://192.168.100.10:5002/v1/audio/transcriptions',
+        asr_realtime_url: ''
+      })
+    )
+  })
+
+  it('shows the authentication-required probe message without labeling it verified', async () => {
+    vi.mocked(testVoiceEndpoints).mockResolvedValueOnce({
+      success: true,
+      data: {
+        ok: false,
+        results: [
+          {
+            id: 'asr_realtime',
+            kind: 'websocket',
+            url: 'ws://192.168.100.10:5002/v1/realtime',
+            ok: false,
+            reachable: true,
+            status_code: 401,
+            capability: 'authentication_required',
+            message: 'Endpoint requires authentication before the WebSocket upgrade'
+          }
+        ]
+      }
+    } as never)
+    const root = await mount(CustomProviderManager, {
+      providers: [asrProvider],
+      settings: [asrSetting]
+    })
+
+    root.querySelector<HTMLButtonElement>('[data-testid="provider-test-voice-endpoints"]')!.click()
+    await nextTick()
+    await nextTick()
+
+    const resultText = root.querySelector('[data-testid="provider-endpoint-test-result"]')!.textContent!
+    expect(resultText).toContain('(401)')
+    expect(resultText).toContain('Endpoint requires authentication before the WebSocket upgrade')
+    expect(resultText).toContain('✕')
+    expect(resultText).not.toContain('✓')
+  })
+
+  it('keeps a user-entered realtime URL through unrelated edits without a probe', async () => {
+    const root = await mount(CustomProviderManager, {
+      providers: [asrProvider],
+      settings: [asrSetting]
+    })
+    const wsInput = root.querySelector<HTMLInputElement>('[data-testid="provider-asr-realtime-url"]')!
+    wsInput.value = 'ws://speech.example/custom-realtime'
+    wsInput.dispatchEvent(new Event('input'))
+    await nextTick()
+
+    // Unrelated edit: change the display name only.
+    const nameInput = Array.from(root.querySelectorAll<HTMLInputElement>('input')).find(
+      input => input.value === asrProvider.name
+    )!
+    nameInput.value = 'Renamed ASR Provider'
+    nameInput.dispatchEvent(new Event('input'))
+    await nextTick()
+
+    Array.from(root.querySelectorAll<HTMLButtonElement>('button'))
+      .find(button => button.textContent?.trim() === '保存')!
+      .click()
+    await nextTick()
+    await nextTick()
+
+    expect(agentSettingsApi.updateProvider).toHaveBeenCalledWith(
+      asrProvider.id,
+      expect.objectContaining({
+        name: 'Renamed ASR Provider',
+        asr_realtime_url: 'ws://speech.example/custom-realtime'
+      })
+    )
+  })
+
+  it('keeps an explicitly cleared realtime URL empty when saving', async () => {
+    const root = await mount(CustomProviderManager, {
+      providers: [asrProvider],
+      settings: [asrSetting]
+    })
+    const wsInput = root.querySelector<HTMLInputElement>('[data-testid="provider-asr-realtime-url"]')!
+    wsInput.value = ''
+    wsInput.dispatchEvent(new Event('input'))
+    await nextTick()
+
+    Array.from(root.querySelectorAll<HTMLButtonElement>('button'))
+      .find(button => button.textContent?.trim() === '保存')!
+      .click()
+    await nextTick()
+    await nextTick()
+
+    // The derived ws:// default must not be silently restored.
+    expect(agentSettingsApi.updateProvider).toHaveBeenCalledWith(
+      asrProvider.id,
+      expect.objectContaining({ asr_realtime_url: '' })
+    )
+  })
+
+  it('loads a saved empty realtime URL as intentionally cleared and keeps it empty on later edits', async () => {
+    const clearedProvider: Provider = { ...asrProvider, asr_realtime_url: '' }
+    const root = await mount(CustomProviderManager, {
+      providers: [clearedProvider],
+      settings: [asrSetting]
+    })
+
+    const wsInput = root.querySelector<HTMLInputElement>('[data-testid="provider-asr-realtime-url"]')!
+    expect(wsInput.value).toBe('')
+    expect(root.textContent).toContain('恢复自动')
+
+    // Later unrelated edit: rename the provider and save again.
+    const nameInput = Array.from(root.querySelectorAll<HTMLInputElement>('input')).find(
+      input => input.value === clearedProvider.name
+    )!
+    nameInput.value = 'Local ASR (batch only)'
+    nameInput.dispatchEvent(new Event('input'))
+    await nextTick()
+
+    Array.from(root.querySelectorAll<HTMLButtonElement>('button'))
+      .find(button => button.textContent?.trim() === '保存')!
+      .click()
+    await nextTick()
+    await nextTick()
+
+    expect(agentSettingsApi.updateProvider).toHaveBeenCalledWith(
+      clearedProvider.id,
+      expect.objectContaining({
+        name: 'Local ASR (batch only)',
+        asr_realtime_url: ''
       })
     )
   })

--- a/homerail_manager/src/server/voice.ts
+++ b/homerail_manager/src/server/voice.ts
@@ -50,6 +50,13 @@ interface VoiceModelBody {
 
 type VoiceEndpointProbeKind = "http" | "websocket";
 
+type VoiceEndpointProbeOutcome =
+  | "verified"
+  | "authentication_required"
+  | "not_found"
+  | "rejected"
+  | "unreachable";
+
 interface VoiceEndpointProbeCandidate {
   id: string;
   kind: VoiceEndpointProbeKind;
@@ -60,6 +67,7 @@ interface VoiceEndpointProbeResult extends VoiceEndpointProbeCandidate {
   ok: boolean;
   reachable: boolean;
   status_code?: number;
+  outcome?: VoiceEndpointProbeOutcome;
   message: string;
 }
 
@@ -709,11 +717,20 @@ async function _probeHttpVoiceEndpoint(
     await response.body?.cancel().catch(() => {});
     const status = response.status;
     const ok = status >= 200 && status < 500 && status !== 404;
+    const outcome: VoiceEndpointProbeOutcome | undefined =
+      status === 401 || status === 403
+        ? "authentication_required"
+        : status === 404
+          ? "not_found"
+          : status >= 500
+            ? "rejected"
+            : undefined;
     return {
       ...candidate,
       ok,
       reachable: true,
       status_code: status,
+      ...(outcome ? { outcome } : {}),
       message: ok
         ? status >= 400 ? "Endpoint is reachable and requested input or authentication" : "Endpoint is reachable"
         : `Endpoint returned HTTP ${status}`,
@@ -723,6 +740,7 @@ async function _probeHttpVoiceEndpoint(
       ...candidate,
       ok: false,
       reachable: false,
+      outcome: "unreachable",
       message: error instanceof Error ? error.message : String(error),
     };
   }
@@ -742,28 +760,60 @@ function _probeWebSocketVoiceEndpoint(
       handshakeTimeout: VOICE_ENDPOINT_PROBE_TIMEOUT_MS,
     });
     socket.once("open", () => {
-      finish({ ...candidate, ok: true, reachable: true, message: "WebSocket handshake succeeded" });
+      // Only a completed WebSocket upgrade/open proves native realtime capability.
+      finish({
+        ...candidate,
+        ok: true,
+        reachable: true,
+        outcome: "verified",
+        message: "WebSocket handshake succeeded",
+      });
       socket.close();
     });
     socket.once("unexpected-response", (_request, response) => {
       const status = response.statusCode ?? 0;
       response.resume();
-      const ok = status >= 200 && status < 500 && status !== 404 && status !== 405;
+      // Any pre-upgrade HTTP response means the WebSocket handshake did not
+      // complete, so it never verifies native realtime support. 401/403 only
+      // prove the endpoint is reachable and requires authentication.
+      const outcome: VoiceEndpointProbeOutcome =
+        status === 401 || status === 403
+          ? "authentication_required"
+          : status === 404 || status === 405
+            ? "not_found"
+            : "rejected";
+      const message =
+        outcome === "authentication_required"
+          ? "WebSocket endpoint is reachable but requires authentication before upgrade"
+          : outcome === "not_found"
+            ? `WebSocket handshake returned HTTP ${status}: endpoint not found or upgrade unsupported`
+            : `WebSocket handshake returned HTTP ${status || "unknown"}`;
       finish({
         ...candidate,
-        ok,
+        ok: false,
         reachable: true,
         status_code: status || undefined,
-        message: ok
-          ? "WebSocket endpoint is reachable and requires authentication or handshake parameters"
-          : `WebSocket handshake returned HTTP ${status || "unknown"}`,
+        outcome,
+        message,
       });
     });
     socket.once("error", (error) => {
-      finish({ ...candidate, ok: false, reachable: false, message: error.message });
+      finish({
+        ...candidate,
+        ok: false,
+        reachable: false,
+        outcome: "unreachable",
+        message: error.message,
+      });
     });
     socket.once("close", () => {
-      finish({ ...candidate, ok: false, reachable: true, message: "WebSocket closed before the handshake completed" });
+      finish({
+        ...candidate,
+        ok: false,
+        reachable: true,
+        outcome: "rejected",
+        message: "WebSocket closed before the handshake completed",
+      });
     });
   });
 }

--- a/homerail_manager/tests/voice-bootstrap.test.ts
+++ b/homerail_manager/tests/voice-bootstrap.test.ts
@@ -1753,7 +1753,7 @@ describe("voice bootstrap routes", () => {
         success: boolean;
         data: {
           ok: boolean;
-          results: Array<{ id: string; ok: boolean; reachable: boolean; status_code?: number }>;
+          results: Array<{ id: string; ok: boolean; reachable: boolean; status_code?: number; outcome?: string }>;
         };
       };
 
@@ -1762,13 +1762,263 @@ describe("voice bootstrap routes", () => {
       expect(body.data.ok).toBe(true);
       expect(body.data.results).toEqual([
         expect.objectContaining({ id: "asr_http", ok: true, reachable: true, status_code: 405 }),
-        expect.objectContaining({ id: "asr_realtime", ok: true, reachable: true }),
+        expect.objectContaining({ id: "asr_realtime", ok: true, reachable: true, outcome: "verified" }),
       ]);
       expect(httpProbeCalls).toBe(1);
     } finally {
       for (const client of websocket.clients) client.terminate();
       await closeWebSocket(websocket);
       await close(upstream);
+    }
+  });
+
+  it("never verifies realtime capability from pre-upgrade HTTP responses", async () => {
+    const statusByPath: Record<string, number> = {
+      "/realtime-401": 401,
+      "/realtime-403": 403,
+      "/realtime-404": 404,
+      "/realtime-405": 405,
+      "/realtime-400": 400,
+    };
+    const upstream = http.createServer((req, res) => {
+      const status = statusByPath[new URL(req.url ?? "/", "http://localhost").pathname] ?? 404;
+      res.writeHead(status).end();
+    });
+    upstream.on("upgrade", (req, socket) => {
+      const status = statusByPath[new URL(req.url ?? "/", "http://localhost").pathname] ?? 404;
+      socket.end(
+        `HTTP/1.1 ${status} ${http.STATUS_CODES[status] ?? "Error"}\r\nConnection: close\r\nContent-Length: 0\r\n\r\n`,
+      );
+    });
+    const upstreamPort = await listen(upstream);
+    const verifiedRealtime = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    const verifiedPort = await listenWebSocket(verifiedRealtime);
+    const refusedPort = await findAvailableManagerAgentPort();
+    const managerPort = await listen(server);
+
+    try {
+      const probe = async (endpoints: Array<{ id: string; kind: "http" | "websocket"; url: string }>) => {
+        const response = await fetch(`http://127.0.0.1:${managerPort}/api/voice/endpoints/test`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ endpoints }),
+        });
+        const body = await response.json() as {
+          success: boolean;
+          data: {
+            ok: boolean;
+            results: Array<{ id: string; ok: boolean; reachable: boolean; status_code?: number; outcome?: string }>;
+          };
+        };
+        expect(response.status).toBe(200);
+        expect(body.success).toBe(true);
+        return body.data;
+      };
+
+      const first = await probe([
+        { id: "ws_verified", kind: "websocket", url: `ws://127.0.0.1:${verifiedPort}/` },
+        { id: "ws_auth_401", kind: "websocket", url: `ws://127.0.0.1:${upstreamPort}/realtime-401` },
+        { id: "ws_auth_403", kind: "websocket", url: `ws://127.0.0.1:${upstreamPort}/realtime-403` },
+        { id: "ws_missing_404", kind: "websocket", url: `ws://127.0.0.1:${upstreamPort}/realtime-404` },
+      ]);
+      expect(first.ok).toBe(false);
+      expect(first.results).toEqual([
+        expect.objectContaining({ id: "ws_verified", ok: true, reachable: true, outcome: "verified" }),
+        expect.objectContaining({
+          id: "ws_auth_401",
+          ok: false,
+          reachable: true,
+          status_code: 401,
+          outcome: "authentication_required",
+        }),
+        expect.objectContaining({
+          id: "ws_auth_403",
+          ok: false,
+          reachable: true,
+          status_code: 403,
+          outcome: "authentication_required",
+        }),
+        expect.objectContaining({ id: "ws_missing_404", ok: false, reachable: true, status_code: 404, outcome: "not_found" }),
+      ]);
+
+      const second = await probe([
+        { id: "ws_missing_405", kind: "websocket", url: `ws://127.0.0.1:${upstreamPort}/realtime-405` },
+        { id: "ws_rejected_400", kind: "websocket", url: `ws://127.0.0.1:${upstreamPort}/realtime-400` },
+        { id: "ws_unreachable", kind: "websocket", url: `ws://127.0.0.1:${refusedPort}/v1/realtime` },
+        { id: "http_auth_401", kind: "http", url: `http://127.0.0.1:${upstreamPort}/realtime-401` },
+      ]);
+      expect(second.ok).toBe(false);
+      expect(second.results).toEqual([
+        expect.objectContaining({ id: "ws_missing_405", ok: false, reachable: true, status_code: 405, outcome: "not_found" }),
+        expect.objectContaining({ id: "ws_rejected_400", ok: false, reachable: true, status_code: 400, outcome: "rejected" }),
+        expect.objectContaining({ id: "ws_unreachable", ok: false, reachable: false, outcome: "unreachable" }),
+        expect.objectContaining({
+          id: "http_auth_401",
+          ok: true,
+          reachable: true,
+          status_code: 401,
+          outcome: "authentication_required",
+        }),
+      ]);
+    } finally {
+      for (const client of verifiedRealtime.clients) client.terminate();
+      await closeWebSocket(verifiedRealtime);
+      await close(upstream);
+    }
+  });
+
+  it("keeps the reporter's batch-only SenseVoice configuration on emulated_batch without a realtime URL", async () => {
+    const port = await listen(server);
+    const baseUrl = `http://127.0.0.1:${port}`;
+    const seenRequests: string[] = [];
+    const upstream = http.createServer((req, res) => {
+      seenRequests.push(`${req.method} ${req.url}`);
+      if (req.method === "POST" && req.url === "/v1/audio/transcriptions") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ text: "sensevoice batch transcript" }));
+        return;
+      }
+      if (req.method === "HEAD" && req.url === "/v1/audio/transcriptions") {
+        res.writeHead(405, { Allow: "POST" });
+        res.end();
+        return;
+      }
+      res.writeHead(404).end();
+    });
+    const upstreamPort = await listen(upstream);
+
+    try {
+      upsertProvider({
+        id: "sensevoice-local",
+        name: "SenseVoice Local",
+        default_model: "SenseVoiceSmall",
+        base_url: `http://127.0.0.1:${upstreamPort}/v1`,
+        supports_llm: false,
+        supports_asr: true,
+        supports_audio_input: true,
+      });
+      const setting = createSetting({
+        provider_id: "sensevoice-local",
+        model_name: "SenseVoiceSmall",
+        api_key: "local-no-key",
+        base_url: `http://127.0.0.1:${upstreamPort}/v1`,
+        supports_llm: false,
+        supports_asr: true,
+        supports_audio_input: true,
+      });
+      expect(setting.asr_realtime_url).toBeUndefined();
+      await fetch(`${baseUrl}/api/voice`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ asr_llm_setting_id: setting.id }),
+      });
+
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/api/voice/asr/realtime`);
+      const done = await new Promise<Record<string, unknown>>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error("timed out waiting for ASR done")), 5_000);
+        ws.on("open", () => {
+          ws.send(Buffer.from([0, 0, 12, 0, 24, 0, 12, 0]));
+          ws.send(JSON.stringify({ type: "finish" }));
+        });
+        ws.on("message", (data) => {
+          const event = JSON.parse(data.toString()) as Record<string, unknown>;
+          if (event.type === "error") {
+            clearTimeout(timer);
+            reject(new Error(String(event.error)));
+          }
+          if (event.type === "transcription.done") {
+            clearTimeout(timer);
+            resolve(event);
+          }
+        });
+        ws.on("error", (err) => {
+          clearTimeout(timer);
+          reject(err);
+        });
+      }).finally(() => ws.close());
+
+      expect(done).toMatchObject({
+        type: "transcription.done",
+        strategy: "emulated_batch",
+        text: "sensevoice batch transcript",
+        transcript: "sensevoice batch transcript",
+      });
+      expect(seenRequests).toContain("POST /v1/audio/transcriptions");
+      expect(seenRequests.some((entry) => entry.includes("/v1/realtime"))).toBe(false);
+    } finally {
+      await close(upstream);
+    }
+  });
+
+  it("keeps native_realtime for an explicit external realtime URL under existing provider rules", async () => {
+    const port = await listen(server);
+    const baseUrl = `http://127.0.0.1:${port}`;
+    const upstream = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    const upstreamPort = await listenWebSocket(upstream);
+    const upstreamHeaders: http.IncomingHttpHeaders[] = [];
+    const upstreamMessages: Array<Record<string, unknown>> = [];
+    upstream.on("connection", (socket, req) => {
+      upstreamHeaders.push(req.headers);
+      socket.on("message", (data) => {
+        upstreamMessages.push(JSON.parse(data.toString()) as Record<string, unknown>);
+      });
+    });
+
+    try {
+      upsertProvider({
+        id: "explicit-realtime-test",
+        name: "Explicit Realtime Test",
+        default_model: "qwen3-asr-realtime",
+        base_url: "http://voice.test/v1",
+        supports_llm: false,
+        supports_asr: true,
+        supports_audio_input: true,
+      });
+      const setting = createSetting({
+        provider_id: "explicit-realtime-test",
+        model_name: "qwen3-asr-realtime",
+        api_key: "explicit-realtime-secret",
+        base_url: "http://voice.test/v1",
+        asr_realtime_url: `ws://127.0.0.1:${upstreamPort}/v1/realtime`,
+        supports_llm: false,
+        supports_asr: true,
+        supports_audio_input: true,
+      });
+      await fetch(`${baseUrl}/api/voice`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ asr_llm_setting_id: setting.id }),
+      });
+
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/api/voice/asr/realtime`);
+      const ready = await new Promise<Record<string, unknown>>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error("timed out waiting for realtime ready")), 5_000);
+        ws.on("message", (data) => {
+          const event = JSON.parse(data.toString()) as Record<string, unknown>;
+          if (event.type === "error") {
+            clearTimeout(timer);
+            reject(new Error(String(event.error)));
+          }
+          if (event.type === "ready") {
+            clearTimeout(timer);
+            resolve(event);
+          }
+        });
+        ws.on("error", (err) => {
+          clearTimeout(timer);
+          reject(err);
+        });
+      }).finally(() => ws.close());
+
+      expect(ready).toMatchObject({ type: "ready" });
+      await vi.waitFor(() => expect(upstreamMessages).toHaveLength(2));
+      expect(upstreamHeaders).toHaveLength(1);
+      expect(upstreamHeaders[0].authorization).toBe("Bearer explicit-realtime-secret");
+      expect(upstreamMessages[0]).toMatchObject({ type: "session.update", model: "qwen3-asr-realtime" });
+      expect(upstreamMessages[1]).toMatchObject({ type: "input_audio_buffer.commit" });
+    } finally {
+      for (const client of upstream.clients) client.terminate();
+      await closeWebSocket(upstream);
     }
   });
 


### PR DESCRIPTION
## Summary

This Draft PR is the bounded write target for an Auto Fix v2 run addressing #193.

The implementation must distinguish batch-only ASR from genuine native realtime ASR without using fnOS-, region-, or private-network-specific heuristics.

## Required reporter cases

The Issue reporter confirmed these production cases, and they are mandatory regression tests:

- a local SenseVoice-compatible service exposes `/v1/audio/transcriptions` but no `/v1/realtime`;
- the incorrect realtime URL is currently derived and saved through both Onboarding and Custom Provider Settings;
- manually clearing `asr_realtime_url` restores the expected `emulated_batch` behavior;
- HTTP 401/403 from a WebSocket candidate means authentication is required, not that realtime capability was confirmed or disproved.

## Scope

- classify voice endpoint probe outcomes without IP-range heuristics;
- auto-persist a derived realtime URL only after a real WebSocket handshake;
- keep authentication-required candidates visible but do not auto-enable them;
- preserve a user-explicit realtime URL while editing unrelated provider fields;
- make Onboarding and Custom Provider Settings use consistent persistence rules;
- verify Manager strategy selection remains `emulated_batch` without an external realtime URL and `native_realtime` with an explicit/confirmed one;
- add focused Manager and Agent UI regression tests.

This PR must not introduce fnOS-specific defaults, scan private-network ranges, redesign #195 deadlines, or change the fnOS/root packaging boundary from #197.

## Validation

Auto Fix v2 will run caller-authored focused Manager and Agent UI tests, package typechecks, and Agent UI build, followed by two fresh-context reviews before the Draft is considered ready for CI.

Fixes #193