### PR TITLE
test: make esbuild harness cross-platform

### DIFF
--- a/homerail_cli/package-lock.json
+++ b/homerail_cli/package-lock.json
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
+        "esbuild": "^0.28.1",
         "tsx": "^4.22.4",
         "typescript": "^5.4.0",
         "vitest": "^4.1.8"

--- a/homerail_cli/package.json
+++ b/homerail_cli/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
+    "esbuild": "^0.28.1",
     "tsx": "^4.22.4",
     "typescript": "^5.4.0",
     "vitest": "^4.1.8"

--- a/homerail_cli/tests/static-ui-admin-proxy.integration.test.ts
+++ b/homerail_cli/tests/static-ui-admin-proxy.integration.test.ts
@@ -821,16 +821,23 @@ async function waitUntil(check: () => Promise<boolean>): Promise<void> {
 describe("runtime UI Origin propagation through hr ui start", () => {
   afterAll(() => {
     if (sharedRuntimeRepoRoot) {
-      fs.rmSync(sharedRuntimeRepoRoot, { recursive: true, force: true });
+      fs.rmSync(sharedRuntimeRepoRoot, {
+        recursive: true,
+        force: true,
+        maxRetries: 5,
+        retryDelay: 100,
+      });
       sharedRuntimeRepoRoot = undefined;
     }
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    const stoppedPids: number[] = [];
     for (const harness of runtimeHarnesses.splice(0)) {
       for (const name of ["ui-https", "ui"] as const) {
         const pid = runtimePidFile(harness.home, name);
         if (pid === undefined) continue;
+        stoppedPids.push(pid);
         try {
           process.kill(-pid, "SIGTERM");
         } catch {
@@ -842,6 +849,7 @@ describe("runtime UI Origin propagation through hr ui start", () => {
         }
       }
     }
+    await Promise.all(stoppedPids.map((pid) => waitForRuntimePidExit(pid)));
   });
 
   it("propagates the explicit external Origin from flag, environment, and stored config into both static listeners", async () => {

--- a/homerail_cli/tests/static-ui-admin-proxy.integration.test.ts
+++ b/homerail_cli/tests/static-ui-admin-proxy.integration.test.ts
@@ -5,6 +5,7 @@ import * as https from "node:https";
 import * as net from "node:net";
 import * as os from "node:os";
 import * as path from "node:path";
+import { buildSync } from "esbuild";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { createProgram } from "../src/index.js";
 
@@ -1157,14 +1158,14 @@ function runtimeRepoRoot(): string {
     path.join(root, "homerail_cli", "package.json"),
     `${JSON.stringify({ name: "homerail-cli-runtime-test", private: true, type: "module" }, null, 2)}\n`,
   );
-  execFileSync(path.resolve("node_modules/esbuild/bin/esbuild"), [
-    path.resolve("src/static-ui-server.ts"),
-    "--bundle",
-    "--platform=node",
-    "--format=esm",
-    "--target=node20",
-    `--outfile=${path.join(root, "homerail_cli", "dist", "static-ui-server.js")}`,
-  ], { stdio: "pipe", timeout: 60_000 });
+  buildSync({
+    entryPoints: [path.resolve("src/static-ui-server.ts")],
+    bundle: true,
+    platform: "node",
+    format: "esm",
+    target: "node20",
+    outfile: path.join(root, "homerail_cli", "dist", "static-ui-server.js"),
+  });
   sharedRuntimeRepoRoot = root;
   return root;
 }

--- a/homerail_cli/tests/static-ui-admin-proxy.integration.test.ts
+++ b/homerail_cli/tests/static-ui-admin-proxy.integration.test.ts
@@ -1201,7 +1201,9 @@ async function createRuntimeHarness(): Promise<RuntimeHarness> {
   const managerUrl = await listen(manager, "127.0.0.1");
   const httpsPort = await reservePort();
   const httpPort = await reservePort();
-  return { home, repoRoot, managerUrl, httpsPort, httpPort, received };
+  const harness = { home, repoRoot, managerUrl, httpsPort, httpPort, received };
+  runtimeHarnesses.push(harness);
+  return harness;
 }
 
 async function runUiStart(


### PR DESCRIPTION
## What changed

- build the static UI test fixture through esbuild's Node API instead of executing its package binary directly
- declare esbuild as a direct CLI test dependency

## Why

The Windows Node 24 CI job cannot execute `node_modules/esbuild/bin/esbuild` as a platform-independent executable and fails with `ENOENT`. The Node API selects the correct platform binary internally and keeps the test harness portable.

## Impact

This changes only the CLI integration-test harness. Runtime behavior is unchanged.

## Validation

- `npm test -- --run tests/static-ui-admin-proxy.integration.test.ts`
- `npm run typecheck`
