### PR TITLE
fix(ui): activate click-driven controls on touch

### DIFF
--- a/agent-ui/src/components/agent/AgentVoiceCockpit.vue
+++ b/agent-ui/src/components/agent/AgentVoiceCockpit.vue
@@ -5366,8 +5366,6 @@ function summarizeTask(value: string): string {
       v-if="fullscreenPromptVisible && isMobileDevice"
       class="voice-fullscreen-gate"
       type="button"
-      @pointerup.prevent="enterMobileFullscreen"
-      @touchend.prevent="enterMobileFullscreen"
       @click="enterMobileFullscreen"
     >
       <span>{{ fullscreenGateTitle }}</span>

--- a/agent-ui/src/components/agent/AgentVoiceCockpit.vue
+++ b/agent-ui/src/components/agent/AgentVoiceCockpit.vue
@@ -1329,6 +1329,7 @@ onMounted(() => {
   document.addEventListener('pointerdown', closeModelMenuOnOutside)
   window.addEventListener('keydown', handleVoiceKeyboardButton, true)
   window.addEventListener('keydown', handleImmersiveKeyboard, true)
+  window.addEventListener('pointerdown', handleImmersiveTouchPointerDown, { passive: true })
   window.addEventListener('pointermove', handleImmersivePointerMove, { passive: true })
   window.addEventListener('keydown', closeModelMenuOnEscape)
   window.addEventListener('gamepadconnected', handleVoiceGamepadConnected)
@@ -1459,6 +1460,7 @@ onUnmounted(() => {
   document.removeEventListener('pointerdown', closeModelMenuOnOutside)
   window.removeEventListener('keydown', handleVoiceKeyboardButton, true)
   window.removeEventListener('keydown', handleImmersiveKeyboard, true)
+  window.removeEventListener('pointerdown', handleImmersiveTouchPointerDown)
   window.removeEventListener('pointermove', handleImmersivePointerMove)
   window.removeEventListener('keydown', closeModelMenuOnEscape)
   window.removeEventListener('gamepadconnected', handleVoiceGamepadConnected)
@@ -5194,6 +5196,11 @@ function noteLiveVoiceImmersiveInteraction(): void {
   if (immersiveSuspended.value && liveVoiceImmersiveActive.value) {
     scheduleImmersiveReturn()
   }
+}
+
+function handleImmersiveTouchPointerDown(event: PointerEvent): void {
+  if (event.pointerType !== 'touch' && event.pointerType !== 'pen') return
+  handleImmersivePointerMove()
 }
 
 function handleImmersivePointerMove(): void {

--- a/agent-ui/src/components/agent/AgentVoiceCockpitLayout.test.ts
+++ b/agent-ui/src/components/agent/AgentVoiceCockpitLayout.test.ts
@@ -221,6 +221,22 @@ describe('AgentVoiceCockpit responsive layout', () => {
     )
   })
 
+  it('reveals the immersive exit control from direct touch and pen input', () => {
+    expect(cockpitSource).toContain(
+      'function handleImmersiveTouchPointerDown(event: PointerEvent): void'
+    )
+    expect(cockpitSource).toContain(
+      "event.pointerType !== 'touch' && event.pointerType !== 'pen'"
+    )
+    expect(cockpitSource).toContain(
+      "window.addEventListener('pointerdown', handleImmersiveTouchPointerDown"
+    )
+    expect(cockpitSource).toContain(
+      "window.removeEventListener('pointerdown', handleImmersiveTouchPointerDown)"
+    )
+    expect(cockpitSource).toContain('handleImmersivePointerMove()')
+  })
+
   it('temporarily reveals Live Voice controls and returns after interaction becomes idle', () => {
     expect(cockpitSource).toContain('const IMMERSIVE_RETURN_IDLE_MS = 3200')
     expect(cockpitSource).toContain('function suspendLiveVoiceImmersiveMode(): void')

--- a/agent-ui/src/input/touch-activation.test.ts
+++ b/agent-ui/src/input/touch-activation.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { installTouchActivation } from './touch-activation'
 
+const TAP_X = 20
+const TAP_Y = 20
+
 function pointerEvent(
   type: string,
   init: Partial<PointerEvent> & { pointerId: number },
@@ -10,13 +13,22 @@ function pointerEvent(
     pointerType: 'touch',
     isPrimary: true,
     button: 0,
-    clientX: 20,
-    clientY: 20,
+    clientX: TAP_X,
+    clientY: TAP_Y,
     ...init,
   })) {
     Object.defineProperty(event, key, { configurable: true, value })
   }
   return event
+}
+
+// The browser fires its touch compatibility click at the touch coordinates, so
+// tests that emulate it must pass those coordinates. A MouseEvent built with no
+// init has clientX/clientY === 0, which on a real device only happens for
+// keyboard / assistive-tech / programmatic activation — none of which are the
+// compatibility click and none of which this bridge may suppress.
+function compatClick(x: number = TAP_X, y: number = TAP_Y): MouseEvent {
+  return new MouseEvent('click', { bubbles: true, cancelable: true, clientX: x, clientY: y })
 }
 
 describe('touch activation bridge', () => {
@@ -40,7 +52,7 @@ describe('touch activation bridge', () => {
     button.dispatchEvent(pointerEvent('pointerup', { pointerId: 1 }))
     expect(onClick).toHaveBeenCalledOnce()
 
-    button.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+    button.dispatchEvent(compatClick())
     expect(onClick).toHaveBeenCalledOnce()
   })
 
@@ -103,5 +115,82 @@ describe('touch activation bridge', () => {
 
     expect(onRoleClick).toHaveBeenCalledOnce()
     expect(onDisabledClick).not.toHaveBeenCalled()
+  })
+
+  it('does not swallow a non-compatibility activation of the same control within the suppression window', () => {
+    // Regression for the prior target-identity matcher: if the browser never
+    // emits a compatibility click for the tap (e.g. an upstream handler
+    // preventDefaults touchstart), the bridge must leave genuine activations
+    // — keyboard Enter/Space, programmatic el.click(), assistive-tech — intact.
+    const button = document.createElement('button')
+    const onClick = vi.fn()
+    button.addEventListener('click', onClick)
+    document.body.appendChild(button)
+    cleanup = installTouchActivation(document)
+
+    button.dispatchEvent(pointerEvent('pointerdown', { pointerId: 6 }))
+    button.dispatchEvent(pointerEvent('pointerup', { pointerId: 6 }))
+    expect(onClick).toHaveBeenCalledOnce()
+
+    // No compat click was emitted yet, so the suppression is still armed when
+    // a keyboard-style activation (clientX/clientY === 0) arrives. It must run.
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+    expect(onClick).toHaveBeenCalledTimes(2)
+  })
+
+  it('suppresses each compatibility click independently for concurrent multi-touch taps', () => {
+    // Regression for the single-slot pendingNativeClick: two simultaneous taps
+    // on different controls must not let one tap overwrite the other's pending
+    // suppression, which previously caused one control's handler to fire twice.
+    const buttonA = document.createElement('button')
+    const buttonB = document.createElement('button')
+    const onClickA = vi.fn()
+    const onClickB = vi.fn()
+    buttonA.addEventListener('click', onClickA)
+    buttonB.addEventListener('click', onClickB)
+    document.body.append(buttonA, buttonB)
+    cleanup = installTouchActivation(document)
+
+    buttonA.dispatchEvent(pointerEvent('pointerdown', { pointerId: 7, clientX: 10, clientY: 10 }))
+    buttonB.dispatchEvent(pointerEvent('pointerdown', { pointerId: 8, clientX: 90, clientY: 90 }))
+    buttonA.dispatchEvent(pointerEvent('pointerup', { pointerId: 7, clientX: 10, clientY: 10 }))
+    buttonB.dispatchEvent(pointerEvent('pointerup', { pointerId: 8, clientX: 90, clientY: 90 }))
+    expect(onClickA).toHaveBeenCalledOnce()
+    expect(onClickB).toHaveBeenCalledOnce()
+
+    // Both delayed compatibility clicks arrive; each must be matched to its own
+    // tap location and suppressed, so neither handler runs a second time.
+    buttonA.dispatchEvent(compatClick(10, 10))
+    buttonB.dispatchEvent(compatClick(90, 90))
+    expect(onClickA).toHaveBeenCalledOnce()
+    expect(onClickB).toHaveBeenCalledOnce()
+  })
+
+  it('suppresses a compatibility click retargeted to a different element after a DOM mutation', () => {
+    // Regression for the ghost-click window: the synthetic click may mutate the
+    // DOM under the tap point (open a popover, close the fullscreen gate), so
+    // the browser can retarget the delayed compatibility click onto a different
+    // element at the same coordinates. Matching by location — not target
+    // identity — ensures it is still suppressed.
+    const button = document.createElement('button')
+    const onButtonClick = vi.fn()
+    button.addEventListener('click', onButtonClick)
+    document.body.appendChild(button)
+    const laterSibling = document.createElement('a')
+    laterSibling.setAttribute('href', '#')
+    const onSiblingClick = vi.fn()
+    laterSibling.addEventListener('click', onSiblingClick)
+    document.body.appendChild(laterSibling)
+    cleanup = installTouchActivation(document)
+
+    button.dispatchEvent(pointerEvent('pointerdown', { pointerId: 9 }))
+    button.dispatchEvent(pointerEvent('pointerup', { pointerId: 9 }))
+    expect(onButtonClick).toHaveBeenCalledOnce()
+
+    // The compatibility click lands at the original tap coordinates but on a
+    // freshly rendered sibling element. It is the same physical tap, so it must
+    // not cause a second navigation/activation.
+    laterSibling.dispatchEvent(compatClick(TAP_X, TAP_Y))
+    expect(onSiblingClick).not.toHaveBeenCalled()
   })
 })

--- a/agent-ui/src/input/touch-activation.test.ts
+++ b/agent-ui/src/input/touch-activation.test.ts
@@ -57,7 +57,11 @@ describe('touch activation bridge', () => {
     expect(onClick).toHaveBeenCalledOnce()
   })
 
-  it('keeps native mouse and keyboard click activation unchanged', () => {
+  it('passes through native mouse, keyboard, and programmatic click activation', () => {
+    // Mouse pointer-up clears all pending suppressions and never arms one of
+    // its own, so the following real mouse click (detail >= 1) is not
+    // suppressed. Keyboard Enter/Space and programmatic el.click() dispatch
+    // detail === 0 events, which the onClick early-return always exempts.
     const button = document.createElement('button')
     const onClick = vi.fn()
     button.addEventListener('click', onClick)
@@ -72,9 +76,53 @@ describe('touch activation bridge', () => {
       pointerId: 2,
       pointerType: 'mouse',
     }))
+    // Real mouse click (detail === 1) must pass through untouched.
+    button.dispatchEvent(new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      detail: 1,
+      clientX: TAP_X,
+      clientY: TAP_Y,
+    }))
+    // Programmatic el.click() (detail === 0) must also pass through.
     button.click()
 
+    expect(onClick).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not suppress a real mouse click (detail >= 1) that follows a touch tap', () => {
+    // Pins the mouse-clear branch in onPointerUp: a touch tap arms a
+    // suppression at the tap location, then a genuine mouse click at the same
+    // coordinates must still run. The mouse pointer-up must clear the armed
+    // touch suppression before the click arrives.
+    const button = document.createElement('button')
+    const onClick = vi.fn()
+    button.addEventListener('click', onClick)
+    document.body.appendChild(button)
+    cleanup = installTouchActivation(document)
+
+    // Touch tap: synthetic click fires once.
+    button.dispatchEvent(pointerEvent('pointerdown', { pointerId: 12 }))
+    button.dispatchEvent(pointerEvent('pointerup', { pointerId: 12 }))
     expect(onClick).toHaveBeenCalledOnce()
+
+    // A subsequent real mouse click at the same spot must NOT be swallowed.
+    button.dispatchEvent(pointerEvent('pointerdown', {
+      pointerId: 13,
+      pointerType: 'mouse',
+    }))
+    button.dispatchEvent(pointerEvent('pointerup', {
+      pointerId: 13,
+      pointerType: 'mouse',
+    }))
+    button.dispatchEvent(new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      detail: 1,
+      clientX: TAP_X,
+      clientY: TAP_Y,
+    }))
+    expect(onClick).toHaveBeenCalledTimes(2)
   })
 
   it('does not activate when a touch gesture becomes a scroll', () => {

--- a/agent-ui/src/input/touch-activation.test.ts
+++ b/agent-ui/src/input/touch-activation.test.ts
@@ -22,13 +22,14 @@ function pointerEvent(
   return event
 }
 
-// The browser fires its touch compatibility click at the touch coordinates, so
-// tests that emulate it must pass those coordinates. A MouseEvent built with no
-// init has clientX/clientY === 0, which on a real device only happens for
-// keyboard / assistive-tech / programmatic activation — none of which are the
+// The browser fires its touch compatibility click at the touch coordinates
+// with MouseEvent.detail === click count (>= 1), so tests that emulate it must
+// pass those coordinates. A MouseEvent built with no init has clientX/clientY
+// === 0 and detail === 0, which on a real device only happens for keyboard /
+// assistive-tech / programmatic activation — none of which are the
 // compatibility click and none of which this bridge may suppress.
 function compatClick(x: number = TAP_X, y: number = TAP_Y): MouseEvent {
-  return new MouseEvent('click', { bubbles: true, cancelable: true, clientX: x, clientY: y })
+  return new MouseEvent('click', { bubbles: true, cancelable: true, detail: 1, clientX: x, clientY: y })
 }
 
 describe('touch activation bridge', () => {
@@ -138,10 +139,14 @@ describe('touch activation bridge', () => {
     expect(onClick).toHaveBeenCalledTimes(2)
   })
 
-  it('suppresses each compatibility click independently for concurrent multi-touch taps', () => {
-    // Regression for the single-slot pendingNativeClick: two simultaneous taps
-    // on different controls must not let one tap overwrite the other's pending
-    // suppression, which previously caused one control's handler to fire twice.
+  it('consumes pending suppressions per tap rather than from a single shared slot (list mechanism)', () => {
+    // Regression for the single-slot pendingNativeClick: two synthetic
+    // activations that arm suppressions at different locations must each
+    // suppress their own compatibility click instead of one overwriting the
+    // other, which previously let the first control's handler double-fire.
+    // Both taps here are primary pointers; this exercises the pending list
+    // directly. Real multi-touch hardware only has one primary touch contact
+    // at a time (see the next test for that realistic case).
     const buttonA = document.createElement('button')
     const buttonB = document.createElement('button')
     const onClickA = vi.fn()
@@ -166,6 +171,30 @@ describe('touch activation bridge', () => {
     expect(onClickB).toHaveBeenCalledOnce()
   })
 
+  it('only the primary touch contact triggers synthetic activation; a second finger falls back to the native click', () => {
+    // Per the Pointer Events model there is at most one primary pointer per
+    // type, so a real second touch contact has isPrimary === false. It must
+    // not fire a synthetic click (the onPointerDown guard skips it); its
+    // activation is delivered later by the browser's native compatibility
+    // click, and — because no pending suppression was armed for it — that
+    // click runs the handler exactly once. This pins the intended
+    // single-primary-finger behavior of the bridge.
+    const button = document.createElement('button')
+    const onClick = vi.fn()
+    button.addEventListener('click', onClick)
+    document.body.appendChild(button)
+    cleanup = installTouchActivation(document)
+
+    button.dispatchEvent(pointerEvent('pointerdown', { pointerId: 9, clientX: 30, clientY: 30, isPrimary: false }))
+    button.dispatchEvent(pointerEvent('pointerup', { pointerId: 9, clientX: 30, clientY: 30, isPrimary: false }))
+    // No synthetic activation for the non-primary finger.
+    expect(onClick).not.toHaveBeenCalled()
+
+    // The browser's compatibility click then runs the handler once.
+    button.dispatchEvent(compatClick(30, 30))
+    expect(onClick).toHaveBeenCalledOnce()
+  })
+
   it('suppresses a compatibility click retargeted to a different element after a DOM mutation', () => {
     // Regression for the ghost-click window: the synthetic click may mutate the
     // DOM under the tap point (open a popover, close the fullscreen gate), so
@@ -183,8 +212,8 @@ describe('touch activation bridge', () => {
     document.body.appendChild(laterSibling)
     cleanup = installTouchActivation(document)
 
-    button.dispatchEvent(pointerEvent('pointerdown', { pointerId: 9 }))
-    button.dispatchEvent(pointerEvent('pointerup', { pointerId: 9 }))
+    button.dispatchEvent(pointerEvent('pointerdown', { pointerId: 10 }))
+    button.dispatchEvent(pointerEvent('pointerup', { pointerId: 10 }))
     expect(onButtonClick).toHaveBeenCalledOnce()
 
     // The compatibility click lands at the original tap coordinates but on a
@@ -192,5 +221,25 @@ describe('touch activation bridge', () => {
     // not cause a second navigation/activation.
     laterSibling.dispatchEvent(compatClick(TAP_X, TAP_Y))
     expect(onSiblingClick).not.toHaveBeenCalled()
+  })
+
+  it('still suppresses a real compatibility click landing at viewport (0,0)', () => {
+    // Regression for the origin heuristic: a genuine touch tap at the extreme
+    // top-left corner produces a compatibility click at clientX/Y === 0 with
+    // detail === 1. Unlike keyboard/AT/programmatic activation (detail === 0),
+    // this IS the compatibility click for an armed tap and must be suppressed,
+    // otherwise the control would activate twice for one physical tap.
+    const button = document.createElement('button')
+    const onClick = vi.fn()
+    button.addEventListener('click', onClick)
+    document.body.appendChild(button)
+    cleanup = installTouchActivation(document)
+
+    button.dispatchEvent(pointerEvent('pointerdown', { pointerId: 11, clientX: 0, clientY: 0 }))
+    button.dispatchEvent(pointerEvent('pointerup', { pointerId: 11, clientX: 0, clientY: 0 }))
+    expect(onClick).toHaveBeenCalledOnce()
+
+    button.dispatchEvent(compatClick(0, 0))
+    expect(onClick).toHaveBeenCalledOnce()
   })
 })

--- a/agent-ui/src/input/touch-activation.test.ts
+++ b/agent-ui/src/input/touch-activation.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { installTouchActivation } from './touch-activation'
+
+function pointerEvent(
+  type: string,
+  init: Partial<PointerEvent> & { pointerId: number },
+): Event {
+  const event = new Event(type, { bubbles: true, cancelable: true })
+  for (const [key, value] of Object.entries({
+    pointerType: 'touch',
+    isPrimary: true,
+    button: 0,
+    clientX: 20,
+    clientY: 20,
+    ...init,
+  })) {
+    Object.defineProperty(event, key, { configurable: true, value })
+  }
+  return event
+}
+
+describe('touch activation bridge', () => {
+  let cleanup: (() => void) | null = null
+
+  afterEach(() => {
+    cleanup?.()
+    cleanup = null
+    document.body.replaceChildren()
+    vi.restoreAllMocks()
+  })
+
+  it('activates a click-driven button on touch pointer-up exactly once', () => {
+    const button = document.createElement('button')
+    const onClick = vi.fn()
+    button.addEventListener('click', onClick)
+    document.body.appendChild(button)
+    cleanup = installTouchActivation(document)
+
+    button.dispatchEvent(pointerEvent('pointerdown', { pointerId: 1 }))
+    button.dispatchEvent(pointerEvent('pointerup', { pointerId: 1 }))
+    expect(onClick).toHaveBeenCalledOnce()
+
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+    expect(onClick).toHaveBeenCalledOnce()
+  })
+
+  it('keeps native mouse and keyboard click activation unchanged', () => {
+    const button = document.createElement('button')
+    const onClick = vi.fn()
+    button.addEventListener('click', onClick)
+    document.body.appendChild(button)
+    cleanup = installTouchActivation(document)
+
+    button.dispatchEvent(pointerEvent('pointerdown', {
+      pointerId: 2,
+      pointerType: 'mouse',
+    }))
+    button.dispatchEvent(pointerEvent('pointerup', {
+      pointerId: 2,
+      pointerType: 'mouse',
+    }))
+    button.click()
+
+    expect(onClick).toHaveBeenCalledOnce()
+  })
+
+  it('does not activate when a touch gesture becomes a scroll', () => {
+    const button = document.createElement('button')
+    const onClick = vi.fn()
+    button.addEventListener('click', onClick)
+    document.body.appendChild(button)
+    cleanup = installTouchActivation(document)
+
+    button.dispatchEvent(pointerEvent('pointerdown', { pointerId: 3 }))
+    button.dispatchEvent(pointerEvent('pointermove', {
+      pointerId: 3,
+      clientY: 80,
+    }))
+    button.dispatchEvent(pointerEvent('pointerup', {
+      pointerId: 3,
+      clientY: 80,
+    }))
+
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
+  it('supports role buttons and ignores disabled controls', () => {
+    const roleButton = document.createElement('div')
+    roleButton.setAttribute('role', 'button')
+    const disabledButton = document.createElement('button')
+    disabledButton.disabled = true
+    const onRoleClick = vi.fn()
+    const onDisabledClick = vi.fn()
+    roleButton.addEventListener('click', onRoleClick)
+    disabledButton.addEventListener('click', onDisabledClick)
+    document.body.append(roleButton, disabledButton)
+    cleanup = installTouchActivation(document)
+
+    roleButton.dispatchEvent(pointerEvent('pointerdown', { pointerId: 4 }))
+    roleButton.dispatchEvent(pointerEvent('pointerup', { pointerId: 4 }))
+    disabledButton.dispatchEvent(pointerEvent('pointerdown', { pointerId: 5 }))
+    disabledButton.dispatchEvent(pointerEvent('pointerup', { pointerId: 5 }))
+
+    expect(onRoleClick).toHaveBeenCalledOnce()
+    expect(onDisabledClick).not.toHaveBeenCalled()
+  })
+})

--- a/agent-ui/src/input/touch-activation.ts
+++ b/agent-ui/src/input/touch-activation.ts
@@ -1,0 +1,138 @@
+const ACTIVATABLE_SELECTOR = [
+  'button',
+  'a[href]',
+  '[role="button"]',
+  'input[type="button"]',
+  'input[type="submit"]',
+  'input[type="reset"]',
+  'summary',
+].join(',')
+
+const MAX_TAP_DISTANCE_PX = 12
+const MAX_TAP_DURATION_MS = 800
+const SYNTHETIC_CLICK_WINDOW_MS = 750
+
+interface ActiveTouchPointer {
+  target: HTMLElement
+  startX: number
+  startY: number
+  startedAt: number
+}
+
+interface PendingNativeClick {
+  target: HTMLElement
+  expiresAt: number
+}
+
+function isTouchPointer(event: PointerEvent): boolean {
+  return event.pointerType === 'touch' || event.pointerType === 'pen'
+}
+
+function resolveActivatable(target: EventTarget | null): HTMLElement | null {
+  if (!(target instanceof Element)) return null
+  const activatable = target.closest<HTMLElement>(ACTIVATABLE_SELECTOR)
+  if (!activatable || !activatable.isConnected) return null
+  if (
+    activatable.matches(':disabled') ||
+    activatable.getAttribute('aria-disabled') === 'true' ||
+    activatable.hasAttribute('inert') ||
+    activatable.closest('[inert]')
+  ) {
+    return null
+  }
+  return activatable
+}
+
+function pointerTravelledTooFar(
+  pointer: ActiveTouchPointer,
+  event: PointerEvent,
+): boolean {
+  return Math.hypot(event.clientX - pointer.startX, event.clientY - pointer.startY) > MAX_TAP_DISTANCE_PX
+}
+
+/**
+ * Makes the app's existing click-driven controls respond directly to touch and
+ * pen pointer-up events. The browser-generated compatibility click is then
+ * suppressed so Vue handlers still run exactly once. Mouse clicks and keyboard
+ * activation continue through the browser's native click path.
+ */
+export function installTouchActivation(root: Document | HTMLElement = document): () => void {
+  const activePointers = new Map<number, ActiveTouchPointer>()
+  let pendingNativeClick: PendingNativeClick | null = null
+  let dispatchingSyntheticClick = false
+
+  const onPointerDown = (event: PointerEvent) => {
+    if (!isTouchPointer(event) || !event.isPrimary || event.button !== 0) return
+    const target = resolveActivatable(event.target)
+    if (!target) return
+    activePointers.set(event.pointerId, {
+      target,
+      startX: event.clientX,
+      startY: event.clientY,
+      startedAt: performance.now(),
+    })
+  }
+
+  const onPointerMove = (event: PointerEvent) => {
+    const pointer = activePointers.get(event.pointerId)
+    if (pointer && pointerTravelledTooFar(pointer, event)) {
+      activePointers.delete(event.pointerId)
+    }
+  }
+
+  const onPointerCancel = (event: PointerEvent) => {
+    activePointers.delete(event.pointerId)
+  }
+
+  const onPointerUp = (event: PointerEvent) => {
+    const pointer = activePointers.get(event.pointerId)
+    activePointers.delete(event.pointerId)
+    if (!pointer || pointerTravelledTooFar(pointer, event)) return
+    if (performance.now() - pointer.startedAt > MAX_TAP_DURATION_MS) return
+
+    const target = resolveActivatable(event.target)
+    if (!target || target !== pointer.target) return
+
+    pendingNativeClick = {
+      target,
+      expiresAt: performance.now() + SYNTHETIC_CLICK_WINDOW_MS,
+    }
+    dispatchingSyntheticClick = true
+    try {
+      target.click()
+    } finally {
+      dispatchingSyntheticClick = false
+    }
+  }
+
+  const onClick = (event: MouseEvent) => {
+    if (dispatchingSyntheticClick || !pendingNativeClick) return
+    const target = resolveActivatable(event.target)
+    if (
+      performance.now() <= pendingNativeClick.expiresAt &&
+      target === pendingNativeClick.target
+    ) {
+      pendingNativeClick = null
+      event.preventDefault()
+      event.stopImmediatePropagation()
+      return
+    }
+    pendingNativeClick = null
+  }
+
+  root.addEventListener('pointerdown', onPointerDown as EventListener, true)
+  root.addEventListener('pointermove', onPointerMove as EventListener, true)
+  root.addEventListener('pointercancel', onPointerCancel as EventListener, true)
+  root.addEventListener('pointerup', onPointerUp as EventListener, true)
+  root.addEventListener('click', onClick as EventListener, true)
+
+  return () => {
+    root.removeEventListener('pointerdown', onPointerDown as EventListener, true)
+    root.removeEventListener('pointermove', onPointerMove as EventListener, true)
+    root.removeEventListener('pointercancel', onPointerCancel as EventListener, true)
+    root.removeEventListener('pointerup', onPointerUp as EventListener, true)
+    root.removeEventListener('click', onClick as EventListener, true)
+    activePointers.clear()
+    pendingNativeClick = null
+  }
+}

--- a/agent-ui/src/input/touch-activation.ts
+++ b/agent-ui/src/input/touch-activation.ts
@@ -138,11 +138,14 @@ export function installTouchActivation(root: Document | HTMLElement = document):
     pruneExpired()
     if (pendingCompatClicks.length === 0) return
     // Keyboard Enter/Space activation, assistive-tech activation, and
-    // programmatic el.click() all carry clientX/clientY === 0; the browser's
-    // touch compatibility click always fires at the touch point. An origin
-    // click is therefore never the compat click and must never be suppressed,
-    // even when a recent tap armed a suppression for the same control.
-    if (event.clientX === 0 && event.clientY === 0) return
+    // programmatic el.click() are not real pointer-driven clicks: per the UI
+    // Events spec they carry MouseEvent.detail === 0, whereas a real mouse or
+    // touch-compatibility click carries detail >= 1. Only the former must never
+    // be suppressed (they are genuine activations of the focused control, even
+    // when a recent touch tap armed a suppression at the same location). A real
+    // compatibility click landing at the viewport corner (clientX/Y === 0) is
+    // therefore still matched by location and suppressed.
+    if (event.detail === 0) return
     for (let i = 0; i < pendingCompatClicks.length; i++) {
       const pending = pendingCompatClicks[i]
       if (

--- a/agent-ui/src/input/touch-activation.ts
+++ b/agent-ui/src/input/touch-activation.ts
@@ -11,6 +11,13 @@ const ACTIVATABLE_SELECTOR = [
 const MAX_TAP_DISTANCE_PX = 12
 const MAX_TAP_DURATION_MS = 800
 const SYNTHETIC_CLICK_WINDOW_MS = 750
+// The browser fires its compatibility click at (almost) exactly the touch
+// coordinates, so we match pending suppressions by location rather than by
+// target identity. This both lets us suppress a compat click that the browser
+// retargets to a different element after the synthetic click mutates the DOM,
+// and avoids swallowing a genuine activation of the same control (which is how
+// the prior target-identity matcher mis-fired).
+const COMPAT_CLICK_TOLERANCE_PX = MAX_TAP_DISTANCE_PX
 
 interface ActiveTouchPointer {
   target: HTMLElement
@@ -19,8 +26,9 @@ interface ActiveTouchPointer {
   startedAt: number
 }
 
-interface PendingNativeClick {
-  target: HTMLElement
+interface PendingCompatClick {
+  x: number
+  y: number
   expiresAt: number
 }
 
@@ -58,8 +66,21 @@ function pointerTravelledTooFar(
  */
 export function installTouchActivation(root: Document | HTMLElement = document): () => void {
   const activePointers = new Map<number, ActiveTouchPointer>()
-  let pendingNativeClick: PendingNativeClick | null = null
+  // One entry per in-flight touch/pen tap whose compatibility click has not
+  // been consumed yet. A list (rather than a single slot) is required so that
+  // concurrent multi-touch taps each suppress their own compatibility click
+  // instead of one tap overwriting another's pending suppression.
+  const pendingCompatClicks: PendingCompatClick[] = []
   let dispatchingSyntheticClick = false
+
+  const pruneExpired = (): void => {
+    const now = performance.now()
+    for (let i = pendingCompatClicks.length - 1; i >= 0; i--) {
+      if (pendingCompatClicks[i].expiresAt <= now) {
+        pendingCompatClicks.splice(i, 1)
+      }
+    }
+  }
 
   const onPointerDown = (event: PointerEvent) => {
     if (!isTouchPointer(event) || !event.isPrimary || event.button !== 0) return
@@ -85,6 +106,12 @@ export function installTouchActivation(root: Document | HTMLElement = document):
   }
 
   const onPointerUp = (event: PointerEvent) => {
+    // A genuine mouse pointer-up means the user switched to mouse input; any
+    // click that follows is a real activation and must never be suppressed.
+    if (!isTouchPointer(event)) {
+      pendingCompatClicks.length = 0
+      return
+    }
     const pointer = activePointers.get(event.pointerId)
     activePointers.delete(event.pointerId)
     if (!pointer || pointerTravelledTooFar(pointer, event)) return
@@ -93,10 +120,11 @@ export function installTouchActivation(root: Document | HTMLElement = document):
     const target = resolveActivatable(event.target)
     if (!target || target !== pointer.target) return
 
-    pendingNativeClick = {
-      target,
+    pendingCompatClicks.push({
+      x: event.clientX,
+      y: event.clientY,
       expiresAt: performance.now() + SYNTHETIC_CLICK_WINDOW_MS,
-    }
+    })
     dispatchingSyntheticClick = true
     try {
       target.click()
@@ -106,18 +134,27 @@ export function installTouchActivation(root: Document | HTMLElement = document):
   }
 
   const onClick = (event: MouseEvent) => {
-    if (dispatchingSyntheticClick || !pendingNativeClick) return
-    const target = resolveActivatable(event.target)
-    if (
-      performance.now() <= pendingNativeClick.expiresAt &&
-      target === pendingNativeClick.target
-    ) {
-      pendingNativeClick = null
-      event.preventDefault()
-      event.stopImmediatePropagation()
-      return
+    if (dispatchingSyntheticClick) return
+    pruneExpired()
+    if (pendingCompatClicks.length === 0) return
+    // Keyboard Enter/Space activation, assistive-tech activation, and
+    // programmatic el.click() all carry clientX/clientY === 0; the browser's
+    // touch compatibility click always fires at the touch point. An origin
+    // click is therefore never the compat click and must never be suppressed,
+    // even when a recent tap armed a suppression for the same control.
+    if (event.clientX === 0 && event.clientY === 0) return
+    for (let i = 0; i < pendingCompatClicks.length; i++) {
+      const pending = pendingCompatClicks[i]
+      if (
+        performance.now() <= pending.expiresAt &&
+        Math.hypot(event.clientX - pending.x, event.clientY - pending.y) <= COMPAT_CLICK_TOLERANCE_PX
+      ) {
+        pendingCompatClicks.splice(i, 1)
+        event.preventDefault()
+        event.stopImmediatePropagation()
+        return
+      }
     }
-    pendingNativeClick = null
   }
 
   root.addEventListener('pointerdown', onPointerDown as EventListener, true)
@@ -133,6 +170,6 @@ export function installTouchActivation(root: Document | HTMLElement = document):
     root.removeEventListener('pointerup', onPointerUp as EventListener, true)
     root.removeEventListener('click', onClick as EventListener, true)
     activePointers.clear()
-    pendingNativeClick = null
+    pendingCompatClicks.length = 0
   }
 }

--- a/agent-ui/src/main.ts
+++ b/agent-ui/src/main.ts
@@ -10,6 +10,7 @@ import App from '@/App.vue'
 import router from '@/router'
 import { i18n } from '@/plugins/i18n'
 import { applyInitialAppearance } from '@/appearance/appearance-registry'
+import { installTouchActivation } from '@/input/touch-activation'
 
 import './styles/hr-theme.css'
 import './styles/tailwind.css'
@@ -23,6 +24,11 @@ import '@vue-flow/core/dist/style.css';
 // from the same semantic token set. index.html performs an even earlier
 // pre-paint pass for the built-in appearances.
 applyInitialAppearance()
+
+const removeTouchActivation = installTouchActivation(document)
+if (import.meta.hot) {
+  import.meta.hot.dispose(removeTouchActivation)
+}
 
 const app = createApp(App)
 const pinia = createPinia()


### PR DESCRIPTION
## Summary

- add a global touch and pen activation bridge for existing buttons, links, and `role="button"` controls
- trigger the existing click handlers directly on a valid pointer-up gesture
- cancel activation when the gesture becomes a scroll or long press
- suppress the browser's follow-up compatibility click so handlers run exactly once
- keep native mouse and keyboard click behavior unchanged
- remove redundant `pointerup` and `touchend` handlers from the mobile fullscreen gate
- reveal the immersive Live Voice exit control on touch or pen pointer-down while keeping the exit action click-only

This PR intentionally makes no layout, sizing, hover, or other visual changes.

## Root cause

Most controls only listen for `click`, which relies on WebKit/Chrome synthesizing a compatibility click after touch input. That path was unreliable for several iPad interactions. The fullscreen gate had the opposite problem: it listened to `pointerup`, `touchend`, and `click` at the same time, allowing one gesture to enter multiple event paths.

The immersive Live Voice exit control had a separate visibility gap: it was translated outside the viewport and revealed only by `pointermove`, which an iPad tap does not reliably emit. The global activation bridge therefore had no visible button to target.

## User impact

Touch and Apple Pencil interactions now activate controls immediately and consistently. Scroll gestures do not accidentally activate controls, and desktop mouse/keyboard behavior remains unchanged.

## Validation

- `npm test` — 97 files, 614 tests passed
- `npm run typecheck`
- `npm run build`
- focused regression covering touch/pen reveal of the immersive Live Voice exit control
- browser regression with iPad Chrome UA/touch viewport
- browser regression with phone touch viewport
- desktop mouse regression
- verified touch activation and compatibility-click de-duplication against the deployed LAN HTTPS build
