### PR TITLE
fix: recover packaged UI relaunch and voice directory modal

### DIFF
--- a/agent-ui/src/components/agent/VoiceDirectoryProjectModal.test.ts
+++ b/agent-ui/src/components/agent/VoiceDirectoryProjectModal.test.ts
@@ -83,15 +83,19 @@ describe('VoiceDirectoryProjectModal directory roots', () => {
         limit: 300,
       })
     })
-    expect(root.querySelector('[data-testid="voice-directory-existing-projects"]')?.textContent)
+    const overlay = document.body.querySelector<HTMLElement>('[data-testid="voice-directory-modal-overlay"]')
+    expect(overlay).not.toBeNull()
+    expect(overlay?.parentElement).toBe(document.body)
+    expect(root.contains(overlay)).toBe(false)
+    expect(overlay?.querySelector('[data-testid="voice-directory-existing-projects"]')?.textContent)
       .toContain('已有项目目录')
-    expect(root.querySelector('[data-testid="voice-directory-project-root"]')?.textContent)
+    expect(overlay?.querySelector('[data-testid="voice-directory-project-root"]')?.textContent)
       .toContain('真实项目')
-    expect(root.textContent).not.toContain('Macintosh HD')
-    expect(root.textContent).not.toContain('HomeRail Home')
-    expect(root.textContent).not.toContain('Default workspace')
+    expect(overlay?.textContent).not.toContain('Macintosh HD')
+    expect(overlay?.textContent).not.toContain('HomeRail Home')
+    expect(overlay?.textContent).not.toContain('Default workspace')
 
