### PR TITLE
fix: complete packaged Worker fingerprint and runtime refresh

### DIFF
--- a/homerail_cli/src/commands/runtime.ts
+++ b/homerail_cli/src/commands/runtime.ts
@@ -68,7 +68,9 @@ interface UiStartOpts {
 }
 
 interface RuntimeStatus {
+  runtimeRoot: string;
   managerPid?: number;
+  managerRuntimeRoot?: string;
   nodePid?: number;
   uiPid?: number;
   uiHttpsPid?: number;
@@ -165,6 +167,8 @@ interface ManagerServiceState {
   port: number;
   accessUrl: string;
   publicUrl?: string;
+  /** Runtime tree that supplied the detached Manager process. */
+  runtimeRoot?: string;
   startedAt: number;
 }
 
@@ -509,6 +513,7 @@ async function startRuntime(
       port: managerPort,
       accessUrl: client.baseUrl,
       publicUrl: managerPublicUrl,
+      runtimeRoot: resolveRepoRoot(),
       startedAt: Date.now(),
     });
     printMessage(`Started Manager pid=${pid}`);
@@ -615,7 +620,9 @@ async function getRuntimeStatus(globalOpts: GlobalOpts): Promise<RuntimeStatus> 
     managerHealthy = false;
   }
   const status: RuntimeStatus = {
+    runtimeRoot: resolveRepoRoot(),
     managerPid,
+    managerRuntimeRoot: managerState?.runtimeRoot,
     nodePid,
     uiPid: uiStatus.uiPid,
     uiHttpsPid: uiStatus.uiHttpsPid,
@@ -1371,6 +1378,9 @@ function readManagerState(): ManagerServiceState | undefined {
         port: parsed.port,
         accessUrl: parsed.accessUrl,
         publicUrl: typeof parsed.publicUrl === "string" ? parsed.publicUrl : undefined,
+        runtimeRoot: typeof parsed.runtimeRoot === "string" && parsed.runtimeRoot
+          ? parsed.runtimeRoot
+          : undefined,
         startedAt: typeof parsed.startedAt === "number" ? parsed.startedAt : 0,
       };
     }

--- a/homerail_cli/tests/commands.test.ts
+++ b/homerail_cli/tests/commands.test.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { Readable } from "node:stream";
 import type { Command } from "commander";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
@@ -1980,6 +1980,7 @@ describe("runtime command", () => {
     await program.parseAsync(["node", "homerail", "--json", "runtime", "status"]);
 
     const parsed = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(parsed.runtimeRoot).toBe(resolve(process.cwd(), ".."));
     expect(parsed.managerBindHost).toBe("127.0.0.1");
     expect(parsed.managerAccessUrl).toBe("http://localhost:19191");
     expect(parsed.uiBindHost).toBe("127.0.0.1");
@@ -2003,6 +2004,7 @@ describe("runtime command", () => {
       port: 19191,
       accessUrl: "http://localhost:19191",
       publicUrl: "https://homerail.example.test",
+      runtimeRoot: "/opt/homerail/runtime-a",
       startedAt: Date.now(),
     }));
     mockFetch({ success: true, data: { connected_nodes: 0, connected_workers: 0 } });
@@ -2018,6 +2020,7 @@ describe("runtime command", () => {
     expect(parsed.managerUrl).toBe("http://localhost:19191");
     expect(parsed.managerAccessUrl).toBe("https://homerail.example.test");
     expect(parsed.managerPublicUrl).toBe("https://homerail.example.test");
+    expect(parsed.managerRuntimeRoot).toBe("/opt/homerail/runtime-a");
   });
 
   it("aborts start when stored model config cannot be applied", () => {

--- a/homerail_cli/tests/runtime-restart.test.ts
+++ b/homerail_cli/tests/runtime-restart.test.ts
@@ -107,6 +107,7 @@ describe("runtime restart --manager-only", () => {
       expect(output).toHaveLength(1);
       const status = JSON.parse(output[0]) as {
         managerPid: number;
+        managerRuntimeRoot: string;
         managerPidRunning: boolean;
         nodePid: number;
         nodePidRunning: boolean;
@@ -116,6 +117,7 @@ describe("runtime restart --manager-only", () => {
       children.push({ pid: status.managerPid } as ChildProcess);
 
       expect(status.managerPid).not.toBe(oldManagerPid);
+      expect(status.managerRuntimeRoot).toBe(repoRoot);
       expect(status.managerPidRunning).toBe(true);
       expect(status.nodePid).toBe(nodePid);
       expect(status.nodePidRunning).toBe(true);

--- a/homerail_manager/src/server/dag-environment.ts
+++ b/homerail_manager/src/server/dag-environment.ts
@@ -28,6 +28,7 @@ import {
 
 const SOURCE_INPUTS = [
   "homerail_worker/Dockerfile",
+  "homerail_worker/native/codex-secret-guard.c",
   "homerail_worker/scripts/configure-apt-sources.mjs",
   "homerail_worker/package.json",
   "homerail_worker/package-lock.json",

--- a/homerail_manager/tests/dag-environment.test.ts
+++ b/homerail_manager/tests/dag-environment.test.ts
@@ -51,6 +51,7 @@ function fingerprintFixture(): string {
   tempDirs.push(repoRoot);
   const files: Record<string, string> = {
     "homerail_worker/Dockerfile": "FROM node:22\n",
+    "homerail_worker/native/codex-secret-guard.c": "int homerail_guard(void) { return 0; }\n",
     "homerail_worker/scripts/configure-apt-sources.mjs": "export const configureAptSources = true;\n",
     "homerail_worker/package.json": JSON.stringify({
       name: "homerail-worker",
@@ -256,6 +257,17 @@ it("changes the Worker source fingerprint when build-relevant content changes", 
   fs.appendFileSync(
     path.join(repoRoot, "homerail_worker", "src", "index.ts"),
     "export const changed = true;\n",
+  );
+
+  expect(dagWorkerSourceFingerprint(repoRoot)).not.toBe(original);
+});
+
+it("changes the Worker source fingerprint when the native secret guard changes", () => {
+  const repoRoot = fingerprintFixture();
+  const original = dagWorkerSourceFingerprint(repoRoot);
+  fs.appendFileSync(
+    path.join(repoRoot, "homerail_worker", "native", "codex-secret-guard.c"),
+    "int homerail_guard_changed(void) { return 1; }\n",
   );
 
   expect(dagWorkerSourceFingerprint(repoRoot)).not.toBe(original);


### PR DESCRIPTION
## Summary

- include the native secret-guard source in the Worker build fingerprint
- persist the runtime tree that started the detached Manager
- expose both the active Manager root and the current CLI root through runtime status
- add regression coverage for packaged runtime upgrades

## Why

The Linux Desktop package now ships the complete Docker context. The Manager fingerprint must include every build input so an edited native guard invalidates the image. AppImage extraction roots also change between launches, so Desktop needs a reliable signal to replace Manager/Node processes left running from the previous package.

## Validation

- `npm test -- --run tests/dag-environment.test.ts` — 33 passed
- `npm --prefix homerail_cli test` — 281 passed
- `npm --prefix homerail_cli run build`
- packaged Worker image built successfully from the resulting runtime and reported compatibility `current`

Follow-up to #206.