### PR TITLE
feat(worker): support configurable build package sources (#196)

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,16 @@ Remote Worker and Node connections require authenticated `wss://` endpoints;
 see [Control-Plane WebSocket Security](docs/control-plane-security.md) for token,
 reverse-proxy, certificate, and compatibility settings.
 
+Worker image builds default to the base image's Debian sources and the
+default npm registry. Operators in restricted networks can opt in to public
+mirrors with `HOMERAIL_WORKER_BUILD_APT_MIRROR`,
+`HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR`, and
+`HOMERAIL_WORKER_BUILD_NPM_REGISTRY`; standard `HTTP_PROXY`/`HTTPS_PROXY`/
+`NO_PROXY` variables are forwarded to Docker by name only, and their values
+are never captured by HomeRail. See
+[Worker build network sources](docs/worker-build-network.md) for the
+validation contract, security boundaries, and fnOS integration notes.
+
 Runtime helpers:
 
 ```bash

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -97,6 +97,15 @@ the production Manager. The newest three releases and their Worker images are
 retained; database, model settings, sessions, certificates, and external Skills
 remain outside release directories.
 
+The revision-tagged Worker image honors the public build network contract:
+optional `HOMERAIL_WORKER_BUILD_APT_MIRROR`,
+`HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR`, and
+`HOMERAIL_WORKER_BUILD_NPM_REGISTRY` values are validated before Docker
+starts and added as build arguments, while unset values keep the default
+Debian sources and npm registry. Standard proxy variables are forwarded to
+Docker by name only; their values never enter deployment argv or logs. See
+[Worker build network sources](worker-build-network.md).
+
 The workflow also has a maintainer-only manual dispatch for immediate recovery
 or an explicitly selected revision. Scheduled and default manual deployments
 resolve `main` at job start. The release switch never changes

--- a/docs/worker-build-network.md
+++ b/docs/worker-build-network.md
@@ -28,8 +28,13 @@ with the same environment names, validation, and argument semantics:
   (also used by the PR Review and Three-Worker Showcase wrappers).
 
 The operator scripts share `scripts/lib/worker-build-network.sh`, which
-validates the environment and assembles a Docker argv array without ever
-evaluating input.
+assembles a Docker argv array without ever evaluating input. The shell
+helper consumes only environment variable names and delegates URL
+normalization and validation to the Worker WHATWG URL helper,
+`homerail_worker/scripts/configure-apt-sources.mjs --print-env NAME`, so a
+source value never appears in argv, captured commands, failures, or logs.
+`${NODE_BIN:-node}` selects the Node binary used for that delegation; the
+helper resolves it from its own repository-relative location.
 
 ## Validation contract
 
@@ -38,7 +43,12 @@ evaluating input.
   username, password, query, fragment, control characters, or raw
   whitespace.
 - Trailing slashes, scheme case, and host case are normalized consistently,
-  so semantically identical URLs produce identical build arguments.
+  so semantically identical URLs produce identical build arguments. Default
+  ports are elided and bracketed IPv6 hosts are lower-cased by the same
+  WHATWG rules.
+- Values are plain ASCII and contain no characters that the URL parser would
+  percent-encode or rewrite; such inputs fail closed instead of shipping a
+  normalized value that differs from what the operator configured.
 - Invalid values are rejected before Docker starts. The error names the
   configuration key but never its value.
 

--- a/docs/worker-build-network.md
+++ b/docs/worker-build-network.md
@@ -1,0 +1,88 @@
+# Worker build network sources
+
+HomeRail builds exactly one canonical Worker image from
+`homerail_worker/Dockerfile`. By default the build uses the Debian
+repositories shipped with the base image and npm's default registry; no
+package-source build arguments are added. Operators whose networks cannot
+reach those public endpoints can opt in to validated public mirrors through
+three environment variables:
+
+| Variable | Effect |
+| --- | --- |
+| `HOMERAIL_WORKER_BUILD_APT_MIRROR` | Replaces the Debian main repository URL in non-security deb822 stanzas. |
+| `HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR` | Replaces the Debian security repository URL in security deb822 stanzas. |
+| `HOMERAIL_WORKER_BUILD_NPM_REGISTRY` | Maps to the Docker `NPM_CONFIG_REGISTRY` build argument observed by every npm operation during the image build. It is build-only and is never persisted as a runtime environment variable. |
+
+The two APT overrides are independent: each one rewrites only its matching
+deb822 stanzas, and either can be used alone.
+
+## Entry points
+
+Every supported Worker image build entry point consumes the same contract
+with the same environment names, validation, and argument semantics:
+
+- the Manager Worker image build (`DagEnvironmentController.runBuild`),
+  resolved by `homerail_manager/src/server/worker-build-network.ts`;
+- production deployment, `scripts/deploy-production.sh`;
+- the live acceptance runner, `scripts/run-dag-patterns-live-runner.sh`
+  (also used by the PR Review and Three-Worker Showcase wrappers).
+
+The operator scripts share `scripts/lib/worker-build-network.sh`, which
+validates the environment and assembles a Docker argv array without ever
+evaluating input.
+
+## Validation contract
+
+- Unset or whitespace-only values leave the corresponding source unchanged.
+- Valid values use `http:` or `https:`, have a hostname, and contain no
+  username, password, query, fragment, control characters, or raw
+  whitespace.
+- Trailing slashes, scheme case, and host case are normalized consistently,
+  so semantically identical URLs produce identical build arguments.
+- Invalid values are rejected before Docker starts. The error names the
+  configuration key but never its value.
+
+## Proxy forwarding
+
+Recognized uppercase and lowercase `HTTP_PROXY`, `HTTPS_PROXY`, and
+`NO_PROXY` variables are forwarded to Docker as value-less
+`--build-arg NAME` entries only when non-empty. HomeRail never declares,
+expands, copies, inspects, persists, or logs their values; the existing
+Docker client and BuildKit proxy configuration remains authoritative. When
+no process proxy variable is forwarded, the Manager reports the proxy mode
+as `docker-managed`, which does not claim that no proxy exists in Docker
+state.
+
+## Redacted status
+
+Manager build status exposes only a redacted `worker_image.build_network`
+summary with modes, never URLs:
+
+- `apt_main`: `default` or `custom`
+- `apt_security`: `default` or `custom`
+- `npm`: `default` or `custom`
+- `proxy`: `environment` or `docker-managed`
+
+No source or proxy URL appears in status, task artifacts, or HomeRail-authored
+build log messages.
+
+## Security boundaries
+
+- Source values are deliberately public build metadata and may be visible in
+  image build metadata. Credential-bearing values are rejected: no username
+  or password, no query or fragment tokens, and no private npm
+  authentication in this revision.
+- The shared shell helper never uses `eval`; validated input only ever
+  reaches Docker argv as array elements.
+- A source configuration change invalidates the affected build layers and
+  requires a Worker rebuild.
+
+## fnOS integration and base-image pulls
+
+- HomeRail does not choose or ship mirror vendors. Concrete fnOS mirror
+  values are owned by the fnOS packaging issue #197 and are injected through
+  the fnOS service environment at build time; this contract only defines the
+  validated injection surface.
+- Pulling the `node:22-slim` base image is not covered by these variables.
+  It remains the responsibility of Docker daemon configuration (daemon
+  proxy, registry mirrors, and DNS), not of the Worker build contract.

--- a/homerail_manager/src/server/dag-environment.ts
+++ b/homerail_manager/src/server/dag-environment.ts
@@ -70,6 +70,7 @@ export type DagEnvironmentReasonCode =
   | "worker_image_missing"
   | "worker_image_stale"
   | "worker_image_incompatible"
+  | "worker_build_network_invalid"
   | "worker_image_build_failed";
 
 export type ImageCompatibility = "current" | "stale" | "incompatible" | "unknown";
@@ -840,7 +841,7 @@ export class DagEnvironmentController {
     if (!network) {
       this.failBuild(
         this.buildNetworkError?.message ?? "Worker build network configuration is invalid.",
-        "worker_image_build_failed",
+        "worker_build_network_invalid",
         operationId,
       );
       return;
@@ -1081,6 +1082,20 @@ export class DagEnvironmentController {
   }
 
   private applyBuildNetworkStatus(): void {
+    if (this.buildNetworkError) {
+      const message = this.buildNetworkError.message;
+      this.status.worker_image = {
+        ...this.status.worker_image,
+        status: "error",
+        image: this.workerImage,
+        reason: "worker_build_network_invalid",
+        reason_code: "worker_build_network_invalid",
+        message,
+        error: message,
+      };
+      delete this.status.worker_image.build_network;
+      return;
+    }
     const summary = this.currentBuildNetworkSummary() ?? this.persistedBuildNetworkSummary;
     if (summary) {
       this.status.worker_image.build_network = summary;

--- a/homerail_manager/src/server/dag-environment.ts
+++ b/homerail_manager/src/server/dag-environment.ts
@@ -17,9 +17,18 @@ import { getHomerailHome } from "../config/env.js";
 import { emit } from "../events/bus.js";
 import { getAllWorkers } from "../worker/registry.js";
 import { dagResourceStatusPath } from "./dag-resource-status.js";
+import {
+  normalizeWorkerBuildNetworkSummary,
+  resolveWorkerBuildNetwork,
+  workerBuildNetworkDockerArgs,
+  workerBuildNetworkSummary,
+  type WorkerBuildNetworkConfig,
+  type WorkerBuildNetworkSummary,
+} from "./worker-build-network.js";
 
 const SOURCE_INPUTS = [
   "homerail_worker/Dockerfile",
+  "homerail_worker/scripts/configure-apt-sources.mjs",
   "homerail_worker/package.json",
   "homerail_worker/package-lock.json",
   "homerail_worker/tsconfig.json",
@@ -132,6 +141,7 @@ export interface DagEnvironmentStatus {
     updated_at?: number;
     error?: string;
     compatibility?: ImageCompatibility;
+    build_network?: WorkerBuildNetworkSummary;
   };
   images: DagEnvironmentImage[];
   workers: DagEnvironmentWorker[];
@@ -437,6 +447,9 @@ export class DagEnvironmentController {
   private readonly statusPath: string;
   private readonly workerImage: string;
   private readonly buildTimeoutMs: number;
+  private readonly buildNetworkConfig?: WorkerBuildNetworkConfig;
+  private readonly buildNetworkError?: Error;
+  private persistedBuildNetworkSummary?: WorkerBuildNetworkSummary;
   private status: DagEnvironmentStatus;
   private checkPromise: Promise<DagEnvironmentStatus> | null = null;
   private monitorTimer: ReturnType<typeof setInterval> | null = null;
@@ -457,7 +470,13 @@ export class DagEnvironmentController {
       ?? nonEmpty(this.env.HOMERAIL_WORKER_IMAGE)
       ?? HOMERAIL_WORKER_IMAGE;
     this.buildTimeoutMs = Math.max(1, options.buildTimeoutMs ?? DEFAULT_BUILD_TIMEOUT_MS);
+    try {
+      this.buildNetworkConfig = resolveWorkerBuildNetwork(this.env);
+    } catch (error) {
+      this.buildNetworkError = error instanceof Error ? error : new Error(String(error));
+    }
     this.status = this.readPersistedStatus();
+    this.persistedBuildNetworkSummary = this.status.worker_image.build_network;
   }
 
   getStatus(): DagEnvironmentStatus {
@@ -470,6 +489,7 @@ export class DagEnvironmentController {
       protocol_version: WORKER_CONTRACT_VERSION,
     };
     this.status.workers = this.connectedWorkers(sourceFingerprint);
+    this.applyBuildNetworkStatus();
     return cloneStatus(this.status);
   }
 
@@ -815,10 +835,27 @@ export class DagEnvironmentController {
     const initialBuild = this.status.build;
     if (!initialBuild) return;
     const operationId = initialBuild.operation_id;
+    // Invalid source configuration must fail the build before Docker starts.
+    const network = this.buildNetworkConfig;
+    if (!network) {
+      this.failBuild(
+        this.buildNetworkError?.message ?? "Worker build network configuration is invalid.",
+        "worker_image_build_failed",
+        operationId,
+      );
+      return;
+    }
+    const networkSummary = workerBuildNetworkSummary(network);
     this.status.build = {
       ...initialBuild,
       status: "running",
-      logs: [...initialBuild.logs, "Checking Docker before build…"],
+      logs: [
+        ...initialBuild.logs,
+        `Worker build network: apt_main=${networkSummary.apt_main}`
+          + ` apt_security=${networkSummary.apt_security}`
+          + ` npm=${networkSummary.npm} proxy=${networkSummary.proxy}`,
+        "Checking Docker before build…",
+      ],
     };
     this.status.worker_image.message = `Building ${this.workerImage}.`;
     this.commit();
@@ -865,6 +902,7 @@ export class DagEnvironmentController {
       "--build-arg", `HOMERAIL_WORKER_PROTOCOL_VERSION=${WORKER_CONTRACT_VERSION}`,
       "--build-arg", `HOMERAIL_WORKER_VERSION=${workerVersion}`,
       "--build-arg", `HOMERAIL_WORKER_IMAGE_REVISION=${revision}`,
+      ...workerBuildNetworkDockerArgs(network),
       "-t", this.workerImage,
       ".",
     ];
@@ -1038,9 +1076,23 @@ export class DagEnvironmentController {
     });
   }
 
+  private currentBuildNetworkSummary(): WorkerBuildNetworkSummary | undefined {
+    return this.buildNetworkConfig ? workerBuildNetworkSummary(this.buildNetworkConfig) : undefined;
+  }
+
+  private applyBuildNetworkStatus(): void {
+    const summary = this.currentBuildNetworkSummary() ?? this.persistedBuildNetworkSummary;
+    if (summary) {
+      this.status.worker_image.build_network = summary;
+    } else {
+      delete this.status.worker_image.build_network;
+    }
+  }
+
   private commit(): void {
     this.status.revision += 1;
     this.status.updated_at = this.now();
+    this.applyBuildNetworkStatus();
     this.status.workers = this.connectedWorkers(this.status.source.fingerprint);
     const dir = path.dirname(this.statusPath);
     fs.mkdirSync(dir, { recursive: true });
@@ -1068,7 +1120,13 @@ export class DagEnvironmentController {
         platform: this.platform,
         source: { ...fallback.source, ...parsed.source, repo_root: this.repoRoot },
         docker: { ...fallback.docker, ...parsed.docker },
-        worker_image: { ...fallback.worker_image, ...parsed.worker_image, image: this.workerImage },
+        worker_image: {
+          ...fallback.worker_image,
+          ...parsed.worker_image,
+          image: this.workerImage,
+          build_network: this.currentBuildNetworkSummary()
+            ?? normalizeWorkerBuildNetworkSummary(parsed.worker_image.build_network),
+        },
         images: Array.isArray(parsed.images) ? parsed.images : [],
         workers: [],
         build: parsed.build?.status === "running" || parsed.build?.status === "queued"

--- a/homerail_manager/src/server/worker-build-network.ts
+++ b/homerail_manager/src/server/worker-build-network.ts
@@ -53,7 +53,8 @@ export class WorkerBuildNetworkError extends Error {
 }
 
 const NON_PRINTABLE_OR_NON_ASCII_SOURCE_CHARACTERS = /[^\u0021-\u007e]/;
-const URL_REWRITE_SOURCE_CHARACTERS = /["<>`{}\\]/;
+const URL_REWRITE_SOURCE_CHARACTERS = /["%<>`^{}|\\]/;
+const URL_PATH_BRACKETS = /[\[\]]/;
 
 function normalizeTrailingSlashes(href: string): string {
   return href.replace(/\/+$/, "");
@@ -95,6 +96,14 @@ function resolveSourceUrl(envKey: string, raw: string | undefined): string | und
   }
   if (parsed.search || parsed.hash) {
     throw new WorkerBuildNetworkError(envKey, "value must not include a query or fragment.");
+  }
+  // Brackets are required around IPv6 hosts, but are not useful in public
+  // mirror paths and have varied normalization behavior across Node releases.
+  if (URL_PATH_BRACKETS.test(parsed.pathname)) {
+    throw new WorkerBuildNetworkError(
+      envKey,
+      "value must not contain path characters that require URL encoding.",
+    );
   }
   return normalizeTrailingSlashes(parsed.toString());
 }

--- a/homerail_manager/src/server/worker-build-network.ts
+++ b/homerail_manager/src/server/worker-build-network.ts
@@ -52,7 +52,8 @@ export class WorkerBuildNetworkError extends Error {
   }
 }
 