-    root.querySelector<HTMLButtonElement>('[data-testid="voice-directory-project-root"]')!.click()
+    overlay?.querySelector<HTMLButtonElement>('[data-testid="voice-directory-project-root"]')!.click()
     await vi.waitFor(() => {
       expect(apiMocks.browseProjectDirectories).toHaveBeenLastCalledWith({
         path: '/work/existing',

--- a/agent-ui/src/components/agent/VoiceDirectoryProjectModal.vue
+++ b/agent-ui/src/components/agent/VoiceDirectoryProjectModal.vue
@@ -241,8 +241,13 @@ function handleProjectNameInput(event: Event): void {
 </script>
 
 <template>
-  <div v-if="open" class="fixed inset-0 z-[70] flex items-center justify-center bg-[var(--hr-overlay)] px-6 backdrop-blur-sm">
-    <section class="flex h-[min(720px,82vh)] w-[min(980px,92vw)] overflow-hidden rounded-[24px] border border-[var(--hr-border-strong)] bg-[var(--hr-panel)] text-[var(--hr-text-1)]" :style="{ boxShadow: 'var(--hr-shadow-floating)' }">
+  <Teleport to="body">
+    <div
+      v-if="open"
+      data-testid="voice-directory-modal-overlay"
+      class="fixed inset-0 z-[70] flex items-center justify-center bg-[var(--hr-overlay)] px-6 backdrop-blur-sm"
+    >
+      <section class="flex h-[min(720px,82vh)] w-[min(980px,92vw)] overflow-hidden rounded-[24px] border border-[var(--hr-border-strong)] bg-[var(--hr-panel)] text-[var(--hr-text-1)]" :style="{ boxShadow: 'var(--hr-shadow-floating)' }">
       <aside class="flex w-64 shrink-0 flex-col border-r border-[var(--hr-border)] bg-[var(--hr-surface-1)] p-4">
         <div class="mb-4 flex items-center justify-between">
           <div>
@@ -429,6 +434,7 @@ function handleProjectNameInput(event: Event): void {
           </aside>
         </main>
       </div>
-    </section>
-  </div>
+      </section>
+    </div>
+  </Teleport>
 </template>

--- a/homerail_cli/src/commands/runtime.ts
+++ b/homerail_cli/src/commands/runtime.ts
@@ -140,6 +140,12 @@ interface UiServiceState {
   port: number;
   protocol?: "http" | "https";
   mode?: "dev" | "static";
+  /**
+   * Absolute directory served by a packaged/static UI child. AppImage
+   * extraction paths change between desktop launches, so a live child whose
+   * recorded root differs from the current runtime must be replaced.
+   */
+  staticUiDir?: string;
   managerUrl?: string;
   publicUrl?: string;
   /**
@@ -783,11 +789,15 @@ async function startUiServer(globalOpts: GlobalOpts, opts: UiStartOpts = {}): Pr
   const httpPublicUrl = explicitPublicUrl ?? configuredUiHttpPublicUrl(cfg, host, httpPort);
   const managerPort = String(configuredManagerPort(managerUrl ? { ...cfg, manager: { ...cfg.manager, url: managerUrl } } : cfg));
   const textModeEnabled = resolveTextModeEnabled(opts.enableTextMode);
-  const serveStatic = shouldServeStaticAgentUi(path.join(resolveRepoRoot(), "agent-ui"));
+  const agentUiDir = path.join(resolveRepoRoot(), "agent-ui");
+  const serveStatic = shouldServeStaticAgentUi(agentUiDir);
+  const staticUiDir = serveStatic ? path.join(agentUiDir, "dist") : undefined;
   restartUiIfTextModeChanged("ui-https", textModeEnabled);
   restartUiIfTextModeChanged("ui", textModeEnabled);
   restartUiIfServingModeChanged("ui-https", serveStatic);
   restartUiIfServingModeChanged("ui", serveStatic);
+  restartUiIfStaticRootChanged("ui-https", staticUiDir);
+  restartUiIfStaticRootChanged("ui", staticUiDir);
   restartUiIfPublicOriginChanged("ui-https", explicitPublicUrl);
   restartUiIfPublicOriginChanged("ui", explicitPublicUrl);
   const existing = getUiStatus(host, httpsPort, httpsPublicUrl, httpPort, httpPublicUrl);
@@ -996,6 +1006,7 @@ function startUiProcess(opts: StartUiProcessOpts): number {
     port: opts.port,
     protocol: opts.protocol,
     mode: serveStatic ? "static" : "dev",
+    staticUiDir: serveStatic ? path.join(agentUiDir, "dist") : undefined,
     managerUrl: opts.managerUrl,
     publicUrl: opts.publicUrl,
     explicitPublicUrl: opts.explicitPublicUrl,
@@ -1081,6 +1092,35 @@ function restartUiIfServingModeChanged(name: "ui" | "ui-https", serveStatic: boo
   if (pid === undefined || !pidIsRunning(pid)) return;
   const desiredMode = serveStatic ? "static" : "dev";
   if (state?.mode !== desiredMode && (state?.mode !== undefined || serveStatic)) {
+    stopService(name);
+  }
+}
+
+/**
+ * A detached packaged UI may outlive the AppImage process that mounted or
+ * extracted its files. The PID then remains alive while every static request
+ * returns 404 because its old resource root has disappeared. Restart it when
+ * the current package resolves to a different root, when that root vanished,
+ * or when upgrading legacy state that did not record the root at all.
+ */
+function restartUiIfStaticRootChanged(
+  name: "ui" | "ui-https",
+  requestedStaticUiDir: string | undefined,
+): void {
+  if (!requestedStaticUiDir) return;
+  const state = readUiState(name);
+  const pid = readPid(name) ?? state?.pid;
+  if (pid === undefined || !pidIsRunning(pid) || state?.mode !== "static") return;
+  const runningStaticUiDir = state.staticUiDir;
+  const runningIndex = runningStaticUiDir
+    ? path.join(runningStaticUiDir, "index.html")
+    : undefined;
+  if (
+    !runningStaticUiDir ||
+    path.resolve(runningStaticUiDir) !== path.resolve(requestedStaticUiDir) ||
+    !runningIndex ||
+    !fs.existsSync(runningIndex)
+  ) {
     stopService(name);
   }
 }
@@ -1371,6 +1411,9 @@ function readUiState(name: "ui" | "ui-https" = "ui"): UiServiceState | undefined
         port: parsed.port,
         protocol: parsed.protocol === "https" ? "https" : "http",
         mode: parsed.mode === "static" ? "static" : parsed.mode === "dev" ? "dev" : undefined,
+        staticUiDir: typeof parsed.staticUiDir === "string" && parsed.staticUiDir
+          ? parsed.staticUiDir
+          : undefined,
         managerUrl: typeof parsed.managerUrl === "string" ? parsed.managerUrl : DEFAULT_MANAGER_URL,
         publicUrl: typeof parsed.publicUrl === "string" ? parsed.publicUrl : undefined,
         explicitPublicUrl: typeof parsed.explicitPublicUrl === "string" && parsed.explicitPublicUrl

--- a/homerail_cli/tests/static-ui-admin-proxy.integration.test.ts
+++ b/homerail_cli/tests/static-ui-admin-proxy.integration.test.ts
@@ -1096,6 +1096,39 @@ describe("runtime UI Origin propagation through hr ui start", () => {
       headers: { Origin: httpsSelfOrigin, "Sec-Fetch-Site": "same-origin" },
     })).status).toBe(200);
   }, 120_000);
+
+  it("restarts packaged UI processes whose recorded static root is stale", async () => {
+    const harness = await createRuntimeHarness();
+    const initial = await runUiStart(harness, []);
+    expect(initial.errors).toEqual([]);
+    const initialPids = runtimePids(harness.home);
+
+    // Reproduce an AppImage relaunch: the detached children are alive, but
+    // their state points to the previous extraction directory.
+    for (const name of ["ui-https", "ui"] as const) {
+      const statePath = path.join(harness.home, "pids", `${name}.json`);
+      const state = JSON.parse(fs.readFileSync(statePath, "utf-8")) as Record<string, unknown>;
+      state.staticUiDir = path.join(harness.home, "missing-old-appimage", "agent-ui", "dist");
+      fs.writeFileSync(statePath, `${JSON.stringify(state, null, 2)}\n`);
+    }
+
+    const restarted = await runUiStart(harness, []);
+    expect(restarted.errors).toEqual([]);
+    const restartedPids = runtimePids(harness.home);
+    expect(restartedPids.https).not.toBe(initialPids.https);
+    expect(restartedPids.http).not.toBe(initialPids.http);
+    await waitForRuntimePidExit(initialPids.https);
+    await waitForRuntimePidExit(initialPids.http);
+    expect(runtimeStateFile(harness.home, "ui-https")?.staticUiDir)
+      .toBe(path.join(harness.repoRoot, "agent-ui", "dist"));
+    expect(runtimeStateFile(harness.home, "ui")?.staticUiDir)
+      .toBe(path.join(harness.repoRoot, "agent-ui", "dist"));
+
+    // A subsequent start from the same package keeps healthy listeners.
+    const unchanged = await runUiStart(harness, []);
+    expect(unchanged.errors).toEqual([]);
+    expect(runtimePids(harness.home)).toEqual(restartedPids);
+  }, 120_000);
 });
 
 interface RuntimeHarness {
@@ -1273,11 +1306,12 @@ function runtimePidFile(home: string, name: "ui" | "ui-https"): number | undefin
 function runtimeStateFile(
   home: string,
   name: "ui" | "ui-https",
-): { pid?: number; explicitPublicUrl?: string } | undefined {
+): { pid?: number; explicitPublicUrl?: string; staticUiDir?: string } | undefined {
   try {
     return JSON.parse(fs.readFileSync(path.join(home, "pids", `${name}.json`), "utf-8")) as {
       pid?: number;
       explicitPublicUrl?: string;
+      staticUiDir?: string;
     };
   } catch {
     return undefined;


### PR DESCRIPTION
## Summary

- record the static Agent UI root used by packaged runtime children
- restart detached UI listeners when an AppImage relaunch changes or removes that root
- render the voice directory project modal through `body` so transformed parent views cannot clip or obscure it
- add regression coverage for both initialization paths

## Why

A packaged UI process could survive after the AppImage extraction directory disappeared. Its PID still looked healthy, but every static request returned 404, leaving the Desktop window black on a later launch. The voice directory modal also inherited an unfavorable stacking context from the agent view.

## Impact

Packaged relaunches replace stale listeners and load a valid UI again. The directory chooser now stays above the surrounding interface and remains usable during initialization.

## Validation

- `npm test -- --run tests/static-ui-admin-proxy.integration.test.ts` — 19 passed
- `npm test -- --run src/components/agent/VoiceDirectoryProjectModal.test.ts` — 1 passed
