### PR TITLE
fix(voice): probe POST-only transcription routes

### DIFF
--- a/homerail_manager/src/server/voice.ts
+++ b/homerail_manager/src/server/voice.ts
@@ -709,12 +709,39 @@ async function _probeHttpVoiceEndpoint(
   try {
     // HEAD verifies routing without uploading audio or triggering synthesis.
     // A 4xx auth/method response still proves that the endpoint exists.
-    const response = await fetch(candidate.url, {
+    let response = await fetch(candidate.url, {
       method: "HEAD",
       redirect: "follow",
       signal: AbortSignal.timeout(VOICE_ENDPOINT_PROBE_TIMEOUT_MS),
     });
     await response.body?.cancel().catch(() => {});
+
+    // Some OpenAI-compatible servers only register POST handlers and return
+    // 404 for HEAD even though the route exists. Retry known POST-only voice
+    // routes with deliberately incomplete input, which validates routing but
+    // cannot upload audio or trigger synthesis.
+    if (response.status === 404) {
+      const pathname = new URL(candidate.url).pathname.replace(/\/+$/, "").toLowerCase();
+      let fallbackBody: BodyInit | undefined;
+      let fallbackHeaders: HeadersInit | undefined;
+      if (pathname.endsWith("/audio/transcriptions")) {
+        fallbackBody = new FormData();
+      } else if (pathname.endsWith("/audio/speech") || pathname.endsWith("/audio/speech/stream")) {
+        fallbackBody = "{}";
+        fallbackHeaders = { "Content-Type": "application/json" };
+      }
+      if (fallbackBody !== undefined) {
+        response = await fetch(candidate.url, {
+          method: "POST",
+          headers: fallbackHeaders,
+          body: fallbackBody,
+          redirect: "follow",
+          signal: AbortSignal.timeout(VOICE_ENDPOINT_PROBE_TIMEOUT_MS),
+        });
+        await response.body?.cancel().catch(() => {});
+      }
+    }
+
     const status = response.status;
     const ok = status >= 200 && status < 500 && status !== 404;
     const outcome: VoiceEndpointProbeOutcome | undefined =

--- a/homerail_manager/tests/voice-bootstrap.test.ts
+++ b/homerail_manager/tests/voice-bootstrap.test.ts
@@ -1772,6 +1772,67 @@ describe("voice bootstrap routes", () => {
     }
   });
 
+  it("retries POST-only transcription routes when HEAD returns 404", async () => {
+    let headProbeCalls = 0;
+    let postProbeCalls = 0;
+    let postProbeBody = "";
+    const upstream = http.createServer((req, res) => {
+      if (req.url === "/v1/audio/transcriptions" && req.method === "HEAD") {
+        headProbeCalls += 1;
+        res.writeHead(404).end();
+        return;
+      }
+      if (req.url === "/v1/audio/transcriptions" && req.method === "POST") {
+        postProbeCalls += 1;
+        req.setEncoding("utf8");
+        req.on("data", (chunk) => {
+          postProbeBody += chunk;
+        });
+        req.on("end", () => {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: { message: "No input file found for transcription" } }));
+        });
+        return;
+      }
+      res.writeHead(404).end();
+    });
+    const upstreamPort = await listen(upstream);
+    const managerPort = await listen(server);
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${managerPort}/api/voice/endpoints/test`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          endpoints: [{
+            id: "asr_http",
+            kind: "http",
+            url: `http://127.0.0.1:${upstreamPort}/v1/audio/transcriptions`,
+          }],
+        }),
+      });
+      const body = await response.json() as {
+        success: boolean;
+        data: {
+          ok: boolean;
+          results: Array<{ id: string; ok: boolean; reachable: boolean; status_code?: number; outcome?: string }>;
+        };
+      };
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.data.ok).toBe(true);
+      expect(body.data.results).toEqual([
+        expect.objectContaining({ id: "asr_http", ok: true, reachable: true, status_code: 400 }),
+      ]);
+      expect(headProbeCalls).toBe(1);
+      expect(postProbeCalls).toBe(1);
+      expect(postProbeBody).not.toContain("audio");
+    } finally {
+      await close(upstream);
+    }
+  });
+
   it("never verifies realtime capability from pre-upgrade HTTP responses", async () => {
     const statusByPath: Record<string, number> = {
       "/realtime-401": 401,


### PR DESCRIPTION
## Summary

Follow up to #200 for OpenAI-compatible ASR servers that only register `POST /v1/audio/transcriptions`.

- keep the existing no-payload `HEAD` probe as the first check
- when a known POST-only voice route answers `HEAD 404`, retry with deliberately incomplete input
- use an empty multipart form for transcription and empty JSON for speech routes, so probing cannot upload audio or trigger synthesis
- accept the resulting input-validation response (for example HTTP 400) as proof that the route exists
- preserve a real 404 from the fallback POST as `not_found`

## Root cause

Some llama.cpp-compatible servers return 404 to `HEAD /v1/audio/transcriptions` even though `POST /v1/audio/transcriptions` is available. HomeRail interpreted the HEAD-only response as a missing endpoint and rejected a valid custom ASR URL during onboarding.

## User impact

A URL such as `http://127.0.0.1:8080/v1/audio/transcriptions` now passes onboarding when the server exposes the OpenAI-compatible POST route. PR #200's realtime capability behavior remains unchanged, so a batch-only service continues to use the Manager's `emulated_batch` bridge.

## Validation

- `npx vitest run tests/voice-bootstrap.test.ts` — 57 passed
- `npm run typecheck`
- full Manager suite — 1368 passed, 2 skipped; one unrelated existing `codex-models.test.ts` PATH-deduplication assertion fails on current main
- fresh packaged Electron initialization against local llama-server: endpoint saved as `http://127.0.0.1:8080/v1`, model `qwen3-asr`, WebSocket session reported `strategy: emulated_batch`
