### PR TITLE
Fix phone add-directory modal in fullscreen

### DIFF
--- a/agent-ui/src/components/agent/AgentVoiceCockpit.vue
+++ b/agent-ui/src/components/agent/AgentVoiceCockpit.vue
@@ -9942,6 +9942,29 @@ function summarizeTask(value: string): string {
   margin-top: 12px;
 }
 
+/* The landscape phone shell is rendered at 0.38–0.62 scale. Reserve the
+   sidebar header for its two actions so their final on-screen hit areas stay
+   at least 44 CSS pixels instead of shrinking to roughly 17 pixels. */
+.voice-cockpit--phone-landscape :deep(.voice-left-rail__title) {
+  display: none;
+}
+
+.voice-cockpit--phone-landscape :deep(.voice-left-rail__header-actions) {
+  width: 100%;
+  gap: 16px;
+}
+
+.voice-cockpit--phone-landscape :deep(.voice-left-rail__header-button) {
+  width: auto;
+  height: 116px;
+  flex: 1 1 0;
+}
+
+.voice-cockpit--phone-landscape :deep(.voice-left-rail__header-button svg) {
+  width: 40px;
+  height: 40px;
+}
+
 .voice-cockpit--phone-landscape .voice-stage {
   margin: 24px;
   padding: 24px;

--- a/agent-ui/src/components/agent/AgentVoiceCockpitLayout.test.ts
+++ b/agent-ui/src/components/agent/AgentVoiceCockpitLayout.test.ts
@@ -37,10 +37,10 @@ describe('AgentVoiceCockpit responsive layout', () => {
     expect(sidebarSource).toContain('data-testid="voice-sidebar-add-directory"')
     expect(sidebarSource.match(/h-11 w-11 shrink-0 touch-manipulation/g)).toHaveLength(2)
     expect(sidebarSource.match(/voice-left-rail__header-button/g)).toHaveLength(2)
-    expect(cockpitSource).toContain(
-      '.voice-cockpit--phone-landscape :deep(.voice-left-rail__header-button)'
-    )
-    expect(cockpitSource).toContain('height: 116px;')
+    const headerButtonRule = cockpitSource.match(
+      /\.voice-cockpit--phone-landscape :deep\(\.voice-left-rail__header-button\) \{([\s\S]*?)\n\}/,
+    )?.[1]
+    expect(headerButtonRule).toContain('height: 116px;')
   })
 
   it('keeps model selection independent from incomplete onboarding status', () => {

--- a/agent-ui/src/components/agent/AgentVoiceCockpitLayout.test.ts
+++ b/agent-ui/src/components/agent/AgentVoiceCockpitLayout.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import cockpitSource from './AgentVoiceCockpit.vue?raw'
+import sidebarSource from './VoiceSessionProjectSidebar.vue?raw'
 
 describe('AgentVoiceCockpit responsive layout', () => {
   it('keeps the phone status message from covering canvas actions', () => {
@@ -21,6 +22,25 @@ describe('AgentVoiceCockpit responsive layout', () => {
     expect(cockpitSource).toContain(
       'class="voice-records-slot min-w-0 overflow-hidden py-0 pr-6"'
     )
+  })
+
+  it('keeps the sidebar touch controls inside the responsive grid column', () => {
+    expect(cockpitSource).toContain(
+      "if (viewportWidth.value <= 1280) return effectiveSidebarOpen.value ? '250px' : '52px'"
+    )
+    expect(sidebarSource).toContain(
+      'voice-left-rail flex h-full min-h-0 w-full'
+    )
+    expect(sidebarSource).not.toContain(
+      'voice-left-rail flex h-full min-h-0 w-[292px]'
+    )
+    expect(sidebarSource).toContain('data-testid="voice-sidebar-add-directory"')
+    expect(sidebarSource.match(/h-11 w-11 shrink-0 touch-manipulation/g)).toHaveLength(2)
+    expect(sidebarSource.match(/voice-left-rail__header-button/g)).toHaveLength(2)
+    expect(cockpitSource).toContain(
+      '.voice-cockpit--phone-landscape :deep(.voice-left-rail__header-button)'
+    )
+    expect(cockpitSource).toContain('height: 116px;')
   })
 
   it('keeps model selection independent from incomplete onboarding status', () => {

--- a/agent-ui/src/components/agent/VoiceDirectoryProjectModal.test.ts
+++ b/agent-ui/src/components/agent/VoiceDirectoryProjectModal.test.ts
@@ -22,9 +22,17 @@ vi.mock('@/api/agent', () => ({
 describe('VoiceDirectoryProjectModal directory roots', () => {
   let app: App<Element> | null = null
   let root: HTMLElement | null = null
+  let fullscreenHost: HTMLElement | null = null
+  let fullscreenElement: Element | null = null
+  let originalFullscreenDescriptor: PropertyDescriptor | undefined
 
   beforeEach(() => {
     vi.clearAllMocks()
+    originalFullscreenDescriptor = Object.getOwnPropertyDescriptor(document, 'fullscreenElement')
+    Object.defineProperty(document, 'fullscreenElement', {
+      configurable: true,
+      get: () => fullscreenElement,
+    })
     i18n.global.locale.value = 'zh-Hans'
     apiMocks.listProjectDirectoryRoots.mockResolvedValue({
       data: {
@@ -54,8 +62,16 @@ describe('VoiceDirectoryProjectModal directory roots', () => {
   afterEach(() => {
     app?.unmount()
     root?.remove()
+    fullscreenHost?.remove()
+    fullscreenElement = null
+    if (originalFullscreenDescriptor) {
+      Object.defineProperty(document, 'fullscreenElement', originalFullscreenDescriptor)
+    } else {
+      delete (document as Document & { fullscreenElement?: Element | null }).fullscreenElement
+    }
     app = null
     root = null
+    fullscreenHost = null
   })
 
   it('starts from the runtime default and only renders persisted project directories', async () => {
@@ -104,5 +120,66 @@ describe('VoiceDirectoryProjectModal directory roots', () => {
         limit: 300,
       })
     })
+  })
+
+  it('moves the modal into an element-level fullscreen host', async () => {
+    const open = ref(true)
+    const Host = defineComponent({
+      setup: () => () => h(VoiceDirectoryProjectModal, {
+        open: open.value,
+        'onUpdate:open': (value: boolean) => { open.value = value },
+      }),
+    })
+    fullscreenHost = document.createElement('div')
+    fullscreenHost.dataset.testid = 'fullscreen-host'
+    document.body.appendChild(fullscreenHost)
+    fullscreenElement = fullscreenHost
+    root = document.createElement('div')
+    document.body.appendChild(root)
+    app = createApp(Host)
+    app.use(i18n)
+    app.mount(root)
+
+    await nextTick()
+
+    const overlay = document.querySelector<HTMLElement>(
+      '[data-testid="voice-directory-modal-overlay"]'
+    )
+    expect(overlay).not.toBeNull()
+    expect(overlay?.parentElement).toBe(fullscreenHost)
+    expect(fullscreenHost.contains(overlay)).toBe(true)
+  })
+
+  it('tracks fullscreen entry and exit while the modal is open', async () => {
+    const open = ref(true)
+    const Host = defineComponent({
+      setup: () => () => h(VoiceDirectoryProjectModal, {
+        open: open.value,
+        'onUpdate:open': (value: boolean) => { open.value = value },
+      }),
+    })
+    fullscreenHost = document.createElement('div')
+    document.body.appendChild(fullscreenHost)
+    root = document.createElement('div')
+    document.body.appendChild(root)
+    app = createApp(Host)
+    app.use(i18n)
+    app.mount(root)
+    await nextTick()
+
+    const overlay = document.querySelector<HTMLElement>(
+      '[data-testid="voice-directory-modal-overlay"]'
+    )
+    expect(overlay?.parentElement).toBe(document.body)
+
+    fullscreenElement = fullscreenHost
+    document.dispatchEvent(new Event('fullscreenchange'))
+    await nextTick()
+    expect(overlay?.parentElement).toBe(fullscreenHost)
+
+    fullscreenElement = null
+    document.dispatchEvent(new Event('fullscreenchange'))
+    await nextTick()
+    expect(overlay?.parentElement).toBe(document.body)
   })
 })

--- a/agent-ui/src/components/agent/VoiceDirectoryProjectModal.test.ts
+++ b/agent-ui/src/components/agent/VoiceDirectoryProjectModal.test.ts
@@ -148,6 +148,9 @@ describe('VoiceDirectoryProjectModal directory roots', () => {
     expect(overlay).not.toBeNull()
     expect(overlay?.parentElement).toBe(fullscreenHost)
     expect(fullscreenHost.contains(overlay)).toBe(true)
+    const overlayZIndex = Number(overlay?.className.match(/z-\[(\d+)\]/)?.[1])
+    expect(overlayZIndex).toBeGreaterThan(170)
+    expect(overlayZIndex).toBeLessThan(220)
   })
 
   it('tracks fullscreen entry and exit while the modal is open', async () => {

--- a/agent-ui/src/components/agent/VoiceDirectoryProjectModal.vue
+++ b/agent-ui/src/components/agent/VoiceDirectoryProjectModal.vue
@@ -270,10 +270,12 @@ function handleProjectNameInput(event: Event): void {
 
 <template>
   <Teleport :to="teleportTarget">
+    <!-- Keep the modal above cockpit menus (up to 170) while preserving the
+         immersive fullscreen exit control at 220. -->
     <div
       v-if="open"
       data-testid="voice-directory-modal-overlay"
-      class="fixed inset-0 z-[70] flex items-center justify-center bg-[var(--hr-overlay)] px-6 backdrop-blur-sm"
+      class="fixed inset-0 z-[180] flex items-center justify-center bg-[var(--hr-overlay)] px-6 backdrop-blur-sm"
     >
       <section class="flex h-[min(720px,82vh)] w-[min(980px,92vw)] overflow-hidden rounded-[24px] border border-[var(--hr-border-strong)] bg-[var(--hr-panel)] text-[var(--hr-text-1)]" :style="{ boxShadow: 'var(--hr-shadow-floating)' }">
       <aside class="flex w-64 shrink-0 flex-col border-r border-[var(--hr-border)] bg-[var(--hr-surface-1)] p-4">

--- a/agent-ui/src/components/agent/VoiceDirectoryProjectModal.vue
+++ b/agent-ui/src/components/agent/VoiceDirectoryProjectModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, shallowRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { Check, ChevronLeft, CornerUpLeft, Folder, FolderOpen, GitBranch, Loader2, Server, X } from 'lucide-vue-next'
 import {
@@ -52,6 +52,11 @@ const selectedRepoFullName = ref('')
 const availableRepos = ref<GitRepositoryInfo[]>([])
 const loadingRepos = ref(false)
 const gitError = ref('')
+const teleportTarget = shallowRef<string | Element>('body')
+
+type WebkitFullscreenDocument = Document & {
+  webkitFullscreenElement?: Element | null
+}
 
 const selectedServer = computed(() => servers.value.find(item => item.id === serverId.value))
 const canCreate = computed(() => currentPath.value.trim() && projectName.value.trim() && !creating.value)
@@ -66,11 +71,34 @@ watch(() => props.open, (open) => {
 
 onMounted(() => {
   window.addEventListener('keydown', handleKeydown)
+  document.addEventListener('fullscreenchange', syncTeleportTarget)
+  document.addEventListener('webkitfullscreenchange', syncTeleportTarget)
+  syncTeleportTarget()
 })
 
 onUnmounted(() => {
   window.removeEventListener('keydown', handleKeydown)
+  document.removeEventListener('fullscreenchange', syncTeleportTarget)
+  document.removeEventListener('webkitfullscreenchange', syncTeleportTarget)
 })
+
+function syncTeleportTarget(): void {
+  const fullscreenElement =
+    document.fullscreenElement ||
+    (document as WebkitFullscreenDocument).webkitFullscreenElement ||
+    null
+
+  // A modal teleported to <body> is outside an element-level fullscreen
+  // subtree and therefore invisible even though its Vue state is open. Keep
+  // the normal body target for document-level fullscreen, but mount inside an
+  // element-level fullscreen host such as the mobile Voice Cockpit.
+  teleportTarget.value =
+    fullscreenElement &&
+    fullscreenElement !== document.documentElement &&
+    fullscreenElement !== document.body
+      ? fullscreenElement
+      : 'body'
+}
 
 function handleKeydown(event: KeyboardEvent): void {
   if (!props.open || event.key !== 'Escape') return
@@ -241,7 +269,7 @@ function handleProjectNameInput(event: Event): void {
 </script>
 
 <template>
-  <Teleport to="body">
+  <Teleport :to="teleportTarget">
     <div
       v-if="open"
       data-testid="voice-directory-modal-overlay"

--- a/agent-ui/src/components/agent/VoiceSessionProjectSidebar.vue
+++ b/agent-ui/src/components/agent/VoiceSessionProjectSidebar.vue
@@ -532,22 +532,25 @@ defineExpose({
 
 <template>
   <aside
-    class="voice-left-rail flex h-full min-h-0 w-[292px] shrink-0 flex-col border-r border-[var(--hr-border)] bg-[var(--hr-surface-1)] px-4 py-5"
+    class="voice-left-rail flex h-full min-h-0 w-full shrink-0 flex-col border-r border-[var(--hr-border)] bg-[var(--hr-surface-1)] px-4 py-5"
   >
-    <div class="mb-4 flex items-center justify-between">
-      <div class="min-w-0">
+    <div class="voice-left-rail__header mb-4 flex items-center justify-between">
+      <div class="voice-left-rail__title min-w-0">
         <div class="truncate text-xl font-semibold text-[var(--hr-text-1)]">{{ t('voice.sidebar.workspace') }}</div>
       </div>
-      <div class="flex items-center gap-2">
+      <div class="voice-left-rail__header-actions flex items-center gap-2">
         <button
-          class="rounded-full border border-[var(--hr-border)] p-2 text-[var(--hr-text-2)] hover:bg-[var(--hr-surface-2)] hover:text-[var(--hr-text-1)]"
+          type="button"
+          class="voice-left-rail__header-button flex h-11 w-11 shrink-0 touch-manipulation items-center justify-center rounded-full border border-[var(--hr-border)] text-[var(--hr-text-2)] hover:bg-[var(--hr-surface-2)] hover:text-[var(--hr-text-1)]"
           :title="t('voice.sidebar.collapse')"
           @click="emit('collapse')"
         >
           <PanelLeftClose class="h-4 w-4" />
         </button>
         <button
-          class="rounded-full border border-[var(--hr-border)] p-2 text-[var(--hr-text-2)] hover:bg-[var(--hr-surface-2)] hover:text-[var(--hr-text-1)]"
+          type="button"
+          data-testid="voice-sidebar-add-directory"
+          class="voice-left-rail__header-button flex h-11 w-11 shrink-0 touch-manipulation items-center justify-center rounded-full border border-[var(--hr-border)] text-[var(--hr-text-2)] hover:bg-[var(--hr-surface-2)] hover:text-[var(--hr-text-1)]"
           :title="t('voice.sidebar.addDirectory')"
           @click="createOpen = true"
         >


### PR DESCRIPTION
## What changed

- keep the Voice Cockpit sidebar inside its responsive grid column and preserve usable phone touch targets
- mount the add-directory modal inside an element-level fullscreen host instead of always teleporting it to `body`
- follow fullscreen entry and exit while the modal is open
- add regression coverage for fullscreen modal placement and transitions

## Root cause

The touch activation did run and set the modal state to open. On Android and desktop-site phone modes, however, the Voice Cockpit itself was the fullscreen element while the modal was teleported to `body`. Browsers only render the fullscreen element and its descendants, so the modal existed in the DOM but was outside the visible fullscreen subtree. To the user, the enlarged button appeared to do nothing.

## Validation

- `npm test` — 107 files, 698 tests passed
- `npm run type-check`
- `npm run build`
- real Playwright `touchscreen.tap` coverage on iPhone 13 landscape, Pixel 7 landscape fullscreen, Pixel 7 standalone, iPad Pro 11 landscape, and phone desktop-site mode
- normal 1440×900 desktop add-directory and sidebar-collapse smoke test
- confirmed the fullscreen modal is a descendant of `document.fullscreenElement` and receives hit testing above the cockpit canvas