-const FORBIDDEN_SOURCE_CHARACTERS = /[\u0000-\u001f\u007f\s]/;
+const NON_PRINTABLE_OR_NON_ASCII_SOURCE_CHARACTERS = /[^\u0021-\u007e]/;
+const URL_REWRITE_SOURCE_CHARACTERS = /["<>`{}\\]/;
 
 function normalizeTrailingSlashes(href: string): string {
   return href.replace(/\/+$/, "");
@@ -62,12 +63,19 @@ function resolveSourceUrl(envKey: string, raw: string | undefined): string | und
   if (typeof raw !== "string") return undefined;
   const trimmed = raw.trim();
   if (!trimmed) return undefined;
-  // URL parsing silently strips ASCII tabs/newlines and tolerates other
-  // surprises, so reject control characters and whitespace up front.
-  if (FORBIDDEN_SOURCE_CHARACTERS.test(trimmed)) {
+  // Match the Worker helper's fail-closed contract before WHATWG parsing:
+  // source URLs are printable ASCII and must not contain characters that the
+  // parser would percent-encode or rewrite.
+  if (NON_PRINTABLE_OR_NON_ASCII_SOURCE_CHARACTERS.test(trimmed)) {
     throw new WorkerBuildNetworkError(
       envKey,
-      "value must not contain whitespace or control characters.",
+      "value must not contain control characters, whitespace, or non-ASCII characters.",
+    );
+  }
+  if (URL_REWRITE_SOURCE_CHARACTERS.test(trimmed)) {
+    throw new WorkerBuildNetworkError(
+      envKey,
+      "value must not contain characters that require URL encoding.",
     );
   }
   let parsed: URL;

--- a/homerail_manager/src/server/worker-build-network.ts
+++ b/homerail_manager/src/server/worker-build-network.ts
@@ -1,0 +1,156 @@
+export const WORKER_BUILD_APT_MIRROR_ENV_KEY = "HOMERAIL_WORKER_BUILD_APT_MIRROR";
+export const WORKER_BUILD_APT_SECURITY_MIRROR_ENV_KEY = "HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR";
+export const WORKER_BUILD_NPM_REGISTRY_ENV_KEY = "HOMERAIL_WORKER_BUILD_NPM_REGISTRY";
+
+export const WORKER_BUILD_APT_MIRROR_BUILD_ARG = "HOMERAIL_WORKER_BUILD_APT_MIRROR";
+export const WORKER_BUILD_APT_SECURITY_MIRROR_BUILD_ARG = "HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR";
+export const WORKER_BUILD_NPM_REGISTRY_BUILD_ARG = "NPM_CONFIG_REGISTRY";
+
+// Uppercase and lowercase spellings are recognized; values are never read
+// beyond an emptiness check and stay solely in the Docker child environment.
+export const WORKER_BUILD_PROXY_VARIABLE_NAMES = [
+  "HTTP_PROXY",
+  "http_proxy",
+  "HTTPS_PROXY",
+  "https_proxy",
+  "NO_PROXY",
+  "no_proxy",
+] as const;
+
+export type WorkerBuildNetworkSourceMode = "default" | "custom";
+export type WorkerBuildNetworkProxyMode = "environment" | "docker-managed";
+
+export interface WorkerBuildNetworkSummary {
+  apt_main: WorkerBuildNetworkSourceMode;
+  apt_security: WorkerBuildNetworkSourceMode;
+  npm: WorkerBuildNetworkSourceMode;
+  proxy: WorkerBuildNetworkProxyMode;
+}
+
+export interface WorkerBuildNetworkConfig {
+  aptMirror?: string;
+  aptSecurityMirror?: string;
+  npmRegistry?: string;
+  proxyVariableNames: string[];
+}
+
+export const DEFAULT_WORKER_BUILD_NETWORK_SUMMARY: WorkerBuildNetworkSummary = {
+  apt_main: "default",
+  apt_security: "default",
+  npm: "default",
+  proxy: "docker-managed",
+};
+
+export class WorkerBuildNetworkError extends Error {
+  readonly envKey: string;
+
+  constructor(envKey: string, reason: string) {
+    // The message names the configuration key but never the rejected value.
+    super(`Invalid ${envKey} configuration: ${reason}`);
+    this.name = "WorkerBuildNetworkError";
+    this.envKey = envKey;
+  }
+}
+
+const FORBIDDEN_SOURCE_CHARACTERS = /[\u0000-\u001f\u007f\s]/;
+
+function normalizeTrailingSlashes(href: string): string {
+  return href.replace(/\/+$/, "");
+}
+
+function resolveSourceUrl(envKey: string, raw: string | undefined): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+  // URL parsing silently strips ASCII tabs/newlines and tolerates other
+  // surprises, so reject control characters and whitespace up front.
+  if (FORBIDDEN_SOURCE_CHARACTERS.test(trimmed)) {
+    throw new WorkerBuildNetworkError(
+      envKey,
+      "value must not contain whitespace or control characters.",
+    );
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new WorkerBuildNetworkError(envKey, "value must be an absolute http: or https: URL.");
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new WorkerBuildNetworkError(envKey, "only http: and https: URLs are supported.");
+  }
+  if (!parsed.hostname) {
+    throw new WorkerBuildNetworkError(envKey, "value must include a hostname.");
+  }
+  if (parsed.username || parsed.password) {
+    throw new WorkerBuildNetworkError(envKey, "credential-bearing URLs are not supported.");
+  }
+  if (parsed.search || parsed.hash) {
+    throw new WorkerBuildNetworkError(envKey, "value must not include a query or fragment.");
+  }
+  return normalizeTrailingSlashes(parsed.toString());
+}
+
+function resolveProxyVariableNames(env: NodeJS.ProcessEnv): string[] {
+  const names: string[] = [];
+  for (const name of WORKER_BUILD_PROXY_VARIABLE_NAMES) {
+    const value = env[name];
+    if (typeof value === "string" && value.trim()) names.push(name);
+  }
+  return names;
+}
+
+export function resolveWorkerBuildNetwork(
+  env: NodeJS.ProcessEnv = process.env,
+): WorkerBuildNetworkConfig {
+  return {
+    aptMirror: resolveSourceUrl(WORKER_BUILD_APT_MIRROR_ENV_KEY, env[WORKER_BUILD_APT_MIRROR_ENV_KEY]),
+    aptSecurityMirror: resolveSourceUrl(
+      WORKER_BUILD_APT_SECURITY_MIRROR_ENV_KEY,
+      env[WORKER_BUILD_APT_SECURITY_MIRROR_ENV_KEY],
+    ),
+    npmRegistry: resolveSourceUrl(WORKER_BUILD_NPM_REGISTRY_ENV_KEY, env[WORKER_BUILD_NPM_REGISTRY_ENV_KEY]),
+    proxyVariableNames: resolveProxyVariableNames(env),
+  };
+}
+
+export function workerBuildNetworkDockerArgs(config: WorkerBuildNetworkConfig): string[] {
+  const args: string[] = [];
+  if (config.aptMirror) {
+    args.push("--build-arg", `${WORKER_BUILD_APT_MIRROR_BUILD_ARG}=${config.aptMirror}`);
+  }
+  if (config.aptSecurityMirror) {
+    args.push("--build-arg", `${WORKER_BUILD_APT_SECURITY_MIRROR_BUILD_ARG}=${config.aptSecurityMirror}`);
+  }
+  if (config.npmRegistry) {
+    args.push("--build-arg", `${WORKER_BUILD_NPM_REGISTRY_BUILD_ARG}=${config.npmRegistry}`);
+  }
+  // Value-less entries let Docker resolve the value from the child
+  // environment; HomeRail never places proxy values in argv.
+  for (const name of config.proxyVariableNames) {
+    args.push("--build-arg", name);
+  }
+  return args;
+}
+
+export function workerBuildNetworkSummary(config: WorkerBuildNetworkConfig): WorkerBuildNetworkSummary {
+  return {
+    apt_main: config.aptMirror ? "custom" : "default",
+    apt_security: config.aptSecurityMirror ? "custom" : "default",
+    npm: config.npmRegistry ? "custom" : "default",
+    proxy: config.proxyVariableNames.length > 0 ? "environment" : "docker-managed",
+  };
+}
+
+export function normalizeWorkerBuildNetworkSummary(
+  value: unknown,
+): WorkerBuildNetworkSummary | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  return {
+    apt_main: record.apt_main === "custom" ? "custom" : "default",
+    apt_security: record.apt_security === "custom" ? "custom" : "default",
+    npm: record.npm === "custom" ? "custom" : "default",
+    proxy: record.proxy === "environment" ? "environment" : "docker-managed",
+  };
+}

--- a/homerail_manager/src/server/worker-build-network.ts
+++ b/homerail_manager/src/server/worker-build-network.ts
@@ -55,6 +55,7 @@ export class WorkerBuildNetworkError extends Error {
 const NON_PRINTABLE_OR_NON_ASCII_SOURCE_CHARACTERS = /[^\u0021-\u007e]/;
 const URL_REWRITE_SOURCE_CHARACTERS = /["%<>`^{}|\\]/;
 const URL_PATH_BRACKETS = /[\[\]]/;
+const URL_AUTHORITY_USERINFO = /^[a-z][a-z0-9+.-]*:\/\/[^/?#]*@/i;
 
 function normalizeTrailingSlashes(href: string): string {
   return href.replace(/\/+$/, "");
@@ -78,6 +79,11 @@ function resolveSourceUrl(envKey: string, raw: string | undefined): string | und
       envKey,
       "value must not contain characters that require URL encoding.",
     );
+  }
+  // Check raw authority text as WHATWG parsing drops an empty userinfo marker
+  // (`https://@host/`) before username/password can expose it.
+  if (URL_AUTHORITY_USERINFO.test(trimmed)) {
+    throw new WorkerBuildNetworkError(envKey, "credential-bearing URLs are not supported.");
   }
   let parsed: URL;
   try {

--- a/homerail_manager/tests/dag-environment.test.ts
+++ b/homerail_manager/tests/dag-environment.test.ts
@@ -1153,6 +1153,35 @@ it("keeps default build arguments and docker-managed proxy mode without configur
   );
 });
 
+it("reports invalid build-network configuration before a build is requested", () => {
+  const runner: DagEnvironmentCommandRunner = vi.fn(async () => dockerVersion());
+  const spawnImpl = vi.fn();
+  const controller = new DagEnvironmentController({
+    commandRunner: runner,
+    spawnImpl: spawnImpl as never,
+    repoRoot: currentRepoRoot(),
+    statusPath: statusPath(),
+    env: {
+      HOMERAIL_WORKER_BUILD_APT_MIRROR: "https://user:secret@mirrors.example.com/debian",
+    },
+  });
+
+  const status = controller.getStatus();
+  expect(status.build).toBeUndefined();
+  expect(status.worker_image).toMatchObject({
+    status: "error",
+    reason: "worker_build_network_invalid",
+    reason_code: "worker_build_network_invalid",
+  });
+  expect(status.worker_image.message).toContain("HOMERAIL_WORKER_BUILD_APT_MIRROR");
+  expect(status.worker_image.error).toContain("HOMERAIL_WORKER_BUILD_APT_MIRROR");
+  expect(status.worker_image.message).not.toContain("secret");
+  expect(status.worker_image.message).not.toContain("mirrors.example.com");
+  expect(status.worker_image.build_network).toBeUndefined();
+  expect(spawnImpl).not.toHaveBeenCalled();
+  expect(runner).not.toHaveBeenCalled();
+});
+
 it("fails the build before Docker starts when build-network configuration is invalid", async () => {
   const runner: DagEnvironmentCommandRunner = vi.fn(async () => dockerVersion());
   const spawnImpl = vi.fn();
@@ -1175,6 +1204,7 @@ it("fails the build before Docker starts when build-network configuration is inv
   expect(status.build?.error).not.toContain("mirrors.example.com");
   expect(status.build?.logs.join("\n")).not.toContain("secret");
   expect(status.worker_image.status).toBe("error");
+  expect(status.worker_image.reason_code).toBe("worker_build_network_invalid");
   expect(status.worker_image.error).toContain("HOMERAIL_WORKER_BUILD_APT_MIRROR");
   expect(status.worker_image.build_network).toBeUndefined();
   expect(spawnImpl).not.toHaveBeenCalled();

--- a/homerail_manager/tests/dag-environment.test.ts
+++ b/homerail_manager/tests/dag-environment.test.ts
@@ -1071,7 +1071,7 @@ it("forwards validated build-network sources and proxy names to the Docker build
   ]));
   // The trailing-slash variant must normalize to the same argument value.
   expect(args.join("\u0000")).not.toContain("debian/\u0000");
-  expect(args).not.toContain("--build-arg\u0000http_proxy");
+  expect(args).not.toContain("http_proxy");
   // Proxy arguments carry names only; values remain in the child environment.
   const proxyIndex = args.indexOf("HTTPS_PROXY");
   expect(proxyIndex).toBeGreaterThan(0);

--- a/homerail_manager/tests/dag-environment.test.ts
+++ b/homerail_manager/tests/dag-environment.test.ts
@@ -51,6 +51,7 @@ function fingerprintFixture(): string {
   tempDirs.push(repoRoot);
   const files: Record<string, string> = {
     "homerail_worker/Dockerfile": "FROM node:22\n",
+    "homerail_worker/scripts/configure-apt-sources.mjs": "export const configureAptSources = true;\n",
     "homerail_worker/package.json": JSON.stringify({
       name: "homerail-worker",
       version: "0.1.0-alpha.1",
@@ -1003,4 +1004,245 @@ it("checks immediately and then at the configured monitoring interval", async ()
   await vi.advanceTimersByTimeAsync(1_000);
   await vi.waitFor(() => expect(versionChecks).toBe(2));
   controller.stopMonitoring();
+});
+
+function readyDockerRunner(fingerprint: string): {
+  runner: DagEnvironmentCommandRunner;
+  markBuilt: () => void;
+} {
+  let built = false;
+  const runner: DagEnvironmentCommandRunner = vi.fn(async (_command, args) => {
+    if (args[0] === "version") return dockerVersion();
+    if (args[0] === "info") return dockerInfo();
+    if (args[1] === "ls") {
+      return {
+        stdout: built
+          ? JSON.stringify({ Repository: "homerail-worker", Tag: "latest", Labels: `${HOMERAIL_WORKER_SOURCE_LABEL}=${fingerprint}` })
+          : "",
+        stderr: "",
+      };
+    }
+    if (args[1] === "inspect" && built) return imageInspection(fingerprint);
+    if (args[1] === "inspect") throw new Error("No such image");
+    throw new Error(`Unexpected Docker arguments: ${args.join(" ")}`);
+  });
+  return { runner, markBuilt: () => { built = true; } };
+}
+
+function buildChild() {
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const child = Object.assign(new EventEmitter(), {
+    stdout,
+    stderr,
+    kill: vi.fn(() => true),
+  });
+  return { child, stdout };
+}
+
+it("forwards validated build-network sources and proxy names to the Docker build", async () => {
+  const fingerprint = dagWorkerSourceFingerprint(currentRepoRoot())!;
+  const { runner, markBuilt } = readyDockerRunner(fingerprint);
+  const { child, stdout } = buildChild();
+  const spawnImpl = vi.fn(() => child as never);
+  const persistedPath = statusPath();
+  const controller = new DagEnvironmentController({
+    commandRunner: runner,
+    spawnImpl,
+    repoRoot: currentRepoRoot(),
+    statusPath: persistedPath,
+    env: {
+      HOMERAIL_WORKER_BUILD_APT_MIRROR: "https://mirrors.example.com/debian/",
+      HOMERAIL_WORKER_BUILD_NPM_REGISTRY: "https://registry.example.com",
+      HTTPS_PROXY: "http://proxy.internal:3128",
+      http_proxy: "",
+    },
+  });
+
+  controller.startBuild();
+
+  await vi.waitFor(() => expect(spawnImpl).toHaveBeenCalledTimes(1));
+  const args = spawnImpl.mock.calls[0]?.[1] as string[];
+  const options = spawnImpl.mock.calls[0]?.[2] as { env: Record<string, string | undefined> };
+  expect(args).toEqual(expect.arrayContaining([
+    "--build-arg", "HOMERAIL_WORKER_BUILD_APT_MIRROR=https://mirrors.example.com/debian",
+    "--build-arg", "NPM_CONFIG_REGISTRY=https://registry.example.com",
+    "--build-arg", "HTTPS_PROXY",
+  ]));
+  // The trailing-slash variant must normalize to the same argument value.
+  expect(args.join("\u0000")).not.toContain("debian/\u0000");
+  expect(args).not.toContain("--build-arg\u0000http_proxy");
+  // Proxy arguments carry names only; values remain in the child environment.
+  const proxyIndex = args.indexOf("HTTPS_PROXY");
+  expect(proxyIndex).toBeGreaterThan(0);
+  expect(args[proxyIndex - 1]).toBe("--build-arg");
+  expect(args[proxyIndex + 1]).not.toContain("proxy.internal");
+  expect(args.join("\u0000")).not.toContain("proxy.internal");
+  expect(options.env.HTTPS_PROXY).toBe("http://proxy.internal:3128");
+
+  markBuilt();
+  stdout.write("step one\n");
+  child.emit("close", 0, null);
+  await vi.waitFor(() => expect(controller.getStatus().worker_image.status).toBe("ready"));
+
+  const status = controller.getStatus();
+  expect(status.worker_image.build_network).toEqual({
+    apt_main: "custom",
+    apt_security: "default",
+    npm: "custom",
+    proxy: "environment",
+  });
+  const logs = status.build?.logs.join("\n") ?? "";
+  expect(logs).toContain("Worker build network: apt_main=custom apt_security=default npm=custom proxy=environment");
+  expect(logs).not.toContain("mirrors.example.com");
+  expect(logs).not.toContain("registry.example.com");
+  expect(logs).not.toContain("proxy.internal");
+  const persisted = fs.readFileSync(persistedPath, "utf8");
+  expect(persisted).toContain("\"build_network\"");
+  expect(persisted).not.toContain("mirrors.example.com");
+  expect(persisted).not.toContain("registry.example.com");
+  expect(persisted).not.toContain("proxy.internal");
+});
+
+it("keeps default build arguments and docker-managed proxy mode without configuration", async () => {
+  const fingerprint = dagWorkerSourceFingerprint(currentRepoRoot())!;
+  const { runner, markBuilt } = readyDockerRunner(fingerprint);
+  const { child, stdout } = buildChild();
+  const spawnImpl = vi.fn(() => child as never);
+  const persistedPath = statusPath();
+  const controller = new DagEnvironmentController({
+    commandRunner: runner,
+    spawnImpl,
+    repoRoot: currentRepoRoot(),
+    statusPath: persistedPath,
+    env: {},
+  });
+
+  controller.startBuild();
+
+  await vi.waitFor(() => expect(spawnImpl).toHaveBeenCalledTimes(1));
+  const argText = (spawnImpl.mock.calls[0]?.[1] as string[]).join("\n");
+  for (const forbidden of [
+    "HOMERAIL_WORKER_BUILD_APT_MIRROR",
+    "HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR",
+    "NPM_CONFIG_REGISTRY",
+    "HTTP_PROXY",
+    "http_proxy",
+    "HTTPS_PROXY",
+    "https_proxy",
+    "NO_PROXY",
+    "no_proxy",
+  ]) {
+    expect(argText).not.toContain(forbidden);
+  }
+
+  markBuilt();
+  stdout.write("step one\n");
+  child.emit("close", 0, null);
+  await vi.waitFor(() => expect(controller.getStatus().worker_image.status).toBe("ready"));
+
+  const status = controller.getStatus();
+  expect(status.worker_image.build_network).toEqual({
+    apt_main: "default",
+    apt_security: "default",
+    npm: "default",
+    proxy: "docker-managed",
+  });
+  expect(status.build?.logs.join("\n")).toContain(
+    "Worker build network: apt_main=default apt_security=default npm=default proxy=docker-managed",
+  );
+});
+
+it("fails the build before Docker starts when build-network configuration is invalid", async () => {
+  const runner: DagEnvironmentCommandRunner = vi.fn(async () => dockerVersion());
+  const spawnImpl = vi.fn();
+  const controller = new DagEnvironmentController({
+    commandRunner: runner,
+    spawnImpl: spawnImpl as never,
+    repoRoot: currentRepoRoot(),
+    statusPath: statusPath(),
+    env: {
+      HOMERAIL_WORKER_BUILD_APT_MIRROR: "https://user:secret@mirrors.example.com/debian",
+    },
+  });
+
+  controller.startBuild();
+
+  await vi.waitFor(() => expect(controller.getStatus().build?.status).toBe("failed"));
+  const status = controller.getStatus();
+  expect(status.build?.error).toContain("HOMERAIL_WORKER_BUILD_APT_MIRROR");
+  expect(status.build?.error).not.toContain("secret");
+  expect(status.build?.error).not.toContain("mirrors.example.com");
+  expect(status.build?.logs.join("\n")).not.toContain("secret");
+  expect(status.worker_image.status).toBe("error");
+  expect(status.worker_image.error).toContain("HOMERAIL_WORKER_BUILD_APT_MIRROR");
+  expect(status.worker_image.build_network).toBeUndefined();
+  expect(spawnImpl).not.toHaveBeenCalled();
+  expect(runner).not.toHaveBeenCalled();
+});
+
+it("normalizes persisted worker_image status that predates build_network", () => {
+  const persistedPath = statusPath();
+  const first = new DagEnvironmentController({
+    repoRoot: currentRepoRoot(),
+    statusPath: persistedPath,
+    env: {},
+  });
+  const snapshot = first.getStatus();
+  snapshot.revision = 7;
+  snapshot.build = {
+    operation_id: "older-build",
+    status: "succeeded",
+    started_at: 100,
+    finished_at: 200,
+    logs: ["complete"],
+  };
+  // Simulate a Manager version that never wrote build_network.
+  delete snapshot.worker_image.build_network;
+  fs.writeFileSync(persistedPath, JSON.stringify(snapshot), "utf8");
+
+  const recovered = new DagEnvironmentController({
+    repoRoot: currentRepoRoot(),
+    statusPath: persistedPath,
+    env: { HOMERAIL_WORKER_BUILD_NPM_REGISTRY: "https://registry.example.com" },
+  }).getStatus();
+  expect(recovered.revision).toBe(7);
+  expect(recovered.build?.operation_id).toBe("older-build");
+  expect(recovered.worker_image.build_network).toEqual({
+    apt_main: "default",
+    apt_security: "default",
+    npm: "custom",
+    proxy: "docker-managed",
+  });
+});
+
+it("normalizes malformed persisted build_network values safely", () => {
+  const persistedPath = statusPath();
+  const first = new DagEnvironmentController({
+    repoRoot: currentRepoRoot(),
+    statusPath: persistedPath,
+    env: {},
+  });
+  const snapshot = first.getStatus();
+  snapshot.revision = 3;
+  (snapshot.worker_image as { build_network?: unknown }).build_network = {
+    apt_main: "weird",
+    apt_security: ["custom"],
+    npm: 1,
+    proxy: "none",
+  };
+  fs.writeFileSync(persistedPath, JSON.stringify(snapshot), "utf8");
+
+  const recovered = new DagEnvironmentController({
+    repoRoot: currentRepoRoot(),
+    statusPath: persistedPath,
+    env: {},
+  }).getStatus();
+  expect(recovered.revision).toBe(3);
+  expect(recovered.worker_image.build_network).toEqual({
+    apt_main: "default",
+    apt_security: "default",
+    npm: "default",
+    proxy: "docker-managed",
+  });
 });

--- a/homerail_manager/tests/worker-build-network.test.ts
+++ b/homerail_manager/tests/worker-build-network.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_WORKER_BUILD_NETWORK_SUMMARY,
+  WorkerBuildNetworkError,
+  normalizeWorkerBuildNetworkSummary,
+  resolveWorkerBuildNetwork,
+  workerBuildNetworkDockerArgs,
+  workerBuildNetworkSummary,
+} from "../src/server/worker-build-network.js";
+
+describe("resolveWorkerBuildNetwork", () => {
+  it("leaves every source default and proxies docker-managed without configuration", () => {
+    const config = resolveWorkerBuildNetwork({});
+    expect(config.aptMirror).toBeUndefined();
+    expect(config.aptSecurityMirror).toBeUndefined();
+    expect(config.npmRegistry).toBeUndefined();
+    expect(config.proxyVariableNames).toEqual([]);
+    expect(workerBuildNetworkDockerArgs(config)).toEqual([]);
+    expect(workerBuildNetworkSummary(config)).toEqual(DEFAULT_WORKER_BUILD_NETWORK_SUMMARY);
+  });
+
+  it("treats whitespace-only values as unset", () => {
+    const config = resolveWorkerBuildNetwork({
+      HOMERAIL_WORKER_BUILD_APT_MIRROR: "   ",
+      HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR: "\t",
+      HOMERAIL_WORKER_BUILD_NPM_REGISTRY: " \r\n ",
+    });
+    expect(workerBuildNetworkDockerArgs(config)).toEqual([]);
+    expect(workerBuildNetworkSummary(config)).toEqual(DEFAULT_WORKER_BUILD_NETWORK_SUMMARY);
+  });
+
+  it("turns valid public source URLs into valued build arguments", () => {
+    const config = resolveWorkerBuildNetwork({
+      HOMERAIL_WORKER_BUILD_APT_MIRROR: "https://mirrors.example.com/debian",
+      HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR: "https://mirrors.example.com/debian-security",
+      HOMERAIL_WORKER_BUILD_NPM_REGISTRY: "https://registry.example.com",
+    });
+    expect(workerBuildNetworkDockerArgs(config)).toEqual([
+      "--build-arg", "HOMERAIL_WORKER_BUILD_APT_MIRROR=https://mirrors.example.com/debian",
+      "--build-arg", "HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR=https://mirrors.example.com/debian-security",
+      "--build-arg", "NPM_CONFIG_REGISTRY=https://registry.example.com",
+    ]);
+    expect(workerBuildNetworkSummary(config)).toEqual({
+      apt_main: "custom",
+      apt_security: "custom",
+      npm: "custom",
+      proxy: "docker-managed",
+    });
+  });
+
+  it("keeps main and security APT overrides independent", () => {
+    const mainOnly = resolveWorkerBuildNetwork({
+      HOMERAIL_WORKER_BUILD_APT_MIRROR: "https://main.example.com/debian",
+    });
+    expect(workerBuildNetworkDockerArgs(mainOnly)).toEqual([
+      "--build-arg", "HOMERAIL_WORKER_BUILD_APT_MIRROR=https://main.example.com/debian",
+    ]);
+    expect(workerBuildNetworkSummary(mainOnly)).toMatchObject({
+      apt_main: "custom",
+      apt_security: "default",
+    });
+
+    const securityOnly = resolveWorkerBuildNetwork({
+      HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR: "https://security.example.com/debian-security",
+    });
+    expect(workerBuildNetworkDockerArgs(securityOnly)).toEqual([
+      "--build-arg", "HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR=https://security.example.com/debian-security",
+    ]);
+    expect(workerBuildNetworkSummary(securityOnly)).toMatchObject({
+      apt_main: "default",
+      apt_security: "custom",
+    });
+  });
+
+  it("normalizes harmless trailing slash differences consistently", () => {
+    const bare = resolveWorkerBuildNetwork({
+      HOMERAIL_WORKER_BUILD_NPM_REGISTRY: "https://registry.example.com",
+    });
+    const slashed = resolveWorkerBuildNetwork({
+      HOMERAIL_WORKER_BUILD_NPM_REGISTRY: "https://registry.example.com/",
+    });
+    expect(slashed.npmRegistry).toBe(bare.npmRegistry);
+    expect(slashed.npmRegistry).toBe("https://registry.example.com");
+
+    const pathBare = resolveWorkerBuildNetwork({
+      HOMERAIL_WORKER_BUILD_APT_MIRROR: "https://mirrors.example.com/debian",
+    });
+    const pathSlashed = resolveWorkerBuildNetwork({
+      HOMERAIL_WORKER_BUILD_APT_MIRROR: "https://mirrors.example.com/debian/",
+    });
+    expect(pathSlashed.aptMirror).toBe(pathBare.aptMirror);
+    expect(pathSlashed.aptMirror).toBe("https://mirrors.example.com/debian");
+  });
+
+  const invalidValues = [
+    "ftp://mirrors.example.com/debian",
+    "file:///etc/passwd",
+    "not a url",
+    "https://",
+    "https://user:secret@mirrors.example.com/debian",
+    "https://user@mirrors.example.com/debian",
+    "https://mirrors.example.com/debian?suite=stable",
+    "https://mirrors.example.com/debian#fragment",
+    "https://mirrors.example.com/deb ian",
+    "https://mirrors.example.com/deb\tian",
+    "https://mirrors.example.com/\u0000debian",
+  ];
+
+  for (const value of invalidValues) {
+    it(`rejects ${JSON.stringify(value)} for every source key without echoing the value`, () => {
+      for (const key of [
+        "HOMERAIL_WORKER_BUILD_APT_MIRROR",
+        "HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR",
+        "HOMERAIL_WORKER_BUILD_NPM_REGISTRY",
+      ]) {
+        let caught: unknown;
+        try {
+          resolveWorkerBuildNetwork({ [key]: value });
+        } catch (error) {
+          caught = error;
+        }
+        expect(caught).toBeInstanceOf(WorkerBuildNetworkError);
+        const message = (caught as Error).message;
+        expect(message).toContain(key);
+        expect(message).not.toContain(value);
+      }
+    });
+  }
+
+  it("forwards only non-empty proxy variable names without values", () => {
+    const config = resolveWorkerBuildNetwork({
+      HTTP_PROXY: "http://proxy.example.com:3128",
+      http_proxy: "",
+      HTTPS_PROXY: "   ",
+      https_proxy: "http://proxy.example.com:3129",
+      NO_PROXY: "localhost,127.0.0.1",
+    });
+    expect(config.proxyVariableNames).toEqual(["HTTP_PROXY", "https_proxy", "NO_PROXY"]);
+    const args = workerBuildNetworkDockerArgs(config);
+    expect(args).toEqual([
+      "--build-arg", "HTTP_PROXY",
+      "--build-arg", "https_proxy",
+      "--build-arg", "NO_PROXY",
+    ]);
+    expect(args.join("\u0000")).not.toContain("proxy.example.com");
+    expect(workerBuildNetworkSummary(config)).toMatchObject({ proxy: "environment" });
+  });
+
+  it("places valued source arguments before value-less proxy arguments", () => {
+    const config = resolveWorkerBuildNetwork({
+      HOMERAIL_WORKER_BUILD_NPM_REGISTRY: "https://registry.example.com",
+      HTTP_PROXY: "http://proxy.example.com:3128",
+    });
+    expect(workerBuildNetworkDockerArgs(config)).toEqual([
+      "--build-arg", "NPM_CONFIG_REGISTRY=https://registry.example.com",
+      "--build-arg", "HTTP_PROXY",
+    ]);
+  });
+});
+
+describe("normalizeWorkerBuildNetworkSummary", () => {
+  it("returns undefined for missing or non-object persisted values", () => {
+    expect(normalizeWorkerBuildNetworkSummary(undefined)).toBeUndefined();
+    expect(normalizeWorkerBuildNetworkSummary(null)).toBeUndefined();
+    expect(normalizeWorkerBuildNetworkSummary("custom")).toBeUndefined();
+    expect(normalizeWorkerBuildNetworkSummary(["custom"])).toBeUndefined();
+    expect(normalizeWorkerBuildNetworkSummary(42)).toBeUndefined();
+  });
+
+  it("keeps valid persisted summaries intact", () => {
+    const summary = {
+      apt_main: "custom",
+      apt_security: "default",
+      npm: "custom",
+      proxy: "environment",
+    };
+    expect(normalizeWorkerBuildNetworkSummary(summary)).toEqual(summary);
+    expect(normalizeWorkerBuildNetworkSummary(DEFAULT_WORKER_BUILD_NETWORK_SUMMARY))
+      .toEqual(DEFAULT_WORKER_BUILD_NETWORK_SUMMARY);
+  });
+
+  it("falls back field by field for unknown or malformed persisted values", () => {
+    expect(normalizeWorkerBuildNetworkSummary({})).toEqual(DEFAULT_WORKER_BUILD_NETWORK_SUMMARY);
+    expect(normalizeWorkerBuildNetworkSummary({
+      apt_main: "weird",
+      apt_security: ["custom"],
+      npm: 1,
+      proxy: "none",
+    })).toEqual(DEFAULT_WORKER_BUILD_NETWORK_SUMMARY);
+    expect(normalizeWorkerBuildNetworkSummary({
+      apt_main: "custom",
+      proxy: "environment",
+    })).toEqual({
+      apt_main: "custom",
+      apt_security: "default",
+      npm: "default",
+      proxy: "environment",
+    });
+  });
+});

--- a/homerail_manager/tests/worker-build-network.test.ts
+++ b/homerail_manager/tests/worker-build-network.test.ts
@@ -143,6 +143,7 @@ describe("resolveWorkerBuildNetwork", () => {
     "https://",
     "https://user:secret@mirrors.example.com/debian",
     "https://user@mirrors.example.com/debian",
+    "https://@mirrors.example.com/debian",
     "https://mirrors.example.com/debian?suite=stable",
     "https://mirrors.example.com/debian#fragment",
     "https://mirrors.example.com/deb ian",
@@ -179,6 +180,13 @@ describe("resolveWorkerBuildNetwork", () => {
       }
     });
   }
+
+  it("allows an at-sign in the path when the authority has no userinfo", () => {
+    const config = resolveWorkerBuildNetwork({
+      HOMERAIL_WORKER_BUILD_NPM_REGISTRY: "https://registry.example.com/scope/@package",
+    });
+    expect(config.npmRegistry).toBe("https://registry.example.com/scope/@package");
+  });
 
   it("forwards only non-empty proxy variable names without values", () => {
     const config = resolveWorkerBuildNetwork({

--- a/homerail_manager/tests/worker-build-network.test.ts
+++ b/homerail_manager/tests/worker-build-network.test.ts
@@ -152,6 +152,11 @@ describe("resolveWorkerBuildNetwork", () => {
     "https://mirrors.example.com/<debian>",
     "https://mirrors.example.com/{debian}",
     "https://mirrors.example.com\\debian",
+    "https://mirrors.example.com/deb%ian",
+    "https://mirrors.example.com/deb|ian",
+    "https://mirrors.example.com/deb^ian",
+    "https://mirrors.example.com/deb[ian",
+    "https://mirrors.example.com/deb]ian",
   ];
 
   for (const value of invalidValues) {

--- a/homerail_manager/tests/worker-build-network.test.ts
+++ b/homerail_manager/tests/worker-build-network.test.ts
@@ -148,6 +148,10 @@ describe("resolveWorkerBuildNetwork", () => {
     "https://mirrors.example.com/deb ian",
     "https://mirrors.example.com/deb\tian",
     "https://mirrors.example.com/\u0000debian",
+    "https://exämple.com/debian",
+    "https://mirrors.example.com/<debian>",
+    "https://mirrors.example.com/{debian}",
+    "https://mirrors.example.com\\debian",
   ];
 
   for (const value of invalidValues) {

--- a/homerail_manager/tests/worker-build-network.test.ts
+++ b/homerail_manager/tests/worker-build-network.test.ts
@@ -92,6 +92,50 @@ describe("resolveWorkerBuildNetwork", () => {
     expect(pathSlashed.aptMirror).toBe("https://mirrors.example.com/debian");
   });
 
+  it("normalizes default ports, scheme/host case, and bracketed IPv6 consistently", () => {
+    const defaultPorts = resolveWorkerBuildNetwork({
+      HOMERAIL_WORKER_BUILD_APT_MIRROR: "http://mirrors.example.com:80/debian",
+      HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR: "https://mirrors.example.com:443/debian-security",
+      HOMERAIL_WORKER_BUILD_NPM_REGISTRY: "HTTPS://REGISTRY.EXAMPLE.COM/",
+    });
+    expect(workerBuildNetworkDockerArgs(defaultPorts)).toEqual([
+      "--build-arg", "HOMERAIL_WORKER_BUILD_APT_MIRROR=http://mirrors.example.com/debian",
+      "--build-arg", "HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR=https://mirrors.example.com/debian-security",
+      "--build-arg", "NPM_CONFIG_REGISTRY=https://registry.example.com",
+    ]);
+
+    const ipv6 = resolveWorkerBuildNetwork({
+      HOMERAIL_WORKER_BUILD_APT_MIRROR: "http://[2001:DB8::1]:8080/debian",
+    });
+    expect(workerBuildNetworkDockerArgs(ipv6)).toEqual([
+      "--build-arg", "HOMERAIL_WORKER_BUILD_APT_MIRROR=http://[2001:db8::1]:8080/debian",
+    ]);
+  });
+
+  it("rejects port 99999 and non-numeric ports for every source key without echoing the value", () => {
+    for (const value of [
+      "http://mirrors.example.com:99999/debian",
+      "https://mirrors.example.com:port/debian",
+    ]) {
+      for (const key of [
+        "HOMERAIL_WORKER_BUILD_APT_MIRROR",
+        "HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR",
+        "HOMERAIL_WORKER_BUILD_NPM_REGISTRY",
+      ]) {
+        let caught: unknown;
+        try {
+          resolveWorkerBuildNetwork({ [key]: value });
+        } catch (error) {
+          caught = error;
+        }
+        expect(caught).toBeInstanceOf(WorkerBuildNetworkError);
+        const message = (caught as Error).message;
+        expect(message).toContain(key);
+        expect(message).not.toContain(value);
+      }
+    }
+  });
+
   const invalidValues = [
     "ftp://mirrors.example.com/debian",
     "file:///etc/passwd",

--- a/homerail_worker/Dockerfile
+++ b/homerail_worker/Dockerfile
@@ -1,6 +1,14 @@
 # Build from repo root: docker build -t homerail-worker:latest -f homerail_worker/Dockerfile .
 FROM node:22-slim AS secret-guard-build
 
+# Optional public Debian mirror overrides for Worker image builds. Unset
+# values keep the base image defaults; the helper rewrites the deb822
+# sources stanza by stanza before the first apt-get update.
+ARG HOMERAIL_WORKER_BUILD_APT_MIRROR
+ARG HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR
+COPY homerail_worker/scripts/configure-apt-sources.mjs /opt/homerail/scripts/configure-apt-sources.mjs
+RUN node /opt/homerail/scripts/configure-apt-sources.mjs
+
 RUN apt-get update \
   && apt-get install -y --no-install-recommends gcc libc6-dev \
   && rm -rf /var/lib/apt/lists/*
@@ -9,6 +17,17 @@ RUN gcc -O2 -Wall -Wextra -Werror -fPIC -shared \
   -o /homerail-codex-secret-guard.so /tmp/codex-secret-guard.c
 
 FROM node:22-slim
+
+# Optional public Debian mirror overrides for Worker image builds. ARG
+# declarations are stage-scoped, so they are repeated in this stage.
+ARG HOMERAIL_WORKER_BUILD_APT_MIRROR
+ARG HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR
+# Optional public npm registry override. Build-only: Docker exposes the ARG
+# to every RUN npm operation in this stage without persisting a runtime ENV.
+ARG NPM_CONFIG_REGISTRY
+
+COPY homerail_worker/scripts/configure-apt-sources.mjs /opt/homerail/scripts/configure-apt-sources.mjs
+RUN node /opt/homerail/scripts/configure-apt-sources.mjs
 
 WORKDIR /app
 ENV PATH="/app/node_modules/.bin:${PATH}"

--- a/homerail_worker/scripts/configure-apt-sources.mjs
+++ b/homerail_worker/scripts/configure-apt-sources.mjs
@@ -55,7 +55,7 @@ export function validateMirrorUrl(rawValue, key) {
   // Fail closed on characters the WHATWG URL parser would percent-encode or
   // rewrite (a backslash becomes a path separator in special schemes), so the
   // normalized output never silently differs from the operator's input.
-  if (/["<>`{}\\]/.test(rawValue)) {
+  if (/["%<>`^{}|\\]/.test(rawValue)) {
     throw new Error(`${key} must not contain characters that require URL encoding.`);
   }
   let parsed;
@@ -75,6 +75,11 @@ export function validateMirrorUrl(rawValue, key) {
   }
   if (parsed.search !== "" || parsed.hash !== "") {
     throw new Error(`${key} must not include a query or fragment.`);
+  }
+  // Preserve bracketed IPv6 hosts while rejecting brackets in mirror paths,
+  // whose normalization behavior can vary between Node releases.
+  if (/[\[\]]/.test(parsed.pathname)) {
+    throw new Error(`${key} must not contain path characters that require URL encoding.`);
   }
   return parsed.toString().replace(/\/+$/, "");
 }

--- a/homerail_worker/scripts/configure-apt-sources.mjs
+++ b/homerail_worker/scripts/configure-apt-sources.mjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /**
  * HomeRail Worker image build helper.
  *

--- a/homerail_worker/scripts/configure-apt-sources.mjs
+++ b/homerail_worker/scripts/configure-apt-sources.mjs
@@ -209,10 +209,18 @@ export function applyDeb822SourceOverrides(content, overrides = {}) {
 
   const { blocks, endsWithNewline } = parseDeb822Sources(content);
   let changed = false;
+  let matchedMain = false;
+  let matchedSecurity = false;
   for (const block of blocks) {
     if (block.kind !== "stanza") continue;
-    const target = isSecurityStanza(block) ? validatedSecurity : validatedMain;
+    const security = isSecurityStanza(block);
+    const target = security ? validatedSecurity : validatedMain;
     if (target === undefined) continue;
+    if (security) {
+      matchedSecurity = true;
+    } else {
+      matchedMain = true;
+    }
     const uris = block.fields.get("URIs");
     const replacement = `URIs: ${target}`;
     if (block.lines[uris.lineIndex] === replacement && uris.continuationIndexes.length === 0) {
@@ -223,6 +231,16 @@ export function applyDeb822SourceOverrides(content, overrides = {}) {
       block.lines.splice(continuationIndex, 1);
     }
     changed = true;
+  }
+  if (validatedMain !== undefined && !matchedMain) {
+    throw new Error(
+      `Malformed deb822 sources: no non-security stanza is available for ${APT_MAIN_MIRROR_ENV}.`,
+    );
+  }
+  if (validatedSecurity !== undefined && !matchedSecurity) {
+    throw new Error(
+      `Malformed deb822 sources: no security stanza is available for ${APT_SECURITY_MIRROR_ENV}.`,
+    );
   }
   const output = blocks.map((block) => block.lines.join("\n")).join("\n") + (endsWithNewline ? "\n" : "");
   return { output, changed };

--- a/homerail_worker/scripts/configure-apt-sources.mjs
+++ b/homerail_worker/scripts/configure-apt-sources.mjs
@@ -57,6 +57,11 @@ export function validateMirrorUrl(rawValue, key) {
   if (/["%<>`^{}|\\]/.test(rawValue)) {
     throw new Error(`${key} must not contain characters that require URL encoding.`);
   }
+  // WHATWG parsing silently drops an empty userinfo marker, so inspect the
+  // raw authority before parsing while still allowing `@` in the URL path.
+  if (/^[a-z][a-z0-9+.-]*:\/\/[^/?#]*@/i.test(rawValue)) {
+    throw new Error(`${key} must not embed credentials.`);
+  }
   let parsed;
   try {
     parsed = new URL(rawValue);

--- a/homerail_worker/scripts/configure-apt-sources.mjs
+++ b/homerail_worker/scripts/configure-apt-sources.mjs
@@ -17,6 +17,15 @@
  *
  * The script is image-owned build tooling. It is part of the Worker source
  * fingerprint and runs before `apt-get update` in every Dockerfile stage.
+ *
+ * The helper also exposes an environment-name-only CLI mode used by
+ * scripts/lib/worker-build-network.sh:
+ *
+ *   configure-apt-sources.mjs --print-env NAME
+ *
+ * It reads only the environment variable NAME, reuses the WHATWG URL
+ * validation above, and prints the normalized public URL. The URL value
+ * itself never appears in argv.
  */
 
 import * as fs from "node:fs";
@@ -36,9 +45,18 @@ export function normalizeMirrorValue(rawValue) {
 }
 
 export function validateMirrorUrl(rawValue, key) {
+  // Public source URLs are plain ASCII. Reject control characters, raw
+  // whitespace, and non-ASCII input up front because URL parsing silently
+  // strips or rewrites some of it.
   // eslint-disable-next-line no-control-regex
-  if (/[\u0000-\u0020\u007f]/.test(rawValue)) {
-    throw new Error(`${key} must not contain control characters or raw whitespace.`);
+  if (/[^\u0021-\u007e]/.test(rawValue)) {
+    throw new Error(`${key} must not contain control characters, whitespace, or non-ASCII characters.`);
+  }
+  // Fail closed on characters the WHATWG URL parser would percent-encode or
+  // rewrite (a backslash becomes a path separator in special schemes), so the
+  // normalized output never silently differs from the operator's input.
+  if (/["<>`{}\\]/.test(rawValue)) {
+    throw new Error(`${key} must not contain characters that require URL encoding.`);
   }
   let parsed;
   try {
@@ -61,6 +79,18 @@ export function validateMirrorUrl(rawValue, key) {
   return parsed.toString().replace(/\/+$/, "");
 }
 
+export const PRINT_ENV_FLAG = "--print-env";
+const ENV_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+export function normalizedEnvSource(name, env) {
+  if (typeof name !== "string" || !ENV_NAME_PATTERN.test(name)) {
+    throw new Error("environment variable name must match [A-Za-z_][A-Za-z0-9_]*.");
+  }
+  const value = normalizeMirrorValue(env[name]);
+  if (value === undefined) return undefined;
+  return validateMirrorUrl(value, name);
+}
+
 export function parseDeb822Sources(content) {
   const text = String(content).replace(/\r\n/g, "\n");
   const lines = text.split("\n");
@@ -77,9 +107,23 @@ export function parseDeb822Sources(content) {
 
   lines.forEach((line, index) => {
     const trimmed = line.trim();
-    if (trimmed === "" || trimmed.startsWith("#")) {
+    if (trimmed === "") {
       closeStanza();
       blocks.push({ kind: "prose", lines: [line] });
+      return;
+    }
+    if (trimmed.startsWith("#")) {
+      if (stanza) {
+        // Only a blank line delimits active deb822 stanzas. Comments inside
+        // an active stanza are preserved exactly; they clear the
+        // continuation-field context so ambiguous continuation lines fail
+        // closed instead of attaching to the wrong field.
+        stanza.lines.push(line);
+        lastField = null;
+      } else {
+        // Comments before any stanza stay prose.
+        blocks.push({ kind: "prose", lines: [line] });
+      }
       return;
     }
     if (line.startsWith(" ") || line.startsWith("\t")) {
@@ -183,6 +227,25 @@ export function runCli(options = {}) {
     fs.writeFileSync(sourcesPath, output, "utf8");
   });
   const fail = options.fail ?? ((message) => process.stderr.write(`${message}\n`));
+  const print = options.print ?? ((line) => process.stdout.write(`${line}\n`));
+
+  if (argv[0] === PRINT_ENV_FLAG) {
+    if (argv.length !== 2) {
+      fail(`usage: configure-apt-sources.mjs ${PRINT_ENV_FLAG} ENVIRONMENT_VARIABLE_NAME`);
+      return 1;
+    }
+    let normalized;
+    try {
+      normalized = normalizedEnvSource(argv[1], env);
+    } catch (error) {
+      fail(`HomeRail Worker build source override failed: ${error.message}`);
+      return 1;
+    }
+    if (normalized !== undefined) {
+      print(normalized);
+    }
+    return 0;
+  }
 
   const sourcesPath = argv[0] || DEFAULT_DEB822_SOURCES_PATH;
   const mainMirror = normalizeMirrorValue(env[APT_MAIN_MIRROR_ENV]);

--- a/homerail_worker/scripts/configure-apt-sources.mjs
+++ b/homerail_worker/scripts/configure-apt-sources.mjs
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+/**
+ * HomeRail Worker image build helper.
+ *
+ * Rewrites the deb822 sources file used by the Worker image (the Debian
+ * bookworm layout ships /etc/apt/sources.list.d/debian.sources) stanza by
+ * stanza so image builds can opt into public Debian mirrors:
+ *
+ *   HOMERAIL_WORKER_BUILD_APT_MIRROR          -> stanzas with non-security suites
+ *   HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR -> stanzas with security suites
+ *
+ * The two overrides are independent: configuring one never touches the other
+ * stanza. Unset or whitespace-only values leave the file completely
+ * untouched, preserving the base image's current Debian defaults. When an
+ * override is requested, missing or malformed deb822 input fails the build
+ * instead of silently keeping another source.
+ *
+ * The script is image-owned build tooling. It is part of the Worker source
+ * fingerprint and runs before `apt-get update` in every Dockerfile stage.
+ */
+
+import * as fs from "node:fs";
+import { pathToFileURL } from "node:url";
+
+export const DEFAULT_DEB822_SOURCES_PATH = "/etc/apt/sources.list.d/debian.sources";
+export const APT_MAIN_MIRROR_ENV = "HOMERAIL_WORKER_BUILD_APT_MIRROR";
+export const APT_SECURITY_MIRROR_ENV = "HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR";
+
+const FIELD_LINE_PATTERN = /^([A-Za-z0-9][A-Za-z0-9_-]*):(?:[ \t]+(.*))?$/;
+const SECURITY_SUITE_PATTERN = /-security$/;
+
+export function normalizeMirrorValue(rawValue) {
+  if (typeof rawValue !== "string") return undefined;
+  const trimmed = rawValue.trim();
+  return trimmed === "" ? undefined : trimmed;
+}
+
+export function validateMirrorUrl(rawValue, key) {
+  // eslint-disable-next-line no-control-regex
+  if (/[\u0000-\u0020\u007f]/.test(rawValue)) {
+    throw new Error(`${key} must not contain control characters or raw whitespace.`);
+  }
+  let parsed;
+  try {
+    parsed = new URL(rawValue);
+  } catch {
+    throw new Error(`${key} must be a valid http: or https: URL.`);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(`${key} must use http: or https:.`);
+  }
+  if (!parsed.hostname) {
+    throw new Error(`${key} must include a hostname.`);
+  }
+  if (parsed.username !== "" || parsed.password !== "") {
+    throw new Error(`${key} must not embed credentials.`);
+  }
+  if (parsed.search !== "" || parsed.hash !== "") {
+    throw new Error(`${key} must not include a query or fragment.`);
+  }
+  return parsed.toString().replace(/\/+$/, "");
+}
+
+export function parseDeb822Sources(content) {
+  const text = String(content).replace(/\r\n/g, "\n");
+  const lines = text.split("\n");
+  if (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
+
+  const blocks = [];
+  let stanza = null;
+  let lastField = null;
+
+  const closeStanza = () => {
+    stanza = null;
+    lastField = null;
+  };
+
+  lines.forEach((line, index) => {
+    const trimmed = line.trim();
+    if (trimmed === "" || trimmed.startsWith("#")) {
+      closeStanza();
+      blocks.push({ kind: "prose", lines: [line] });
+      return;
+    }
+    if (line.startsWith(" ") || line.startsWith("\t")) {
+      if (!stanza || !lastField) {
+        throw new Error(
+          `Malformed deb822 sources: line ${index + 1} is a continuation line without a field.`,
+        );
+      }
+      stanza.lines.push(line);
+      lastField.continuationIndexes.push(stanza.lines.length - 1);
+      lastField.valueParts.push(trimmed);
+      return;
+    }
+    const match = FIELD_LINE_PATTERN.exec(line);
+    if (!match) {
+      throw new Error(`Malformed deb822 sources: line ${index + 1} is not a valid deb822 field.`);
+    }
+    if (!stanza) {
+      stanza = { kind: "stanza", lines: [], fields: new Map() };
+      blocks.push(stanza);
+    }
+    const name = match[1];
+    if (stanza.fields.has(name)) {
+      throw new Error(`Malformed deb822 sources: line ${index + 1} duplicates field "${name}".`);
+    }
+    stanza.lines.push(line);
+    lastField = {
+      name,
+      lineIndex: stanza.lines.length - 1,
+      valueParts: [(match[2] ?? "").trimEnd()],
+      continuationIndexes: [],
+    };
+    stanza.fields.set(name, lastField);
+  });
+  closeStanza();
+
+  const stanzas = blocks.filter((block) => block.kind === "stanza");
+  if (stanzas.length === 0) {
+    throw new Error("Malformed deb822 sources: no deb822 stanzas found.");
+  }
+  for (const candidate of stanzas) {
+    for (const required of ["Types", "URIs", "Suites"]) {
+      const field = candidate.fields.get(required);
+      const value = field ? field.valueParts.join(" ").trim() : "";
+      if (value === "") {
+        throw new Error(`Malformed deb822 sources: stanza is missing a usable ${required} field.`);
+      }
+    }
+  }
+  return { blocks, stanzas, endsWithNewline: text.endsWith("\n") };
+}
+
+export function isSecurityStanza(stanza) {
+  const suites = stanza.fields.get("Suites");
+  return suites.valueParts
+    .join(" ")
+    .split(/\s+/)
+    .filter(Boolean)
+    .some((suite) => SECURITY_SUITE_PATTERN.test(suite));
+}
+
+export function applyDeb822SourceOverrides(content, overrides = {}) {
+  const mainMirror = normalizeMirrorValue(overrides.mainMirror);
+  const securityMirror = normalizeMirrorValue(overrides.securityMirror);
+  if (mainMirror === undefined && securityMirror === undefined) {
+    return { output: String(content), changed: false };
+  }
+  const validatedMain = mainMirror === undefined
+    ? undefined
+    : validateMirrorUrl(mainMirror, APT_MAIN_MIRROR_ENV);
+  const validatedSecurity = securityMirror === undefined
+    ? undefined
+    : validateMirrorUrl(securityMirror, APT_SECURITY_MIRROR_ENV);
+
+  const { blocks, endsWithNewline } = parseDeb822Sources(content);
+  let changed = false;
+  for (const block of blocks) {
+    if (block.kind !== "stanza") continue;
+    const target = isSecurityStanza(block) ? validatedSecurity : validatedMain;
+    if (target === undefined) continue;
+    const uris = block.fields.get("URIs");
+    const replacement = `URIs: ${target}`;
+    if (block.lines[uris.lineIndex] === replacement && uris.continuationIndexes.length === 0) {
+      continue;
+    }
+    block.lines[uris.lineIndex] = replacement;
+    for (const continuationIndex of [...uris.continuationIndexes].sort((left, right) => right - left)) {
+      block.lines.splice(continuationIndex, 1);
+    }
+    changed = true;
+  }
+  const output = blocks.map((block) => block.lines.join("\n")).join("\n") + (endsWithNewline ? "\n" : "");
+  return { output, changed };
+}
+
+export function runCli(options = {}) {
+  const argv = options.argv ?? process.argv.slice(2);
+  const env = options.env ?? process.env;
+  const readFile = options.readFile ?? ((sourcesPath) => fs.readFileSync(sourcesPath, "utf8"));
+  const writeFile = options.writeFile ?? ((sourcesPath, output) => {
+    fs.writeFileSync(sourcesPath, output, "utf8");
+  });
+  const fail = options.fail ?? ((message) => process.stderr.write(`${message}\n`));
+
+  const sourcesPath = argv[0] || DEFAULT_DEB822_SOURCES_PATH;
+  const mainMirror = normalizeMirrorValue(env[APT_MAIN_MIRROR_ENV]);
+  const securityMirror = normalizeMirrorValue(env[APT_SECURITY_MIRROR_ENV]);
+  if (mainMirror === undefined && securityMirror === undefined) {
+    return 0;
+  }
+
+  let content;
+  try {
+    content = readFile(sourcesPath);
+  } catch (error) {
+    fail(
+      `HomeRail Worker APT source override failed: unable to read deb822 sources at ${sourcesPath}. `
+      + "Refusing to build against unknown Debian sources when an override is requested.",
+    );
+    return 1;
+  }
+
+  let result;
+  try {
+    result = applyDeb822SourceOverrides(content, { mainMirror, securityMirror });
+  } catch (error) {
+    fail(`HomeRail Worker APT source override failed: ${error.message}`);
+    return 1;
+  }
+
+  if (result.changed) {
+    writeFile(sourcesPath, result.output);
+  }
+  return 0;
+}
+
+function isDirectExecution() {
+  if (!process.argv[1]) return false;
+  try {
+    return import.meta.url === pathToFileURL(process.argv[1]).href;
+  } catch {
+    return false;
+  }
+}
+
+if (isDirectExecution()) {
+  process.exit(runCli());
+}

--- a/homerail_worker/src/__tests__/build-sources.test.ts
+++ b/homerail_worker/src/__tests__/build-sources.test.ts
@@ -264,6 +264,24 @@ describe("Worker deb822 source override helper", () => {
     expect(securityOnly.output).toContain("URIs: http://deb.debian.org/debian\n");
   });
 
+  it("fails closed when the requested main or security stanza class is absent", () => {
+    const [mainStanza, securityStanza] = DEBIAN_SOURCES_FIXTURE.trimEnd().split("\n\n");
+    expect(() => helper.applyDeb822SourceOverrides(`${securityStanza}\n`, {
+      mainMirror: "https://mirror.example.com/debian",
+    })).toThrow(helper.APT_MAIN_MIRROR_ENV);
+    expect(() => helper.applyDeb822SourceOverrides(`${mainStanza}\n`, {
+      securityMirror: "https://mirror.example.com/debian-security",
+    })).toThrow(helper.APT_SECURITY_MIRROR_ENV);
+  });
+
+  it("counts an already-matching stanza as an applied override", () => {
+    const result = helper.applyDeb822SourceOverrides(DEBIAN_SOURCES_FIXTURE, {
+      mainMirror: "http://deb.debian.org/debian",
+    });
+    expect(result.changed).toBe(false);
+    expect(result.output).toBe(DEBIAN_SOURCES_FIXTURE);
+  });
+
   it("replaces the node:22-slim main stanza without touching the security stanza or its snapshot comment", () => {
     const result = helper.applyDeb822SourceOverrides(NODE_SLIM_DEB822_FIXTURE, {
       mainMirror: "https://mirror.example.com/debian",
@@ -474,6 +492,20 @@ describe("Worker deb822 source override CLI", () => {
     expect(failure?.code).toBe(1);
     expect(String(failure?.stderr)).toContain("Malformed deb822 sources");
     expect(readFileSync(sourcesPath, "utf8")).toBe("not deb822 at all\n");
+  });
+
+  it("fails without writing when the configured stanza class is absent", async () => {
+    const mainOnly = `${DEBIAN_SOURCES_FIXTURE.trimEnd().split("\n\n")[0]}\n`;
+    const sourcesPath = makeSourcesFile(mainOnly);
+    const failure = await execFileAsync(process.execPath, [helperScriptPath, sourcesPath], {
+      env: cliEnv({
+        [helper.APT_SECURITY_MIRROR_ENV]: "https://mirror.example.com/debian-security",
+      }),
+    }).then(() => undefined, (error) => error);
+    expect(failure).toBeDefined();
+    expect(failure?.code).toBe(1);
+    expect(String(failure?.stderr)).toContain(helper.APT_SECURITY_MIRROR_ENV);
+    expect(readFileSync(sourcesPath, "utf8")).toBe(mainOnly);
   });
 
   it("fails for invalid mirror values naming the key without echoing the value", async () => {

--- a/homerail_worker/src/__tests__/build-sources.test.ts
+++ b/homerail_worker/src/__tests__/build-sources.test.ts
@@ -213,6 +213,7 @@ describe("Worker deb822 source override helper", () => {
       "http://mirror.example.com:99999/debian",
       "https://mirror.example.com:port/debian",
       "https://user:password@mirror.example.com/debian",
+      "https://@mirror.example.com/debian",
       "https://mirror.example.com/debian?suite=stable",
       "https://mirror.example.com/debian#fragment",
       "https://mirror.example.com/deb ian",
@@ -374,6 +375,7 @@ describe("Worker deb822 source override helper", () => {
       "ftp://mirror.example.com/debian",
       "not a url",
       "https://user:password@mirror.example.com/debian",
+      "https://@mirror.example.com/debian",
       "https://mirror.example.com/debian?component=main",
       "https://mirror.example.com/debian#fragment",
       "https://mirror.example.com/deb ian",
@@ -547,6 +549,7 @@ describe("Worker build source environment-name CLI mode", () => {
     const prohibited = [
       "http://mirror.example.com:99999/debian",
       "https://user:secret@mirror.example.com/debian",
+      "https://@mirror.example.com/debian",
       "https://mirror.example.com/debian?suite=stable",
       "https://mirror.example.com/debian#fragment",
       "https://mirror.example.com/deb ian",
@@ -589,6 +592,13 @@ describe("Worker build source environment-name CLI mode", () => {
     expect(exitCode).toBe(0);
     expect(printed).toEqual(["https://registry.example.com"]);
     expect(failures).toEqual([]);
+  });
+
+  it("allows an at-sign in a source path without treating it as userinfo", () => {
+    expect(helper.validateMirrorUrl(
+      "https://registry.example.com/scope/@package",
+      NPM_REGISTRY_ENV,
+    )).toBe("https://registry.example.com/scope/@package");
   });
 
   it("rejects malformed invocations without printing a URL", () => {

--- a/homerail_worker/src/__tests__/build-sources.test.ts
+++ b/homerail_worker/src/__tests__/build-sources.test.ts
@@ -1,0 +1,399 @@
+import { execFile } from "node:child_process";
+import {
+  lstatSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { afterAll, describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+
+const helperModuleUrl = new URL("../../scripts/configure-apt-sources.mjs", import.meta.url);
+const helperScriptPath = fileURLToPath(helperModuleUrl);
+const workerRoot = fileURLToPath(new URL("../..", import.meta.url));
+const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
+const dockerfile = readFileSync(new URL("../../Dockerfile", import.meta.url), "utf8")
+  .replace(/\r\n/g, "\n");
+
+interface BuildSourcesHelperModule {
+  DEFAULT_DEB822_SOURCES_PATH: string;
+  APT_MAIN_MIRROR_ENV: string;
+  APT_SECURITY_MIRROR_ENV: string;
+  normalizeMirrorValue: (rawValue: unknown) => string | undefined;
+  validateMirrorUrl: (rawValue: string, key: string) => string;
+  applyDeb822SourceOverrides: (
+    content: string,
+    overrides?: { mainMirror?: string; securityMirror?: string },
+  ) => { output: string; changed: boolean };
+  runCli: (options?: {
+    argv?: string[];
+    env?: Record<string, string | undefined>;
+    readFile?: (sourcesPath: string) => string;
+    writeFile?: (sourcesPath: string, output: string) => void;
+    fail?: (message: string) => void;
+  }) => number;
+}
+
+const helper = (await import(helperModuleUrl.href)) as BuildSourcesHelperModule;
+
+const DEBIAN_SOURCES_FIXTURE = [
+  "Types: deb",
+  "URIs: http://deb.debian.org/debian",
+  "Suites: bookworm bookworm-updates",
+  "Components: main",
+  "Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg",
+  "",
+  "Types: deb",
+  "URIs: http://deb.debian.org/debian-security",
+  "Suites: bookworm-security",
+  "Components: main",
+  "Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg",
+  "",
+].join("\n");
+
+const MAIN_STANZA_SECURITY_BY = "Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg";
+
+function dockerfileStages(): { header: string; lines: string[] }[] {
+  const chunks = dockerfile.split(/^FROM /m).slice(1);
+  return chunks.map((chunk) => {
+    const [header, ...rest] = chunk.split("\n");
+    return { header: header ?? "", lines: rest };
+  });
+}
+
+interface DockerRunInstruction {
+  lineIndex: number;
+  text: string;
+}
+
+function runInstructions(lines: string[]): DockerRunInstruction[] {
+  const instructions: DockerRunInstruction[] = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!/^RUN(\s|$)/.test(lines[index])) continue;
+    const parts: string[] = [];
+    let cursor = index;
+    while (cursor < lines.length) {
+      const line = lines[cursor];
+      const continued = line.endsWith("\\");
+      parts.push(continued ? line.slice(0, -1) : line);
+      if (!continued) break;
+      cursor += 1;
+    }
+    instructions.push({ lineIndex: index, text: parts.join(" ") });
+  }
+  return instructions;
+}
+
+function npmInstructions(lines: string[]): DockerRunInstruction[] {
+  return runInstructions(lines).filter((instruction) => /(^|[\s&|;(])npm([\s@]|$)/.test(instruction.text));
+}
+
+const tempDirs: string[] = [];
+
+afterAll(() => {
+  for (const dir of tempDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("Worker deb822 source override helper", () => {
+  it("treats unset and whitespace-only values as unconfigured", () => {
+    expect(helper.normalizeMirrorValue(undefined)).toBeUndefined();
+    expect(helper.normalizeMirrorValue("")).toBeUndefined();
+    expect(helper.normalizeMirrorValue("   \t ")).toBeUndefined();
+    expect(helper.normalizeMirrorValue(" https://mirror.example.com/debian "))
+      .toBe("https://mirror.example.com/debian");
+
+    for (const overrides of [
+      {},
+      { mainMirror: "", securityMirror: "   " },
+      undefined,
+    ]) {
+      const result = helper.applyDeb822SourceOverrides(DEBIAN_SOURCES_FIXTURE, overrides);
+      expect(result.changed).toBe(false);
+      expect(result.output).toBe(DEBIAN_SOURCES_FIXTURE);
+    }
+  });
+
+  it("replaces the main stanza without touching the security stanza", () => {
+    const result = helper.applyDeb822SourceOverrides(DEBIAN_SOURCES_FIXTURE, {
+      mainMirror: "https://mirror.example.com/debian",
+    });
+    expect(result.changed).toBe(true);
+    expect(result.output).toContain("URIs: https://mirror.example.com/debian\nSuites: bookworm bookworm-updates");
+    expect(result.output).toContain("URIs: http://deb.debian.org/debian-security");
+  });
+
+  it("replaces the security stanza without touching the main stanza", () => {
+    const result = helper.applyDeb822SourceOverrides(DEBIAN_SOURCES_FIXTURE, {
+      securityMirror: "https://mirror.example.com/debian-security",
+    });
+    expect(result.changed).toBe(true);
+    expect(result.output).toContain("URIs: https://mirror.example.com/debian-security\nSuites: bookworm-security");
+    expect(result.output).toContain("URIs: http://deb.debian.org/debian\nSuites: bookworm bookworm-updates");
+  });
+
+  it("replaces both stanzas when both overrides are configured", () => {
+    const result = helper.applyDeb822SourceOverrides(DEBIAN_SOURCES_FIXTURE, {
+      mainMirror: "https://mirror.example.com/debian",
+      securityMirror: "https://mirror.example.com/debian-security",
+    });
+    expect(result.changed).toBe(true);
+    expect(result.output).not.toContain("deb.debian.org");
+    expect(result.output).toContain("URIs: https://mirror.example.com/debian");
+    expect(result.output).toContain("URIs: https://mirror.example.com/debian-security");
+  });
+
+  it("normalizes harmless trailing slash differences consistently", () => {
+    const plain = helper.applyDeb822SourceOverrides(DEBIAN_SOURCES_FIXTURE, {
+      mainMirror: "https://mirror.example.com/debian",
+    });
+    const slashed = helper.applyDeb822SourceOverrides(DEBIAN_SOURCES_FIXTURE, {
+      mainMirror: "https://mirror.example.com/debian///",
+    });
+    expect(slashed.output).toBe(plain.output);
+    expect(helper.validateMirrorUrl("https://mirror.example.com/debian/", helper.APT_MAIN_MIRROR_ENV))
+      .toBe("https://mirror.example.com/debian");
+  });
+
+  it("preserves unrelated deb822 fields and stanza structure", () => {
+    const result = helper.applyDeb822SourceOverrides(DEBIAN_SOURCES_FIXTURE, {
+      mainMirror: "https://mirror.example.com/debian",
+    });
+    const expected = DEBIAN_SOURCES_FIXTURE.replace(
+      "URIs: http://deb.debian.org/debian\n",
+      "URIs: https://mirror.example.com/debian\n",
+    );
+    expect(result.output).toBe(expected);
+    expect(result.output.match(/Signed-By: /g)).toHaveLength(2);
+    expect(result.output).toContain(MAIN_STANZA_SECURITY_BY);
+    expect(result.output.endsWith("\n")).toBe(true);
+  });
+
+  it("keeps a stanza untouched when only the other override is configured", () => {
+    const securityOnly = helper.applyDeb822SourceOverrides(DEBIAN_SOURCES_FIXTURE, {
+      securityMirror: "https://mirror.example.com/debian-security",
+    });
+    expect(securityOnly.output).toContain("URIs: http://deb.debian.org/debian\n");
+  });
+
+  it("fails when an override is requested but the deb822 input is malformed", () => {
+    const malformedInputs = [
+      "",
+      "   \n",
+      "garbage line without a field\n",
+      " continuation without a field\n",
+      "Types: deb\nSuites: bookworm\nComponents: main\n",
+      "Types: deb\nURIs: http://deb.debian.org/debian\nURIs: http://other.example.com/debian\nSuites: bookworm\n",
+      "Types: deb\nURIs: http://deb.debian.org/debian\n",
+    ];
+    for (const content of malformedInputs) {
+      expect(() => helper.applyDeb822SourceOverrides(content, {
+        mainMirror: "https://mirror.example.com/debian",
+      })).toThrow(/Malformed deb822 sources/);
+      expect(() => helper.applyDeb822SourceOverrides(content, {
+        securityMirror: "https://mirror.example.com/debian-security",
+      })).toThrow(/Malformed deb822 sources/);
+    }
+  });
+
+  it("rejects invalid mirror URLs naming the configuration key but not the value", () => {
+    const invalidValues = [
+      "ftp://mirror.example.com/debian",
+      "not a url",
+      "https://user:password@mirror.example.com/debian",
+      "https://mirror.example.com/debian?component=main",
+      "https://mirror.example.com/debian#fragment",
+      "https://mirror.example.com/deb ian",
+      "https://mirror.example.com/debian\u0000",
+      "file:///etc/passwd",
+    ];
+    for (const value of invalidValues) {
+      let caught: unknown;
+      try {
+        helper.applyDeb822SourceOverrides(DEBIAN_SOURCES_FIXTURE, { mainMirror: value });
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      const message = (caught as Error).message;
+      expect(message).toContain(helper.APT_MAIN_MIRROR_ENV);
+      expect(message).not.toContain(value);
+      expect(() => helper.validateMirrorUrl(value, helper.APT_SECURITY_MIRROR_ENV))
+        .toThrow(helper.APT_SECURITY_MIRROR_ENV);
+    }
+  });
+
+  it("runs entirely in-process through runCli when nothing is configured", () => {
+    let written = false;
+    const exitCode = helper.runCli({
+      argv: [],
+      env: {},
+      readFile: () => {
+        throw new Error("helper must not read sources when unconfigured");
+      },
+      writeFile: () => {
+        written = true;
+      },
+    });
+    expect(exitCode).toBe(0);
+    expect(written).toBe(false);
+  });
+});
+
+describe("Worker deb822 source override CLI", () => {
+  function makeSourcesFile(content: string): string {
+    const dir = mkdtempSync(join(tmpdir(), "homerail-worker-apt-sources-"));
+    tempDirs.push(dir);
+    const sourcesPath = join(dir, "debian.sources");
+    writeFileSync(sourcesPath, content, "utf8");
+    return sourcesPath;
+  }
+
+  function cliEnv(overrides: Record<string, string> = {}): NodeJS.ProcessEnv {
+    const env: NodeJS.ProcessEnv = { ...process.env };
+    delete env[helper.APT_MAIN_MIRROR_ENV];
+    delete env[helper.APT_SECURITY_MIRROR_ENV];
+    return { ...env, ...overrides };
+  }
+
+  it("leaves the sources file untouched when nothing is configured", async () => {
+    const sourcesPath = makeSourcesFile(DEBIAN_SOURCES_FIXTURE);
+    await execFileAsync(process.execPath, [helperScriptPath, sourcesPath], { env: cliEnv() });
+    expect(readFileSync(sourcesPath, "utf8")).toBe(DEBIAN_SOURCES_FIXTURE);
+  });
+
+  it("rewrites only the configured stanzas in place", async () => {
+    const sourcesPath = makeSourcesFile(DEBIAN_SOURCES_FIXTURE);
+    await execFileAsync(process.execPath, [helperScriptPath, sourcesPath], {
+      env: cliEnv({
+        [helper.APT_MAIN_MIRROR_ENV]: "https://mirror.example.com/debian/",
+        [helper.APT_SECURITY_MIRROR_ENV]: "https://mirror.example.com/debian-security",
+      }),
+    });
+    const rewritten = readFileSync(sourcesPath, "utf8");
+    expect(rewritten).toContain("URIs: https://mirror.example.com/debian\n");
+    expect(rewritten).toContain("URIs: https://mirror.example.com/debian-security\n");
+    expect(rewritten).not.toContain("deb.debian.org");
+  });
+
+  it("fails before apt when the sources file is missing and an override is requested", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "homerail-worker-apt-sources-"));
+    tempDirs.push(dir);
+    const missingPath = join(dir, "debian.sources");
+    await expect(execFileAsync(process.execPath, [helperScriptPath, missingPath], {
+      env: cliEnv({ [helper.APT_MAIN_MIRROR_ENV]: "https://mirror.example.com/debian" }),
+    })).rejects.toMatchObject({ code: 1 });
+  });
+
+  it("fails when an override is requested for malformed deb822 input", async () => {
+    const sourcesPath = makeSourcesFile("not deb822 at all\n");
+    const failure = await execFileAsync(process.execPath, [helperScriptPath, sourcesPath], {
+      env: cliEnv({ [helper.APT_SECURITY_MIRROR_ENV]: "https://mirror.example.com/debian-security" }),
+    }).then(() => undefined, (error) => error);
+    expect(failure).toBeDefined();
+    expect(failure?.code).toBe(1);
+    expect(String(failure?.stderr)).toContain("Malformed deb822 sources");
+    expect(readFileSync(sourcesPath, "utf8")).toBe("not deb822 at all\n");
+  });
+
+  it("fails for invalid mirror values naming the key without echoing the value", async () => {
+    const sourcesPath = makeSourcesFile(DEBIAN_SOURCES_FIXTURE);
+    const invalidValue = "https://user:secret@mirror.example.com/debian";
+    const failure = await execFileAsync(process.execPath, [helperScriptPath, sourcesPath], {
+      env: cliEnv({ [helper.APT_MAIN_MIRROR_ENV]: invalidValue }),
+    }).then(() => undefined, (error) => error);
+    expect(failure).toBeDefined();
+    expect(failure?.code).toBe(1);
+    expect(String(failure?.stderr)).toContain(helper.APT_MAIN_MIRROR_ENV);
+    expect(String(failure?.stderr)).not.toContain(invalidValue);
+    expect(readFileSync(sourcesPath, "utf8")).toBe(DEBIAN_SOURCES_FIXTURE);
+  });
+});
+
+describe("Worker Dockerfile source wiring", () => {
+  it("keeps exactly one canonical Worker Dockerfile", () => {
+    const dockerfiles: string[] = [];
+    const visit = (dir: string): void => {
+      for (const name of readdirSync(dir)) {
+        if (name === "node_modules" || name === "dist") continue;
+        const full = join(dir, name);
+        if (lstatSync(full).isDirectory()) {
+          visit(full);
+          continue;
+        }
+        if (/^dockerfile/i.test(name)) dockerfiles.push(full);
+      }
+    };
+    visit(workerRoot);
+    expect(dockerfiles).toEqual([join(workerRoot, "Dockerfile")]);
+  });
+
+  it("wires the APT override helper into every stage before apt-get update", () => {
+    const stages = dockerfileStages();
+    expect(stages.length).toBe(2);
+    for (const stage of stages) {
+      const body = stage.lines.join("\n");
+      expect(body).toMatch(/^ARG HOMERAIL_WORKER_BUILD_APT_MIRROR$/m);
+      expect(body).toMatch(/^ARG HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR$/m);
+      expect(body).toContain(
+        "COPY homerail_worker/scripts/configure-apt-sources.mjs /opt/homerail/scripts/configure-apt-sources.mjs",
+      );
+      const helperRunIndex = stage.lines
+        .findIndex((line) => line === "RUN node /opt/homerail/scripts/configure-apt-sources.mjs");
+      const aptUpdateIndex = runInstructions(stage.lines)
+        .find((instruction) => instruction.text.includes("apt-get update"))?.lineIndex ?? -1;
+      expect(helperRunIndex).toBeGreaterThanOrEqual(0);
+      expect(aptUpdateIndex).toBeGreaterThanOrEqual(0);
+      expect(helperRunIndex).toBeLessThan(aptUpdateIndex);
+    }
+  });
+
+  it("keeps the APT override arguments optional with no vendor default", () => {
+    expect(dockerfile).not.toMatch(/ARG HOMERAIL_WORKER_BUILD_APT_MIRROR=/);
+    expect(dockerfile).not.toMatch(/ARG HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR=/);
+  });
+
+  it("declares NPM_CONFIG_REGISTRY before every npm build operation in the final stage", () => {
+    const stages = dockerfileStages();
+    const finalStage = stages[stages.length - 1];
+    const argIndex = finalStage.lines.findIndex((line) => line === "ARG NPM_CONFIG_REGISTRY");
+    expect(argIndex).toBeGreaterThanOrEqual(0);
+    const npmRuns = npmInstructions(finalStage.lines);
+    expect(npmRuns.length).toBeGreaterThan(0);
+    for (const instruction of npmRuns) {
+      expect(instruction.lineIndex).toBeGreaterThan(argIndex);
+    }
+    expect(dockerfile.match(/^ARG NPM_CONFIG_REGISTRY$/gm)).toHaveLength(1);
+  });
+
+  it("keeps the npm registry override build-only", () => {
+    expect(dockerfile).not.toMatch(/ARG NPM_CONFIG_REGISTRY=/);
+    expect(dockerfile).not.toMatch(/ENV[^\n]*NPM_CONFIG_REGISTRY/);
+    expect(dockerfile).not.toMatch(/ENV[^\n]*HOMERAIL_WORKER_BUILD_APT/);
+  });
+});
+
+describe("Worker source fingerprint participation", () => {
+  it("includes the APT sources helper in the Manager fingerprint inputs", () => {
+    const dagEnvironmentSource = readFileSync(
+      join(repoRoot, "homerail_manager", "src", "server", "dag-environment.ts"),
+      "utf8",
+    );
+    expect(dagEnvironmentSource).toContain("\"homerail_worker/scripts/configure-apt-sources.mjs\"");
+    const inputsMatch = /const SOURCE_INPUTS = \[(.*?)\] as const;/s.exec(dagEnvironmentSource);
+    expect(inputsMatch).not.toBeNull();
+    expect(inputsMatch?.[1]).toContain("homerail_worker/scripts/configure-apt-sources.mjs");
+  });
+
+  it("ships the helper file referenced by the fingerprint inputs", () => {
+    expect(lstatSync(helperScriptPath).isFile()).toBe(true);
+  });
+});

--- a/homerail_worker/src/__tests__/build-sources.test.ts
+++ b/homerail_worker/src/__tests__/build-sources.test.ts
@@ -26,8 +26,13 @@ interface BuildSourcesHelperModule {
   DEFAULT_DEB822_SOURCES_PATH: string;
   APT_MAIN_MIRROR_ENV: string;
   APT_SECURITY_MIRROR_ENV: string;
+  PRINT_ENV_FLAG: string;
   normalizeMirrorValue: (rawValue: unknown) => string | undefined;
   validateMirrorUrl: (rawValue: string, key: string) => string;
+  normalizedEnvSource: (
+    name: string,
+    env: Record<string, string | undefined>,
+  ) => string | undefined;
   applyDeb822SourceOverrides: (
     content: string,
     overrides?: { mainMirror?: string; securityMirror?: string },
@@ -38,6 +43,7 @@ interface BuildSourcesHelperModule {
     readFile?: (sourcesPath: string) => string;
     writeFile?: (sourcesPath: string, output: string) => void;
     fail?: (message: string) => void;
+    print?: (line: string) => void;
   }) => number;
 }
 
@@ -51,6 +57,29 @@ const DEBIAN_SOURCES_FIXTURE = [
   "Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg",
   "",
   "Types: deb",
+  "URIs: http://deb.debian.org/debian-security",
+  "Suites: bookworm-security",
+  "Components: main",
+  "Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg",
+  "",
+].join("\n");
+
+// Exact /etc/apt/sources.list.d/debian.sources snapshot shipped with the
+// node:22-slim base image: the snapshot comments live inside active stanzas,
+// so only blank lines may delimit stanzas and the comments must survive
+// replacement byte for byte.
+const NODE_SLIM_SNAPSHOT_MAIN_COMMENT = "# http://snapshot.debian.org/archive/debian/20260803T000000Z";
+const NODE_SLIM_SNAPSHOT_SECURITY_COMMENT = "# http://snapshot.debian.org/archive/debian-security/20260803T000000Z";
+const NODE_SLIM_DEB822_FIXTURE = [
+  "Types: deb",
+  NODE_SLIM_SNAPSHOT_MAIN_COMMENT,
+  "URIs: http://deb.debian.org/debian",
+  "Suites: bookworm bookworm-updates",
+  "Components: main",
+  "Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg",
+  "",
+  "Types: deb",
+  NODE_SLIM_SNAPSHOT_SECURITY_COMMENT,
   "URIs: http://deb.debian.org/debian-security",
   "Suites: bookworm-security",
   "Components: main",
@@ -163,6 +192,48 @@ describe("Worker deb822 source override helper", () => {
       .toBe("https://mirror.example.com/debian");
   });
 
+  it("normalizes default ports, scheme/host case, and bracketed IPv6 consistently", () => {
+    expect(helper.validateMirrorUrl("http://mirror.example.com:80/debian", helper.APT_MAIN_MIRROR_ENV))
+      .toBe("http://mirror.example.com/debian");
+    expect(helper.validateMirrorUrl("https://mirror.example.com:443/", helper.APT_MAIN_MIRROR_ENV))
+      .toBe("https://mirror.example.com");
+    expect(helper.validateMirrorUrl("HTTP://MIRROR.EXAMPLE.COM/debian", helper.APT_MAIN_MIRROR_ENV))
+      .toBe("http://mirror.example.com/debian");
+    expect(helper.validateMirrorUrl("http://[2001:DB8::1]:8080/debian", helper.APT_MAIN_MIRROR_ENV))
+      .toBe("http://[2001:db8::1]:8080/debian");
+    expect(helper.validateMirrorUrl("https://[2001:db8::1]/debian", helper.APT_SECURITY_MIRROR_ENV))
+      .toBe("https://[2001:db8::1]/debian");
+  });
+
+  it("rejects port 99999 and every prohibited URL form naming the key but never the value", () => {
+    const prohibited = [
+      "http://mirror.example.com:99999/debian",
+      "https://mirror.example.com:port/debian",
+      "https://user:password@mirror.example.com/debian",
+      "https://mirror.example.com/debian?suite=stable",
+      "https://mirror.example.com/debian#fragment",
+      "https://mirror.example.com/deb ian",
+      "https://mirror.example.com/debian\u0000",
+      "https://mirror.example.com/<script>",
+      "https://ex\u00e4mple.example.com/debian",
+      "ftp://mirror.example.com/debian",
+      "file:///etc/passwd",
+      "not a url",
+    ];
+    for (const value of prohibited) {
+      let caught: unknown;
+      try {
+        helper.validateMirrorUrl(value, helper.APT_SECURITY_MIRROR_ENV);
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      const message = (caught as Error).message;
+      expect(message).toContain(helper.APT_SECURITY_MIRROR_ENV);
+      expect(message).not.toContain(value);
+    }
+  });
+
   it("preserves unrelated deb822 fields and stanza structure", () => {
     const result = helper.applyDeb822SourceOverrides(DEBIAN_SOURCES_FIXTURE, {
       mainMirror: "https://mirror.example.com/debian",
@@ -182,6 +253,92 @@ describe("Worker deb822 source override helper", () => {
       securityMirror: "https://mirror.example.com/debian-security",
     });
     expect(securityOnly.output).toContain("URIs: http://deb.debian.org/debian\n");
+  });
+
+  it("replaces the node:22-slim main stanza without touching the security stanza or its snapshot comment", () => {
+    const result = helper.applyDeb822SourceOverrides(NODE_SLIM_DEB822_FIXTURE, {
+      mainMirror: "https://mirror.example.com/debian",
+    });
+    expect(result.changed).toBe(true);
+    expect(result.output).toBe(NODE_SLIM_DEB822_FIXTURE.replace(
+      "URIs: http://deb.debian.org/debian\n",
+      "URIs: https://mirror.example.com/debian\n",
+    ));
+    expect(result.output).toContain(
+      `Types: deb\n${NODE_SLIM_SNAPSHOT_MAIN_COMMENT}\nURIs: https://mirror.example.com/debian\n`,
+    );
+    expect(result.output).toContain(
+      `${NODE_SLIM_SNAPSHOT_SECURITY_COMMENT}\nURIs: http://deb.debian.org/debian-security\n`,
+    );
+  });
+
+  it("replaces the node:22-slim security stanza without touching the main stanza or its snapshot comment", () => {
+    const result = helper.applyDeb822SourceOverrides(NODE_SLIM_DEB822_FIXTURE, {
+      securityMirror: "https://mirror.example.com/debian-security",
+    });
+    expect(result.changed).toBe(true);
+    expect(result.output).toBe(NODE_SLIM_DEB822_FIXTURE.replace(
+      "URIs: http://deb.debian.org/debian-security\n",
+      "URIs: https://mirror.example.com/debian-security\n",
+    ));
+    expect(result.output).toContain(
+      `${NODE_SLIM_SNAPSHOT_MAIN_COMMENT}\nURIs: http://deb.debian.org/debian\n`,
+    );
+  });
+
+  it("replaces both node:22-slim stanzas independently while preserving every snapshot comment exactly", () => {
+    const result = helper.applyDeb822SourceOverrides(NODE_SLIM_DEB822_FIXTURE, {
+      mainMirror: "https://mirror.example.com/debian",
+      securityMirror: "https://mirror.example.com/debian-security",
+    });
+    expect(result.changed).toBe(true);
+    expect(result.output).toContain("URIs: https://mirror.example.com/debian\n");
+    expect(result.output).toContain("URIs: https://mirror.example.com/debian-security\n");
+    expect(result.output.split(NODE_SLIM_SNAPSHOT_MAIN_COMMENT).length).toBe(2);
+    expect(result.output.split(NODE_SLIM_SNAPSHOT_SECURITY_COMMENT).length).toBe(2);
+    expect(result.output).not.toContain("deb.debian.org");
+  });
+
+  it("keeps the node:22-slim snapshot byte-identical when nothing is configured", () => {
+    const result = helper.applyDeb822SourceOverrides(NODE_SLIM_DEB822_FIXTURE, {});
+    expect(result.changed).toBe(false);
+    expect(result.output).toBe(NODE_SLIM_DEB822_FIXTURE);
+  });
+
+  it("keeps comments before any stanza as prose and comments inside stanzas exact", () => {
+    const content = [
+      "# leading prose comment",
+      "Types: deb",
+      "# in-stanza snapshot comment",
+      "URIs: http://deb.debian.org/debian",
+      "Suites: bookworm",
+      "",
+    ].join("\n");
+    const result = helper.applyDeb822SourceOverrides(content, {
+      mainMirror: "https://mirror.example.com/debian",
+    });
+    expect(result.output).toBe([
+      "# leading prose comment",
+      "Types: deb",
+      "# in-stanza snapshot comment",
+      "URIs: https://mirror.example.com/debian",
+      "Suites: bookworm",
+      "",
+    ].join("\n"));
+  });
+
+  it("fails closed on continuation lines after an in-stanza comment", () => {
+    const ambiguous = [
+      "Types: deb",
+      "# snapshot comment clears continuation context",
+      " continuation without a field",
+      "URIs: http://deb.debian.org/debian",
+      "Suites: bookworm",
+      "",
+    ].join("\n");
+    expect(() => helper.applyDeb822SourceOverrides(ambiguous, {
+      mainMirror: "https://mirror.example.com/debian",
+    })).toThrow(/Malformed deb822 sources/);
   });
 
   it("fails when an override is requested but the deb822 input is malformed", () => {
@@ -315,6 +472,125 @@ describe("Worker deb822 source override CLI", () => {
     expect(String(failure?.stderr)).toContain(helper.APT_MAIN_MIRROR_ENV);
     expect(String(failure?.stderr)).not.toContain(invalidValue);
     expect(readFileSync(sourcesPath, "utf8")).toBe(DEBIAN_SOURCES_FIXTURE);
+  });
+});
+
+describe("Worker build source environment-name CLI mode", () => {
+  const NPM_REGISTRY_ENV = "HOMERAIL_WORKER_BUILD_NPM_REGISTRY";
+
+  function printCliEnv(overrides: Record<string, string> = {}): NodeJS.ProcessEnv {
+    return { PATH: process.env.PATH ?? "", ...overrides };
+  }
+
+  function runPrintEnv(name: string, overrides: Record<string, string> = {}) {
+    return execFileAsync(process.execPath, [helperScriptPath, helper.PRINT_ENV_FLAG, name], {
+      env: printCliEnv(overrides),
+    }).then(
+      (result) => ({ code: 0, stdout: String(result.stdout), stderr: String(result.stderr) }),
+      (error) => {
+        const failure = error as { code?: number | string; stdout?: unknown; stderr?: unknown };
+        return {
+          code: Number(failure.code ?? 1),
+          stdout: String(failure.stdout ?? ""),
+          stderr: String(failure.stderr ?? ""),
+        };
+      },
+    );
+  }
+
+  it("prints only the normalized public URL and receives only the variable name in argv", async () => {
+    const result = await runPrintEnv(helper.APT_MAIN_MIRROR_ENV, {
+      [helper.APT_MAIN_MIRROR_ENV]: "HTTPS://Mirror.Example.com/debian/",
+    });
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe("https://mirror.example.com/debian\n");
+    expect(result.stderr).toBe("");
+  });
+
+  it("normalizes default ports and bracketed IPv6 identically for every source key", async () => {
+    const cases: [string, string][] = [
+      ["http://mirror.example.com:80/debian", "http://mirror.example.com/debian"],
+      ["https://mirror.example.com:443/", "https://mirror.example.com"],
+      ["http://[2001:DB8::1]:8080/debian", "http://[2001:db8::1]:8080/debian"],
+    ];
+    for (const name of [helper.APT_MAIN_MIRROR_ENV, helper.APT_SECURITY_MIRROR_ENV, NPM_REGISTRY_ENV]) {
+      for (const [value, expected] of cases) {
+        const result = await runPrintEnv(name, { [name]: value });
+        expect(result.code).toBe(0);
+        expect(result.stdout).toBe(`${expected}\n`);
+      }
+    }
+  });
+
+  it("prints nothing and exits 0 for unset-equivalent values", async () => {
+    for (const overrides of [{}, { [helper.APT_MAIN_MIRROR_ENV]: " \t " }]) {
+      const result = await runPrintEnv(helper.APT_MAIN_MIRROR_ENV, overrides);
+      expect(result.code).toBe(0);
+      expect(result.stdout).toBe("");
+    }
+  });
+
+  it("fails before any consumer for prohibited values, naming the key and never echoing the value", async () => {
+    const prohibited = [
+      "http://mirror.example.com:99999/debian",
+      "https://user:secret@mirror.example.com/debian",
+      "https://mirror.example.com/debian?suite=stable",
+      "https://mirror.example.com/debian#fragment",
+      "https://mirror.example.com/deb ian",
+      "https://mirror.example.com/<script>",
+      "ftp://mirror.example.com/debian",
+      "file:///etc/passwd",
+      "not a url",
+    ];
+    // Null bytes cannot cross the process boundary in an environment value;
+    // the in-process validation tests cover that rejection above.
+    for (const value of prohibited) {
+      const result = await runPrintEnv(NPM_REGISTRY_ENV, { [NPM_REGISTRY_ENV]: value });
+      expect(result.code).toBe(1);
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toContain(NPM_REGISTRY_ENV);
+      expect(result.stderr).not.toContain(value);
+    }
+  });
+
+  it("runs entirely in-process through runCli without reading the sources file", () => {
+    const printed: string[] = [];
+    const failures: string[] = [];
+    const exitCode = helper.runCli({
+      argv: [helper.PRINT_ENV_FLAG, NPM_REGISTRY_ENV],
+      env: { [NPM_REGISTRY_ENV]: " https://registry.example.com/ " },
+      readFile: () => {
+        throw new Error("print-env mode must not read the sources file");
+      },
+      writeFile: () => {
+        throw new Error("print-env mode must not write the sources file");
+      },
+      print: (line) => printed.push(line),
+      fail: (message) => failures.push(message),
+    });
+    expect(exitCode).toBe(0);
+    expect(printed).toEqual(["https://registry.example.com"]);
+    expect(failures).toEqual([]);
+  });
+
+  it("rejects malformed invocations without printing a URL", () => {
+    for (const argv of [
+      [helper.PRINT_ENV_FLAG],
+      [helper.PRINT_ENV_FLAG, helper.APT_MAIN_MIRROR_ENV, "extra"],
+      [helper.PRINT_ENV_FLAG, "not a variable name"],
+    ]) {
+      const printed: string[] = [];
+      const failures: string[] = [];
+      const exitCode = helper.runCli({
+        argv,
+        env: { [helper.APT_MAIN_MIRROR_ENV]: "https://mirror.example.com/debian" },
+        print: (line) => printed.push(line),
+        fail: (message) => failures.push(message),
+      });
+      expect(exitCode).toBe(1);
+      expect(printed).toEqual([]);
+      expect(failures).toHaveLength(1);
+    }
   });
 });
 

--- a/homerail_worker/src/__tests__/build-sources.test.ts
+++ b/homerail_worker/src/__tests__/build-sources.test.ts
@@ -15,8 +15,8 @@ import { afterAll, describe, expect, it } from "vitest";
 
 const execFileAsync = promisify(execFile);
 
-const helperModuleUrl = new URL("../../scripts/configure-apt-sources.mjs", import.meta.url);
-const helperScriptPath = fileURLToPath(helperModuleUrl);
+const helperScriptUrl = new URL("../../scripts/configure-apt-sources.mjs", import.meta.url);
+const helperScriptPath = fileURLToPath(helperScriptUrl);
 const workerRoot = fileURLToPath(new URL("../..", import.meta.url));
 const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
 const dockerfile = readFileSync(new URL("../../Dockerfile", import.meta.url), "utf8")
@@ -47,7 +47,10 @@ interface BuildSourcesHelperModule {
   }) => number;
 }
 
-const helper = (await import(helperModuleUrl.href)) as BuildSourcesHelperModule;
+// The runtime-owned ESM helper intentionally ships without TypeScript declarations.
+// Keep the specifier relative so Vitest resolves it consistently on Windows and POSIX.
+// @ts-expect-error -- the interface below is the test-side contract for this JavaScript module.
+const helper = (await import("../../scripts/configure-apt-sources.mjs")) as BuildSourcesHelperModule;
 
 const DEBIAN_SOURCES_FIXTURE = [
   "Types: deb",
@@ -215,6 +218,11 @@ describe("Worker deb822 source override helper", () => {
       "https://mirror.example.com/deb ian",
       "https://mirror.example.com/debian\u0000",
       "https://mirror.example.com/<script>",
+      "https://mirror.example.com/deb%ian",
+      "https://mirror.example.com/deb|ian",
+      "https://mirror.example.com/deb^ian",
+      "https://mirror.example.com/deb[ian",
+      "https://mirror.example.com/deb]ian",
       "https://ex\u00e4mple.example.com/debian",
       "ftp://mirror.example.com/debian",
       "file:///etc/passwd",
@@ -370,6 +378,11 @@ describe("Worker deb822 source override helper", () => {
       "https://mirror.example.com/debian#fragment",
       "https://mirror.example.com/deb ian",
       "https://mirror.example.com/debian\u0000",
+      "https://mirror.example.com/deb%ian",
+      "https://mirror.example.com/deb|ian",
+      "https://mirror.example.com/deb^ian",
+      "https://mirror.example.com/deb[ian",
+      "https://mirror.example.com/deb]ian",
       "file:///etc/passwd",
     ];
     for (const value of invalidValues) {
@@ -538,6 +551,11 @@ describe("Worker build source environment-name CLI mode", () => {
       "https://mirror.example.com/debian#fragment",
       "https://mirror.example.com/deb ian",
       "https://mirror.example.com/<script>",
+      "https://mirror.example.com/deb%ian",
+      "https://mirror.example.com/deb|ian",
+      "https://mirror.example.com/deb^ian",
+      "https://mirror.example.com/deb[ian",
+      "https://mirror.example.com/deb]ian",
       "ftp://mirror.example.com/debian",
       "file:///etc/passwd",
       "not a url",

--- a/homerail_worker/src/__tests__/runtime-version.test.ts
+++ b/homerail_worker/src/__tests__/runtime-version.test.ts
@@ -60,6 +60,19 @@ describe("Worker runtime version identity", () => {
     expect(dockerfile).toContain('HOMERAIL_WORKER_PROTOCOL_VERSION="${HOMERAIL_WORKER_PROTOCOL_VERSION}"');
   });
 
+  it("keeps Worker build source overrides optional, build-only Docker arguments", () => {
+    const dockerfile = readFileSync(new URL("../../Dockerfile", import.meta.url), "utf8")
+      .replace(/\r\n/g, "\n");
+    expect(dockerfile.match(/^ARG HOMERAIL_WORKER_BUILD_APT_MIRROR$/gm)).toHaveLength(2);
+    expect(dockerfile.match(/^ARG HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR$/gm)).toHaveLength(2);
+    expect(dockerfile.match(/^ARG NPM_CONFIG_REGISTRY$/gm)).toHaveLength(1);
+    expect(dockerfile).not.toMatch(/ARG HOMERAIL_WORKER_BUILD_APT_MIRROR=/);
+    expect(dockerfile).not.toMatch(/ARG HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR=/);
+    expect(dockerfile).not.toMatch(/ARG NPM_CONFIG_REGISTRY=/);
+    expect(dockerfile).not.toMatch(/ENV[^\n]*NPM_CONFIG_REGISTRY/);
+    expect(dockerfile).not.toMatch(/ENV[^\n]*HOMERAIL_WORKER_BUILD_APT/);
+  });
+
   it("uses the package-derived version in every Worker agent identity", () => {
     const expectedOccurrences = new Map([
       ["../agent/claude-sdk.ts", 1],

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 SOURCE_ROOT="${GITHUB_WORKSPACE:-$(cd "$(dirname "$0")/.." && pwd)}"
 source "$SOURCE_ROOT/scripts/lib/production-runtime.sh"
+source "$SOURCE_ROOT/scripts/lib/worker-build-network.sh"
 PRODUCTION_ROOT="${HOMERAIL_PRODUCTION_ROOT:-$HOME/.local/share/homerail-production}"
 HOMERAIL_HOME="${HOMERAIL_PRODUCTION_HOME:-$HOME/.local/share/homerail-production-data}"
 RESOURCE_ROOT="${HOMERAIL_PRODUCTION_RESOURCES:-$HOME/.local/share/homerail-resources}"
@@ -204,6 +205,10 @@ fi
 
 SHORT_REVISION="${REVISION:0:12}"
 WORKER_IMAGE="homerail-worker:production-$SHORT_REVISION"
+# Validate the public Worker build source contract and assemble Docker
+# arguments without evaluating input. Invalid values fail here, before Docker starts.
+WORKER_BUILD_NETWORK_ARGS=()
+homerail_worker_build_network_args WORKER_BUILD_NETWORK_ARGS
 echo "Building production Worker image $WORKER_IMAGE"
 docker build \
   --label "org.homerail.production_revision=$REVISION" \
@@ -216,6 +221,7 @@ docker build \
   --build-arg "HOMERAIL_WORKER_PROTOCOL_VERSION=$WORKER_CONTRACT_VERSION" \
   --build-arg "HOMERAIL_WORKER_VERSION=$WORKER_VERSION" \
   --build-arg "HOMERAIL_WORKER_IMAGE_REVISION=$REVISION" \
+  ${WORKER_BUILD_NETWORK_ARGS[@]+"${WORKER_BUILD_NETWORK_ARGS[@]}"} \
   -t "$WORKER_IMAGE" \
   -f "$SOURCE_ROOT/homerail_worker/Dockerfile" \
   "$SOURCE_ROOT"

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -207,8 +207,7 @@ SHORT_REVISION="${REVISION:0:12}"
 WORKER_IMAGE="homerail-worker:production-$SHORT_REVISION"
 # Validate the public Worker build source contract and assemble Docker
 # arguments without evaluating input. Invalid values fail here, before Docker starts.
-WORKER_BUILD_NETWORK_ARGS=()
-homerail_worker_build_network_args WORKER_BUILD_NETWORK_ARGS
+homerail_worker_build_network_args
 echo "Building production Worker image $WORKER_IMAGE"
 docker build \
   --label "org.homerail.production_revision=$REVISION" \
@@ -221,7 +220,7 @@ docker build \
   --build-arg "HOMERAIL_WORKER_PROTOCOL_VERSION=$WORKER_CONTRACT_VERSION" \
   --build-arg "HOMERAIL_WORKER_VERSION=$WORKER_VERSION" \
   --build-arg "HOMERAIL_WORKER_IMAGE_REVISION=$REVISION" \
-  ${WORKER_BUILD_NETWORK_ARGS[@]+"${WORKER_BUILD_NETWORK_ARGS[@]}"} \
+  ${HOMERAIL_WORKER_BUILD_NETWORK_ARGS[@]+"${HOMERAIL_WORKER_BUILD_NETWORK_ARGS[@]}"} \
   -t "$WORKER_IMAGE" \
   -f "$SOURCE_ROOT/homerail_worker/Dockerfile" \
   "$SOURCE_ROOT"

--- a/scripts/lib/worker-build-network.sh
+++ b/scripts/lib/worker-build-network.sh
@@ -22,8 +22,10 @@
 # when non-empty. Their values are never expanded into argv, inspected, or
 # logged; the Docker client/BuildKit proxy configuration remains authoritative.
 #
-# The helper only appends to a caller-provided argv array. It never evaluates
-# or executes validated input. Callers must use `set -euo pipefail`.
+# The helper populates the global HOMERAIL_WORKER_BUILD_NETWORK_ARGS argv
+# array. This avoids Bash 4.3 namerefs so the contract also works with the
+# Bash 3.2 runtime shipped by macOS. It never evaluates or executes validated
+# input. Callers must use `set -euo pipefail`.
 
 # homerail_worker_build_network_helper_path
 #
@@ -67,10 +69,10 @@ homerail_worker_build_network_normalize_source() {
   return 0
 }
 
-# homerail_worker_build_network_args ARRAY_NAME
+# homerail_worker_build_network_args
 #
 # Validates the public build source settings from the environment and appends
-# Docker build arguments to the caller's argv array named ARRAY_NAME:
+# Docker build arguments to the global HOMERAIL_WORKER_BUILD_NETWORK_ARGS array:
 #   --build-arg HOMERAIL_WORKER_BUILD_APT_MIRROR=<url>
 #   --build-arg HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR=<url>
 #   --build-arg NPM_CONFIG_REGISTRY=<url>
@@ -78,7 +80,7 @@ homerail_worker_build_network_normalize_source() {
 # proxy variable. Returns 1 before any Docker invocation when a value is
 # invalid.
 homerail_worker_build_network_args() {
-  local -n _homerail_worker_build_network_args="$1"
+  HOMERAIL_WORKER_BUILD_NETWORK_ARGS=()
   local name normalized proxy_name
   for name in HOMERAIL_WORKER_BUILD_APT_MIRROR HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR HOMERAIL_WORKER_BUILD_NPM_REGISTRY; do
     if ! normalized="$(homerail_worker_build_network_normalize_source "$name")"; then
@@ -86,15 +88,15 @@ homerail_worker_build_network_args() {
     fi
     if [ -n "$normalized" ]; then
       if [ "$name" = "HOMERAIL_WORKER_BUILD_NPM_REGISTRY" ]; then
-        _homerail_worker_build_network_args+=("--build-arg" "NPM_CONFIG_REGISTRY=$normalized")
+        HOMERAIL_WORKER_BUILD_NETWORK_ARGS+=("--build-arg" "NPM_CONFIG_REGISTRY=$normalized")
       else
-        _homerail_worker_build_network_args+=("--build-arg" "$name=$normalized")
+        HOMERAIL_WORKER_BUILD_NETWORK_ARGS+=("--build-arg" "$name=$normalized")
       fi
     fi
   done
   for proxy_name in HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy; do
     if [ -n "${!proxy_name-}" ]; then
-      _homerail_worker_build_network_args+=("--build-arg" "$proxy_name")
+      HOMERAIL_WORKER_BUILD_NETWORK_ARGS+=("--build-arg" "$proxy_name")
     fi
   done
   return 0

--- a/scripts/lib/worker-build-network.sh
+++ b/scripts/lib/worker-build-network.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+
+# Shared Worker build network contract for operator entry points.
+#
+# Public source settings (identical names and validation to the Manager's
+# resolver in homerail_manager/src/server/worker-build-network.ts):
+#
+#   HOMERAIL_WORKER_BUILD_APT_MIRROR           optional Debian main repository URL
+#   HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR  optional Debian security repository URL
+#   HOMERAIL_WORKER_BUILD_NPM_REGISTRY         optional npm registry URL
+#
+# Unset or whitespace-only values leave the corresponding source unchanged.
+# Valid values use http: or https:, have a hostname, and contain no username,
+# password, query, fragment, control characters, or raw whitespace. Trailing
+# slashes, scheme case, and host case are normalized so semantically identical
+# URLs produce identical build arguments. Invalid values fail before Docker
+# starts; the error names the configuration key but never its value.
+#
+# Recognized uppercase and lowercase HTTP_PROXY, HTTPS_PROXY, and NO_PROXY
+# variables are forwarded as value-less Docker --build-arg NAME entries only
+# when non-empty. Their values are never expanded into argv, inspected, or
+# logged; the Docker client/BuildKit proxy configuration remains authoritative.
+#
+# The helper only appends to a caller-provided argv array. It never evaluates
+# or executes validated input. Callers must use `set -euo pipefail`.
+
+# homerail_worker_build_network_normalize_source NAME VALUE
+#
+# Prints the normalized URL for the public source setting NAME. Prints nothing
+# and returns 0 when VALUE is unset-equivalent (empty or whitespace-only).
+# Returns 1 with an error naming NAME (never VALUE) when VALUE is invalid.
+homerail_worker_build_network_normalize_source() {
+  local LC_ALL=C
+  local name="$1"
+  local value="${2-}"
+  local error="$name must be a public http: or https: URL with a hostname and no credentials, query, fragment, control characters, or whitespace."
+
+  # Trim surrounding whitespace; whitespace-only values leave the source unchanged.
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  if [ -z "$value" ]; then
+    return 0
+  fi
+
+  # Reject control characters and raw whitespace anywhere in the value.
+  if ! [[ "$value" =~ ^[[:print:]]+$ ]] || [[ "$value" == *" "* ]]; then
+    echo "$error" >&2
+    return 1
+  fi
+
+  local lower scheme rest
+  lower="${value,,}"
+  case "$lower" in
+    http://*) scheme="http"; rest="${value:7}" ;;
+    https://*) scheme="https"; rest="${value:8}" ;;
+    *)
+      echo "$error" >&2
+      return 1
+      ;;
+  esac
+
+  # Credentials, queries, and fragments are rejected outright.
+  case "$rest" in
+    *"@"* | *"?"* | *"#"*)
+      echo "$error" >&2
+      return 1
+      ;;
+  esac
+
+  local authority url_path
+  if [[ "$rest" == */* ]]; then
+    authority="${rest%%/*}"
+    url_path="/${rest#*/}"
+  else
+    authority="$rest"
+    url_path=""
+  fi
+  if [ -z "$authority" ]; then
+    echo "$error" >&2
+    return 1
+  fi
+
+  local host port_part=""
+  if [[ "$authority" == "["* ]]; then
+    if [[ ! "$authority" =~ ^\[([0-9A-Fa-f:]+)\](:[0-9]+)?$ ]] || [[ "${BASH_REMATCH[1]}" != *::* ]]; then
+      echo "$error" >&2
+      return 1
+    fi
+    host="[${BASH_REMATCH[1],,}]"
+    port_part="${BASH_REMATCH[2]}"
+  else
+    if [[ "$authority" == *:* ]]; then
+      host="${authority%%:*}"
+      port_part=":${authority#*:}"
+    else
+      host="$authority"
+    fi
+    if [[ ! "$host" =~ ^[A-Za-z0-9._~-]+$ ]]; then
+      echo "$error" >&2
+      return 1
+    fi
+    host="${host,,}"
+  fi
+  if [ -n "$port_part" ] && [[ ! "$port_part" =~ ^:[0-9]{1,5}$ ]]; then
+    echo "$error" >&2
+    return 1
+  fi
+
+  # Paths keep only unreserved/sub-delimiter URL characters; anything else
+  # fails closed instead of reaching Docker argv.
+  local path_pattern="^/[A-Za-z0-9._~:/!$&'()*+,;=%-]*$"
+  if [ -n "$url_path" ] && ! [[ "$url_path" =~ $path_pattern ]]; then
+    echo "$error" >&2
+    return 1
+  fi
+
+  # Normalize harmless trailing-slash differences.
+  while [[ "$url_path" == */ ]]; do
+    url_path="${url_path%/}"
+  done
+
+  printf '%s://%s%s%s\n' "$scheme" "$host" "$port_part" "$url_path"
+}
+
+# homerail_worker_build_network_args ARRAY_NAME
+#
+# Validates the public build source settings from the environment and appends
+# Docker build arguments to the caller's argv array named ARRAY_NAME:
+#   --build-arg HOMERAIL_WORKER_BUILD_APT_MIRROR=<url>
+#   --build-arg HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR=<url>
+#   --build-arg NPM_CONFIG_REGISTRY=<url>
+# plus one value-less --build-arg NAME entry for every non-empty recognized
+# proxy variable. Returns 1 before any Docker invocation when a value is
+# invalid.
+homerail_worker_build_network_args() {
+  local -n _homerail_worker_build_network_args="$1"
+  local name normalized proxy_name
+  for name in HOMERAIL_WORKER_BUILD_APT_MIRROR HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR HOMERAIL_WORKER_BUILD_NPM_REGISTRY; do
+    if ! normalized="$(homerail_worker_build_network_normalize_source "$name" "${!name-}")"; then
+      return 1
+    fi
+    if [ -n "$normalized" ]; then
+      if [ "$name" = "HOMERAIL_WORKER_BUILD_NPM_REGISTRY" ]; then
+        _homerail_worker_build_network_args+=("--build-arg" "NPM_CONFIG_REGISTRY=$normalized")
+      else
+        _homerail_worker_build_network_args+=("--build-arg" "$name=$normalized")
+      fi
+    fi
+  done
+  for proxy_name in HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy; do
+    if [ -n "${!proxy_name-}" ]; then
+      _homerail_worker_build_network_args+=("--build-arg" "$proxy_name")
+    fi
+  done
+  return 0
+}

--- a/scripts/lib/worker-build-network.sh
+++ b/scripts/lib/worker-build-network.sh
@@ -19,8 +19,9 @@
 #
 # Recognized uppercase and lowercase HTTP_PROXY, HTTPS_PROXY, and NO_PROXY
 # variables are forwarded as value-less Docker --build-arg NAME entries only
-# when non-empty. Their values are never expanded into argv, inspected, or
-# logged; the Docker client/BuildKit proxy configuration remains authoritative.
+# when they contain a non-whitespace character. Their values are never expanded
+# into argv, inspected, or logged; the Docker client/BuildKit proxy configuration
+# remains authoritative.
 #
 # The helper populates the global HOMERAIL_WORKER_BUILD_NETWORK_ARGS argv
 # array. This avoids Bash 4.3 namerefs so the contract also works with the
@@ -76,9 +77,9 @@ homerail_worker_build_network_normalize_source() {
 #   --build-arg HOMERAIL_WORKER_BUILD_APT_MIRROR=<url>
 #   --build-arg HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR=<url>
 #   --build-arg NPM_CONFIG_REGISTRY=<url>
-# plus one value-less --build-arg NAME entry for every non-empty recognized
-# proxy variable. Returns 1 before any Docker invocation when a value is
-# invalid.
+# plus one value-less --build-arg NAME entry for every recognized proxy variable
+# containing a non-whitespace character. Returns 1 before any Docker invocation
+# when a value is invalid.
 homerail_worker_build_network_args() {
   HOMERAIL_WORKER_BUILD_NETWORK_ARGS=()
   local name normalized proxy_name
@@ -95,7 +96,7 @@ homerail_worker_build_network_args() {
     fi
   done
   for proxy_name in HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy; do
-    if [ -n "${!proxy_name-}" ]; then
+    if [[ "${!proxy_name-}" =~ [^[:space:]] ]]; then
       HOMERAIL_WORKER_BUILD_NETWORK_ARGS+=("--build-arg" "$proxy_name")
     fi
   done

--- a/scripts/lib/worker-build-network.sh
+++ b/scripts/lib/worker-build-network.sh
@@ -10,11 +10,12 @@
 #   HOMERAIL_WORKER_BUILD_NPM_REGISTRY         optional npm registry URL
 #
 # Unset or whitespace-only values leave the corresponding source unchanged.
-# Valid values use http: or https:, have a hostname, and contain no username,
-# password, query, fragment, control characters, or raw whitespace. Trailing
-# slashes, scheme case, and host case are normalized so semantically identical
-# URLs produce identical build arguments. Invalid values fail before Docker
-# starts; the error names the configuration key but never its value.
+# Normalization and validation are delegated to the Worker WHATWG URL helper
+# at homerail_worker/scripts/configure-apt-sources.mjs: this script passes
+# only the environment variable name, so a source value never appears in
+# argv, captured commands, or logs. ${NODE_BIN:-node} selects the Node binary
+# used for that delegation. Invalid values fail before Docker starts; the
+# error names the configuration key but never its value.
 #
 # Recognized uppercase and lowercase HTTP_PROXY, HTTPS_PROXY, and NO_PROXY
 # variables are forwarded as value-less Docker --build-arg NAME entries only
@@ -24,102 +25,46 @@
 # The helper only appends to a caller-provided argv array. It never evaluates
 # or executes validated input. Callers must use `set -euo pipefail`.
 
-# homerail_worker_build_network_normalize_source NAME VALUE
+# homerail_worker_build_network_helper_path
 #
-# Prints the normalized URL for the public source setting NAME. Prints nothing
-# and returns 0 when VALUE is unset-equivalent (empty or whitespace-only).
-# Returns 1 with an error naming NAME (never VALUE) when VALUE is invalid.
+# Prints the absolute path of the Worker WHATWG URL helper, derived safely
+# from this file's own location so the repository-relative contract path
+# homerail_worker/scripts/configure-apt-sources.mjs resolves in any checkout,
+# staged release, or contract-test sandbox.
+homerail_worker_build_network_helper_path() {
+  local lib_dir repo_root
+  lib_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)" || return 1
+  repo_root="$(cd -- "$lib_dir/../.." >/dev/null 2>&1 && pwd -P)" || return 1
+  printf '%s/homerail_worker/scripts/configure-apt-sources.mjs\n' "$repo_root"
+}
+
+# homerail_worker_build_network_normalize_source NAME
+#
+# Prints the normalized URL for the public source setting NAME. Only NAME
+# crosses the process boundary; the Worker helper reads the value from the
+# environment itself and prints the normalized public URL. Prints nothing and
+# returns 0 when the variable is unset-equivalent (empty or whitespace-only).
+# Returns 1 with an error naming NAME (never its value) when the value is
+# invalid, or when the Worker helper is unavailable.
 homerail_worker_build_network_normalize_source() {
-  local LC_ALL=C
   local name="$1"
-  local value="${2-}"
-  local error="$name must be a public http: or https: URL with a hostname and no credentials, query, fragment, control characters, or whitespace."
-
-  # Trim surrounding whitespace; whitespace-only values leave the source unchanged.
-  value="${value#"${value%%[![:space:]]*}"}"
-  value="${value%"${value##*[![:space:]]}"}"
-  if [ -z "$value" ]; then
-    return 0
-  fi
-
-  # Reject control characters and raw whitespace anywhere in the value.
-  if ! [[ "$value" =~ ^[[:print:]]+$ ]] || [[ "$value" == *" "* ]]; then
-    echo "$error" >&2
+  local helper_path
+  if ! helper_path="$(homerail_worker_build_network_helper_path)"; then
+    echo "$name cannot be validated: unable to resolve the repository root from scripts/lib/worker-build-network.sh." >&2
     return 1
   fi
-
-  local lower scheme rest
-  lower="${value,,}"
-  case "$lower" in
-    http://*) scheme="http"; rest="${value:7}" ;;
-    https://*) scheme="https"; rest="${value:8}" ;;
-    *)
-      echo "$error" >&2
-      return 1
-      ;;
-  esac
-
-  # Credentials, queries, and fragments are rejected outright.
-  case "$rest" in
-    *"@"* | *"?"* | *"#"*)
-      echo "$error" >&2
-      return 1
-      ;;
-  esac
-
-  local authority url_path
-  if [[ "$rest" == */* ]]; then
-    authority="${rest%%/*}"
-    url_path="/${rest#*/}"
-  else
-    authority="$rest"
-    url_path=""
-  fi
-  if [ -z "$authority" ]; then
-    echo "$error" >&2
+  if [ ! -f "$helper_path" ]; then
+    echo "$name cannot be validated: homerail_worker/scripts/configure-apt-sources.mjs is missing." >&2
     return 1
   fi
-
-  local host port_part=""
-  if [[ "$authority" == "["* ]]; then
-    if [[ ! "$authority" =~ ^\[([0-9A-Fa-f:]+)\](:[0-9]+)?$ ]] || [[ "${BASH_REMATCH[1]}" != *::* ]]; then
-      echo "$error" >&2
-      return 1
-    fi
-    host="[${BASH_REMATCH[1],,}]"
-    port_part="${BASH_REMATCH[2]}"
-  else
-    if [[ "$authority" == *:* ]]; then
-      host="${authority%%:*}"
-      port_part=":${authority#*:}"
-    else
-      host="$authority"
-    fi
-    if [[ ! "$host" =~ ^[A-Za-z0-9._~-]+$ ]]; then
-      echo "$error" >&2
-      return 1
-    fi
-    host="${host,,}"
-  fi
-  if [ -n "$port_part" ] && [[ ! "$port_part" =~ ^:[0-9]{1,5}$ ]]; then
-    echo "$error" >&2
+  local normalized
+  if ! normalized="$("${NODE_BIN:-node}" "$helper_path" --print-env "$name")"; then
     return 1
   fi
-
-  # Paths keep only unreserved/sub-delimiter URL characters; anything else
-  # fails closed instead of reaching Docker argv.
-  local path_pattern="^/[A-Za-z0-9._~:/!$&'()*+,;=%-]*$"
-  if [ -n "$url_path" ] && ! [[ "$url_path" =~ $path_pattern ]]; then
-    echo "$error" >&2
-    return 1
+  if [ -n "$normalized" ]; then
+    printf '%s\n' "$normalized"
   fi
-
-  # Normalize harmless trailing-slash differences.
-  while [[ "$url_path" == */ ]]; do
-    url_path="${url_path%/}"
-  done
-
-  printf '%s://%s%s%s\n' "$scheme" "$host" "$port_part" "$url_path"
+  return 0
 }
 
 # homerail_worker_build_network_args ARRAY_NAME
@@ -136,7 +81,7 @@ homerail_worker_build_network_args() {
   local -n _homerail_worker_build_network_args="$1"
   local name normalized proxy_name
   for name in HOMERAIL_WORKER_BUILD_APT_MIRROR HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR HOMERAIL_WORKER_BUILD_NPM_REGISTRY; do
-    if ! normalized="$(homerail_worker_build_network_normalize_source "$name" "${!name-}")"; then
+    if ! normalized="$(homerail_worker_build_network_normalize_source "$name")"; then
       return 1
     fi
     if [ -n "$normalized" ]; then

--- a/scripts/live-runner-isolation.test.mjs
+++ b/scripts/live-runner-isolation.test.mjs
@@ -23,6 +23,9 @@ test("routes live jobs to isolated runner slots and serializes only Manager port
   assert.doesNotMatch(review, /HOMERAIL_LIVE_SLOT|HOMERAIL_MANAGER_PORT/);
   assert.match(actionlint, /- homerail-pr-review/);
   assert.match(runner, /org\.homerail\.live_slot=\$LIVE_SLOT/);
+  assert.match(runner, /source "\$REPO_ROOT\/scripts\/lib\/worker-build-network\.sh"/);
+  assert.match(runner, /homerail_worker_build_network_args LIVE_BUILD_NETWORK_ARGS/);
+  assert.doesNotMatch(runner, /\beval\b/);
   assert.match(runner, /LIVE_RUN_LABEL="org\.homerail\.live_run_v2"/);
   assert.match(runner, /--label "\$LIVE_RUN_LABEL=\$RUN_KEY"/);
   assert.match(runner, /manager-port-allocation\.lock/);
@@ -212,4 +215,114 @@ esac
   removals = fs.readFileSync(dockerLog, "utf8").split("\n").filter((line) => /^(rm -f|image rm -f)/.test(line));
   assert.ok(removals.includes("rm -f container-b"));
   assert.ok(removals.includes("image rm -f image-b"));
+});
+
+
+test("live runner builds the worker image through the shared build network contract", { skip: process.platform !== "linux" }, (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-live-runner-build-network-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const runnerBase = path.join(root, "runner");
+  const homeRoot = path.join(root, "home");
+  const artifactRoot = path.join(root, "artifacts");
+  const fakeBin = path.join(root, "bin");
+  const fakeHome = path.join(root, "user-home");
+  const capturePath = path.join(root, "docker-build-args.txt");
+  fs.mkdirSync(fakeBin, { recursive: true });
+  fs.mkdirSync(fakeHome, { recursive: true });
+
+  const fakeCommand = (name, content) => {
+    fs.writeFileSync(path.join(fakeBin, name), content, { mode: 0o755 });
+  };
+
+  fakeCommand("docker", "#!/usr/bin/env bash\nif [ \"${1:-}\" = build ]; then printf '%s\\n' \"$@\" > \"$CAPTURE_DOCKER_BUILD_ARGS\"; fi\nexit 0\n");
+  fakeCommand("curl", "#!/usr/bin/env bash\nexit 0\n");
+  fakeCommand("python3", "#!/usr/bin/env bash\nexit 0\n");
+  fakeCommand("ss", "#!/usr/bin/env bash\nexit 0\n");
+  fakeCommand("node", "#!/usr/bin/env bash\nfor arg in \"$@\"; do\n  if [ \"$arg\" = start ]; then exit 3; fi\ndone\nexit 0\n");
+
+  const baseEnv = {
+    PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+    HOME: fakeHome,
+    GITHUB_RUN_ID: "contract",
+    GITHUB_RUN_ATTEMPT: "1",
+    HOMERAIL_RUNNER_BASE: runnerBase,
+    HOMERAIL_LIVE_HOME_BASE: homeRoot,
+    HOMERAIL_LIVE_ARTIFACTS: artifactRoot,
+    HOMERAIL_LIVE_REPORT_PATH: path.join(root, "report", "dag-patterns-live.json"),
+    HOMERAIL_LIVE_SLOT: "buildnet",
+    HOMERAIL_LIVE_PATTERNS: "handoff-contracts",
+    HOMERAIL_PATTERN_MODEL_BASE_URL: "http://model.contract.test",
+    HOMERAIL_DAG_APPROVAL_TOKEN: "contract-approval-token",
+    HOMERAIL_DAG_MUTATION_TOKEN: "contract-mutation-token",
+    HOMERAIL_MANAGER_ADMIN_TOKEN: "contract-admin-token",
+    HOMERAIL_WORKER_BUILD_APT_MIRROR: "",
+    HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR: "",
+    HOMERAIL_WORKER_BUILD_NPM_REGISTRY: "",
+    HTTP_PROXY: "",
+    HTTPS_PROXY: "",
+    NO_PROXY: "",
+    http_proxy: "",
+    https_proxy: "",
+    no_proxy: "",
+  };
+
+  const runnerScript = path.join(repoRoot, "scripts", "run-dag-patterns-live-runner.sh");
+  const runRunner = (extraEnv = {}) => {
+    fs.rmSync(capturePath, { force: true });
+    return spawnSync("bash", [runnerScript], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: { ...baseEnv, CAPTURE_DOCKER_BUILD_ARGS: capturePath, ...extraEnv },
+    });
+  };
+
+  // The fake Manager start exits 3 after the Worker image build, so a healthy
+  // run is observed through the captured Docker argv, not the exit status.
+  const baseline = runRunner();
+  assert.equal(baseline.status, 3, baseline.stderr);
+  assert.deepEqual(fs.readFileSync(capturePath, "utf8").trim().split("\n"), [
+    "build",
+    "--label",
+    "org.homerail.live_run_v2=contract-1",
+    "--label",
+    "org.homerail.live_slot=buildnet",
+    "-t",
+    "homerail-worker:dag-live-contract-1",
+    "-f",
+    path.join(repoRoot, "homerail_worker", "Dockerfile"),
+    repoRoot,
+  ]);
+
+  const custom = runRunner({
+    HOMERAIL_WORKER_BUILD_APT_MIRROR: "https://deb.live.example/debian/",
+    HOMERAIL_WORKER_BUILD_NPM_REGISTRY: "https://npm.live.example",
+  });
+  assert.equal(custom.status, 3, custom.stderr);
+  const customArgs = fs.readFileSync(capturePath, "utf8");
+  assert.match(customArgs, /--build-arg\nHOMERAIL_WORKER_BUILD_APT_MIRROR=https:\/\/deb\.live\.example\/debian\n/);
+  assert.match(customArgs, /--build-arg\nNPM_CONFIG_REGISTRY=https:\/\/npm\.live\.example\n/);
+  assert.doesNotMatch(customArgs, /HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR/);
+
+  const proxy = runRunner({
+    HTTPS_PROXY: "http://proxy.live.example:3128",
+    no_proxy: "localhost",
+  });
+  assert.equal(proxy.status, 3, proxy.stderr);
+  const proxyArgs = fs.readFileSync(capturePath, "utf8");
+  const proxyArgLines = proxyArgs.split("\n");
+  const valuelessProxyArgs = [];
+  for (let index = 0; index < proxyArgLines.length - 1; index += 1) {
+    if (proxyArgLines[index] === "--build-arg" && !proxyArgLines[index + 1].includes("=")) {
+      valuelessProxyArgs.push(proxyArgLines[index + 1]);
+    }
+  }
+  assert.deepEqual(valuelessProxyArgs, ["HTTPS_PROXY", "no_proxy"]);
+  assert.doesNotMatch(proxyArgs, /proxy\.live\.example/);
+
+  const invalid = runRunner({ HOMERAIL_WORKER_BUILD_APT_MIRROR: "http://user:pass@deb.live.example" });
+  assert.equal(invalid.status, 1, invalid.stderr);
+  assert.match(invalid.stderr, /HOMERAIL_WORKER_BUILD_APT_MIRROR/);
+  assert.doesNotMatch(invalid.stderr, /user:pass/);
+  assert.equal(fs.existsSync(capturePath), false);
 });

--- a/scripts/live-runner-isolation.test.mjs
+++ b/scripts/live-runner-isolation.test.mjs
@@ -343,6 +343,9 @@ exec "${process.execPath}" "$@"
   const proxy = runRunner({
     HTTPS_PROXY: "http://proxy.live.example:3128",
     no_proxy: "localhost",
+    HTTP_PROXY: " \t ",
+    https_proxy: "\n ",
+    NO_PROXY: "   ",
   });
   assert.equal(proxy.status, 3, proxy.stderr);
   const proxyArgs = fs.readFileSync(capturePath, "utf8");

--- a/scripts/live-runner-isolation.test.mjs
+++ b/scripts/live-runner-isolation.test.mjs
@@ -231,6 +231,24 @@ test("live runner builds the worker image through the shared build network contr
   fs.mkdirSync(fakeBin, { recursive: true });
   fs.mkdirSync(fakeHome, { recursive: true });
 
+  // The sandbox stages a partial repository. Every sandbox that sources or
+  // executes scripts/lib/worker-build-network.sh must also copy the delegated
+  // Worker helper to its exact repository-relative path, or the shared
+  // contract must fail closed instead of silently keeping unknown sources.
+  const sourceRoot = path.join(root, "repo");
+  for (const relative of [
+    "scripts/run-dag-patterns-live-runner.sh",
+    "scripts/cleanup-dag-patterns-live-runner.sh",
+    "scripts/lib/worker-build-network.sh",
+    "homerail_worker/scripts/configure-apt-sources.mjs",
+    "homerail_worker/Dockerfile",
+  ]) {
+    const target = path.join(sourceRoot, relative);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.copyFileSync(path.join(repoRoot, relative), target);
+    fs.chmodSync(target, 0o755);
+  }
+
   const fakeCommand = (name, content) => {
     fs.writeFileSync(path.join(fakeBin, name), content, { mode: 0o755 });
   };
@@ -241,9 +259,26 @@ test("live runner builds the worker image through the shared build network contr
   fakeCommand("ss", "#!/usr/bin/env bash\nexit 0\n");
   fakeCommand("node", "#!/usr/bin/env bash\nfor arg in \"$@\"; do\n  if [ \"$arg\" = start ]; then exit 3; fi\ndone\nexit 0\n");
 
+  // The shared helper delegates URL validation to ${NODE_BIN:-node}. The shim
+  // captures the exact argv handed to Node before delegating to the real
+  // binary: only environment variable names may cross the boundary, never
+  // source or proxy values.
+  const argvLog = path.join(root, "node-argv.txt");
+  const nodeShim = path.join(root, "node-shim.sh");
+  fs.writeFileSync(
+    nodeShim,
+    `#!/usr/bin/env bash
+printf '%s\\n' "$@" >> "$ARGV_LOG"
+exec "${process.execPath}" "$@"
+`,
+    { mode: 0o755 },
+  );
+
   const baseEnv = {
     PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
     HOME: fakeHome,
+    NODE_BIN: nodeShim,
+    ARGV_LOG: argvLog,
     GITHUB_RUN_ID: "contract",
     GITHUB_RUN_ATTEMPT: "1",
     HOMERAIL_RUNNER_BASE: runnerBase,
@@ -267,11 +302,11 @@ test("live runner builds the worker image through the shared build network contr
     no_proxy: "",
   };
 
-  const runnerScript = path.join(repoRoot, "scripts", "run-dag-patterns-live-runner.sh");
+  const runnerScript = path.join(sourceRoot, "scripts", "run-dag-patterns-live-runner.sh");
   const runRunner = (extraEnv = {}) => {
     fs.rmSync(capturePath, { force: true });
     return spawnSync("bash", [runnerScript], {
-      cwd: repoRoot,
+      cwd: sourceRoot,
       encoding: "utf8",
       env: { ...baseEnv, CAPTURE_DOCKER_BUILD_ARGS: capturePath, ...extraEnv },
     });
@@ -290,8 +325,8 @@ test("live runner builds the worker image through the shared build network contr
     "-t",
     "homerail-worker:dag-live-contract-1",
     "-f",
-    path.join(repoRoot, "homerail_worker", "Dockerfile"),
-    repoRoot,
+    path.join(sourceRoot, "homerail_worker", "Dockerfile"),
+    sourceRoot,
   ]);
 
   const custom = runRunner({
@@ -319,6 +354,25 @@ test("live runner builds the worker image through the shared build network contr
   }
   assert.deepEqual(valuelessProxyArgs, ["HTTPS_PROXY", "no_proxy"]);
   assert.doesNotMatch(proxyArgs, /proxy\.live\.example/);
+
+  const capturedArgv = fs.readFileSync(argvLog, "utf8");
+  assert.match(capturedArgv, /--print-env/);
+  assert.match(capturedArgv, /configure-apt-sources\.mjs/);
+  for (const expected of [
+    "HOMERAIL_WORKER_BUILD_APT_MIRROR",
+    "HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR",
+    "HOMERAIL_WORKER_BUILD_NPM_REGISTRY",
+  ]) {
+    assert.ok(capturedArgv.includes(expected), `delegation must name ${expected} only`);
+  }
+  for (const prohibited of [
+    "https://deb.live.example/debian/",
+    "https://npm.live.example",
+    "http://proxy.live.example:3128",
+    "http://user:pass@deb.live.example",
+  ]) {
+    assert.ok(!capturedArgv.includes(prohibited), "source and proxy values must never reach argv");
+  }
 
   const invalid = runRunner({ HOMERAIL_WORKER_BUILD_APT_MIRROR: "http://user:pass@deb.live.example" });
   assert.equal(invalid.status, 1, invalid.stderr);

--- a/scripts/live-runner-isolation.test.mjs
+++ b/scripts/live-runner-isolation.test.mjs
@@ -24,7 +24,8 @@ test("routes live jobs to isolated runner slots and serializes only Manager port
   assert.match(actionlint, /- homerail-pr-review/);
   assert.match(runner, /org\.homerail\.live_slot=\$LIVE_SLOT/);
   assert.match(runner, /source "\$REPO_ROOT\/scripts\/lib\/worker-build-network\.sh"/);
-  assert.match(runner, /homerail_worker_build_network_args LIVE_BUILD_NETWORK_ARGS/);
+  assert.match(runner, /homerail_worker_build_network_args/);
+  assert.match(runner, /HOMERAIL_WORKER_BUILD_NETWORK_ARGS/);
   assert.doesNotMatch(runner, /\beval\b/);
   assert.match(runner, /LIVE_RUN_LABEL="org\.homerail\.live_run_v2"/);
   assert.match(runner, /--label "\$LIVE_RUN_LABEL=\$RUN_KEY"/);

--- a/scripts/production-deploy-contracts.test.mjs
+++ b/scripts/production-deploy-contracts.test.mjs
@@ -516,6 +516,9 @@ test("production deployment preserves database compatibility across success and 
       HTTPS_PROXY: "http://proxy.fn.example:3128",
       http_proxy: "http://proxy.fn.example:3128",
       NO_PROXY: "localhost",
+      HTTP_PROXY: " \t ",
+      https_proxy: "\n ",
+      no_proxy: "   ",
     },
   });
   try {
@@ -614,6 +617,14 @@ test("worker build network helper validates sources and forwards proxy names onl
   const whitespaceOnly = runHelper({ HOMERAIL_WORKER_BUILD_APT_MIRROR: " \t " });
   assert.equal(whitespaceOnly.status, 0, whitespaceOnly.stderr);
   assert.equal(whitespaceOnly.stdout, "");
+
+  const whitespaceOnlyProxy = runHelper({
+    HTTP_PROXY: " \t ",
+    https_proxy: "\n  ",
+    NO_PROXY: "   ",
+  });
+  assert.equal(whitespaceOnlyProxy.status, 0, whitespaceOnlyProxy.stderr);
+  assert.equal(whitespaceOnlyProxy.stdout, "");
 
   const custom = runHelper({
     HOMERAIL_WORKER_BUILD_APT_MIRROR: "HTTPS://DEB.example.com:8443/debian/",

--- a/scripts/production-deploy-contracts.test.mjs
+++ b/scripts/production-deploy-contracts.test.mjs
@@ -260,6 +260,7 @@ test("production deployment preserves database compatibility across success and 
   const runDeployment = (smokeExit, {
     previousDatabaseCompatible = true,
     failUnitMove = false,
+    extraEnv = {},
   } = {}) => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-production-deploy-"));
     const sourceRoot = path.join(tempRoot, "source");
@@ -348,6 +349,7 @@ test("production deployment preserves database compatibility across success and 
     write("assets/orchestrations/public-two-node.yaml.template", "schema_version: 1\n");
     write("scripts/run-production-service.sh", "#!/usr/bin/env bash\nexit 0\n", 0o755);
     write("scripts/lib/production-runtime.sh", fs.readFileSync(path.join(repoRoot, "scripts", "lib", "production-runtime.sh"), "utf8"), 0o755);
+    write("scripts/lib/worker-build-network.sh", fs.readFileSync(path.join(repoRoot, "scripts", "lib", "worker-build-network.sh"), "utf8"), 0o755);
 
     fakeCommand("docker", `#!/usr/bin/env bash\nif [ "${'${1:-}'}" = network ] && [ "${'${2:-}'}" = inspect ] && [ "${'${3:-}'}" = bridge ]; then echo 172.17.0.1; fi\nif [ "${'${1:-}'}" = build ]; then printf '%s\\n' "$@" > "$CAPTURE_DOCKER_BUILD_ARGS"; fi\nif [ "${'${1:-}'}" = image ] && [ "${'${2:-}'}" = rm ]; then printf '%s\\n' "${'${3:-}'}" >> "$CAPTURE_DOCKER_REMOVALS"; fi\nexit 0\n`);
     fakeCommand("codex", "#!/usr/bin/env bash\nexit 0\n");
@@ -383,6 +385,16 @@ test("production deployment preserves database compatibility across success and 
         CAPTURE_DOCKER_REMOVALS: dockerRemovalsPath,
         CAPTURE_SYSTEMCTL: systemctlLogPath,
         FAKE_FIND_OUTPUT: findOutputPath,
+        HOMERAIL_WORKER_BUILD_APT_MIRROR: "",
+        HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR: "",
+        HOMERAIL_WORKER_BUILD_NPM_REGISTRY: "",
+        HTTP_PROXY: "",
+        HTTPS_PROXY: "",
+        NO_PROXY: "",
+        http_proxy: "",
+        https_proxy: "",
+        no_proxy: "",
+        ...extraEnv,
       },
     });
     return {
@@ -462,6 +474,9 @@ test("production deployment preserves database compatibility across success and 
     assert.match(dockerBuildArgs, /HOMERAIL_WORKER_PROTOCOL_VERSION=1/);
     assert.match(dockerBuildArgs, /HOMERAIL_WORKER_VERSION=0\.1\.0/);
     assert.match(dockerBuildArgs, new RegExp(`HOMERAIL_WORKER_IMAGE_REVISION=${revision}`));
+    assert.doesNotMatch(dockerBuildArgs, /HOMERAIL_WORKER_BUILD_APT/);
+    assert.doesNotMatch(dockerBuildArgs, /NPM_CONFIG_REGISTRY/);
+    assert.doesNotMatch(dockerBuildArgs, /(?:HTTP|HTTPS|NO)_PROXY/i);
     const unit = fs.readFileSync(passed.unitPath, "utf8");
     assert.match(unit, /StartLimitIntervalSec=0/);
     assert.doesNotMatch(unit, /StartLimitBurst=/);
@@ -472,6 +487,59 @@ test("production deployment preserves database compatibility across success and 
     );
   } finally {
     fs.rmSync(passed.tempRoot, { recursive: true, force: true });
+  }
+
+  const customSources = runDeployment(0, {
+    extraEnv: {
+      HOMERAIL_WORKER_BUILD_APT_MIRROR: "https://deb.fn.example/debian/",
+      HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR: "https://deb.fn.example/debian-security",
+      HOMERAIL_WORKER_BUILD_NPM_REGISTRY: "https://npm.fn.example",
+    },
+  });
+  try {
+    assert.equal(customSources.result.status, 0, customSources.result.stderr);
+    const customBuildArgs = fs.readFileSync(customSources.dockerBuildArgsPath, "utf8");
+    assert.match(customBuildArgs, /--build-arg\nHOMERAIL_WORKER_BUILD_APT_MIRROR=https:\/\/deb\.fn\.example\/debian\n/);
+    assert.match(customBuildArgs, /--build-arg\nHOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR=https:\/\/deb\.fn\.example\/debian-security\n/);
+    assert.match(customBuildArgs, /--build-arg\nNPM_CONFIG_REGISTRY=https:\/\/npm\.fn\.example\n/);
+    assert.match(customBuildArgs, new RegExp(`HOMERAIL_WORKER_SOURCE_FINGERPRINT=${workerFingerprint}`));
+  } finally {
+    fs.rmSync(customSources.tempRoot, { recursive: true, force: true });
+  }
+
+  const proxyForwarding = runDeployment(0, {
+    extraEnv: {
+      HTTPS_PROXY: "http://proxy.fn.example:3128",
+      http_proxy: "http://proxy.fn.example:3128",
+      NO_PROXY: "localhost",
+    },
+  });
+  try {
+    assert.equal(proxyForwarding.result.status, 0, proxyForwarding.result.stderr);
+    const proxyBuildArgs = fs.readFileSync(proxyForwarding.dockerBuildArgsPath, "utf8");
+    const proxyArgLines = proxyBuildArgs.split("\n");
+    const valuelessProxyArgs = [];
+    for (let index = 0; index < proxyArgLines.length - 1; index += 1) {
+      if (proxyArgLines[index] === "--build-arg" && !proxyArgLines[index + 1].includes("=")) {
+        valuelessProxyArgs.push(proxyArgLines[index + 1]);
+      }
+    }
+    assert.deepEqual(valuelessProxyArgs, ["HTTPS_PROXY", "NO_PROXY", "http_proxy"]);
+    assert.doesNotMatch(proxyBuildArgs, /proxy\.fn\.example/);
+  } finally {
+    fs.rmSync(proxyForwarding.tempRoot, { recursive: true, force: true });
+  }
+
+  const invalidSource = runDeployment(0, {
+    extraEnv: { HOMERAIL_WORKER_BUILD_NPM_REGISTRY: "ftp://npm.fn.example" },
+  });
+  try {
+    assert.notEqual(invalidSource.result.status, 0);
+    assert.match(invalidSource.result.stderr, /HOMERAIL_WORKER_BUILD_NPM_REGISTRY/);
+    assert.doesNotMatch(invalidSource.result.stderr, /ftp:\/\/npm\.fn\.example/);
+    assert.equal(fs.existsSync(invalidSource.dockerBuildArgsPath), false);
+  } finally {
+    fs.rmSync(invalidSource.tempRoot, { recursive: true, force: true });
   }
 });
 
@@ -490,4 +558,107 @@ test("tracked deployment configuration contains no machine-local identity", () =
   assert.doesNotMatch(trackedConfiguration, /\b(?:10|192\.168|172\.(?:1[6-9]|2[0-9]|3[01]))\.[0-9]{1,3}\.[0-9]{1,3}\b/);
   assert.doesNotMatch(trackedConfiguration, /\/(?:Users|home|vol[0-9]*|mnt)\//);
   assert.doesNotMatch(trackedConfiguration, /\bssh\s+[A-Za-z0-9._-]+@/i);
+});
+
+
+test("worker build network contract is shared by production and live entry points", () => {
+  const helper = fs.readFileSync(path.join(repoRoot, "scripts", "lib", "worker-build-network.sh"), "utf8");
+  const deploy = fs.readFileSync(path.join(repoRoot, "scripts", "deploy-production.sh"), "utf8");
+  const runner = fs.readFileSync(path.join(repoRoot, "scripts", "run-dag-patterns-live-runner.sh"), "utf8");
+
+  assert.match(deploy, /source "\$SOURCE_ROOT\/scripts\/lib\/worker-build-network\.sh"/);
+  assert.match(deploy, /homerail_worker_build_network_args WORKER_BUILD_NETWORK_ARGS/);
+  assert.match(runner, /source "\$REPO_ROOT\/scripts\/lib\/worker-build-network\.sh"/);
+  assert.match(runner, /homerail_worker_build_network_args LIVE_BUILD_NETWORK_ARGS/);
+  assert.doesNotMatch(helper, /\beval\b/);
+  assert.doesNotMatch(deploy, /\beval\b/);
+  assert.doesNotMatch(runner, /\beval\b/);
+  for (const name of [
+    "HOMERAIL_WORKER_BUILD_APT_MIRROR",
+    "HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR",
+    "HOMERAIL_WORKER_BUILD_NPM_REGISTRY",
+  ]) {
+    assert.ok(helper.includes(name), `helper must consume ${name}`);
+  }
+  assert.ok(
+    helper.includes("HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy"),
+    "helper must forward every recognized proxy variable name in a fixed order",
+  );
+  assert.match(helper, /NPM_CONFIG_REGISTRY=/);
+});
+
+test("worker build network helper validates sources and forwards proxy names only", { skip: process.platform === "win32" }, () => {
+  const helperPath = path.join(repoRoot, "scripts", "lib", "worker-build-network.sh");
+  const runHelper = (extraEnv = {}) => spawnSync("bash", [
+    "-c",
+    [
+      "set -euo pipefail",
+      'source "$1"',
+      "args=()",
+      "homerail_worker_build_network_args args || exit 1",
+      'if [ ${#args[@]} -gt 0 ]; then printf "%s\\n" "${args[@]}"; fi',
+    ].join("\n"),
+    "worker-build-network-helper-test",
+    helperPath,
+  ], { encoding: "utf8", env: { PATH: process.env.PATH, ...extraEnv } });
+
+  const baseline = runHelper();
+  assert.equal(baseline.status, 0, baseline.stderr);
+  assert.equal(baseline.stdout, "");
+
+  const whitespaceOnly = runHelper({ HOMERAIL_WORKER_BUILD_APT_MIRROR: " \t " });
+  assert.equal(whitespaceOnly.status, 0, whitespaceOnly.stderr);
+  assert.equal(whitespaceOnly.stdout, "");
+
+  const custom = runHelper({
+    HOMERAIL_WORKER_BUILD_APT_MIRROR: "HTTPS://DEB.example.com:8443/debian/",
+    HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR: "  https://deb.example.com/debian-security  ",
+    HOMERAIL_WORKER_BUILD_NPM_REGISTRY: "https://npm.example.com/",
+    HTTP_PROXY: "http://proxy.example:3128",
+    no_proxy: "localhost",
+    HTTPS_PROXY: "",
+  });
+  assert.equal(custom.status, 0, custom.stderr);
+  assert.deepEqual(custom.stdout.trim().split("\n"), [
+    "--build-arg",
+    "HOMERAIL_WORKER_BUILD_APT_MIRROR=https://deb.example.com:8443/debian",
+    "--build-arg",
+    "HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR=https://deb.example.com/debian-security",
+    "--build-arg",
+    "NPM_CONFIG_REGISTRY=https://npm.example.com",
+    "--build-arg",
+    "HTTP_PROXY",
+    "--build-arg",
+    "no_proxy",
+  ]);
+  assert.doesNotMatch(custom.stdout, /proxy\.example/);
+
+  const invalidValues = {
+    HOMERAIL_WORKER_BUILD_APT_MIRROR: [
+      "ftp://deb.example.com",
+      "http://user:pass@deb.example.com",
+      "http://deb.example.com/?mirror=1",
+      "http://deb.example.com/#debian",
+      "http://",
+      "http://deb.example.com/debian suite",
+      "http://deb.example.com/\u0001",
+    ],
+    HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR: [
+      "not-a-url",
+      "https://",
+      "https://deb.example.com:port",
+    ],
+    HOMERAIL_WORKER_BUILD_NPM_REGISTRY: [
+      "ftp://npm.example.com",
+      "https://npm.example.com/<script>",
+    ],
+  };
+  for (const [name, values] of Object.entries(invalidValues)) {
+    for (const value of values) {
+      const failed = runHelper({ [name]: value });
+      assert.notEqual(failed.status, 0, `${name} must reject invalid value`);
+      assert.match(failed.stderr, new RegExp(name));
+      assert.ok(!failed.stderr.includes(value), "error must not echo the rejected value");
+    }
+  }
 });

--- a/scripts/production-deploy-contracts.test.mjs
+++ b/scripts/production-deploy-contracts.test.mjs
@@ -350,6 +350,10 @@ test("production deployment preserves database compatibility across success and 
     write("scripts/run-production-service.sh", "#!/usr/bin/env bash\nexit 0\n", 0o755);
     write("scripts/lib/production-runtime.sh", fs.readFileSync(path.join(repoRoot, "scripts", "lib", "production-runtime.sh"), "utf8"), 0o755);
     write("scripts/lib/worker-build-network.sh", fs.readFileSync(path.join(repoRoot, "scripts", "lib", "worker-build-network.sh"), "utf8"), 0o755);
+    // The shared helper delegates URL validation to this Worker script; the
+    // sandbox must stage it at the exact repository-relative path or builds
+    // must fail closed instead of silently keeping unknown sources.
+    write("homerail_worker/scripts/configure-apt-sources.mjs", fs.readFileSync(path.join(repoRoot, "homerail_worker/scripts/configure-apt-sources.mjs"), "utf8"), 0o755);
 
     fakeCommand("docker", `#!/usr/bin/env bash\nif [ "${'${1:-}'}" = network ] && [ "${'${2:-}'}" = inspect ] && [ "${'${3:-}'}" = bridge ]; then echo 172.17.0.1; fi\nif [ "${'${1:-}'}" = build ]; then printf '%s\\n' "$@" > "$CAPTURE_DOCKER_BUILD_ARGS"; fi\nif [ "${'${1:-}'}" = image ] && [ "${'${2:-}'}" = rm ]; then printf '%s\\n' "${'${3:-}'}" >> "$CAPTURE_DOCKER_REMOVALS"; fi\nexit 0\n`);
     fakeCommand("codex", "#!/usr/bin/env bash\nexit 0\n");
@@ -632,6 +636,57 @@ test("worker build network helper validates sources and forwards proxy names onl
     "no_proxy",
   ]);
   assert.doesNotMatch(custom.stdout, /proxy\.example/);
+
+  // A NODE_BIN shim captures the exact argv handed to Node: only environment
+  // variable names and the helper path may cross the boundary, never values.
+  const argvCaptureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-build-network-argv-"));
+  const argvLog = path.join(argvCaptureRoot, "node-argv.txt");
+  const nodeShim = path.join(argvCaptureRoot, "node");
+  fs.writeFileSync(
+    nodeShim,
+    `#!/usr/bin/env bash
+printf '%s\\n' "$@" >> "$ARGV_LOG"
+exec "${process.execPath}" "$@"
+`,
+    { mode: 0o755 },
+  );
+  try {
+    const shimmed = runHelper({
+      NODE_BIN: nodeShim,
+      ARGV_LOG: argvLog,
+      HOMERAIL_WORKER_BUILD_APT_MIRROR: "https://deb.example.com/debian/",
+      HOMERAIL_WORKER_BUILD_NPM_REGISTRY: "https://npm.example.com/",
+      HTTPS_PROXY: "http://proxy.example:3128",
+    });
+    assert.equal(shimmed.status, 0, shimmed.stderr);
+    assert.deepEqual(shimmed.stdout.trim().split("\n"), [
+      "--build-arg",
+      "HOMERAIL_WORKER_BUILD_APT_MIRROR=https://deb.example.com/debian",
+      "--build-arg",
+      "NPM_CONFIG_REGISTRY=https://npm.example.com",
+      "--build-arg",
+      "HTTPS_PROXY",
+    ]);
+    const capturedArgv = fs.readFileSync(argvLog, "utf8");
+    assert.match(capturedArgv, /--print-env/);
+    assert.match(capturedArgv, /configure-apt-sources\.mjs/);
+    for (const expected of [
+      "HOMERAIL_WORKER_BUILD_APT_MIRROR",
+      "HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR",
+      "HOMERAIL_WORKER_BUILD_NPM_REGISTRY",
+    ]) {
+      assert.ok(capturedArgv.includes(expected), `delegation must name ${expected} only`);
+    }
+    for (const prohibited of [
+      "https://deb.example.com/debian/",
+      "https://npm.example.com/",
+      "http://proxy.example:3128",
+    ]) {
+      assert.ok(!capturedArgv.includes(prohibited), "source and proxy values must never reach argv");
+    }
+  } finally {
+    fs.rmSync(argvCaptureRoot, { recursive: true, force: true });
+  }
 
   const invalidValues = {
     HOMERAIL_WORKER_BUILD_APT_MIRROR: [

--- a/scripts/production-deploy-contracts.test.mjs
+++ b/scripts/production-deploy-contracts.test.mjs
@@ -571,9 +571,11 @@ test("worker build network contract is shared by production and live entry point
   const runner = fs.readFileSync(path.join(repoRoot, "scripts", "run-dag-patterns-live-runner.sh"), "utf8");
 
   assert.match(deploy, /source "\$SOURCE_ROOT\/scripts\/lib\/worker-build-network\.sh"/);
-  assert.match(deploy, /homerail_worker_build_network_args WORKER_BUILD_NETWORK_ARGS/);
+  assert.match(deploy, /homerail_worker_build_network_args/);
+  assert.match(deploy, /HOMERAIL_WORKER_BUILD_NETWORK_ARGS/);
   assert.match(runner, /source "\$REPO_ROOT\/scripts\/lib\/worker-build-network\.sh"/);
-  assert.match(runner, /homerail_worker_build_network_args LIVE_BUILD_NETWORK_ARGS/);
+  assert.match(runner, /homerail_worker_build_network_args/);
+  assert.match(runner, /HOMERAIL_WORKER_BUILD_NETWORK_ARGS/);
   assert.doesNotMatch(helper, /\beval\b/);
   assert.doesNotMatch(deploy, /\beval\b/);
   assert.doesNotMatch(runner, /\beval\b/);
@@ -598,9 +600,8 @@ test("worker build network helper validates sources and forwards proxy names onl
     [
       "set -euo pipefail",
       'source "$1"',
-      "args=()",
-      "homerail_worker_build_network_args args || exit 1",
-      'if [ ${#args[@]} -gt 0 ]; then printf "%s\\n" "${args[@]}"; fi',
+      "homerail_worker_build_network_args || exit 1",
+      'if [ ${#HOMERAIL_WORKER_BUILD_NETWORK_ARGS[@]} -gt 0 ]; then printf "%s\\n" "${HOMERAIL_WORKER_BUILD_NETWORK_ARGS[@]}"; fi',
     ].join("\n"),
     "worker-build-network-helper-test",
     helperPath,

--- a/scripts/run-dag-patterns-live-runner.sh
+++ b/scripts/run-dag-patterns-live-runner.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+source "$REPO_ROOT/scripts/lib/worker-build-network.sh"
 LIVE_TASK="${HOMERAIL_LIVE_TASK:-patterns}"
 RUNNER_BASE="${HOMERAIL_RUNNER_BASE:-$HOME/.homerail-runners}"
 HOME_ROOT="${HOMERAIL_LIVE_HOME_BASE:-$RUNNER_BASE/homerail_home}"
@@ -281,10 +282,15 @@ if [ "$LIVE_TASK" = "patterns" ] \
   export HOMERAIL_LIVE_ISSUE_REVISION
 fi
 
+# Validate the public Worker build source contract and assemble Docker
+# arguments without evaluating input. Invalid values fail here, before Docker starts.
+LIVE_BUILD_NETWORK_ARGS=()
+homerail_worker_build_network_args LIVE_BUILD_NETWORK_ARGS
 echo "Building isolated worker image $HOMERAIL_WORKER_IMAGE"
 docker build \
   --label "$LIVE_RUN_LABEL=$RUN_KEY" \
   --label "org.homerail.live_slot=$LIVE_SLOT" \
+  ${LIVE_BUILD_NETWORK_ARGS[@]+"${LIVE_BUILD_NETWORK_ARGS[@]}"} \
   -t "$HOMERAIL_WORKER_IMAGE" \
   -f "$REPO_ROOT/homerail_worker/Dockerfile" \
   "$REPO_ROOT"

--- a/scripts/run-dag-patterns-live-runner.sh
+++ b/scripts/run-dag-patterns-live-runner.sh
@@ -284,13 +284,12 @@ fi
 
 # Validate the public Worker build source contract and assemble Docker
 # arguments without evaluating input. Invalid values fail here, before Docker starts.
-LIVE_BUILD_NETWORK_ARGS=()
-homerail_worker_build_network_args LIVE_BUILD_NETWORK_ARGS
+homerail_worker_build_network_args
 echo "Building isolated worker image $HOMERAIL_WORKER_IMAGE"
 docker build \
   --label "$LIVE_RUN_LABEL=$RUN_KEY" \
   --label "org.homerail.live_slot=$LIVE_SLOT" \
-  ${LIVE_BUILD_NETWORK_ARGS[@]+"${LIVE_BUILD_NETWORK_ARGS[@]}"} \
+  ${HOMERAIL_WORKER_BUILD_NETWORK_ARGS[@]+"${HOMERAIL_WORKER_BUILD_NETWORK_ARGS[@]}"} \
   -t "$HOMERAIL_WORKER_IMAGE" \
   -f "$REPO_ROOT/homerail_worker/Dockerfile" \
   "$REPO_ROOT"


### PR DESCRIPTION
## Summary

This Draft PR is the bound publication target for the Auto Fix v2 implementation of #196.

The task keeps one canonical Worker Dockerfile and adds opt-in, validated public APT/npm source overrides shared by Manager, production deployment, and the live runner. Zero-configuration behavior remains unchanged, Docker/BuildKit proxy handling remains authoritative, and no vendor mirror is hardcoded.

## Planned impact

- Add optional Worker build source environment variables.
- Pass only validated, non-secret source URLs to Docker builds.
- Forward standard proxy variable names without exposing their values.
- Report only redacted build-network modes in Manager status and logs.
- Add focused Worker, Manager, deployment-script, and live-runner tests.

## Validation

Auto Fix v2 will run the bounded tests declared in its immutable task plan. Repository CI will run after the Draft PR converges and is reviewed.

Refs #196.
