### PR TITLE
feat: add experimental DeepSeek Harness backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,11 @@ jobs:
       - name: Build Worker image
         run: docker build -t homerail-worker:ci -f homerail_worker/Dockerfile .
 
+      - name: Exercise packaged DeepSeek Harness runtime
+        run: >-
+          docker run --rm --user root --workdir /app --entrypoint npm homerail-worker:ci
+          test -- --run src/__tests__/deepseek-harness-runtime.integration.test.ts
+
   live-dag-patterns:
     name: Live DAG patterns (self-hosted Qwen3.6)
     if: >-

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -163,7 +163,9 @@ jobs:
         id: review
         env:
           HOMERAIL_PR_REVIEW_INPUT: ${{ steps.input.outputs.json }}
-          HOMERAIL_PR_REVIEW_PROFILE_ID: ${{ inputs.profile_id || 'pr-review-mixed' }}
+          # Keep DSH isolated even while the stable adapter is still running
+          # a release that predates agent-type-specific profile derivation.
+          HOMERAIL_PR_REVIEW_PROFILE_ID: ${{ inputs.profile_id || (inputs.agent_type == 'deepseek_harness' && 'pr-review-dsh' || 'pr-review-mixed') }}
           HOMERAIL_PR_REVIEW_MODEL: ${{ inputs.model }}
           HOMERAIL_PR_REVIEW_AGENT_TYPE: ${{ inputs.agent_type || 'claude-sdk' }}
         run: bash "${{ steps.adapter.outputs.path }}"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -163,9 +163,9 @@ jobs:
         id: review
         env:
           HOMERAIL_PR_REVIEW_INPUT: ${{ steps.input.outputs.json }}
-          HOMERAIL_PR_REVIEW_PROFILE_ID: ${{ inputs.profile_id }}
+          HOMERAIL_PR_REVIEW_PROFILE_ID: ${{ inputs.profile_id || 'pr-review-mixed' }}
           HOMERAIL_PR_REVIEW_MODEL: ${{ inputs.model }}
-          HOMERAIL_PR_REVIEW_AGENT_TYPE: ${{ inputs.agent_type }}
+          HOMERAIL_PR_REVIEW_AGENT_TYPE: ${{ inputs.agent_type || 'claude-sdk' }}
         run: bash "${{ steps.adapter.outputs.path }}"
 
       - name: Publish Check summary

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -23,6 +23,22 @@ on:
         description: Optional immutable head commit SHA
         type: string
         required: false
+      profile_id:
+        description: Optional private runtime profile id for this review
+        type: string
+        required: false
+      model:
+        description: Optional single Manager LLM setting selector for all three independent reviewers
+        type: string
+        required: false
+      agent_type:
+        description: Harness used by all three independent reviewers
+        type: choice
+        options:
+          - claude-sdk
+          - deepseek_harness
+        default: claude-sdk
+        required: false
 
 permissions:
   contents: read
@@ -147,6 +163,9 @@ jobs:
         id: review
         env:
           HOMERAIL_PR_REVIEW_INPUT: ${{ steps.input.outputs.json }}
+          HOMERAIL_PR_REVIEW_PROFILE_ID: ${{ inputs.profile_id }}
+          HOMERAIL_PR_REVIEW_MODEL: ${{ inputs.model }}
+          HOMERAIL_PR_REVIEW_AGENT_TYPE: ${{ inputs.agent_type }}
         run: bash "${{ steps.adapter.outputs.path }}"
 
       - name: Publish Check summary

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -31,6 +31,10 @@ on:
         description: Optional single Manager LLM setting selector for all three independent reviewers
         type: string
         required: false
+      reasoning_effort:
+        description: Optional model-owned reasoning selector for all three independent reviewers
+        type: string
+        required: false
       agent_type:
         description: Harness used by all three independent reviewers
         type: choice
@@ -168,6 +172,7 @@ jobs:
           HOMERAIL_PR_REVIEW_PROFILE_ID: ${{ inputs.profile_id || (inputs.agent_type == 'deepseek_harness' && 'pr-review-dsh' || 'pr-review-mixed') }}
           HOMERAIL_PR_REVIEW_MODEL: ${{ inputs.model }}
           HOMERAIL_PR_REVIEW_AGENT_TYPE: ${{ inputs.agent_type || 'claude-sdk' }}
+          HOMERAIL_PR_REVIEW_REASONING_EFFORT: ${{ inputs.reasoning_effort }}
         run: bash "${{ steps.adapter.outputs.path }}"
 
       - name: Publish Check summary

--- a/README.md
+++ b/README.md
@@ -383,9 +383,12 @@ foundation here is the first step; see [ROADMAP.md](ROADMAP.md) for the plan.
 For the voice Manager Agent, **Codex (`codex_appserver`) is the recommended
 harness today**: it is the only path that auto-synthesizes the `commentary`
 speech channel from the model's native reasoning stream, so the user hears
-progress while work happens. Other harnesses (`claude-sdk`, `kimi-code`) are
-silent during execution — this is a provider capability gap, not something
-HomeRail can close.
+progress while work happens. `claude-sdk` and `kimi-code` are silent during
+execution — this is a provider capability gap, not something HomeRail can
+close. An experimental `deepseek_harness` backend now runs the owner-maintained
+[DSH fork](docs/architecture/deepseek-harness-integration.md) out of process and
+maps its reasoning stream into HomeRail thinking events; it is not yet the
+recommended Manager Agent runtime.
 
 ## License
 

--- a/docs/architecture/deepseek-harness-integration.md
+++ b/docs/architecture/deepseek-harness-integration.md
@@ -17,8 +17,10 @@ barrier that prevents a first prompt from racing asynchronous MCP discovery.
 1. starts a dedicated DSH JSON-RPC child process through the published
    `@deepseek-ai/dsh-sdk-client` transport;
 2. starts a loopback-only HTTP bridge protected by a random bearer token;
-3. exposes only that turn's HomeRail DAG tools through a temporary stdio MCP
-   proxy, under DSH names such as `mcp__homerail__handoff`;
+3. exposes that turn's HomeRail DAG tools and, when the DAG explicitly requests
+   them, HomeRail-managed `Read`, `Grep`, `Glob`, and `LS` implementations
+   through a temporary stdio MCP proxy, under DSH names such as
+   `mcp__homerail__handoff`;
 4. maps DSH text, reasoning, tool, usage, and turn events back to HomeRail; and
 5. closes the child, bridge, temporary proxy, and session directory when the
    turn ends.
@@ -26,9 +28,12 @@ barrier that prevents a first prompt from racing asynchronous MCP discovery.
 The child receives the same sanitized environment used by other agent
 backends. Manager/Worker control-plane tokens are removed, the external model
 credential is supplied only to DSH, and bridge credentials are scoped to the
-turn. The DSH composition mounts no shell, filesystem, Skill, runtime-context,
-or job tools. Claude, Codex, and Kimi adapters keep their existing registry
-entries and code paths.
+turn. The DSH composition itself mounts no shell, filesystem, Skill,
+runtime-context, or job tools. Read-only filesystem calls are implemented by
+the Worker bridge, confined to the DAG's declared `workspace_access` roots,
+bounded for input/output size and call count, and protected against traversal
+and symlink escapes. Claude, Codex, and Kimi adapters keep their existing
+registry entries and code paths.
 
 ## Runtime packaging and source checkout setup
 
@@ -89,9 +94,10 @@ interrupts do not require Claude-specific protocol emulation.
 - The standard UI and onboarding flow do not yet offer DSH as a polished
   selection; the protocol, runtime resolver, CLI doctor, and Worker backend are
   present for manual/WIP use.
-- HomeRail rejects exact `allowed_builtin_tools` assertions for DSH. The WIP
-  composition instead disables all DSH built-ins and exposes only HomeRail MCP
-  tools.
+- DSH accepts exact `allowed_builtin_tools` only for `Read`, `Grep`, `Glob`, and
+  `LS`. Shell and mutation tools remain unsupported and fail closed. These
+  four names are HomeRail-managed MCP implementations, not DSH-native
+  filesystem plugins.
 - DSH is not yet a complete Claude Code replacement in HomeRail: persistent
   sessions, full Manager Agent product integration, image-size optimization,
   and longer live reliability runs remain follow-up work.
@@ -99,7 +105,8 @@ interrupts do not require Claude-specific protocol emulation.
 ## Validation
 
 The adapter unit tests cover event mapping, sanitized child environments,
-live steering, and cooperative cancellation. A keyless integration smoke uses
+workspace-confined read/search tools, tool budgets, live steering, and
+cooperative cancellation. A keyless integration smoke uses
 the actual fork runtime and MCP client with a local OpenAI-compatible SSE
 server. It verifies that the first model request contains
 `mcp__homerail__handoff`, DSH invokes the HomeRail handler with structured

--- a/docs/architecture/deepseek-harness-integration.md
+++ b/docs/architecture/deepseek-harness-integration.md
@@ -109,6 +109,14 @@ interrupts do not require Claude-specific protocol emulation.
   `LS`. Shell and mutation tools remain unsupported and fail closed. These
   four names are HomeRail-managed MCP implementations, not DSH-native
   filesystem plugins.
+- HomeRail passes the runtime profile's DSH reasoning effort through to the
+  fork. Other DSH callers retain the fork's `high` default; the local-Qwen PR
+  Review profile defaults to `medium` so three concurrent reviewers do not
+  repeatedly fill their histories with `xhigh` reasoning.
+- DSH-managed read/search tools have an adapter-local default budget of 24
+  calls when the workflow does not provide an explicit budget. The
+  handoff tool is outside that budget, so exhaustion tells the model to stop
+  inspecting and submit its result. Other harness adapters are unchanged.
 - DSH is not yet a complete Claude Code replacement in HomeRail: persistent
   sessions, full Manager Agent product integration, image-size optimization,
   and longer live reliability runs remain follow-up work.

--- a/docs/architecture/deepseek-harness-integration.md
+++ b/docs/architecture/deepseek-harness-integration.md
@@ -148,3 +148,23 @@ results appended after each exact cached prefix, or private session tails
 evicted under concurrent KV pressure. No DSH compaction plugin was mounted and
 the transcripts contained no compaction event. The observed prefill was normal
 multi-turn reconstruction and cache eviction, not conversation compression.
+
+The follow-up `medium` diagnostic
+([Actions](https://github.com/xiaotianfotos/homerail/actions/runs/32030182632),
+HomeRail run `1ee15bc9-db13-47ca-8d71-c55dda6a9dea`) completed successfully in
+about 47 minutes 35 seconds with a 9/9 scorecard. All three reviewers produced
+accepted approve votes, attested 33/33-file coverage, retained no findings, and
+used no correction or automatic handoff fallback. Their final cumulative DSH
+usage was about 5.54 million input tokens and 133,526 output tokens across 66
+tool calls. The first two reviewers finished in about 23 and 24 minutes after
+17 and 21 built-in calls, respectively. The slow reviewer took about 47
+minutes, emitted 72,938 output tokens, attempted 25 built-in calls, received
+one denial from the run's experimental 24-call limit, and then handed off.
+
+This proved that the DSH tool and handoff path can complete a real review, but
+also that the local Qwen3.8 27B FP8 configuration is not yet practical for an
+unattended three-reviewer DAG: `medium` reasoning still allowed multi-minute
+6,000--17,000-token model rounds. The final integration does not keep that
+experiment as an adapter default. A call limit is enforced only when the
+workflow explicitly requests one; model-specific late convergence is not
+converted into a global DSH policy.

--- a/docs/architecture/deepseek-harness-integration.md
+++ b/docs/architecture/deepseek-harness-integration.md
@@ -1,12 +1,13 @@
 # DeepSeek Harness integration (WIP)
 
 Status: experimental Draft integration, validated against fork commit
-`ec75587a05bf0cc3f29dd0d5f875d3235f7deae6` on 2026-08-17.
+`554b7b931a503f8af98614dc8002862f13eb9298` on 2026-08-19. That commit
+merges the current official `master` into the HomeRail integration branch.
 
 HomeRail uses the owner-maintained
 [`xiaotianfotos/deepseek-harness`](https://github.com/xiaotianfotos/deepseek-harness)
-fork. The integration branch is `agent/homerail-sdk-control`; its base is a
-shallow clone of the official repository. The fork carries the HomeRail
+fork. The integration branch is `agent/homerail-sdk-control` and tracks the
+official repository through explicit merge commits. The fork carries the HomeRail
 composition, SDK steering and cancellation requests, and an initialization
 barrier that prevents a first prompt from racing asynchronous MCP discovery.
 
@@ -30,11 +31,22 @@ default, leaving room in large context windows for the prompt and accumulated
 tool transcript. Operators can set `HOMERAIL_DSH_MAX_TOKENS` to another
 positive integer when a model requires a tighter limit.
 
-The HomeRail Cordis composition reads `DSH_REASONING_EFFORT`, using `high` when
-the caller does not select an effort. The pinned fork's native
-chat-completions adapter passes `low`, `medium`, `high`, `xhigh`, and `max`
-through unchanged; `off` disables thinking. This lets a runtime profile tune
-the local Qwen endpoint without changing the official DeepSeek default.
+The HomeRail Cordis composition mounts DSH's configurable `llm-pi-ai` adapter.
+For each turn the Worker builds a provider route from the selected HomeRail
+model setting, including its provider id, model id, Chat Completions URL, and
+credential reference. It does not route arbitrary OpenAI-compatible models
+through the native official-DeepSeek adapter.
+
+Reasoning is a model-owned capability. A setting may declare
+`reasoning_effort_map`, whose keys are the DSH/pi-ai selector ids that this
+specific model offers and whose values are the spellings sent to its provider.
+For example, `{ "off": null, "medium": "balanced", "high": "deep" }`
+offers three choices while translating two of them to gateway-specific wire
+values. `false` explicitly declares no selectable reasoning; omission leaves
+the provider in control. `default_reasoning_effort` is optional and must name
+a key in the same map. HomeRail has no global DSH effort list and supplies no
+implicit `medium` or `high` default. A DAG profile may select only a level
+declared by every model setting it assigns.
 
 The child receives the same sanitized environment used by other agent
 backends. Manager/Worker control-plane tokens are removed, the external model
@@ -109,10 +121,10 @@ interrupts do not require Claude-specific protocol emulation.
   `LS`. Shell and mutation tools remain unsupported and fail closed. These
   four names are HomeRail-managed MCP implementations, not DSH-native
   filesystem plugins.
-- HomeRail passes the runtime profile's DSH reasoning effort through to the
-  fork. Other DSH callers retain the fork's `high` default; the local-Qwen PR
-  Review profile defaults to `medium` so three concurrent reviewers do not
-  repeatedly fill their histories with `xhigh` reasoning.
+- A model setting must declare `reasoning_effort_map` before a DAG can select a
+  reasoning level. Settings without that capability use the provider's own
+  default. This is intentional: HomeRail does not infer one provider's
+  reasoning vocabulary from Codex or from another model.
 - DSH-managed read/search tools enforce a call budget only when the workflow
   explicitly sets `max_builtin_tool_calls`. HomeRail does not impose a DSH
   default merely to compensate for one model's late handoff behavior. The
@@ -149,7 +161,8 @@ evicted under concurrent KV pressure. No DSH compaction plugin was mounted and
 the transcripts contained no compaction event. The observed prefill was normal
 multi-turn reconstruction and cache eviction, not conversation compression.
 
-The follow-up `medium` diagnostic
+The follow-up diagnostic explicitly selected `medium` in that historical
+runtime profile
 ([Actions](https://github.com/xiaotianfotos/homerail/actions/runs/32030182632),
 HomeRail run `1ee15bc9-db13-47ca-8d71-c55dda6a9dea`) completed successfully in
 about 47 minutes 35 seconds with a 9/9 scorecard. All three reviewers produced

--- a/docs/architecture/deepseek-harness-integration.md
+++ b/docs/architecture/deepseek-harness-integration.md
@@ -1,8 +1,8 @@
 # DeepSeek Harness integration (WIP)
 
 Status: experimental Draft integration, validated against fork commit
-`dc04fa3dbdcedc512322fff199b5cfef9169ea21` on 2026-08-21. That commit
-merges official `dsh-v0.1.0-rc.8` (`141eb6fef83422698aef7a981029e843e8161534`)
+`f4fd5f005636cdcbf9d95f70f04d05afa8c0db54` on 2026-08-23. That commit
+merges official `dsh-v0.1.1-rc.2` (`b150a551b8d465e31e418e1b2eaf5e79bbb7d28e`)
 into the HomeRail integration branch.
 
 HomeRail uses the owner-maintained

--- a/docs/architecture/deepseek-harness-integration.md
+++ b/docs/architecture/deepseek-harness-integration.md
@@ -1,15 +1,17 @@
 # DeepSeek Harness integration (WIP)
 
 Status: experimental Draft integration, validated against fork commit
-`554b7b931a503f8af98614dc8002862f13eb9298` on 2026-08-19. That commit
-merges the current official `master` into the HomeRail integration branch.
+`dc04fa3dbdcedc512322fff199b5cfef9169ea21` on 2026-08-21. That commit
+merges official `dsh-v0.1.0-rc.8` (`141eb6fef83422698aef7a981029e843e8161534`)
+into the HomeRail integration branch.
 
 HomeRail uses the owner-maintained
 [`xiaotianfotos/deepseek-harness`](https://github.com/xiaotianfotos/deepseek-harness)
 fork. The integration branch is `agent/homerail-sdk-control` and tracks the
 official repository through explicit merge commits. The fork carries the HomeRail
 composition, SDK steering and cancellation requests, and an initialization
-barrier that prevents a first prompt from racing asynchronous MCP discovery.
+contract compatible with the official runtime-readiness barrier, which prevents
+a first prompt from racing asynchronous MCP discovery.
 
 ## Runtime boundary
 

--- a/docs/architecture/deepseek-harness-integration.md
+++ b/docs/architecture/deepseek-harness-integration.md
@@ -43,8 +43,11 @@ turn. The DSH composition itself mounts no shell, filesystem, Skill,
 runtime-context, or job tools. Read-only filesystem calls are implemented by
 the Worker bridge, confined to the DAG's declared `workspace_access` roots,
 bounded for input/output size, optionally bounded by an explicit workflow call
-limit, and protected against traversal and symlink escapes. Claude, Codex, and
-Kimi adapters keep their existing registry entries and code paths.
+limit, and protected against traversal and symlink escapes. Glob matching uses
+a non-regex bounded matcher; model-supplied Grep regular expressions execute in
+a disposable Worker thread with a two-second timeout so they cannot block the
+HomeRail Worker event loop. Claude, Codex, and Kimi adapters keep their existing
+registry entries and code paths.
 
 ## Runtime packaging and source checkout setup
 

--- a/docs/architecture/deepseek-harness-integration.md
+++ b/docs/architecture/deepseek-harness-integration.md
@@ -1,7 +1,7 @@
 # DeepSeek Harness integration (WIP)
 
 Status: experimental Draft integration, validated against fork commit
-`559cd23cc2f1b96da2fde230064da2dc3781b126` on 2026-08-17.
+`ec75587a05bf0cc3f29dd0d5f875d3235f7deae6` on 2026-08-17.
 
 HomeRail uses the owner-maintained
 [`xiaotianfotos/deepseek-harness`](https://github.com/xiaotianfotos/deepseek-harness)
@@ -29,6 +29,12 @@ Each DSH conversation-model request is capped at 32,768 output tokens by
 default, leaving room in large context windows for the prompt and accumulated
 tool transcript. Operators can set `HOMERAIL_DSH_MAX_TOKENS` to another
 positive integer when a model requires a tighter limit.
+
+The HomeRail Cordis composition selects reasoning effort `xhigh`. The pinned
+fork's native chat-completions adapter passes `low`, `medium`, `high`, `xhigh`,
+and `max` through unchanged, while preserving DSH's `high` default when a
+composition does not choose an effort. This lets the local Qwen endpoint use
+its declared vocabulary without changing the official DeepSeek default.
 
 The child receives the same sanitized environment used by other agent
 backends. Manager/Worker control-plane tokens are removed, the external model

--- a/docs/architecture/deepseek-harness-integration.md
+++ b/docs/architecture/deepseek-harness-integration.md
@@ -30,11 +30,11 @@ default, leaving room in large context windows for the prompt and accumulated
 tool transcript. Operators can set `HOMERAIL_DSH_MAX_TOKENS` to another
 positive integer when a model requires a tighter limit.
 
-The HomeRail Cordis composition selects reasoning effort `xhigh`. The pinned
-fork's native chat-completions adapter passes `low`, `medium`, `high`, `xhigh`,
-and `max` through unchanged, while preserving DSH's `high` default when a
-composition does not choose an effort. This lets the local Qwen endpoint use
-its declared vocabulary without changing the official DeepSeek default.
+The HomeRail Cordis composition reads `DSH_REASONING_EFFORT`, using `high` when
+the caller does not select an effort. The pinned fork's native
+chat-completions adapter passes `low`, `medium`, `high`, `xhigh`, and `max`
+through unchanged; `off` disables thinking. This lets a runtime profile tune
+the local Qwen endpoint without changing the official DeepSeek default.
 
 The child receives the same sanitized environment used by other agent
 backends. Manager/Worker control-plane tokens are removed, the external model
@@ -42,9 +42,9 @@ credential is supplied only to DSH, and bridge credentials are scoped to the
 turn. The DSH composition itself mounts no shell, filesystem, Skill,
 runtime-context, or job tools. Read-only filesystem calls are implemented by
 the Worker bridge, confined to the DAG's declared `workspace_access` roots,
-bounded for input/output size and call count, and protected against traversal
-and symlink escapes. Claude, Codex, and Kimi adapters keep their existing
-registry entries and code paths.
+bounded for input/output size, optionally bounded by an explicit workflow call
+limit, and protected against traversal and symlink escapes. Claude, Codex, and
+Kimi adapters keep their existing registry entries and code paths.
 
 ## Runtime packaging and source checkout setup
 
@@ -113,10 +113,10 @@ interrupts do not require Claude-specific protocol emulation.
   fork. Other DSH callers retain the fork's `high` default; the local-Qwen PR
   Review profile defaults to `medium` so three concurrent reviewers do not
   repeatedly fill their histories with `xhigh` reasoning.
-- DSH-managed read/search tools have an adapter-local default budget of 24
-  calls when the workflow does not provide an explicit budget. The
-  handoff tool is outside that budget, so exhaustion tells the model to stop
-  inspecting and submit its result. Other harness adapters are unchanged.
+- DSH-managed read/search tools enforce a call budget only when the workflow
+  explicitly sets `max_builtin_tool_calls`. HomeRail does not impose a DSH
+  default merely to compensate for one model's late handoff behavior. The
+  handoff tool remains outside any explicitly selected read/search budget.
 - DSH is not yet a complete Claude Code replacement in HomeRail: persistent
   sessions, full Manager Agent product integration, image-size optimization,
   and longer live reliability runs remain follow-up work.
@@ -130,3 +130,21 @@ the actual fork runtime and MCP client with a local OpenAI-compatible SSE
 server. It verifies that the first model request contains
 `mcp__homerail__handoff`, DSH invokes the HomeRail handler with structured
 arguments, and a second model request completes with mapped text and usage.
+
+The 2026-08-17 FP8 live test used the existing three-reviewer PR Review DAG,
+three independent DSH processes, and the same local Qwen3.8 27B model setting
+for all historical reviewer labels. The unbounded `xhigh` run
+([Actions](https://github.com/xiaotianfotos/homerail/actions/runs/32023994801),
+HomeRail run `d40c93aa-d9ff-4b57-a97c-e1c98c8d3e14`) reached the stable
+runner's 70-minute limit. One reviewer completed through a correction turn;
+the other two were still inspecting after 32 and 37 tool calls. The model
+service reported no request errors, but the three long contexts drove KV use
+to 93--99.7 percent and caused 18 preemptions.
+
+That run processed about 8.16 million prompt tokens: about 4.96 million were
+local prefix-cache hits and 3.20 million were recomputed. Cache therefore
+worked, but it could not accelerate roughly 166,000 generated tokens, new tool
+results appended after each exact cached prefix, or private session tails
+evicted under concurrent KV pressure. No DSH compaction plugin was mounted and
+the transcripts contained no compaction event. The observed prefill was normal
+multi-turn reconstruction and cache eviction, not conversation compression.

--- a/docs/architecture/deepseek-harness-integration.md
+++ b/docs/architecture/deepseek-harness-integration.md
@@ -1,0 +1,106 @@
+# DeepSeek Harness integration (WIP)
+
+Status: experimental Draft integration, validated against fork commit
+`559cd23cc2f1b96da2fde230064da2dc3781b126` on 2026-08-17.
+
+HomeRail uses the owner-maintained
+[`xiaotianfotos/deepseek-harness`](https://github.com/xiaotianfotos/deepseek-harness)
+fork. The integration branch is `agent/homerail-sdk-control`; its base is a
+shallow clone of the official repository. The fork carries the HomeRail
+composition, SDK steering and cancellation requests, and an initialization
+barrier that prevents a first prompt from racing asynchronous MCP discovery.
+
+## Runtime boundary
+
+`deepseek_harness` is an independent Worker backend. For each HomeRail turn it:
+
+1. starts a dedicated DSH JSON-RPC child process through the published
+   `@deepseek-ai/dsh-sdk-client` transport;
+2. starts a loopback-only HTTP bridge protected by a random bearer token;
+3. exposes only that turn's HomeRail DAG tools through a temporary stdio MCP
+   proxy, under DSH names such as `mcp__homerail__handoff`;
+4. maps DSH text, reasoning, tool, usage, and turn events back to HomeRail; and
+5. closes the child, bridge, temporary proxy, and session directory when the
+   turn ends.
+
+The child receives the same sanitized environment used by other agent
+backends. Manager/Worker control-plane tokens are removed, the external model
+credential is supplied only to DSH, and bridge credentials are scoped to the
+turn. The DSH composition mounts no shell, filesystem, Skill, runtime-context,
+or job tools. Claude, Codex, and Kimi adapters keep their existing registry
+entries and code paths.
+
+## Runtime packaging and source checkout setup
+
+The standard Worker image builds the pinned fork in an isolated Docker stage,
+materializes its symlink-free Node deploy closure, and copies only that closure
+into `/opt/deepseek-harness-runtime`. It also sets the runtime command,
+arguments, and HomeRail Cordis config in the image, so ordinary DAG containers
+need no DSH-specific host setup. Changing the fork revision is an intentional
+Dockerfile change and therefore changes the Worker source fingerprint.
+
+For host-shell Manager Agent development, build the same pinned fork checkout:
+
+```bash
+git clone --depth 1 --branch agent/homerail-sdk-control \
+  https://github.com/xiaotianfotos/deepseek-harness.git
+cd deepseek-harness
+corepack pnpm install --frozen-lockfile
+corepack pnpm run build:lib:host
+corepack pnpm exec tsx scripts/build-exe-for-python-sdk.ts --skip-build --node-only
+```
+
+Point the Worker at the fork's generic runtime and HomeRail composition. Values
+must be absolute paths; runtime arguments are a JSON string array.
+
+```bash
+export HOMERAIL_DSH_RUNTIME_COMMAND=/usr/bin/node
+export HOMERAIL_DSH_RUNTIME_ARGS='["/absolute/path/deepseek-harness/python/sdk-runtime/src/deepseek_harness_runtime/runtime/node/node_modules/@deepseek-ai/dsh-sdk-jsonrpc-demo/lib/packaged-bin.js"]'
+export HOMERAIL_DSH_CORDIS_CONFIG=/absolute/path/homerail/homerail_worker/dsh/homerail.cordis.yml
+```
+
+Select `deepseek_harness` (aliases `dsh`, `deepseek`, and `deepseek-harness`
+are accepted) and an active HomeRail model setting whose protocol is
+`openai_compatible`. Both Manager Agent host-shell placement and DAG container
+placement resolve through the same runtime contract. A missing fork runtime,
+invalid runtime-argument JSON, or non-OpenAI-compatible endpoint fails instead
+of falling back to another harness.
+
+## Control protocol
+
+The adapter uses ordinary `initialize`, `session/prompt`, and session event
+notifications from the released TypeScript SDK. It subscribes before sending
+the prompt, then binds HomeRail's turn controller as soon as the prompt receipt
+arrives, so queued steering and cancellation do not race the first model step.
+The fork extends the generic JSON-RPC client with two independent requests:
+
+- `session/steer` queues a user message for the nearest later agent step and
+  returns its durable `messageId`;
+- `session/cancel` requests cooperative cancellation of a running session and
+  returns whether it was accepted.
+
+HomeRail binds these requests to its turn controller, so live steering and
+interrupts do not require Claude-specific protocol emulation.
+
+## Current limitations
+
+- The adapter deliberately starts one DSH process per turn. Persistent DSH
+  session resume and reuse across turns are not implemented.
+- The standard UI and onboarding flow do not yet offer DSH as a polished
+  selection; the protocol, runtime resolver, CLI doctor, and Worker backend are
+  present for manual/WIP use.
+- HomeRail rejects exact `allowed_builtin_tools` assertions for DSH. The WIP
+  composition instead disables all DSH built-ins and exposes only HomeRail MCP
+  tools.
+- DSH is not yet a complete Claude Code replacement in HomeRail: persistent
+  sessions, full Manager Agent product integration, image-size optimization,
+  and longer live reliability runs remain follow-up work.
+
+## Validation
+
+The adapter unit tests cover event mapping, sanitized child environments,
+live steering, and cooperative cancellation. A keyless integration smoke uses
+the actual fork runtime and MCP client with a local OpenAI-compatible SSE
+server. It verifies that the first model request contains
+`mcp__homerail__handoff`, DSH invokes the HomeRail handler with structured
+arguments, and a second model request completes with mapped text and usage.

--- a/docs/architecture/deepseek-harness-integration.md
+++ b/docs/architecture/deepseek-harness-integration.md
@@ -25,6 +25,11 @@ barrier that prevents a first prompt from racing asynchronous MCP discovery.
 5. closes the child, bridge, temporary proxy, and session directory when the
    turn ends.
 
+Each DSH conversation-model request is capped at 32,768 output tokens by
+default, leaving room in large context windows for the prompt and accumulated
+tool transcript. Operators can set `HOMERAIL_DSH_MAX_TOKENS` to another
+positive integer when a model requires a tighter limit.
+
 The child receives the same sanitized environment used by other agent
 backends. Manager/Worker control-plane tokens are removed, the external model
 credential is supplied only to DSH, and bridge credentials are scoped to the

--- a/docs/dag-patterns.md
+++ b/docs/dag-patterns.md
@@ -157,8 +157,11 @@ allowlists for backend-provided shell/file tools and HomeRail DAG tools.
 Omitting either field preserves that tool set's default; `[]` disables it.
 Agent nodes with outputs must retain `handoff`. Contract-correction turns always
 override both declarations to expose only `handoff` and no built-ins. The
-`claude-sdk` adapter enforces the built-in allowlist; backends that cannot
-enforce it reject the node instead of silently widening access.
+`claude-sdk` adapter enforces the full built-in allowlist. `deepseek_harness`
+enforces the read-only subset (`Read`, `Grep`, `Glob`, `LS`) through bounded
+HomeRail MCP handlers confined by `workspace_access`; it rejects shell or
+mutation tools. Other backends that cannot enforce an asserted allowlist reject
+the node instead of silently widening access.
 
 Manager-to-Node and Manager-to-Worker WebSocket upgrades are authenticated
 before registration. Connections without configured credentials are restricted

--- a/docs/scenarios/pr-review.md
+++ b/docs/scenarios/pr-review.md
@@ -117,7 +117,8 @@ review after evaluating that boundary.
 Manual dispatch may also select one Manager LLM setting and
 `deepseek_harness` for all three reviewer slots. This creates three independent
 DSH processes and votes while intentionally sharing the same model setting; it
-does not overwrite the normal mixed-model profile.
+uses the separate `pr-review-dsh` profile by default and cannot overwrite the
+normal mixed-model profile.
 
 PR Review jobs require a dedicated self-hosted runner with the
 `homerail-pr-review` label. Live catalog validation continues to use the

--- a/docs/scenarios/pr-review.md
+++ b/docs/scenarios/pr-review.md
@@ -45,11 +45,13 @@ metadata.
    security, compatibility, tests, and user-visible behavior, then casts one
    `approve` or `request_changes` vote. The trusted checkout is
    mounted read-only. Reviewers that need repository evidence receive only the
-   SDK's read-only `Read`, `Grep`, `Glob`, and `LS` tools, so they can inspect
+   read-only `Read`, `Grep`, `Glob`, and `LS` tools, so they can inspect
    complete files, trace callers, and search tests without granting untrusted PR
-   content a shell or write primitive. A Worker pre-tool hook resolves real paths
-   and denies omitted paths, traversal, absolute paths outside the declared
-   workspace roots, and symlink escapes before a read/search tool executes.
+   content a shell or write primitive. The selected backend either applies a
+   Worker pre-tool hook or uses the HomeRail-managed DSH MCP implementations;
+   both resolve real paths and deny omitted paths, traversal, absolute paths
+   outside the declared workspace roots, and symlink escapes before a
+   read/search tool executes.
    The supplied patch is an index rather than the sole evidence source, and
    prompts require every diff chunk to be read while keeping follow-up
    inspection proportional. Model-specific output contracts reject a mislabeled
@@ -74,7 +76,8 @@ metadata.
 
 - `pr-review.json`
 - `pr-review.md`
-- three normalized reviews and votes from distinct models
+- three normalized independent reviews and votes (model settings are selected
+  by the private Runtime Profile)
 - deterministic approval-threshold and finding-veto payload
 - Manager audit summary and per-node metrics
 - HomeRail run id and replayable event history
@@ -111,6 +114,11 @@ created by the trusted maintainer. This avoids running untrusted fork content on
 the `.112` runner. Maintainers can use `workflow_dispatch` for an explicit
 review after evaluating that boundary.
 
+Manual dispatch may also select one Manager LLM setting and
+`deepseek_harness` for all three reviewer slots. This creates three independent
+DSH processes and votes while intentionally sharing the same model setting; it
+does not overwrite the normal mixed-model profile.
+
 PR Review jobs require a dedicated self-hosted runner with the
 `homerail-pr-review` label. Live catalog validation continues to use the
 `homerail-live` label and may start a current-commit transient runtime because it
@@ -131,8 +139,10 @@ Runner repository configuration:
 - `HOMERAIL_PR_REVIEW_ARBITER_MODEL`: a distinct active setting selected from
   the same database and drives the second review;
 - `HOMERAIL_PR_REVIEW_THIRD_MODEL`: a third distinct active setting that drives
-  the final review vote. All three settings must expose Anthropic-compatible
-  endpoints because these DAG workers use the Claude Agent SDK harness.
+  the final review vote. The normal mixed profile requires all three settings
+  to expose Anthropic-compatible endpoints because it uses the Claude Agent SDK
+  harness. An explicit DSH dispatch instead requires one OpenAI-compatible
+  Chat Completions setting.
 
 The production profile binds `qwen_reviewer` to the released `qwen3.8-max`
 Aliyun Token Plan setting, `kimi_reviewer` to K3, and `glm_reviewer` to

--- a/docs/worker-build-network.md
+++ b/docs/worker-build-network.md
@@ -2,16 +2,17 @@
 
 HomeRail builds exactly one canonical Worker image from
 `homerail_worker/Dockerfile`. By default the build uses the Debian
-repositories shipped with the base image and npm's default registry; no
-package-source build arguments are added. Operators whose networks cannot
+repositories shipped with the base image, npm's default registry, and the
+pinned DeepSeek Harness repository on GitHub. Operators whose networks cannot
 reach those public endpoints can opt in to validated public mirrors through
-three environment variables:
+four environment variables:
 
 | Variable | Effect |
 | --- | --- |
 | `HOMERAIL_WORKER_BUILD_APT_MIRROR` | Replaces the Debian main repository URL in non-security deb822 stanzas. |
 | `HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR` | Replaces the Debian security repository URL in security deb822 stanzas. |
-| `HOMERAIL_WORKER_BUILD_NPM_REGISTRY` | Maps to the Docker `NPM_CONFIG_REGISTRY` build argument observed by every npm operation during the image build. It is build-only and is never persisted as a runtime environment variable. |
+| `HOMERAIL_WORKER_BUILD_NPM_REGISTRY` | Maps to the Docker `NPM_CONFIG_REGISTRY` build argument observed by every npm/pnpm operation and to `COREPACK_NPM_REGISTRY` while Corepack resolves pnpm. It is build-only and is never persisted as a runtime environment variable. |
+| `HOMERAIL_WORKER_BUILD_DSH_GIT_REMOTE` | Maps to the Docker `HOMERAIL_DSH_FORK_REPOSITORY` build argument used to fetch the immutable DSH fork commit, allowing an internal read-only Git mirror instead of GitHub. |
 
 The two APT overrides are independent: each one rewrites only its matching
 deb822 stanzas, and either can be used alone.
@@ -71,6 +72,7 @@ summary with modes, never URLs:
 - `apt_main`: `default` or `custom`
 - `apt_security`: `default` or `custom`
 - `npm`: `default` or `custom`
+- `dsh_git`: `default` or `custom`
 - `proxy`: `environment` or `docker-managed`
 
 No source or proxy URL appears in status, task artifacts, or HomeRail-authored

--- a/homerail_cli/src/commands/doctor.ts
+++ b/homerail_cli/src/commands/doctor.ts
@@ -51,6 +51,8 @@ interface LlmSettingSummary {
   endpointName?: unknown;
   base_url?: unknown;
   baseUrl?: unknown;
+  chat_completions_base_url?: unknown;
+  chatCompletionsBaseUrl?: unknown;
   anthropic_base_url?: unknown;
   anthropicBaseUrl?: unknown;
   is_active?: unknown;
@@ -142,6 +144,13 @@ function anthropicCompatibleBaseUrl(setting: LlmSettingSummary): string {
 
 function modelRuntimeBaseUrl(setting: LlmSettingSummary): string {
   return stringValue(setting.base_url ?? setting.baseUrl);
+}
+
+function deepSeekHarnessBaseUrl(setting: LlmSettingSummary): string {
+  if (stringValue(setting.protocol) !== "openai_compatible") return "";
+  return stringValue(
+    setting.chat_completions_base_url ?? setting.chatCompletionsBaseUrl ?? setting.base_url ?? setting.baseUrl,
+  );
 }
 
 function isKimiCodeCompatibleSetting(setting: LlmSettingSummary): boolean {
@@ -265,6 +274,9 @@ export function managerAgentReadiness(
   } else if (harness === "kimi_code") {
     const compatible = settings.filter((setting) => KIMI_PROVIDER_IDS.has(providerId(setting)));
     selected = compatible.find(isDefaultSetting) ?? compatible[0];
+  } else if (harness === "deepseek_harness") {
+    const compatible = settings.filter((setting) => Boolean(deepSeekHarnessBaseUrl(setting)));
+    selected = compatible.find(isDefaultSetting) ?? compatible[0];
   } else {
     const compatible = settings.filter((setting) => Boolean(anthropicCompatibleBaseUrl(setting)));
     selected = compatible.find(isDefaultSetting) ?? compatible[0];
@@ -276,6 +288,8 @@ export function managerAgentReadiness(
       ok: false,
       detail: harness === "kimi_code"
         ? "run: hr model configure or hr llm-settings add with an active Kimi setting"
+        : harness === "deepseek_harness"
+        ? "run: hr model configure or hr llm-settings add with an OpenAI-compatible endpoint"
         : "run: hr model configure or hr llm-settings add with an Anthropic-compatible endpoint",
     };
   }
@@ -295,6 +309,16 @@ export function managerAgentReadiness(
       };
     }
     return { name: "manager-agent", ok: true, detail: `${settingLabel(selected)} via kimi_code` };
+  }
+  if (harness === "deepseek_harness") {
+    if (!deepSeekHarnessBaseUrl(selected)) {
+      return {
+        name: "manager-agent",
+        ok: false,
+        detail: `${settingLabel(selected)} is not OpenAI-compatible for deepseek_harness`,
+      };
+    }
+    return { name: "manager-agent", ok: true, detail: `${settingLabel(selected)} via deepseek_harness` };
   }
   if (!anthropicCompatibleBaseUrl(selected)) {
     return {

--- a/homerail_cli/tests/doctor.test.ts
+++ b/homerail_cli/tests/doctor.test.ts
@@ -169,6 +169,50 @@ describe("doctor readiness helpers", () => {
     });
   });
 
+  it("accepts an OpenAI-compatible setting for DeepSeek Harness", () => {
+    const resp = settings([
+      {
+        id: "deepseek-chat",
+        provider_id: "deepseek",
+        model_name: "deepseek-chat",
+        is_active: true,
+        is_default: true,
+        supports_llm: true,
+        protocol: "openai_compatible",
+        chat_completions_base_url: "https://api.deepseek.com/v1",
+      },
+    ]);
+
+    expect(managerAgentReadiness({ harness: "dsh" }, resp)).toEqual({
+      name: "manager-agent",
+      ok: true,
+      detail: "deepseek/deepseek-chat via deepseek_harness",
+    });
+  });
+
+  it("rejects an explicitly selected non-OpenAI setting for DeepSeek Harness", () => {
+    const resp = settings([
+      {
+        id: "anthropic-only",
+        provider_id: "custom",
+        model_name: "claude-compatible",
+        is_active: true,
+        supports_llm: true,
+        protocol: "anthropic_compatible",
+        base_url: "https://example.invalid/anthropic",
+      },
+    ]);
+
+    expect(managerAgentReadiness({
+      harness: "deepseek_harness",
+      llm_setting_id: "anthropic-only",
+    }, resp)).toEqual({
+      name: "manager-agent",
+      ok: false,
+      detail: "custom/claude-compatible is not OpenAI-compatible for deepseek_harness",
+    });
+  });
+
   it("reports Docker CLI absence for Docker-backed DAG readiness", () => {
     const checks = dockerReadiness(runnerFor([
       { status: null, error: Object.assign(new Error("spawn docker ENOENT"), { code: "ENOENT" }) },

--- a/homerail_manager/src/orchestration/graph.ts
+++ b/homerail_manager/src/orchestration/graph.ts
@@ -21,6 +21,7 @@ export interface DAGAgentConfig {
     protocol?: string;
     anthropic_auth_mode?: "api_key" | "auth_token";
     reasoning_effort?: string;
+    reasoning_effort_map?: Record<string, string | null> | false;
     service_tier?: string | null;
   };
   model?: string;

--- a/homerail_manager/src/persistence/llm-settings.ts
+++ b/homerail_manager/src/persistence/llm-settings.ts
@@ -1511,6 +1511,26 @@ export function findActiveCodexCompatibleSetting(): LLMSetting | undefined {
     })[0];
 }
 
+export function resolveDeepSeekHarnessBaseUrlForSetting(setting: LLMSetting): string | undefined {
+  if (setting.protocol !== "openai_compatible") return undefined;
+  return setting.chat_completions_base_url ?? setting.base_url;
+}
+
+export function findActiveDeepSeekHarnessCompatibleSetting(): LLMSetting | undefined {
+  return _readSettings()
+    .filter((setting) => (
+      setting.is_active &&
+      setting.preset_status !== "missing" &&
+      setting.supports_llm &&
+      !isVoiceServiceSetting(setting) &&
+      Boolean(resolveDeepSeekHarnessBaseUrlForSetting(setting))
+    ))
+    .sort((left, right) => {
+      if (left.is_default !== right.is_default) return left.is_default ? -1 : 1;
+      return right.updated_at.localeCompare(left.updated_at);
+    })[0];
+}
+
 export function findActiveLlmRuntimeSetting(): LLMSetting | undefined {
   return _readSettings()
     .filter((s) => s.is_active && s.preset_status !== "missing" && s.supports_llm && !isVoiceServiceSetting(s))

--- a/homerail_manager/src/persistence/llm-settings.ts
+++ b/homerail_manager/src/persistence/llm-settings.ts
@@ -21,19 +21,23 @@ import {
   type LLMAuthType,
   type LLMPlanType,
   type LLMProtocol,
+  type ModelReasoningCapabilities,
   type ModelCapabilities,
   type ProviderEndpointPreset,
   type AnthropicAuthMode,
   type ProviderModelPreset,
+  type ReasoningEffortMap,
 } from "./provider-catalog.js";
 
 export type {
   LLMAuthType,
   LLMPlanType,
   LLMProtocol,
+  ModelReasoningCapabilities,
   ModelCapabilities,
   ProviderEndpointPreset,
   ProviderModelPreset,
+  ReasoningEffortMap,
 } from "./provider-catalog.js";
 
 export interface ProviderInfo extends ModelCapabilities {
@@ -72,7 +76,7 @@ export interface ProviderInput extends ModelCapabilities {
   asr_async_url?: string;
 }
 
-export interface LLMSettingInput extends ModelCapabilities {
+export interface LLMSettingInput extends ModelCapabilities, ModelReasoningCapabilities {
   provider_id: string;
   model_name: string;
   /** 该凭证可用的模型列表（多模型凭证）。若提供，model_name 取第一个作为主模型。 */
@@ -105,7 +109,7 @@ export interface LLMSettingInput extends ModelCapabilities {
   is_default?: boolean;
 }
 
-export interface LLMSetting extends Required<ModelCapabilities> {
+export interface LLMSetting extends Required<ModelCapabilities>, ModelReasoningCapabilities {
   id: string;
   provider_id: string;
   model_name: string;
@@ -415,6 +419,31 @@ function _capability(
   if (typeof endpointValue === "boolean") return endpointValue;
   if (typeof providerValue === "boolean") return providerValue;
   return fallback;
+}
+
+function _reasoningEffortMap(value: unknown): ReasoningEffortMap | false | undefined {
+  if (value === false) return false;
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
+  const normalized: ReasoningEffortMap = {};
+  for (const [rawSelector, rawWireValue] of Object.entries(value)) {
+    const selector = rawSelector.trim();
+    if (!selector || (rawWireValue !== null && (typeof rawWireValue !== "string" || !rawWireValue.trim()))) {
+      return undefined;
+    }
+    normalized[selector] = typeof rawWireValue === "string" ? rawWireValue.trim() : null;
+  }
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+function _reasoningDefault(
+  value: unknown,
+  effortMap: ReasoningEffortMap | false | undefined,
+): string | undefined {
+  const selected = typeof value === "string" && value.trim() ? value.trim() : undefined;
+  return selected && effortMap !== undefined && effortMap !== false
+      && Object.prototype.hasOwnProperty.call(effortMap, selected)
+    ? selected
+    : undefined;
 }
 
 function _normalizeProvider(raw: unknown): ProviderInfo | undefined {
@@ -896,6 +925,12 @@ function _resolveEffectiveSetting(raw: unknown): { setting?: LLMSetting; needsSe
       (rec.models as string[]).map((item) => canonicalModelNameForEndpoint(providerId, resolvedEndpointId, item)),
     ))
     : [modelName];
+  const reasoningEffortMap = _reasoningEffortMap(rec.reasoning_effort_map)
+    ?? modelPreset?.reasoning_effort_map;
+  const defaultReasoningEffort = _reasoningDefault(
+    rec.default_reasoning_effort ?? modelPreset?.default_reasoning_effort,
+    reasoningEffortMap,
+  );
 
   const setting: LLMSetting = {
     id: rec.id,
@@ -982,6 +1017,8 @@ function _resolveEffectiveSetting(raw: unknown): { setting?: LLMSetting; needsSe
       provider?.supports_video_input,
       false,
     ),
+    reasoning_effort_map: reasoningEffortMap,
+    default_reasoning_effort: defaultReasoningEffort,
     created_at: typeof rec.created_at === "string" ? rec.created_at : new Date().toISOString(),
     updated_at: typeof rec.updated_at === "string" ? rec.updated_at : new Date().toISOString(),
     preset_source: endpointResolution.source,
@@ -1105,6 +1142,8 @@ function _storedSetting(setting: LLMSetting): StoredLLMSetting {
     tts_voice: setting.tts_voice,
     tts_format: setting.tts_format,
     tts_sample_rate: setting.tts_sample_rate,
+    reasoning_effort_map: setting.reasoning_effort_map,
+    default_reasoning_effort: setting.default_reasoning_effort,
     is_active: setting.is_active,
     is_default: setting.is_default,
     created_at: setting.created_at,
@@ -1601,7 +1640,7 @@ function _resolveSettingMetadata(
   existing?: LLMSetting,
 ): {
   endpoint?: ProviderEndpointPreset;
-  modelCapabilities?: ModelCapabilities;
+  modelCapabilities?: ProviderModelPreset;
   endpoint_id: string;
   endpoint_name?: string;
   plan_type: LLMPlanType;
@@ -1710,6 +1749,24 @@ function _buildSetting(
   const displayName = input.display_name?.trim() || input.alias?.trim() ||
     (existing && existing.model_name === input.model_name ? existing.display_name : undefined) ||
     input.model_name;
+  const explicitReasoningEffortMap = _reasoningEffortMap(input.reasoning_effort_map);
+  if (input.reasoning_effort_map !== undefined && explicitReasoningEffortMap === undefined) {
+    throw new Error("reasoning_effort_map must be false or a non-empty selector-to-wire-value object");
+  }
+  const reasoningEffortMap = input.reasoning_effort_map !== undefined
+    ? explicitReasoningEffortMap
+    : modelPreset?.reasoning_effort_map ?? existing?.reasoning_effort_map;
+  const requestedDefaultReasoningEffort = reasoningEffortMap === false
+    ? undefined
+    : input.default_reasoning_effort?.trim()
+      || modelPreset?.default_reasoning_effort
+      || existing?.default_reasoning_effort;
+  const defaultReasoningEffort = _reasoningDefault(requestedDefaultReasoningEffort, reasoningEffortMap);
+  if (requestedDefaultReasoningEffort && !defaultReasoningEffort) {
+    throw new Error(
+      `default_reasoning_effort '${requestedDefaultReasoningEffort}' is not declared by reasoning_effort_map`,
+    );
+  }
   const builtinPreset = Boolean(
     endpoint && findCatalogProvider(input.provider_id) && _isReadonlyEndpoint(input.provider_id, endpoint.id),
   );
@@ -1756,6 +1813,8 @@ function _buildSetting(
       provider.supports_image_input ?? existing?.supports_image_input ?? false,
     supports_video_input: input.supports_video_input ?? modelPreset?.supports_video_input ?? endpoint?.supports_video_input ??
       provider.supports_video_input ?? existing?.supports_video_input ?? false,
+    reasoning_effort_map: reasoningEffortMap,
+    default_reasoning_effort: defaultReasoningEffort,
     created_at: existing?.created_at ?? now,
     updated_at: now,
     preset_source: builtinPreset ? "builtin" : "custom",

--- a/homerail_manager/src/persistence/manager-agent-config.ts
+++ b/homerail_manager/src/persistence/manager-agent-config.ts
@@ -58,8 +58,13 @@ function _string(value: unknown): string | null {
   return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
-function _reasoningEffort(value: unknown): ManagerAgentConfig["reasoning_effort"] {
-  return _string(value) ?? DEFAULT_MANAGER_AGENT_CONFIG.reasoning_effort;
+function _reasoningEffort(
+  value: unknown,
+  harness: ManagerAgentHarness,
+): ManagerAgentConfig["reasoning_effort"] {
+  return _string(value) ?? (harness === "deepseek_harness"
+    ? ""
+    : DEFAULT_MANAGER_AGENT_CONFIG.reasoning_effort);
 }
 
 function _serviceTier(value: unknown): ManagerAgentConfig["service_tier"] {
@@ -85,7 +90,7 @@ function _normalize(raw?: Record<string, unknown> | null): ManagerAgentConfig {
     llm_setting_id: _string(base.llm_setting_id),
     provider_name: _string(base.provider_name),
     model_name: _string(base.model_name),
-    reasoning_effort: _reasoningEffort(base.reasoning_effort),
+    reasoning_effort: _reasoningEffort(base.reasoning_effort, harness),
     service_tier: _serviceTier(base.service_tier),
     generative_ui_mode: parseGenerativeUiMode(base.generative_ui_mode),
     system_prompt: typeof base.system_prompt === "string" ? base.system_prompt : "",

--- a/homerail_manager/src/persistence/provider-catalog.ts
+++ b/homerail_manager/src/persistence/provider-catalog.ts
@@ -12,7 +12,17 @@ export interface ModelCapabilities {
   supports_video_input?: boolean;
 }
 
-export interface ProviderModelPreset extends ModelCapabilities {
+/** Model-owned reasoning selectors mapped to their provider wire values. */
+export type ReasoningEffortMap = Record<string, string | null>;
+
+export interface ModelReasoningCapabilities {
+  /** False declares no selectable reasoning; omission leaves support unknown. */
+  reasoning_effort_map?: ReasoningEffortMap | false;
+  /** Optional selector used when a caller does not choose one. */
+  default_reasoning_effort?: string;
+}
+
+export interface ProviderModelPreset extends ModelCapabilities, ModelReasoningCapabilities {
   id: string;
   name?: string;
   display_name?: string;

--- a/homerail_manager/src/runtime/active-runs.ts
+++ b/homerail_manager/src/runtime/active-runs.ts
@@ -5871,6 +5871,7 @@ function _withDispatchCredentials(agentConfig: DAGAgentConfig): DispatchCredenti
           protocol: resolved.protocol,
           anthropic_auth_mode: resolved.anthropic_auth_mode,
           reasoning_effort: resolved.reasoning_effort,
+          reasoning_effort_map: resolved.reasoning_effort_map,
           service_tier: resolved.service_tier,
         },
       },

--- a/homerail_manager/src/runtime/agent-runtime-resolver.ts
+++ b/homerail_manager/src/runtime/agent-runtime-resolver.ts
@@ -38,6 +38,8 @@ import {
 
 export type AgentRuntimeSurface = "manager_agent" | "dag";
 
+const DSH_REASONING_EFFORTS = new Set(["off", "low", "medium", "high", "xhigh", "max"]);
+
 export interface AgentRuntimeResolutionInput {
   surface: AgentRuntimeSurface;
   providerName?: string;
@@ -244,6 +246,14 @@ export function resolveAgentRuntimeConfig(input: AgentRuntimeResolutionInput): A
     if (serviceTier && supportedTiers && !supportedTiers.includes(serviceTier)) {
       throw new Error(
         `Codex Responses model '${setting.provider_id}/${model}' does not support service tier '${serviceTier}'.`,
+      );
+    }
+  } else if (agentType === "deepseek_harness") {
+    reasoningEffort = input.reasoningEffort?.trim() || undefined;
+    if (reasoningEffort && !DSH_REASONING_EFFORTS.has(reasoningEffort)) {
+      throw new Error(
+        `DeepSeek Harness does not support reasoning effort '${reasoningEffort}'. `
+        + `Supported values: ${[...DSH_REASONING_EFFORTS].join(", ")}.`,
       );
     }
   }

--- a/homerail_manager/src/runtime/agent-runtime-resolver.ts
+++ b/homerail_manager/src/runtime/agent-runtime-resolver.ts
@@ -1,5 +1,6 @@
 import {
   findActiveCodexCompatibleSetting,
+  findActiveDeepSeekHarnessCompatibleSetting,
   findActiveClaudeSdkCompatibleSetting,
   findActiveLlmRuntimeSetting,
   findActiveSetting,
@@ -7,6 +8,7 @@ import {
   getSetting,
   isVoiceServiceSetting,
   resolveCodexResponsesBaseUrlForSetting,
+  resolveDeepSeekHarnessBaseUrlForSetting,
   resolveClaudeSdkBaseUrlForSetting,
   resolveClaudeSdkAuthModeForSetting,
   type LLMSetting,
@@ -127,6 +129,8 @@ function settingForInput(input: AgentRuntimeResolutionInput): LLMSetting {
     ? findActiveKimiSetting(input.modelName)
     : requested === "codex_appserver"
     ? findActiveCodexCompatibleSetting()
+    : requested === "deepseek_harness"
+    ? findActiveDeepSeekHarnessCompatibleSetting()
     : input.surface === "manager_agent" || requested === "claude-sdk"
     ? findActiveClaudeSdkCompatibleSetting()
     : input.surface === "dag"
@@ -165,6 +169,9 @@ function baseUrlForSetting(setting: LLMSetting, agentType: string): string | und
   if (agentType === "claude-sdk") return resolveClaudeSdkBaseUrlForSetting(setting);
   if (agentType === "codex_appserver") return resolveCodexResponsesBaseUrlForSetting(setting);
   if (agentType === "kimi_code") return setting.base_url ?? setting.chat_completions_base_url;
+  if (agentType === "deepseek_harness") {
+    return resolveDeepSeekHarnessBaseUrlForSetting(setting);
+  }
   return setting.base_url ?? setting.chat_completions_base_url;
 }
 
@@ -196,6 +203,9 @@ export function resolveAgentRuntimeConfig(input: AgentRuntimeResolutionInput): A
 
   const setting = settingForInput(input);
   const agentType = agentTypeForSetting(setting, input);
+  if (agentType === "deepseek_harness" && setting.protocol !== "openai_compatible") {
+    throw new Error(`DeepSeek Harness requires an OpenAI-compatible setting, got ${setting.provider_id}/${setting.model_name} (${setting.protocol})`);
+  }
   const baseUrl = baseUrlForSetting(setting, agentType);
   const requestedModel = input.modelName
     ? canonicalModelNameForEndpoint(setting.provider_id, setting.endpoint_id, input.modelName)

--- a/homerail_manager/src/runtime/agent-runtime-resolver.ts
+++ b/homerail_manager/src/runtime/agent-runtime-resolver.ts
@@ -12,6 +12,7 @@ import {
   resolveClaudeSdkBaseUrlForSetting,
   resolveClaudeSdkAuthModeForSetting,
   type LLMSetting,
+  type ReasoningEffortMap,
 } from "../persistence/llm-settings.js";
 import {
   canonicalModelNameForEndpoint,
@@ -38,8 +39,6 @@ import {
 
 export type AgentRuntimeSurface = "manager_agent" | "dag";
 
-const DSH_REASONING_EFFORTS = new Set(["off", "low", "medium", "high", "xhigh", "max"]);
-
 export interface AgentRuntimeResolutionInput {
   surface: AgentRuntimeSurface;
   providerName?: string;
@@ -64,6 +63,7 @@ export interface AgentRuntimeResolution {
   runtime_placement: ManagerAgentRuntimePlacementValue;
   llm_setting_id?: string;
   reasoning_effort?: string;
+  reasoning_effort_map?: ReasoningEffortMap | false;
   service_tier?: string | null;
 }
 
@@ -217,6 +217,12 @@ export function resolveAgentRuntimeConfig(input: AgentRuntimeResolutionInput): A
     findCatalogEndpoint(setting.provider_id, setting.endpoint_id),
     model,
   );
+  const reasoningEffortMap = model === setting.model_name
+    ? setting.reasoning_effort_map
+    : catalogModel?.reasoning_effort_map;
+  const defaultReasoningEffort = model === setting.model_name
+    ? setting.default_reasoning_effort
+    : catalogModel?.default_reasoning_effort;
   if (agentType === "codex_appserver" && codexResponsesModelSupport(setting.provider_id, model) === "unsupported") {
     throw new Error(`Codex app-server Responses is not supported for ${setting.provider_id}/${model}`);
   }
@@ -249,11 +255,17 @@ export function resolveAgentRuntimeConfig(input: AgentRuntimeResolutionInput): A
       );
     }
   } else if (agentType === "deepseek_harness") {
-    reasoningEffort = input.reasoningEffort?.trim() || undefined;
-    if (reasoningEffort && !DSH_REASONING_EFFORTS.has(reasoningEffort)) {
+    reasoningEffort = input.reasoningEffort?.trim() || defaultReasoningEffort;
+    if (reasoningEffort && (reasoningEffortMap === undefined || reasoningEffortMap === false)) {
       throw new Error(
-        `DeepSeek Harness does not support reasoning effort '${reasoningEffort}'. `
-        + `Supported values: ${[...DSH_REASONING_EFFORTS].join(", ")}.`,
+        `DeepSeek Harness model '${setting.provider_id}/${model}' does not declare selectable reasoning efforts.`,
+      );
+    }
+    if (reasoningEffort && reasoningEffortMap !== undefined && reasoningEffortMap !== false
+      && !Object.prototype.hasOwnProperty.call(reasoningEffortMap, reasoningEffort)) {
+      throw new Error(
+        `DeepSeek Harness model '${setting.provider_id}/${model}' does not support reasoning effort '${reasoningEffort}'. `
+        + `Supported values: ${Object.keys(reasoningEffortMap).join(", ")}.`,
       );
     }
   }
@@ -278,6 +290,9 @@ export function resolveAgentRuntimeConfig(input: AgentRuntimeResolutionInput): A
     runtime_placement: runtimePlacementForAgentType(agentType, input.surface),
     llm_setting_id: setting.id,
     ...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
+    ...(agentType === "deepseek_harness" && reasoningEffortMap !== undefined
+      ? { reasoning_effort_map: reasoningEffortMap }
+      : {}),
     ...(serviceTier !== undefined ? { service_tier: serviceTier } : {}),
   };
 }

--- a/homerail_manager/src/server/dag-environment.ts
+++ b/homerail_manager/src/server/dag-environment.ts
@@ -856,7 +856,8 @@ export class DagEnvironmentController {
         ...initialBuild.logs,
         `Worker build network: apt_main=${networkSummary.apt_main}`
           + ` apt_security=${networkSummary.apt_security}`
-          + ` npm=${networkSummary.npm} proxy=${networkSummary.proxy}`,
+          + ` npm=${networkSummary.npm} dsh_git=${networkSummary.dsh_git}`
+          + ` proxy=${networkSummary.proxy}`,
         "Checking Docker before build…",
       ],
     };

--- a/homerail_manager/src/server/dag-environment.ts
+++ b/homerail_manager/src/server/dag-environment.ts
@@ -33,6 +33,7 @@ const SOURCE_INPUTS = [
   "homerail_worker/package.json",
   "homerail_worker/package-lock.json",
   "homerail_worker/tsconfig.json",
+  "homerail_worker/dsh",
   "homerail_worker/src",
   "homerail_protocol/package.json",
   "homerail_protocol/package-lock.json",

--- a/homerail_manager/src/server/llm-settings.ts
+++ b/homerail_manager/src/server/llm-settings.ts
@@ -362,6 +362,33 @@ function _voiceAdapter(value: unknown): ProviderInput["voice_adapter"] {
     : undefined;
 }
 
+function _reasoningEffortMap(value: unknown): Record<string, string | null> | false | undefined {
+  if (value === false) return false;
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
+  const entries = Object.entries(value);
+  if (entries.length === 0) return undefined;
+  const normalized: Record<string, string | null> = {};
+  for (const [rawSelector, rawWireValue] of entries) {
+    const selector = rawSelector.trim();
+    if (!selector || (rawWireValue !== null && (typeof rawWireValue !== "string" || !rawWireValue.trim()))) {
+      return undefined;
+    }
+    normalized[selector] = typeof rawWireValue === "string" ? rawWireValue.trim() : null;
+  }
+  return normalized;
+}
+
+function _reasoningEffortMapField(
+  body: Record<string, unknown>,
+): Record<string, string | null> | false | undefined {
+  if (!Object.prototype.hasOwnProperty.call(body, "reasoning_effort_map")) return undefined;
+  const parsed = _reasoningEffortMap(body.reasoning_effort_map);
+  if (parsed === undefined) {
+    throw new Error("reasoning_effort_map must be false or a non-empty selector-to-wire-value object");
+  }
+  return parsed;
+}
+
 function _providerBody(body: Record<string, unknown>, idOverride?: string): ProviderInput {
   return {
     id: idOverride ?? _requiredString(body, "id") ?? "",
@@ -429,6 +456,8 @@ function _settingCreateBody(b: Record<string, unknown>) {
     supports_audio_input: typeof b.supports_audio_input === "boolean" ? b.supports_audio_input : undefined,
     supports_image_input: typeof b.supports_image_input === "boolean" ? b.supports_image_input : undefined,
     supports_video_input: typeof b.supports_video_input === "boolean" ? b.supports_video_input : undefined,
+    reasoning_effort_map: _reasoningEffortMapField(b),
+    default_reasoning_effort: _requiredString(b, "default_reasoning_effort"),
   };
 }
 
@@ -793,6 +822,12 @@ export function llmSettingsRoutesHandler(
         if (typeof b.supports_audio_input === "boolean") patch.supports_audio_input = b.supports_audio_input;
         if (typeof b.supports_image_input === "boolean") patch.supports_image_input = b.supports_image_input;
         if (typeof b.supports_video_input === "boolean") patch.supports_video_input = b.supports_video_input;
+        if (Object.prototype.hasOwnProperty.call(b, "reasoning_effort_map")) {
+          patch.reasoning_effort_map = _reasoningEffortMapField(b);
+        }
+        if (typeof b.default_reasoning_effort === "string") {
+          patch.default_reasoning_effort = b.default_reasoning_effort.trim();
+        }
 
         try {
           const updated = updateSetting(id, patch);

--- a/homerail_manager/src/server/manager-agent-config.ts
+++ b/homerail_manager/src/server/manager-agent-config.ts
@@ -122,6 +122,10 @@ function patchedConfig(patch: Record<string, unknown>): ManagerAgentConfig {
   const providerName = _string(patch.provider_name);
   const modelName = _string(patch.model_name);
   const reasoningEffort = _string(patch.reasoning_effort);
+  const hasReasoningEffortPatch = Object.prototype.hasOwnProperty.call(patch, "reasoning_effort");
+  const explicitReasoningEffort = hasReasoningEffortPatch
+    ? reasoningEffort ?? ""
+    : undefined;
   const serviceTier = _string(patch.service_tier);
   const generativeUiMode = patch.generative_ui_mode === undefined
     ? current.generative_ui_mode
@@ -147,7 +151,7 @@ function patchedConfig(patch: Record<string, unknown>): ManagerAgentConfig {
   const mergedSettingId = settingId === undefined ? current.llm_setting_id : settingId;
   const mergedProviderName = providerName === undefined ? current.provider_name : providerName;
   const mergedModelName = modelName === undefined ? current.model_name : modelName;
-  const mergedReasoningEffort = reasoningEffort ?? current.reasoning_effort;
+  const mergedReasoningEffort = explicitReasoningEffort ?? current.reasoning_effort;
   const mergedServiceTier = serviceTier === undefined
     ? current.service_tier
     : normalizedServiceTier(serviceTier);
@@ -178,11 +182,20 @@ function patchedConfig(patch: Record<string, unknown>): ManagerAgentConfig {
       llm_setting_id: preferredSetting?.id ?? (useAutomaticProvider || useExplicitSubscriptionModel ? null : mergedSettingId),
       provider_name: preferredSetting?.provider_id ?? (useAutomaticProvider || useExplicitSubscriptionModel ? null : mergedProviderName),
       model_name: preferredSetting?.model_name ?? (useAutomaticProvider && modelName === undefined ? null : mergedModelName),
-      reasoning_effort: reasoningEffort ?? selectedProviderDefault ?? mergedReasoningEffort,
+      reasoning_effort: explicitReasoningEffort ?? selectedProviderDefault ?? mergedReasoningEffort,
       service_tier: mergedServiceTier,
       generative_ui_mode: generativeUiMode,
     };
   }
+  const dshRuntimeSelectionChanged = harness === "deepseek_harness" && (
+    current.harness !== "deepseek_harness"
+    || settingId !== undefined
+    || providerName !== undefined
+    || modelName !== undefined
+  );
+  const dshSetting = harness === "deepseek_harness" && typeof mergedSettingId === "string"
+    ? getSetting(mergedSettingId)
+    : undefined;
   return {
     ...current,
     harness,
@@ -191,7 +204,8 @@ function patchedConfig(patch: Record<string, unknown>): ManagerAgentConfig {
     llm_setting_id: mergedSettingId,
     provider_name: mergedProviderName,
     model_name: mergedModelName,
-    reasoning_effort: mergedReasoningEffort,
+    reasoning_effort: explicitReasoningEffort
+      ?? (dshRuntimeSelectionChanged ? dshSetting?.default_reasoning_effort ?? "" : mergedReasoningEffort),
     service_tier: mergedServiceTier,
     generative_ui_mode: generativeUiMode,
   };

--- a/homerail_manager/src/server/manager-agent-config.ts
+++ b/homerail_manager/src/server/manager-agent-config.ts
@@ -122,15 +122,15 @@ function patchedConfig(patch: Record<string, unknown>): ManagerAgentConfig {
   const providerName = _string(patch.provider_name);
   const modelName = _string(patch.model_name);
   const reasoningEffort = _string(patch.reasoning_effort);
+  const harness = normalizeManagerAgentHarness(patch.harness) ?? current.harness;
   const hasReasoningEffortPatch = Object.prototype.hasOwnProperty.call(patch, "reasoning_effort");
   const explicitReasoningEffort = hasReasoningEffortPatch
-    ? reasoningEffort ?? ""
+    ? reasoningEffort ?? (harness === "deepseek_harness" ? "" : undefined)
     : undefined;
   const serviceTier = _string(patch.service_tier);
   const generativeUiMode = patch.generative_ui_mode === undefined
     ? current.generative_ui_mode
     : parseGenerativeUiMode(patch.generative_ui_mode);
-  const harness = normalizeManagerAgentHarness(patch.harness) ?? current.harness;
   if (patch.live_voice_enabled !== undefined && typeof patch.live_voice_enabled !== "boolean") {
     throw new Error("live_voice_enabled must be a boolean");
   }

--- a/homerail_manager/src/server/manager-agent-runtime-config.ts
+++ b/homerail_manager/src/server/manager-agent-runtime-config.ts
@@ -8,6 +8,7 @@ import {
   type ManagerAgentReasoningEffort,
   type ManagerAgentServiceTier,
 } from "homerail-protocol";
+import type { ReasoningEffortMap } from "../persistence/llm-settings.js";
 
 export type ManagerAgentHostRuntimePlacement = "host" | "host_shell";
 
@@ -24,6 +25,7 @@ export interface ManagerAgentRuntimeConfig {
   project_id?: string;
   project_workspace?: string;
   reasoning_effort?: ManagerAgentReasoningEffort;
+  reasoning_effort_map?: ReasoningEffortMap | false;
   service_tier: ManagerAgentServiceTier;
 }
 
@@ -73,7 +75,8 @@ export function resolveManagerAgentConfig(
     runtime_placement: resolved.runtime_placement,
     project_id: projectId,
     project_workspace: resolveProjectWorkspace(projectId),
-    reasoning_effort: resolved.reasoning_effort ?? effort ?? "low",
+    reasoning_effort: resolved.reasoning_effort ?? effort,
+    reasoning_effort_map: resolved.reasoning_effort_map,
     service_tier: resolved.service_tier ?? normalizedServiceTier,
   };
 }

--- a/homerail_manager/src/server/worker-build-network.ts
+++ b/homerail_manager/src/server/worker-build-network.ts
@@ -58,7 +58,7 @@ export class WorkerBuildNetworkError extends Error {
 }
 
 const NON_PRINTABLE_OR_NON_ASCII_SOURCE_CHARACTERS = /[^\u0021-\u007e]/;
-const URL_REWRITE_SOURCE_CHARACTERS = /["%<>`^{}|\\]/;
+const URL_REWRITE_SOURCE_CHARACTERS = /["$()%<>`^{}|\\]/;
 const URL_PATH_BRACKETS = /[\[\]]/;
 const URL_AUTHORITY_USERINFO = /^[a-z][a-z0-9+.-]*:\/\/[^/?#]*@/i;
 
@@ -82,7 +82,7 @@ function resolveSourceUrl(envKey: string, raw: string | undefined): string | und
   if (URL_REWRITE_SOURCE_CHARACTERS.test(trimmed)) {
     throw new WorkerBuildNetworkError(
       envKey,
-      "value must not contain characters that require URL encoding.",
+      "value must not contain unsupported URL characters.",
     );
   }
   // Check raw authority text as WHATWG parsing drops an empty userinfo marker

--- a/homerail_manager/src/server/worker-build-network.ts
+++ b/homerail_manager/src/server/worker-build-network.ts
@@ -1,10 +1,12 @@
 export const WORKER_BUILD_APT_MIRROR_ENV_KEY = "HOMERAIL_WORKER_BUILD_APT_MIRROR";
 export const WORKER_BUILD_APT_SECURITY_MIRROR_ENV_KEY = "HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR";
 export const WORKER_BUILD_NPM_REGISTRY_ENV_KEY = "HOMERAIL_WORKER_BUILD_NPM_REGISTRY";
+export const WORKER_BUILD_DSH_GIT_REMOTE_ENV_KEY = "HOMERAIL_WORKER_BUILD_DSH_GIT_REMOTE";
 
 export const WORKER_BUILD_APT_MIRROR_BUILD_ARG = "HOMERAIL_WORKER_BUILD_APT_MIRROR";
 export const WORKER_BUILD_APT_SECURITY_MIRROR_BUILD_ARG = "HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR";
 export const WORKER_BUILD_NPM_REGISTRY_BUILD_ARG = "NPM_CONFIG_REGISTRY";
+export const WORKER_BUILD_DSH_GIT_REMOTE_BUILD_ARG = "HOMERAIL_DSH_FORK_REPOSITORY";
 
 // Uppercase and lowercase spellings are recognized; values are never read
 // beyond an emptiness check and stay solely in the Docker child environment.
@@ -24,6 +26,7 @@ export interface WorkerBuildNetworkSummary {
   apt_main: WorkerBuildNetworkSourceMode;
   apt_security: WorkerBuildNetworkSourceMode;
   npm: WorkerBuildNetworkSourceMode;
+  dsh_git: WorkerBuildNetworkSourceMode;
   proxy: WorkerBuildNetworkProxyMode;
 }
 
@@ -31,6 +34,7 @@ export interface WorkerBuildNetworkConfig {
   aptMirror?: string;
   aptSecurityMirror?: string;
   npmRegistry?: string;
+  dshGitRemote?: string;
   proxyVariableNames: string[];
 }
 
@@ -38,6 +42,7 @@ export const DEFAULT_WORKER_BUILD_NETWORK_SUMMARY: WorkerBuildNetworkSummary = {
   apt_main: "default",
   apt_security: "default",
   npm: "default",
+  dsh_git: "default",
   proxy: "docker-managed",
 };
 
@@ -133,6 +138,10 @@ export function resolveWorkerBuildNetwork(
       env[WORKER_BUILD_APT_SECURITY_MIRROR_ENV_KEY],
     ),
     npmRegistry: resolveSourceUrl(WORKER_BUILD_NPM_REGISTRY_ENV_KEY, env[WORKER_BUILD_NPM_REGISTRY_ENV_KEY]),
+    dshGitRemote: resolveSourceUrl(
+      WORKER_BUILD_DSH_GIT_REMOTE_ENV_KEY,
+      env[WORKER_BUILD_DSH_GIT_REMOTE_ENV_KEY],
+    ),
     proxyVariableNames: resolveProxyVariableNames(env),
   };
 }
@@ -148,6 +157,9 @@ export function workerBuildNetworkDockerArgs(config: WorkerBuildNetworkConfig): 
   if (config.npmRegistry) {
     args.push("--build-arg", `${WORKER_BUILD_NPM_REGISTRY_BUILD_ARG}=${config.npmRegistry}`);
   }
+  if (config.dshGitRemote) {
+    args.push("--build-arg", `${WORKER_BUILD_DSH_GIT_REMOTE_BUILD_ARG}=${config.dshGitRemote}`);
+  }
   // Value-less entries let Docker resolve the value from the child
   // environment; HomeRail never places proxy values in argv.
   for (const name of config.proxyVariableNames) {
@@ -161,6 +173,7 @@ export function workerBuildNetworkSummary(config: WorkerBuildNetworkConfig): Wor
     apt_main: config.aptMirror ? "custom" : "default",
     apt_security: config.aptSecurityMirror ? "custom" : "default",
     npm: config.npmRegistry ? "custom" : "default",
+    dsh_git: config.dshGitRemote ? "custom" : "default",
     proxy: config.proxyVariableNames.length > 0 ? "environment" : "docker-managed",
   };
 }
@@ -174,6 +187,7 @@ export function normalizeWorkerBuildNetworkSummary(
     apt_main: record.apt_main === "custom" ? "custom" : "default",
     apt_security: record.apt_security === "custom" ? "custom" : "default",
     npm: record.npm === "custom" ? "custom" : "default",
+    dsh_git: record.dsh_git === "custom" ? "custom" : "default",
     proxy: record.proxy === "environment" ? "environment" : "docker-managed",
   };
 }

--- a/homerail_manager/tests/agent-runtime-resolver.test.ts
+++ b/homerail_manager/tests/agent-runtime-resolver.test.ts
@@ -503,6 +503,73 @@ describe("agent runtime resolver", () => {
     }).runtime_placement).toBe("container");
   });
 
+  it("resolves DeepSeek Harness against OpenAI-compatible settings on both surfaces", () => {
+    upsertProvider({
+      id: "dsh-provider",
+      name: "DSH Provider",
+      default_model: "dsh-model",
+      base_url: "https://dsh.example/v1",
+      chat_completions_base_url: "https://dsh.example/v1",
+    });
+    const setting = createSetting({
+      provider_id: "dsh-provider",
+      model_name: "dsh-model",
+      api_key: "dsh-secret",
+      protocol: "openai_compatible",
+      base_url: "https://dsh.example/v1",
+      chat_completions_base_url: "https://dsh.example/v1",
+      is_active: true,
+      is_default: true,
+    });
+
+    const manager = resolveAgentRuntimeConfig({
+      surface: "manager_agent",
+      settingId: setting.id,
+      harness: "dsh",
+    });
+    const dag = resolveAgentRuntimeConfig({
+      surface: "dag",
+      settingId: setting.id,
+      agentType: "deepseek-harness",
+    });
+
+    expect(manager).toMatchObject({
+      agent_type: "deepseek_harness",
+      protocol: "openai_compatible",
+      base_url: "https://dsh.example/v1",
+      runtime_placement: "host_shell",
+    });
+    expect(dag).toMatchObject({
+      agent_type: "deepseek_harness",
+      protocol: "openai_compatible",
+      base_url: "https://dsh.example/v1",
+      runtime_placement: "container",
+    });
+  });
+
+  it("rejects DeepSeek Harness for non-Chat-Completions settings", () => {
+    upsertProvider({
+      id: "dsh-anthropic-only",
+      default_model: "anthropic-model",
+      anthropic_base_url: "https://dsh.example/anthropic",
+    });
+    const setting = createSetting({
+      provider_id: "dsh-anthropic-only",
+      model_name: "anthropic-model",
+      api_key: "dsh-secret",
+      protocol: "anthropic_compatible",
+      anthropic_base_url: "https://dsh.example/anthropic",
+      is_active: true,
+      is_default: true,
+    });
+
+    expect(() => resolveAgentRuntimeConfig({
+      surface: "manager_agent",
+      settingId: setting.id,
+      harness: "deepseek_harness",
+    })).toThrow(/requires an OpenAI-compatible setting/);
+  });
+
   it("rejects Claude SDK when only a Chat Completions endpoint is configured", () => {
     upsertProvider({
       id: "chat-only-provider",

--- a/homerail_manager/tests/agent-runtime-resolver.test.ts
+++ b/homerail_manager/tests/agent-runtime-resolver.test.ts
@@ -518,6 +518,8 @@ describe("agent runtime resolver", () => {
       protocol: "openai_compatible",
       base_url: "https://dsh.example/v1",
       chat_completions_base_url: "https://dsh.example/v1",
+      reasoning_effort_map: { off: null, medium: "balanced", high: "deep" },
+      default_reasoning_effort: "medium",
       is_active: true,
       is_default: true,
     });
@@ -531,20 +533,23 @@ describe("agent runtime resolver", () => {
       surface: "dag",
       settingId: setting.id,
       agentType: "deepseek-harness",
-      reasoningEffort: "medium",
+      reasoningEffort: "high",
     });
 
     expect(manager).toMatchObject({
       agent_type: "deepseek_harness",
       protocol: "openai_compatible",
       base_url: "https://dsh.example/v1",
+      reasoning_effort: "medium",
+      reasoning_effort_map: { off: null, medium: "balanced", high: "deep" },
       runtime_placement: "host_shell",
     });
     expect(dag).toMatchObject({
       agent_type: "deepseek_harness",
       protocol: "openai_compatible",
       base_url: "https://dsh.example/v1",
-      reasoning_effort: "medium",
+      reasoning_effort: "high",
+      reasoning_effort_map: { off: null, medium: "balanced", high: "deep" },
       runtime_placement: "container",
     });
     expect(() => resolveAgentRuntimeConfig({
@@ -552,7 +557,38 @@ describe("agent runtime resolver", () => {
       settingId: setting.id,
       agentType: "deepseek-harness",
       reasoningEffort: "ultra",
-    })).toThrow(/DeepSeek Harness does not support reasoning effort 'ultra'/);
+    })).toThrow(/does not support reasoning effort 'ultra'/);
+  });
+
+  it("preserves provider defaults when a DSH model declares no selectable reasoning", () => {
+    upsertProvider({
+      id: "dsh-provider-default",
+      default_model: "provider-default-model",
+      base_url: "https://dsh-default.example/v1",
+      chat_completions_base_url: "https://dsh-default.example/v1",
+    });
+    const setting = createSetting({
+      provider_id: "dsh-provider-default",
+      model_name: "provider-default-model",
+      api_key: "dsh-secret",
+      protocol: "openai_compatible",
+      base_url: "https://dsh-default.example/v1",
+      chat_completions_base_url: "https://dsh-default.example/v1",
+      is_active: true,
+      is_default: true,
+    });
+
+    expect(resolveAgentRuntimeConfig({
+      surface: "dag",
+      settingId: setting.id,
+      agentType: "deepseek_harness",
+    })).not.toHaveProperty("reasoning_effort");
+    expect(() => resolveAgentRuntimeConfig({
+      surface: "dag",
+      settingId: setting.id,
+      agentType: "deepseek_harness",
+      reasoningEffort: "medium",
+    })).toThrow(/does not declare selectable reasoning efforts/);
   });
 
   it("rejects DeepSeek Harness for non-Chat-Completions settings", () => {

--- a/homerail_manager/tests/agent-runtime-resolver.test.ts
+++ b/homerail_manager/tests/agent-runtime-resolver.test.ts
@@ -531,6 +531,7 @@ describe("agent runtime resolver", () => {
       surface: "dag",
       settingId: setting.id,
       agentType: "deepseek-harness",
+      reasoningEffort: "medium",
     });
 
     expect(manager).toMatchObject({
@@ -543,8 +544,15 @@ describe("agent runtime resolver", () => {
       agent_type: "deepseek_harness",
       protocol: "openai_compatible",
       base_url: "https://dsh.example/v1",
+      reasoning_effort: "medium",
       runtime_placement: "container",
     });
+    expect(() => resolveAgentRuntimeConfig({
+      surface: "dag",
+      settingId: setting.id,
+      agentType: "deepseek-harness",
+      reasoningEffort: "ultra",
+    })).toThrow(/DeepSeek Harness does not support reasoning effort 'ultra'/);
   });
 
   it("rejects DeepSeek Harness for non-Chat-Completions settings", () => {

--- a/homerail_manager/tests/codex-models.test.ts
+++ b/homerail_manager/tests/codex-models.test.ts
@@ -378,6 +378,53 @@ describe("Codex model catalog", () => {
     });
   });
 
+  it.each([null, ""])(
+    "treats an explicit %j Codex reasoning effort as absent",
+    async (reasoningEffort) => {
+      const catalog: CodexModelCatalog = {
+        binary: "/opt/homebrew/bin/codex",
+        models: [{
+          id: "gpt-5.6-sol",
+          model: "gpt-5.6-sol",
+          display_name: "GPT-5.6-Sol",
+          description: "",
+          is_default: true,
+          default_reasoning_effort: "low",
+          supported_reasoning_efforts: ["low", "high"],
+          service_tiers: [],
+        }],
+      };
+      server = http.createServer((req, res) => {
+        managerAgentConfigRoutesHandler(req, res, { loadCodexModels: async () => catalog });
+      });
+      await new Promise<void>((resolve) => server?.listen(0, "127.0.0.1", () => resolve()));
+      const address = server.address();
+      if (!address || typeof address === "string") throw new Error("Expected TCP server address");
+      const baseUrl = `http://127.0.0.1:${address.port}`;
+
+      const configured = await fetch(`${baseUrl}/api/manager-agent/config`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          harness: "codex_appserver",
+          model_name: "gpt-5.6-sol",
+          reasoning_effort: "high",
+        }),
+      });
+      expect(configured.status).toBe(200);
+
+      const response = await fetch(`${baseUrl}/api/manager-agent/config`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reasoning_effort: reasoningEffort }),
+      });
+      const body = await response.json() as { data?: { reasoning_effort?: string } };
+
+      expect(response.status).toBe(200);
+      expect(body.data?.reasoning_effort).toBe("high");
+    },
+  );
+
   it("rejects an unknown provider setting instead of replacing an active subscription Codex model", async () => {
     const catalog: CodexModelCatalog = {
       binary: "/opt/homebrew/bin/codex",

--- a/homerail_manager/tests/dag-environment.test.ts
+++ b/homerail_manager/tests/dag-environment.test.ts
@@ -1078,6 +1078,7 @@ it("forwards validated build-network sources and proxy names to the Docker build
     env: {
       HOMERAIL_WORKER_BUILD_APT_MIRROR: "https://mirrors.example.com/debian/",
       HOMERAIL_WORKER_BUILD_NPM_REGISTRY: "https://registry.example.com",
+      HOMERAIL_WORKER_BUILD_DSH_GIT_REMOTE: "https://git.example.com/deepseek-harness.git",
       HTTPS_PROXY: "http://proxy.internal:3128",
       http_proxy: "",
     },
@@ -1091,6 +1092,7 @@ it("forwards validated build-network sources and proxy names to the Docker build
   expect(args).toEqual(expect.arrayContaining([
     "--build-arg", "HOMERAIL_WORKER_BUILD_APT_MIRROR=https://mirrors.example.com/debian",
     "--build-arg", "NPM_CONFIG_REGISTRY=https://registry.example.com",
+    "--build-arg", "HOMERAIL_DSH_FORK_REPOSITORY=https://git.example.com/deepseek-harness.git",
     "--build-arg", "HTTPS_PROXY",
   ]));
   // The trailing-slash variant must normalize to the same argument value.
@@ -1114,17 +1116,20 @@ it("forwards validated build-network sources and proxy names to the Docker build
     apt_main: "custom",
     apt_security: "default",
     npm: "custom",
+    dsh_git: "custom",
     proxy: "environment",
   });
   const logs = status.build?.logs.join("\n") ?? "";
-  expect(logs).toContain("Worker build network: apt_main=custom apt_security=default npm=custom proxy=environment");
+  expect(logs).toContain("Worker build network: apt_main=custom apt_security=default npm=custom dsh_git=custom proxy=environment");
   expect(logs).not.toContain("mirrors.example.com");
   expect(logs).not.toContain("registry.example.com");
+  expect(logs).not.toContain("git.example.com");
   expect(logs).not.toContain("proxy.internal");
   const persisted = fs.readFileSync(persistedPath, "utf8");
   expect(persisted).toContain("\"build_network\"");
   expect(persisted).not.toContain("mirrors.example.com");
   expect(persisted).not.toContain("registry.example.com");
+  expect(persisted).not.toContain("git.example.com");
   expect(persisted).not.toContain("proxy.internal");
 });
 
@@ -1150,6 +1155,7 @@ it("keeps default build arguments and docker-managed proxy mode without configur
     "HOMERAIL_WORKER_BUILD_APT_MIRROR",
     "HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR",
     "NPM_CONFIG_REGISTRY",
+    "HOMERAIL_DSH_FORK_REPOSITORY",
     "HTTP_PROXY",
     "http_proxy",
     "HTTPS_PROXY",
@@ -1170,10 +1176,11 @@ it("keeps default build arguments and docker-managed proxy mode without configur
     apt_main: "default",
     apt_security: "default",
     npm: "default",
+    dsh_git: "default",
     proxy: "docker-managed",
   });
   expect(status.build?.logs.join("\n")).toContain(
-    "Worker build network: apt_main=default apt_security=default npm=default proxy=docker-managed",
+    "Worker build network: apt_main=default apt_security=default npm=default dsh_git=default proxy=docker-managed",
   );
 });
 
@@ -1266,6 +1273,7 @@ it("normalizes persisted worker_image status that predates build_network", () =>
     apt_main: "default",
     apt_security: "default",
     npm: "custom",
+    dsh_git: "default",
     proxy: "docker-managed",
   });
 });
@@ -1283,6 +1291,7 @@ it("normalizes malformed persisted build_network values safely", () => {
     apt_main: "weird",
     apt_security: ["custom"],
     npm: 1,
+    dsh_git: ["custom"],
     proxy: "none",
   };
   fs.writeFileSync(persistedPath, JSON.stringify(snapshot), "utf8");
@@ -1297,6 +1306,7 @@ it("normalizes malformed persisted build_network values safely", () => {
     apt_main: "default",
     apt_security: "default",
     npm: "default",
+    dsh_git: "default",
     proxy: "docker-managed",
   });
 });

--- a/homerail_manager/tests/dag-environment.test.ts
+++ b/homerail_manager/tests/dag-environment.test.ts
@@ -68,6 +68,7 @@ function fingerprintFixture(): string {
       },
     }),
     "homerail_worker/tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+    "homerail_worker/dsh/homerail.cordis.yml": "name: homerail-dsh-test\n",
     "homerail_worker/src/index.ts": "export const worker = true;\n",
     "homerail_protocol/package.json": JSON.stringify({
       name: "homerail-protocol",
@@ -257,6 +258,17 @@ it("changes the Worker source fingerprint when build-relevant content changes", 
   fs.appendFileSync(
     path.join(repoRoot, "homerail_worker", "src", "index.ts"),
     "export const changed = true;\n",
+  );
+
+  expect(dagWorkerSourceFingerprint(repoRoot)).not.toBe(original);
+});
+
+it("changes the Worker source fingerprint when the DSH composition changes", () => {
+  const repoRoot = fingerprintFixture();
+  const original = dagWorkerSourceFingerprint(repoRoot);
+  fs.appendFileSync(
+    path.join(repoRoot, "homerail_worker", "dsh", "homerail.cordis.yml"),
+    "changed: true\n",
   );
 
   expect(dagWorkerSourceFingerprint(repoRoot)).not.toBe(original);

--- a/homerail_manager/tests/llm-providers.test.ts
+++ b/homerail_manager/tests/llm-providers.test.ts
@@ -1100,6 +1100,8 @@ describe("custom LLM providers", () => {
       endpoint_id: "aliyun_dashscope_cn_token_plan",
       model_name: "qwen3.8-max",
       api_key: "sk-sp-code-authoritative",
+      reasoning_effort_map: { off: null, medium: "balanced", high: "deep" },
+      default_reasoning_effort: "medium",
       is_active: true,
       is_default: true,
     });
@@ -1128,6 +1130,10 @@ describe("custom LLM providers", () => {
     expect(storedData).not.toHaveProperty("base_url");
     expect(storedData).not.toHaveProperty("protocol");
     expect(storedData).not.toHaveProperty("auth_type");
+    expect(storedData).toMatchObject({
+      reasoning_effort_map: { off: null, medium: "balanced", high: "deep" },
+      default_reasoning_effort: "medium",
+    });
 
     expect(getSetting(setting.id)).toMatchObject({
       endpoint_id: "aliyun_dashscope_cn_token_plan",
@@ -1139,6 +1145,8 @@ describe("custom LLM providers", () => {
       auth_type: "bearer",
       supports_llm: true,
       supports_image_input: false,
+      reasoning_effort_map: { off: null, medium: "balanced", high: "deep" },
+      default_reasoning_effort: "medium",
     });
   });
 
@@ -1186,6 +1194,39 @@ describe("custom LLM providers", () => {
       preset_source: "custom",
       preset_status: "custom",
       base_url: "https://override.example/v1",
+    });
+  });
+
+  it("persists model-owned DSH reasoning capabilities without a global effort list", () => {
+    upsertProvider({
+      id: "reasoning-gateway",
+      name: "Reasoning gateway",
+      default_model: "gateway-model",
+      base_url: "https://reasoning.example/v1",
+      chat_completions_base_url: "https://reasoning.example/v1",
+    });
+    const setting = createSetting({
+      provider_id: "reasoning-gateway",
+      endpoint_id: "reasoning-gateway_custom",
+      model_name: "gateway-model",
+      api_key: "private-key",
+      protocol: "openai_compatible",
+      base_url: "https://reasoning.example/v1",
+      chat_completions_base_url: "https://reasoning.example/v1",
+      reasoning_effort_map: { off: null, medium: "balanced", high: "deep" },
+      default_reasoning_effort: "medium",
+    });
+
+    expect(getSetting(setting.id)).toMatchObject({
+      reasoning_effort_map: { off: null, medium: "balanced", high: "deep" },
+      default_reasoning_effort: "medium",
+    });
+    expect(() => updateSetting(setting.id, {
+      reasoning_effort_map: { off: null, high: "deep" },
+    })).toThrow(/default_reasoning_effort 'medium' is not declared/);
+    expect(updateSetting(setting.id, { reasoning_effort_map: false })).toMatchObject({
+      reasoning_effort_map: false,
+      default_reasoning_effort: undefined,
     });
   });
 

--- a/homerail_manager/tests/manager-chat.test.ts
+++ b/homerail_manager/tests/manager-chat.test.ts
@@ -408,6 +408,92 @@ describe("/api/manager/chat", () => {
     expect(body.data.reasoning_effort).toBe("");
   });
 
+  it.each([null, ""])(
+    "preserves a Claude Manager Agent effort when a patch sends %j",
+    async (reasoningEffort) => {
+      upsertProvider({
+        id: "claude-compatible",
+        name: "Claude compatible",
+        default_model: "claude-compatible-model",
+        base_url: "https://claude.example/v1",
+        anthropic_base_url: "https://claude.example/v1",
+      });
+      const setting = createSetting({
+        provider_id: "claude-compatible",
+        endpoint_id: "claude-compatible_custom",
+        model_name: "claude-compatible-model",
+        api_key: "pk-test-manager-chat",
+        protocol: "anthropic_compatible",
+        base_url: "https://claude.example/v1",
+        anthropic_base_url: "https://claude.example/v1",
+        is_active: true,
+        is_default: true,
+      });
+      const port = await listen(server);
+      const baseUrl = `http://127.0.0.1:${port}`;
+      const configured = await fetch(`${baseUrl}/api/manager-agent/config`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          harness: "claude_agent_sdk",
+          llm_setting_id: setting.id,
+          reasoning_effort: "high",
+        }),
+      });
+      expect(configured.status).toBe(200);
+
+      const response = await fetch(`${baseUrl}/api/manager-agent/config`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reasoning_effort: reasoningEffort }),
+      });
+      const body = await response.json() as { data: { reasoning_effort: string } };
+
+      expect(response.status).toBe(200);
+      expect(body.data.reasoning_effort).toBe("high");
+    },
+  );
+
+  it.each([null, ""])(
+    "clears a DSH Manager Agent effort when a patch sends %j",
+    async (reasoningEffort) => {
+      const setting = createSetting({
+        provider_id: "glm",
+        model_name: "glm-5.3",
+        api_key: "pk-test-manager-chat",
+        protocol: "openai_compatible",
+        base_url: "https://glm.example/v1",
+        chat_completions_base_url: "https://glm.example/v1",
+        reasoning_effort_map: { off: null, deep: "deep" },
+        default_reasoning_effort: "deep",
+        is_active: true,
+        is_default: true,
+      });
+      const port = await listen(server);
+      const baseUrl = `http://127.0.0.1:${port}`;
+      const configured = await fetch(`${baseUrl}/api/manager-agent/config`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          harness: "deepseek_harness",
+          llm_setting_id: setting.id,
+          reasoning_effort: "deep",
+        }),
+      });
+      expect(configured.status).toBe(200);
+
+      const response = await fetch(`${baseUrl}/api/manager-agent/config`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reasoning_effort: reasoningEffort }),
+      });
+      const body = await response.json() as { data: { reasoning_effort: string } };
+
+      expect(response.status).toBe(200);
+      expect(body.data.reasoning_effort).toBe("");
+    },
+  );
+
   it("selects claude-sdk only with an Anthropic-compatible Manager Agent endpoint", () => {
     upsertProvider({
       id: "qwen36",

--- a/homerail_manager/tests/manager-chat.test.ts
+++ b/homerail_manager/tests/manager-chat.test.ts
@@ -320,8 +320,92 @@ describe("/api/manager/chat", () => {
 
   it("keeps runtime placement as the only harness boundary", () => {
     expect(managerAgentRuntimePlacementForHarness("codex_appserver")).toBe("host");
+    expect(managerAgentRuntimePlacementForHarness("deepseek_harness")).toBe("host_shell");
     expect(managerAgentRuntimePlacementForHarness("kimi_code")).toBe("host_shell");
     expect(managerAgentRuntimePlacementForHarness("claude_agent_sdk")).toBe("host_shell");
+  });
+
+  it("preserves provider-owned reasoning defaults for DeepSeek Harness Manager Agent settings", () => {
+    const setting = createSetting({
+      provider_id: "glm",
+      model_name: "glm-5.3",
+      api_key: "pk-test-manager-chat",
+      protocol: "openai_compatible",
+      base_url: "https://glm.example/v1",
+      chat_completions_base_url: "https://glm.example/v1",
+      is_active: true,
+      is_default: true,
+    });
+
+    const config = resolveManagerAgentConfig(
+      undefined,
+      undefined,
+      undefined,
+      setting.id,
+      "deepseek_harness",
+    );
+
+    expect(config).toMatchObject({
+      provider_name: "glm",
+      model: "glm-5.3",
+      protocol: "openai_compatible",
+      agent_type: "deepseek_harness",
+      runtime_placement: "host_shell",
+    });
+    expect(config.reasoning_effort).toBeUndefined();
+    expect(config.reasoning_effort_map).toBeUndefined();
+  });
+
+  it("forwards a declared DeepSeek Harness reasoning selector map", () => {
+    const setting = createSetting({
+      provider_id: "glm",
+      model_name: "glm-5.3",
+      api_key: "pk-test-manager-chat",
+      protocol: "openai_compatible",
+      base_url: "https://glm.example/v1",
+      chat_completions_base_url: "https://glm.example/v1",
+      reasoning_effort_map: { off: null, deep: "deep" },
+      default_reasoning_effort: "deep",
+      is_active: true,
+      is_default: true,
+    });
+
+    const config = resolveManagerAgentConfig(
+      undefined,
+      undefined,
+      undefined,
+      setting.id,
+      "deepseek_harness",
+    );
+
+    expect(config.reasoning_effort).toBe("deep");
+    expect(config.reasoning_effort_map).toEqual({ off: null, deep: "deep" });
+  });
+
+  it("resets a legacy Manager Agent effort when switching to a DSH setting without selectors", async () => {
+    const setting = createSetting({
+      provider_id: "glm",
+      model_name: "glm-5.3",
+      api_key: "pk-test-manager-chat",
+      protocol: "openai_compatible",
+      base_url: "https://glm.example/v1",
+      chat_completions_base_url: "https://glm.example/v1",
+      is_active: true,
+      is_default: true,
+    });
+    const port = await listen(server);
+    const response = await fetch(`http://127.0.0.1:${port}/api/manager-agent/config`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        harness: "deepseek_harness",
+        llm_setting_id: setting.id,
+      }),
+    });
+    const body = await response.json() as { data: { reasoning_effort: string } };
+
+    expect(response.status).toBe(200);
+    expect(body.data.reasoning_effort).toBe("");
   });
 
   it("selects claude-sdk only with an Anthropic-compatible Manager Agent endpoint", () => {

--- a/homerail_manager/tests/worker-build-network.test.ts
+++ b/homerail_manager/tests/worker-build-network.test.ts
@@ -162,6 +162,8 @@ describe("resolveWorkerBuildNetwork", () => {
     "https://mirrors.example.com/deb%ian",
     "https://mirrors.example.com/deb|ian",
     "https://mirrors.example.com/deb^ian",
+    "https://mirrors.example.com/deb$(touch)/ian",
+    "https://mirrors.example.com/deb(ian)",
     "https://mirrors.example.com/deb[ian",
     "https://mirrors.example.com/deb]ian",
   ];

--- a/homerail_manager/tests/worker-build-network.test.ts
+++ b/homerail_manager/tests/worker-build-network.test.ts
@@ -14,6 +14,7 @@ describe("resolveWorkerBuildNetwork", () => {
     expect(config.aptMirror).toBeUndefined();
     expect(config.aptSecurityMirror).toBeUndefined();
     expect(config.npmRegistry).toBeUndefined();
+    expect(config.dshGitRemote).toBeUndefined();
     expect(config.proxyVariableNames).toEqual([]);
     expect(workerBuildNetworkDockerArgs(config)).toEqual([]);
     expect(workerBuildNetworkSummary(config)).toEqual(DEFAULT_WORKER_BUILD_NETWORK_SUMMARY);
@@ -24,6 +25,7 @@ describe("resolveWorkerBuildNetwork", () => {
       HOMERAIL_WORKER_BUILD_APT_MIRROR: "   ",
       HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR: "\t",
       HOMERAIL_WORKER_BUILD_NPM_REGISTRY: " \r\n ",
+      HOMERAIL_WORKER_BUILD_DSH_GIT_REMOTE: "  ",
     });
     expect(workerBuildNetworkDockerArgs(config)).toEqual([]);
     expect(workerBuildNetworkSummary(config)).toEqual(DEFAULT_WORKER_BUILD_NETWORK_SUMMARY);
@@ -34,16 +36,19 @@ describe("resolveWorkerBuildNetwork", () => {
       HOMERAIL_WORKER_BUILD_APT_MIRROR: "https://mirrors.example.com/debian",
       HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR: "https://mirrors.example.com/debian-security",
       HOMERAIL_WORKER_BUILD_NPM_REGISTRY: "https://registry.example.com",
+      HOMERAIL_WORKER_BUILD_DSH_GIT_REMOTE: "https://git.example.com/deepseek-harness.git",
     });
     expect(workerBuildNetworkDockerArgs(config)).toEqual([
       "--build-arg", "HOMERAIL_WORKER_BUILD_APT_MIRROR=https://mirrors.example.com/debian",
       "--build-arg", "HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR=https://mirrors.example.com/debian-security",
       "--build-arg", "NPM_CONFIG_REGISTRY=https://registry.example.com",
+      "--build-arg", "HOMERAIL_DSH_FORK_REPOSITORY=https://git.example.com/deepseek-harness.git",
     ]);
     expect(workerBuildNetworkSummary(config)).toEqual({
       apt_main: "custom",
       apt_security: "custom",
       npm: "custom",
+      dsh_git: "custom",
       proxy: "docker-managed",
     });
   });
@@ -121,6 +126,7 @@ describe("resolveWorkerBuildNetwork", () => {
         "HOMERAIL_WORKER_BUILD_APT_MIRROR",
         "HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR",
         "HOMERAIL_WORKER_BUILD_NPM_REGISTRY",
+        "HOMERAIL_WORKER_BUILD_DSH_GIT_REMOTE",
       ]) {
         let caught: unknown;
         try {
@@ -166,6 +172,7 @@ describe("resolveWorkerBuildNetwork", () => {
         "HOMERAIL_WORKER_BUILD_APT_MIRROR",
         "HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR",
         "HOMERAIL_WORKER_BUILD_NPM_REGISTRY",
+        "HOMERAIL_WORKER_BUILD_DSH_GIT_REMOTE",
       ]) {
         let caught: unknown;
         try {
@@ -233,6 +240,7 @@ describe("normalizeWorkerBuildNetworkSummary", () => {
       apt_main: "custom",
       apt_security: "default",
       npm: "custom",
+      dsh_git: "custom",
       proxy: "environment",
     };
     expect(normalizeWorkerBuildNetworkSummary(summary)).toEqual(summary);
@@ -246,6 +254,7 @@ describe("normalizeWorkerBuildNetworkSummary", () => {
       apt_main: "weird",
       apt_security: ["custom"],
       npm: 1,
+      dsh_git: ["custom"],
       proxy: "none",
     })).toEqual(DEFAULT_WORKER_BUILD_NETWORK_SUMMARY);
     expect(normalizeWorkerBuildNetworkSummary({
@@ -255,6 +264,7 @@ describe("normalizeWorkerBuildNetworkSummary", () => {
       apt_main: "custom",
       apt_security: "default",
       npm: "default",
+      dsh_git: "default",
       proxy: "environment",
     });
   });

--- a/homerail_protocol/src/manager-agent.ts
+++ b/homerail_protocol/src/manager-agent.ts
@@ -6,6 +6,7 @@
 export const ManagerAgentHarness = {
   CLAUDE_AGENT_SDK: "claude_agent_sdk",
   CODEX_APPSERVER: "codex_appserver",
+  DEEPSEEK_HARNESS: "deepseek_harness",
   KIMI_CODE: "kimi_code",
 } as const;
 export type ManagerAgentHarness = (typeof ManagerAgentHarness)[keyof typeof ManagerAgentHarness];
@@ -21,7 +22,7 @@ export type ManagerAgentRuntimePlacement =
 // Canonical agent_type strings are intentionally stable because they can appear
 // in env vars and persisted runtime config. Aliases accept common spelling
 // variants, but these canonical values should not be renamed casually.
-export type ManagerAgentRuntimeAgentType = "claude-sdk" | "codex_appserver" | "kimi_code";
+export type ManagerAgentRuntimeAgentType = "claude-sdk" | "codex_appserver" | "deepseek_harness" | "kimi_code";
 
 // app-server advertises model-specific, forward-compatible effort strings via model/list.
 export type ManagerAgentReasoningEffort = string;
@@ -44,6 +45,11 @@ export const MANAGER_AGENT_HARNESSES: Record<ManagerAgentHarness, ManagerAgentHa
     agent_type: "kimi_code",
     runtime_placement: ManagerAgentRuntimePlacement.HOST_SHELL,
   },
+  [ManagerAgentHarness.DEEPSEEK_HARNESS]: {
+    harness: ManagerAgentHarness.DEEPSEEK_HARNESS,
+    agent_type: "deepseek_harness",
+    runtime_placement: ManagerAgentRuntimePlacement.HOST_SHELL,
+  },
   [ManagerAgentHarness.CLAUDE_AGENT_SDK]: {
     harness: ManagerAgentHarness.CLAUDE_AGENT_SDK,
     agent_type: "claude-sdk",
@@ -64,6 +70,10 @@ const MANAGER_AGENT_HARNESS_ALIASES: Record<string, ManagerAgentHarness> = {
   codex: ManagerAgentHarness.CODEX_APPSERVER,
   codex_appserver: ManagerAgentHarness.CODEX_APPSERVER,
   "codex-appserver": ManagerAgentHarness.CODEX_APPSERVER,
+  deepseek: ManagerAgentHarness.DEEPSEEK_HARNESS,
+  dsh: ManagerAgentHarness.DEEPSEEK_HARNESS,
+  deepseek_harness: ManagerAgentHarness.DEEPSEEK_HARNESS,
+  "deepseek-harness": ManagerAgentHarness.DEEPSEEK_HARNESS,
   kimi: ManagerAgentHarness.KIMI_CODE,
   kimi_code: ManagerAgentHarness.KIMI_CODE,
   "kimi-code": ManagerAgentHarness.KIMI_CODE,
@@ -104,6 +114,7 @@ export function isKimiCodeCompatibleModelSetting(
 export function isManagerAgentHarness(value: unknown): value is ManagerAgentHarness {
   return value === ManagerAgentHarness.CLAUDE_AGENT_SDK ||
     value === ManagerAgentHarness.CODEX_APPSERVER ||
+    value === ManagerAgentHarness.DEEPSEEK_HARNESS ||
     value === ManagerAgentHarness.KIMI_CODE;
 }
 

--- a/homerail_protocol/src/types.ts
+++ b/homerail_protocol/src/types.ts
@@ -608,6 +608,8 @@ export interface DagNodeConfig {
   agent_type: string;
   model: string;
   reasoning_effort?: string;
+  /** Model-declared reasoning selectors mapped to provider wire values. */
+  reasoning_effort_map?: Record<string, string | null> | false;
   service_tier?: string | null;
   /** Codex command sandbox selected by the trusted WorkflowSpec runtime policy. */
   codex_sandbox?: "read-only" | "workspace-write" | "danger-full-access";

--- a/homerail_protocol/tests/manager-agent.test.ts
+++ b/homerail_protocol/tests/manager-agent.test.ts
@@ -164,6 +164,7 @@ describe("Manager Agent harness contract", () => {
     expect(DEFAULT_MANAGER_AGENT_HARNESS).toBe("claude_agent_sdk");
     expect(isManagerAgentHarness("claude_agent_sdk")).toBe(true);
     expect(isManagerAgentHarness("codex_appserver")).toBe(true);
+    expect(isManagerAgentHarness("deepseek_harness")).toBe(true);
     expect(isManagerAgentHarness("kimi_code")).toBe(true);
     expect(isManagerAgentHarness("claude-sdk")).toBe(false);
     expect(isManagerAgentHarness("direct-llm")).toBe(false);
@@ -176,6 +177,9 @@ describe("Manager Agent harness contract", () => {
     expect(normalizeManagerAgentHarness("claude-agent-sdk")).toBe("claude_agent_sdk");
     expect(normalizeManagerAgentHarness("codex")).toBe("codex_appserver");
     expect(normalizeManagerAgentHarness("codex-appserver")).toBe("codex_appserver");
+    expect(normalizeManagerAgentHarness("dsh")).toBe("deepseek_harness");
+    expect(normalizeManagerAgentHarness("deepseek")).toBe("deepseek_harness");
+    expect(normalizeManagerAgentHarness("deepseek-harness")).toBe("deepseek_harness");
     expect(normalizeManagerAgentHarness("kimi")).toBe("kimi_code");
     expect(normalizeManagerAgentHarness("kimi-code")).toBe("kimi_code");
     expect(normalizeManagerAgentHarness("unknown")).toBeUndefined();
@@ -184,17 +188,20 @@ describe("Manager Agent harness contract", () => {
   it("declares the only Manager Agent runtime placement boundary", () => {
     expect(Object.values(ManagerAgentRuntimePlacement)).toEqual(["host", "host_shell", "container"]);
     expect(managerAgentRuntimePlacementForHarness("codex_appserver")).toBe("host");
+    expect(managerAgentRuntimePlacementForHarness("deepseek_harness")).toBe("host_shell");
     expect(managerAgentRuntimePlacementForHarness("kimi_code")).toBe("host_shell");
     expect(managerAgentRuntimePlacementForHarness("claude_agent_sdk")).toBe("host_shell");
   });
 
   it("maps public harness ids to runtime agent types", () => {
     expect(managerAgentRuntimeAgentTypeForHarness("codex_appserver")).toBe("codex_appserver");
+    expect(managerAgentRuntimeAgentTypeForHarness("deepseek_harness")).toBe("deepseek_harness");
     expect(managerAgentRuntimeAgentTypeForHarness("kimi_code")).toBe("kimi_code");
     expect(managerAgentRuntimeAgentTypeForHarness("claude_agent_sdk")).toBe("claude-sdk");
     expect(MANAGER_AGENT_PRODUCTION_RUNTIME_AGENT_TYPES).toEqual([
       "codex_appserver",
       "kimi_code",
+      "deepseek_harness",
       "claude-sdk",
     ]);
     expect(managerAgentHarnessDefinition("codex_appserver")).toMatchObject({
@@ -206,6 +213,8 @@ describe("Manager Agent harness contract", () => {
 
   it("normalizes runtime agent_type aliases while preserving unknown custom backends", () => {
     expect(normalizeManagerAgentRuntimeAgentType("claude-agent-sdk")).toBe("claude-sdk");
+    expect(normalizeManagerAgentRuntimeAgentType("dsh")).toBe("deepseek_harness");
+    expect(normalizeManagerAgentRuntimeAgentType("deepseek-harness")).toBe("deepseek_harness");
     expect(normalizeManagerAgentRuntimeAgentType("kimi-code")).toBe("kimi_code");
     expect(normalizeManagerAgentRuntimeAgentType("codex")).toBe("codex_appserver");
     expect(normalizeManagerAgentRuntimeAgentType("fixture-kimi-code")).toBe("fixture-kimi-code");

--- a/homerail_worker/Dockerfile
+++ b/homerail_worker/Dockerfile
@@ -16,6 +16,32 @@ COPY homerail_worker/native/codex-secret-guard.c /tmp/codex-secret-guard.c
 RUN gcc -O2 -Wall -Wextra -Werror -fPIC -shared \
   -o /homerail-codex-secret-guard.so /tmp/codex-secret-guard.c
 
+FROM node:22-slim AS dsh-runtime-build
+
+# HomeRail's owner-maintained DSH fork is pinned by immutable commit. The
+# deploy closure is generated in this stage so the final Worker image does not
+# depend on a source checkout or a package registry at runtime.
+ARG HOMERAIL_WORKER_BUILD_APT_MIRROR
+ARG HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR
+ARG NPM_CONFIG_REGISTRY
+ARG HOMERAIL_DSH_FORK_COMMIT=559cd23cc2f1b96da2fde230064da2dc3781b126
+COPY homerail_worker/scripts/configure-apt-sources.mjs /opt/homerail/scripts/configure-apt-sources.mjs
+RUN node /opt/homerail/scripts/configure-apt-sources.mjs
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates git python3 make g++ \
+  && rm -rf /var/lib/apt/lists/*
+RUN npm install --global corepack@0.34.0 && corepack enable
+RUN git init /src/deepseek-harness \
+  && cd /src/deepseek-harness \
+  && git remote add origin https://github.com/xiaotianfotos/deepseek-harness.git \
+  && git fetch --depth=1 origin "${HOMERAIL_DSH_FORK_COMMIT}" \
+  && git checkout --detach FETCH_HEAD \
+  && test "$(git rev-parse HEAD)" = "${HOMERAIL_DSH_FORK_COMMIT}"
+WORKDIR /src/deepseek-harness
+RUN corepack pnpm install --frozen-lockfile
+RUN corepack pnpm run build:lib:host
+RUN corepack pnpm exec tsx scripts/build-exe-for-python-sdk.ts --skip-build --node-only
+
 FROM node:22-slim
 
 # Optional public Debian mirror overrides for Worker image builds. ARG
@@ -40,6 +66,9 @@ ENV HOMERAIL_WORKER_VERSION="${HOMERAIL_WORKER_VERSION}" \
     HOMERAIL_WORKER_PROTOCOL_VERSION="${HOMERAIL_WORKER_PROTOCOL_VERSION}" \
     HOMERAIL_WORKER_SOURCE_FINGERPRINT="${HOMERAIL_WORKER_SOURCE_FINGERPRINT}" \
     HOMERAIL_WORKER_IMAGE_REVISION="${HOMERAIL_WORKER_IMAGE_REVISION}"
+ENV HOMERAIL_DSH_RUNTIME_COMMAND="/usr/local/bin/node" \
+    HOMERAIL_DSH_RUNTIME_ARGS="[\"/opt/deepseek-harness-runtime/node_modules/@deepseek-ai/dsh-sdk-jsonrpc-demo/lib/packaged-bin.js\"]" \
+    HOMERAIL_DSH_CORDIS_CONFIG="/app/dsh/homerail.cordis.yml"
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends bash ca-certificates curl git openssh-client \
@@ -82,9 +111,25 @@ RUN cd /opt/homerail-dependency-cache/agent-ui && npm ci --ignore-scripts
 
 COPY homerail_worker/tsconfig.json ./
 COPY homerail_worker/src ./src
+COPY homerail_worker/dsh ./dsh
+COPY --from=dsh-runtime-build \
+  /src/deepseek-harness/python/sdk-runtime/src/deepseek_harness_runtime/runtime/node \
+  /opt/deepseek-harness-runtime
 RUN npm run build
 
-RUN mkdir -p /workspace && chown -R node:node /workspace
+# Workspace checkouts can be created with owner-only source modes. Normalize
+# only the copied metadata/config files the unprivileged runtime reads; npm and
+# the DSH deploy step already materialize their output with public read modes.
+RUN chmod a+r \
+  /app/package*.json \
+  /app/tsconfig.json \
+  /app/dsh/homerail.cordis.yml \
+  /homerail_protocol/package*.json \
+  /homerail_protocol/tsconfig.json \
+  && find /opt/homerail-dependency-cache -mindepth 2 -maxdepth 2 -type f \
+    \( -name package.json -o -name package-lock.json \) -exec chmod a+r {} + \
+  && mkdir -p /workspace \
+  && chown -R node:node /workspace
 
 USER node
 WORKDIR /workspace

--- a/homerail_worker/Dockerfile
+++ b/homerail_worker/Dockerfile
@@ -24,7 +24,7 @@ FROM node:22-slim AS dsh-runtime-build
 ARG HOMERAIL_WORKER_BUILD_APT_MIRROR
 ARG HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR
 ARG NPM_CONFIG_REGISTRY
-ARG HOMERAIL_DSH_FORK_COMMIT=ec75587a05bf0cc3f29dd0d5f875d3235f7deae6
+ARG HOMERAIL_DSH_FORK_COMMIT=554b7b931a503f8af98614dc8002862f13eb9298
 COPY homerail_worker/scripts/configure-apt-sources.mjs /opt/homerail/scripts/configure-apt-sources.mjs
 RUN node /opt/homerail/scripts/configure-apt-sources.mjs
 RUN apt-get update \

--- a/homerail_worker/Dockerfile
+++ b/homerail_worker/Dockerfile
@@ -24,6 +24,7 @@ FROM node:22-slim AS dsh-runtime-build
 ARG HOMERAIL_WORKER_BUILD_APT_MIRROR
 ARG HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR
 ARG NPM_CONFIG_REGISTRY
+ARG HOMERAIL_DSH_FORK_REPOSITORY=https://github.com/xiaotianfotos/deepseek-harness.git
 ARG HOMERAIL_DSH_FORK_COMMIT=ec75587a05bf0cc3f29dd0d5f875d3235f7deae6
 COPY homerail_worker/scripts/configure-apt-sources.mjs /opt/homerail/scripts/configure-apt-sources.mjs
 RUN node /opt/homerail/scripts/configure-apt-sources.mjs
@@ -33,14 +34,15 @@ RUN apt-get update \
 RUN npm install --global corepack@0.34.0 && corepack enable
 RUN git init /src/deepseek-harness \
   && cd /src/deepseek-harness \
-  && git remote add origin https://github.com/xiaotianfotos/deepseek-harness.git \
+  && git remote add origin "${HOMERAIL_DSH_FORK_REPOSITORY}" \
   && git fetch --depth=1 origin "${HOMERAIL_DSH_FORK_COMMIT}" \
   && git checkout --detach FETCH_HEAD \
   && test "$(git rev-parse HEAD)" = "${HOMERAIL_DSH_FORK_COMMIT}"
 WORKDIR /src/deepseek-harness
-RUN corepack pnpm install --frozen-lockfile
-RUN corepack pnpm run build:lib:host
-RUN corepack pnpm exec tsx scripts/build-exe-for-python-sdk.ts --skip-build --node-only
+RUN if [ -n "${NPM_CONFIG_REGISTRY:-}" ]; then export COREPACK_NPM_REGISTRY="$NPM_CONFIG_REGISTRY"; fi \
+  && corepack pnpm install --frozen-lockfile \
+  && corepack pnpm run build:lib:host \
+  && corepack pnpm exec tsx scripts/build-exe-for-python-sdk.ts --skip-build --node-only
 
 FROM node:22-slim
 

--- a/homerail_worker/Dockerfile
+++ b/homerail_worker/Dockerfile
@@ -25,7 +25,7 @@ ARG HOMERAIL_WORKER_BUILD_APT_MIRROR
 ARG HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR
 ARG NPM_CONFIG_REGISTRY
 ARG HOMERAIL_DSH_FORK_REPOSITORY=https://github.com/xiaotianfotos/deepseek-harness.git
-ARG HOMERAIL_DSH_FORK_COMMIT=554b7b931a503f8af98614dc8002862f13eb9298
+ARG HOMERAIL_DSH_FORK_COMMIT=dc04fa3dbdcedc512322fff199b5cfef9169ea21
 COPY homerail_worker/scripts/configure-apt-sources.mjs /opt/homerail/scripts/configure-apt-sources.mjs
 RUN node /opt/homerail/scripts/configure-apt-sources.mjs
 RUN apt-get update \

--- a/homerail_worker/Dockerfile
+++ b/homerail_worker/Dockerfile
@@ -24,7 +24,7 @@ FROM node:22-slim AS dsh-runtime-build
 ARG HOMERAIL_WORKER_BUILD_APT_MIRROR
 ARG HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR
 ARG NPM_CONFIG_REGISTRY
-ARG HOMERAIL_DSH_FORK_COMMIT=559cd23cc2f1b96da2fde230064da2dc3781b126
+ARG HOMERAIL_DSH_FORK_COMMIT=ec75587a05bf0cc3f29dd0d5f875d3235f7deae6
 COPY homerail_worker/scripts/configure-apt-sources.mjs /opt/homerail/scripts/configure-apt-sources.mjs
 RUN node /opt/homerail/scripts/configure-apt-sources.mjs
 RUN apt-get update \

--- a/homerail_worker/Dockerfile
+++ b/homerail_worker/Dockerfile
@@ -25,7 +25,7 @@ ARG HOMERAIL_WORKER_BUILD_APT_MIRROR
 ARG HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR
 ARG NPM_CONFIG_REGISTRY
 ARG HOMERAIL_DSH_FORK_REPOSITORY=https://github.com/xiaotianfotos/deepseek-harness.git
-ARG HOMERAIL_DSH_FORK_COMMIT=dc04fa3dbdcedc512322fff199b5cfef9169ea21
+ARG HOMERAIL_DSH_FORK_COMMIT=f4fd5f005636cdcbf9d95f70f04d05afa8c0db54
 COPY homerail_worker/scripts/configure-apt-sources.mjs /opt/homerail/scripts/configure-apt-sources.mjs
 RUN node /opt/homerail/scripts/configure-apt-sources.mjs
 RUN apt-get update \

--- a/homerail_worker/Dockerfile
+++ b/homerail_worker/Dockerfile
@@ -91,7 +91,31 @@ COPY homerail_worker/package.json homerail_worker/package-lock.json* ./
 # --ignore-scripts skips postinstall since homerail_protocol is already built above
 RUN npm ci --ignore-scripts
 RUN command -v kimi
-RUN command -v codex && codex --version
+# npm treats the Claude SDK and Codex native platform payloads as optional, so
+# a transient fetch failure can leave a successful install with unusable agent
+# backends. Repair only the current Linux architecture at the exact pinned
+# versions, without changing the image-owned package lock, then verify them.
+RUN codex_arch="$(dpkg --print-architecture)" \
+  && case "$codex_arch" in \
+    amd64) codex_arch=x64 ;; \
+    arm64) codex_arch=arm64 ;; \
+    *) echo "Unsupported Codex Worker architecture: $codex_arch" >&2; exit 1 ;; \
+  esac \
+  && claude_version="$(node -p 'require("./node_modules/@anthropic-ai/claude-agent-sdk/package.json").version')" \
+  && claude_platform="@anthropic-ai/claude-agent-sdk-linux-${codex_arch}" \
+  && if [ ! -d "node_modules/${claude_platform}" ]; then \
+    npm install --no-save --package-lock=false --ignore-scripts \
+      "${claude_platform}@${claude_version}"; \
+  fi \
+  && codex_version="$(node -p 'require("./node_modules/@openai/codex/package.json").version')" \
+  && codex_platform="@openai/codex-linux-${codex_arch}" \
+  && if [ ! -d "node_modules/${codex_platform}" ]; then \
+    npm install --no-save --package-lock=false --ignore-scripts \
+      "${codex_platform}@npm:@openai/codex@${codex_version}-linux-${codex_arch}"; \
+  fi \
+  && test -x "node_modules/${claude_platform}/claude" \
+  && command -v codex \
+  && codex --version
 
 # Auto Fix coding Workers run without network access. Keep a trusted dependency
 # cache in the image for the HomeRail packages exercised by implementation and

--- a/homerail_worker/dsh/homerail.cordis.yml
+++ b/homerail_worker/dsh/homerail.cordis.yml
@@ -5,6 +5,7 @@
   name: '@deepseek-ai/dsh-llm-deepseek'
   config:
     apiKeyEnv: DEEPSEEK_API_KEY
+    reasoningEffort: xhigh
     streamIdleTimeoutMs: 172800000
     models:
       - id: !!js process.env.DSH_MODEL

--- a/homerail_worker/dsh/homerail.cordis.yml
+++ b/homerail_worker/dsh/homerail.cordis.yml
@@ -1,15 +1,10 @@
 # HomeRail-owned, unattended DeepSeek Harness composition.
 # stdout is reserved for the SDK JSON-RPC transport.
 
-- id: llm-deepseek
-  name: '@deepseek-ai/dsh-llm-deepseek'
+- id: llm-pi-ai
+  name: '@deepseek-ai/dsh-llm-pi-ai'
   config:
-    apiKeyEnv: DEEPSEEK_API_KEY
-    reasoningEffort: !!js process.env.DSH_REASONING_EFFORT || 'high'
-    streamIdleTimeoutMs: 172800000
-    models:
-      - id: !!js process.env.DSH_MODEL
-        contextWindow: !!js Number(process.env.DSH_CONTEXT_WINDOW ?? 200000)
+    providers: !!js JSON.parse(process.env.HOMERAIL_DSH_PROVIDERS_JSON || '{}')
 
 - id: homerail-tools
   name: '@deepseek-ai/dsh-mcp-client'

--- a/homerail_worker/dsh/homerail.cordis.yml
+++ b/homerail_worker/dsh/homerail.cordis.yml
@@ -1,0 +1,52 @@
+# HomeRail-owned, unattended DeepSeek Harness composition.
+# stdout is reserved for the SDK JSON-RPC transport.
+
+- id: llm-deepseek
+  name: '@deepseek-ai/dsh-llm-deepseek'
+  config:
+    apiKeyEnv: DEEPSEEK_API_KEY
+    streamIdleTimeoutMs: 172800000
+    models:
+      - id: !!js process.env.DSH_MODEL
+        contextWindow: !!js Number(process.env.DSH_CONTEXT_WINDOW ?? 200000)
+
+- id: homerail-tools
+  name: '@deepseek-ai/dsh-mcp-client'
+  config:
+    serverName: homerail
+    transport: stdio
+    command: !!js process.execPath
+    args:
+      - !!js process.env.HOMERAIL_DSH_MCP_SCRIPT
+    cwd: !!js process.env.DSH_CWD
+    env:
+      HOMERAIL_MCP_BRIDGE_URL: !!js process.env.HOMERAIL_MCP_BRIDGE_URL
+      HOMERAIL_MCP_BRIDGE_TOKEN: !!js process.env.HOMERAIL_MCP_BRIDGE_TOKEN
+    failOnStartupError: true
+    reconnect:
+      enabled: false
+
+- id: agent-spine
+  name: '@deepseek-ai/dsh-agent-spine-demo'
+  config:
+    includeHarnessIdentity: false
+    includeRuntimeContext: false
+    persona: !!js process.env.DSH_SYSTEM_PROMPT
+    workspaceContext: false
+    skills:
+      enabled: false
+    toolBash: false
+    toolJobs: false
+
+- id: sessions
+  name: '@deepseek-ai/dsh-session-persistence-jsonl'
+  config:
+    root: !!js process.env.DSH_SESSION_ROOT
+    compression: none
+
+# The fork's protocol handshake waits for Loader settlement, so MCP discovery
+# is complete before the caller can send the first turn.
+- id: sdk-jsonrpc-server
+  name: '@deepseek-ai/dsh-sdk-jsonrpc-server'
+  config:
+    maxTokensAsSuccess: true

--- a/homerail_worker/dsh/homerail.cordis.yml
+++ b/homerail_worker/dsh/homerail.cordis.yml
@@ -5,7 +5,7 @@
   name: '@deepseek-ai/dsh-llm-deepseek'
   config:
     apiKeyEnv: DEEPSEEK_API_KEY
-    reasoningEffort: xhigh
+    reasoningEffort: !!js process.env.DSH_REASONING_EFFORT || 'high'
     streamIdleTimeoutMs: 172800000
     models:
       - id: !!js process.env.DSH_MODEL

--- a/homerail_worker/package-lock.json
+++ b/homerail_worker/package-lock.json
@@ -11,6 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.222",
+        "@deepseek-ai/dsh-sdk-client": "0.0.1-rc.1",
         "@moonshot-ai/kimi-agent-sdk": "^0.1.8",
         "@moonshot-ai/kimi-code": "^0.24.2",
         "@openai/codex": "0.145.0",
@@ -104,9 +105,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -119,9 +117,6 @@
       "integrity": "sha512-sVvPAUzRq+Am3+wNrFJ7URaWORu8t5hOu4vJnMhOeey66ZFFfzNwP0uz/7sTWjg+cRse/wG/hek34lZ0Gdu2+w==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -136,9 +131,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -151,9 +143,6 @@
       "integrity": "sha512-vM48p8GRM5N57+jPFdPj1ZS8Y770frJ1NTRecA06/GXtRANn7dOUVpvJbpu6fJBFF3BCacM1uVcBCMZh6wEMjw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -217,6 +206,316 @@
       "peer": true,
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@deepseek-ai/cordis": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis/-/cordis-4.0.1.tgz",
+      "integrity": "sha512-YBdskTU2Po1kru3GgcUWUbkTsPMA9LkSQDAY8rBkFJeajdgcQad3QPJZE26JyK99Xb6HaASvoXg2DSUTeN/0Nw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.2",
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "bin": {
+        "cordis": "bin.js"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis-plugin-include": "^1.0.6",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.2"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/cordis-plugin-include": {
+          "optional": true
+        },
+        "@deepseek-ai/cordis-plugin-loader": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/cosmokit": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cosmokit/-/cosmokit-1.8.2.tgz",
+      "integrity": "sha512-muBOKtSrUKU5m/xpq8ZXWL6hQ/jgd4PhU2PqH97bcxIiLEJfNwZOGQEx4t/aS/GgxRAR+ra9pMHPMtTHU4sqqA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@deepseek-ai/dsh-agent": {
+      "version": "0.0.1-rc.5",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent/-/dsh-agent-0.0.1-rc.5.tgz",
+      "integrity": "sha512-eJoG89GRf8d7SCjGiSsC5g0fPijuNnJWIis5MmzIRoPSEv73PFOYs+EBHDEpPCQkFNmQjYtviiFhbhNPg9+3CQ==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1-rc.4",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-llm": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-scope": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-session": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-system-prompt": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-typert-protocol": "^0.0.1-rc.5"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-attachment": {
+      "version": "0.0.1-rc.5",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-attachment/-/dsh-attachment-0.0.1-rc.5.tgz",
+      "integrity": "sha512-mjv3gtW39nFJX0MQHZlW9PBlZVLDUZ5HqCfr2gr+ypPQ86RNtHzmLI/9XHF0xcMkT8VMCs6x53bipi87BEQMCg==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1-rc.4",
+        "@deepseek-ai/dsh-brand": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-brand": {
+      "version": "0.0.1-rc.5",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-brand/-/dsh-brand-0.0.1-rc.5.tgz",
+      "integrity": "sha512-aVHMvG5hYLYIXUsvf9mfi0Fvr8w3oU6y1qbhiOiWUVSQu2pKkFgiKJGPIHhMLoj0q4IkewNvsVFQeECdsLLXYg==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1-rc.4",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-code-runtime": {
+      "version": "0.0.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-code-runtime/-/dsh-code-runtime-0.0.1-rc.1.tgz",
+      "integrity": "sha512-lfHc2HevlivlnKWt876s1rOSov5PyR9tPpPiQFEs46jREF5JjwMdE8yTUbpEnBt9A97NZ+vKl2o7LbqVZPSSxg==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-invariants": {
+      "version": "0.0.1-rc.5",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.0.1-rc.5.tgz",
+      "integrity": "sha512-63LTrIMPAeJowv5E9Sr87w1SPs1Ign2/ofr+LPdrgAi4Pi32YFK9o4vSVv7osRHAIzlwxRCoFksythq+Jire3w==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1-rc.4"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1-rc.4"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-llm": {
+      "version": "0.0.1-rc.5",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm/-/dsh-llm-0.0.1-rc.5.tgz",
+      "integrity": "sha512-+w+bYuimnZZwQshdEkZynFPH9FwYfRrEDkgnBshfkjDe1nqqH3h/K6amu8pcIZ2J8XaI6osAImyz7BAAuN589g==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1-rc.4"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1-rc.4",
+        "@deepseek-ai/dsh-attachment": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-brand": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-timeout": "^0.0.1-rc.5"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-scope": {
+      "version": "0.0.1-rc.5",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-scope/-/dsh-scope-0.0.1-rc.5.tgz",
+      "integrity": "sha512-9dPbw8Lj2VMmbFqUKMlzhudSN/Z5xVY6otDMSKBqnF88WnOugslZXkYToOMQO8EUEJorE0d0M+aUAq4titzOwA==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1-rc.4",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-client": {
+      "version": "0.0.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sdk-client/-/dsh-sdk-client-0.0.1-rc.1.tgz",
+      "integrity": "sha512-qHdB9PIkLwbX0HATMLPaYq69up7Ny/ooFh0Da3UCM2qkXj4k7ZmAl35WXLA01anuapdWl17sH78bvVO2Nu41iA==",
+      "license": "BSD-3-Clause",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-sdk-protocol": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.0.1-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-protocol": {
+      "version": "0.0.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sdk-protocol/-/dsh-sdk-protocol-0.0.1-rc.1.tgz",
+      "integrity": "sha512-qFR4rvJvgUTvzEtDPCQtzrAM0MS0WAjIyXiWcYeNj+dJjSHXm8/9TJBzNAscrR4V7aI4tnx6tdfw5OlYyHzj6g==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.0.1-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session": {
+      "version": "0.0.1-rc.5",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session/-/dsh-session-0.0.1-rc.5.tgz",
+      "integrity": "sha512-/xFNk3scb0KXGKW9vjpW4drNTHVJYEw5gdW8xOPbgO+8/4AEtrS2m69P5ancdgcpufheLgJQ1H6sacFUAP1IpQ==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1-rc.4",
+        "@deepseek-ai/dsh-brand": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-llm": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-scope": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-typert-protocol": "^0.0.1-rc.5"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-subagent": {
+      "version": "0.0.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent/-/dsh-subagent-0.0.1-rc.1.tgz",
+      "integrity": "sha512-HBx1nUlXSHzDGk9OqnNBGVxWW9PVjJpgD0ifklU66Y0wKyXbgv858+75+9oGYdFyi0AVYxF7IJ443yDvEubeEQ==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1-rc.1",
+        "@deepseek-ai/dsh-agent": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-agent-presets": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-tasks": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.0.1-rc.1"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-agent-presets": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-sandbox": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-sandbox-policy": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-persistence": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-projection": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-projection-cache": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-tasks": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-user-approval": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-system-prompt": {
+      "version": "0.0.1-rc.5",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.0.1-rc.5.tgz",
+      "integrity": "sha512-IMB3dT8ErPWq15tIXdItQ+OOzHKYdLGl6vwNkeZf2n3hlw0bxDzj1AmLCgE4vDByDue9BQTWl4cMfNN0NxVMfA==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1-rc.4"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1-rc.4",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-llm": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-scope": "^0.0.1-rc.5"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-timeout": {
+      "version": "0.0.1-rc.5",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-timeout/-/dsh-timeout-0.0.1-rc.5.tgz",
+      "integrity": "sha512-SxuBtgHCQx5bOqua/U/5H2jMio8w1SXpjcDqmd0WBZ7OvmgnLovvbmCrEQeH0jtbkqL25yEZ/dDCr6cE27Pi5Q==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1-rc.4",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tools": {
+      "version": "0.0.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tools/-/dsh-tools-0.0.1-rc.1.tgz",
+      "integrity": "sha512-mrtq+UXc6UVidrGo4GM8RAH0Gqc4iFOmtPeQAz59Phhjl3EmzkFI0Mo6dQlHQamrc2J9jppPtGtUzW9qHmwxDQ==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1-rc.1",
+        "@deepseek-ai/dsh-agent": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-code-runtime": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.0.1-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-typert-protocol": {
+      "version": "0.0.1-rc.5",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-protocol/-/dsh-typert-protocol-0.0.1-rc.5.tgz",
+      "integrity": "sha512-8ierrjmlloXATrJHeIE6EeItOT0M1kPmk+MTvV4600CD1XuAigVpktYc4HsbXw5jaKzt/jQK4eRCARYWeuvwhw==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1-rc.4",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-user-approval": {
+      "version": "0.0.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-approval/-/dsh-user-approval-0.0.1-rc.1.tgz",
+      "integrity": "sha512-28J7iT2fl9I0haeCRwVIWqhFBO3xG+A1GAdfhLJG/9YkB0F3Cs6FUoRtNQ7pjxkJ6QzELY/gRBE7axCP0ETHcA==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1-rc.1",
+        "@deepseek-ai/dsh-agent": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.0.1-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/schemastery": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.1.tgz",
+      "integrity": "sha512-Qn0FCSwCQnpnj6SB31I6i2sIKgKWnkbJM8O0EU91Gv2UsYVvtZTl6IA0sCwk2e2MZf5S8w5hpq9QkeVvK9qwxg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.2",
+        "@standard-schema/spec": "^1.1.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -953,7 +1252,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {

--- a/homerail_worker/package.json
+++ b/homerail_worker/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.222",
+    "@deepseek-ai/dsh-sdk-client": "0.0.1-rc.1",
     "@moonshot-ai/kimi-agent-sdk": "^0.1.8",
     "@moonshot-ai/kimi-code": "^0.24.2",
     "@openai/codex": "0.145.0",

--- a/homerail_worker/scripts/configure-apt-sources.mjs
+++ b/homerail_worker/scripts/configure-apt-sources.mjs
@@ -54,8 +54,8 @@ export function validateMirrorUrl(rawValue, key) {
   // Fail closed on characters the WHATWG URL parser would percent-encode or
   // rewrite (a backslash becomes a path separator in special schemes), so the
   // normalized output never silently differs from the operator's input.
-  if (/["%<>`^{}|\\]/.test(rawValue)) {
-    throw new Error(`${key} must not contain characters that require URL encoding.`);
+  if (/["$()%<>`^{}|\\]/.test(rawValue)) {
+    throw new Error(`${key} must not contain unsupported URL characters.`);
   }
   // WHATWG parsing silently drops an empty userinfo marker, so inspect the
   // raw authority before parsing while still allowing `@` in the URL path.

--- a/homerail_worker/src/__tests__/agent.test.ts
+++ b/homerail_worker/src/__tests__/agent.test.ts
@@ -13,6 +13,7 @@ import { resolveWorkerAgentBackend } from "../agent/backend-selection.js";
 import { ClaudeSdkAdapter } from "../agent/claude-sdk.js";
 import { KimiCodeAdapter } from "../agent/kimi-code.js";
 import { CodexAppServerAdapter } from "../agent/codex-appserver.js";
+import { DeepSeekHarnessAdapter } from "../agent/deepseek-harness.js";
 import { DeterministicClient } from "../agent/deterministic.js";
 import { ManagerAgentSmokeClient } from "../agent/manager-agent-smoke.js";
 import type { AgentClient, AgentEvent, DagToolDefinition } from "../agent/types.js";
@@ -70,6 +71,12 @@ describe("agent factory", () => {
   it("creates kimi_code backend", () => {
     const client = createAgentClient("kimi_code");
     expect(client).toBeInstanceOf(KimiCodeAdapter);
+  });
+
+  it("creates DeepSeek Harness backend from public aliases", () => {
+    expect(createAgentClient("deepseek_harness")).toBeInstanceOf(DeepSeekHarnessAdapter);
+    expect(createAgentClient("deepseek-harness")).toBeInstanceOf(DeepSeekHarnessAdapter);
+    expect(createAgentClient("dsh")).toBeInstanceOf(DeepSeekHarnessAdapter);
   });
 
   it("creates Kimi Code backend from public aliases", () => {

--- a/homerail_worker/src/__tests__/build-sources.test.ts
+++ b/homerail_worker/src/__tests__/build-sources.test.ts
@@ -222,6 +222,8 @@ describe("Worker deb822 source override helper", () => {
       "https://mirror.example.com/deb%ian",
       "https://mirror.example.com/deb|ian",
       "https://mirror.example.com/deb^ian",
+      "https://mirror.example.com/deb$(touch)/ian",
+      "https://mirror.example.com/deb(ian)",
       "https://mirror.example.com/deb[ian",
       "https://mirror.example.com/deb]ian",
       "https://ex\u00e4mple.example.com/debian",

--- a/homerail_worker/src/__tests__/build-sources.test.ts
+++ b/homerail_worker/src/__tests__/build-sources.test.ts
@@ -674,7 +674,7 @@ describe("Worker Dockerfile source wiring", () => {
 
   it("wires the APT override helper into every stage before apt-get update", () => {
     const stages = dockerfileStages();
-    expect(stages.length).toBe(2);
+    expect(stages.length).toBeGreaterThanOrEqual(2);
     for (const stage of stages) {
       const body = stage.lines.join("\n");
       expect(body).toMatch(/^ARG HOMERAIL_WORKER_BUILD_APT_MIRROR$/m);
@@ -697,17 +697,18 @@ describe("Worker Dockerfile source wiring", () => {
     expect(dockerfile).not.toMatch(/ARG HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR=/);
   });
 
-  it("declares NPM_CONFIG_REGISTRY before every npm build operation in the final stage", () => {
+  it("declares NPM_CONFIG_REGISTRY before every npm build operation", () => {
     const stages = dockerfileStages();
-    const finalStage = stages[stages.length - 1];
-    const argIndex = finalStage.lines.findIndex((line) => line === "ARG NPM_CONFIG_REGISTRY");
-    expect(argIndex).toBeGreaterThanOrEqual(0);
-    const npmRuns = npmInstructions(finalStage.lines);
-    expect(npmRuns.length).toBeGreaterThan(0);
-    for (const instruction of npmRuns) {
-      expect(instruction.lineIndex).toBeGreaterThan(argIndex);
+    const npmStages = stages.filter((stage) => npmInstructions(stage.lines).length > 0);
+    expect(npmStages.length).toBeGreaterThan(0);
+    for (const stage of npmStages) {
+      const argIndex = stage.lines.findIndex((line) => line === "ARG NPM_CONFIG_REGISTRY");
+      expect(argIndex).toBeGreaterThanOrEqual(0);
+      for (const instruction of npmInstructions(stage.lines)) {
+        expect(instruction.lineIndex).toBeGreaterThan(argIndex);
+      }
     }
-    expect(dockerfile.match(/^ARG NPM_CONFIG_REGISTRY$/gm)).toHaveLength(1);
+    expect(dockerfile.match(/^ARG NPM_CONFIG_REGISTRY$/gm)).toHaveLength(npmStages.length);
   });
 
   it("keeps the npm registry override build-only", () => {

--- a/homerail_worker/src/__tests__/build-sources.test.ts
+++ b/homerail_worker/src/__tests__/build-sources.test.ts
@@ -716,6 +716,21 @@ describe("Worker Dockerfile source wiring", () => {
     expect(dockerfile).not.toMatch(/ENV[^\n]*NPM_CONFIG_REGISTRY/);
     expect(dockerfile).not.toMatch(/ENV[^\n]*HOMERAIL_WORKER_BUILD_APT/);
   });
+
+  it("allows the pinned DSH fork and Corepack bootstrap to use validated mirrors", () => {
+    expect(dockerfile).toContain(
+      "ARG HOMERAIL_DSH_FORK_REPOSITORY=https://github.com/xiaotianfotos/deepseek-harness.git",
+    );
+    expect(dockerfile).toContain('git remote add origin "${HOMERAIL_DSH_FORK_REPOSITORY}"');
+    const dshStage = dockerfileStages().find((stage) => stage.header.includes(" AS dsh-runtime-build"));
+    expect(dshStage).toBeDefined();
+    const corepackRuns = runInstructions(dshStage?.lines ?? [])
+      .filter((instruction) => instruction.text.includes("corepack pnpm"));
+    expect(corepackRuns.length).toBeGreaterThan(0);
+    for (const instruction of corepackRuns) {
+      expect(instruction.text).toContain('export COREPACK_NPM_REGISTRY="$NPM_CONFIG_REGISTRY"');
+    }
+  });
 });
 
 describe("Worker source fingerprint participation", () => {

--- a/homerail_worker/src/__tests__/build-sources.test.ts
+++ b/homerail_worker/src/__tests__/build-sources.test.ts
@@ -717,6 +717,27 @@ describe("Worker Dockerfile source wiring", () => {
     expect(dockerfile).not.toMatch(/ENV[^\n]*HOMERAIL_WORKER_BUILD_APT/);
   });
 
+  it("repairs skipped optional agent platform payloads before verifying the CLIs", () => {
+    const finalStage = dockerfileStages().at(-1);
+    expect(finalStage).toBeDefined();
+    const runs = runInstructions(finalStage?.lines ?? []);
+    const installIndex = runs.findIndex((instruction) => instruction.text.includes("npm ci --ignore-scripts"));
+    const repairIndex = runs.findIndex((instruction) => instruction.text.includes("codex_platform="));
+    expect(installIndex).toBeGreaterThanOrEqual(0);
+    expect(repairIndex).toBeGreaterThan(installIndex);
+
+    const repair = runs[repairIndex]?.text ?? "";
+    expect(repair).toContain("amd64) codex_arch=x64");
+    expect(repair).toContain("arm64) codex_arch=arm64");
+    expect(repair).toContain("node_modules/@anthropic-ai/claude-agent-sdk/package.json");
+    expect(repair).toContain("@anthropic-ai/claude-agent-sdk-linux-${codex_arch}");
+    expect(repair).toContain("node_modules/@openai/codex/package.json");
+    expect(repair).toContain("npm install --no-save --package-lock=false --ignore-scripts");
+    expect(repair).toContain("@npm:@openai/codex@${codex_version}-linux-${codex_arch}");
+    expect(repair).toContain("node_modules/${claude_platform}/claude");
+    expect(repair).toContain("codex --version");
+  });
+
   it("allows the pinned DSH fork and Corepack bootstrap to use validated mirrors", () => {
     expect(dockerfile).toContain(
       "ARG HOMERAIL_DSH_FORK_REPOSITORY=https://github.com/xiaotianfotos/deepseek-harness.git",

--- a/homerail_worker/src/__tests__/claude-sdk.test.ts
+++ b/homerail_worker/src/__tests__/claude-sdk.test.ts
@@ -1013,7 +1013,10 @@ describe("ClaudeSdkAdapter", () => {
     for await (const e of adapter.run("test", [], {
       ...ctx,
       apiKey: "anthropic-secret-value",
-      environmentVariables: { SERVICE_TEST_TOKEN: "turn-scoped-value" },
+      environmentVariables: {
+        SERVICE_TEST_TOKEN: "turn-scoped-value",
+        HOMERAIL_WORKER_TOKEN: "reserved-turn-value",
+      },
     })) {
       events.push(e);
     }
@@ -1021,6 +1024,7 @@ describe("ClaudeSdkAdapter", () => {
     expect((captured[0].env as Record<string, string>).ANTHROPIC_API_KEY).toBe("anthropic-secret-value");
     expect((captured[0].env as Record<string, string>).ANTHROPIC_AUTH_TOKEN).toBeUndefined();
     expect((captured[0].env as Record<string, string>).SERVICE_TEST_TOKEN).toBe("turn-scoped-value");
+    expect((captured[0].env as Record<string, string>).HOMERAIL_WORKER_TOKEN).toBeUndefined();
     expect((captured[0].env as Record<string, string>).ANTHROPIC_BASE_URL).toBe("https://api.anthropic.com");
     expect((captured[0].env as Record<string, string>).LLM_BASE_URL).toBe("https://api.anthropic.com");
     // Claude Code internal/background model + telemetry are pinned so gateway

--- a/homerail_worker/src/__tests__/deepseek-harness-read-tools.test.ts
+++ b/homerail_worker/src/__tests__/deepseek-harness-read-tools.test.ts
@@ -1,0 +1,87 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createDeepSeekHarnessReadTools } from "../agent/deepseek-harness-read-tools.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function fixture() {
+  const workspace = mkdtempSync(join(tmpdir(), "homerail-dsh-read-tools-"));
+  roots.push(workspace);
+  mkdirSync(join(workspace, "repository", "src"), { recursive: true });
+  mkdirSync(join(workspace, "outside"), { recursive: true });
+  writeFileSync(join(workspace, "repository", "src", "alpha.ts"), "export const alpha = true;\nsecond line\n");
+  writeFileSync(join(workspace, "repository", "README.md"), "alpha docs\n");
+  writeFileSync(join(workspace, "outside", "secret.txt"), "do not read\n");
+  return workspace;
+}
+
+function tools(workspace: string, maxCalls?: number) {
+  return new Map(createDeepSeekHarnessReadTools({
+    workspace,
+    workspaceAccess: { writable_paths: [], readonly_paths: ["repository"] },
+    allowedTools: ["Read", "Grep", "Glob", "LS"],
+    maxCalls,
+  }).map((tool) => [tool.name, tool]));
+}
+
+describe("DeepSeek Harness HomeRail-managed read tools", () => {
+  it("reads, searches, globs, and lists only declared workspace roots", async () => {
+    const workspace = fixture();
+    const available = tools(workspace);
+
+    await expect(available.get("Read")!.handler({
+      file_path: "repository/src/alpha.ts",
+      offset: 1,
+      limit: 1,
+    })).resolves.toMatchObject({
+      content: [{ text: expect.stringContaining("1\texport const alpha = true;") }],
+    });
+    await expect(available.get("Grep")!.handler({
+      pattern: "alpha",
+      path: "repository",
+      glob: "**/*.ts",
+    })).resolves.toMatchObject({
+      content: [{ text: "src/alpha.ts:1:export const alpha = true;" }],
+    });
+    await expect(available.get("Glob")!.handler({
+      pattern: "**/*.ts",
+      path: "repository",
+    })).resolves.toMatchObject({ content: [{ text: "src/alpha.ts" }] });
+    await expect(available.get("LS")!.handler({ path: "repository" }))
+      .resolves.toMatchObject({ content: [{ text: "README.md\nsrc/" }] });
+
+    await expect(available.get("Read")!.handler({ file_path: "outside/secret.txt" }))
+      .resolves.toMatchObject({ is_error: true, content: [{ text: expect.stringContaining("outside") }] });
+    await expect(available.get("Read")!.handler({ file_path: "../etc/passwd" }))
+      .resolves.toMatchObject({ is_error: true, content: [{ text: expect.stringContaining("traversal-free") }] });
+  });
+
+  it("rejects symlink escapes and enforces a shared built-in call budget", async () => {
+    const workspace = fixture();
+    symlinkSync(join(workspace, "outside", "secret.txt"), join(workspace, "repository", "escape"));
+    const available = tools(workspace, 1);
+
+    await expect(available.get("Read")!.handler({ file_path: "repository/escape" }))
+      .resolves.toMatchObject({ is_error: true, content: [{ text: expect.stringContaining("outside") }] });
+    await expect(available.get("LS")!.handler({ path: "repository" }))
+      .resolves.toMatchObject({
+        is_error: true,
+        content: [{ text: expect.stringContaining("Built-in tool budget exhausted (1/1)") }],
+      });
+  });
+
+  it("refuses mutating or shell built-ins", () => {
+    const workspace = fixture();
+    expect(() => createDeepSeekHarnessReadTools({
+      workspace,
+      workspaceAccess: { writable_paths: [], readonly_paths: ["repository"] },
+      allowedTools: ["Read", "Write"],
+    })).toThrow(/only supports HomeRail-managed read tools/);
+  });
+});

--- a/homerail_worker/src/__tests__/deepseek-harness-read-tools.test.ts
+++ b/homerail_worker/src/__tests__/deepseek-harness-read-tools.test.ts
@@ -21,12 +21,13 @@ function fixture() {
   return workspace;
 }
 
-function tools(workspace: string, maxCalls?: number) {
+function tools(workspace: string, maxCalls?: number, grepTimeoutMs?: number) {
   return new Map(createDeepSeekHarnessReadTools({
     workspace,
     workspaceAccess: { writable_paths: [], readonly_paths: ["repository"] },
     allowedTools: ["Read", "Grep", "Glob", "LS"],
     maxCalls,
+    grepTimeoutMs,
   }).map((tool) => [tool.name, tool]));
 }
 
@@ -74,6 +75,54 @@ describe("DeepSeek Harness HomeRail-managed read tools", () => {
         is_error: true,
         content: [{ text: expect.stringContaining("Built-in tool budget exhausted (1/1)") }],
       });
+  });
+
+  it("allows a declared root to be created after tool initialization and still resolves it safely", async () => {
+    const workspace = fixture();
+    const available = new Map(createDeepSeekHarnessReadTools({
+      workspace,
+      workspaceAccess: { writable_paths: ["generated"], readonly_paths: ["future-link"] },
+      allowedTools: ["Read", "LS"],
+    }).map((tool) => [tool.name, tool]));
+
+    await expect(available.get("LS")!.handler({ path: "generated" }))
+      .resolves.toMatchObject({ is_error: true });
+    mkdirSync(join(workspace, "generated"));
+    writeFileSync(join(workspace, "generated", "result.txt"), "ready\n");
+    await expect(available.get("Read")!.handler({ file_path: "generated/result.txt" }))
+      .resolves.toMatchObject({ content: [{ text: expect.stringContaining("ready") }] });
+
+    const escapedRoot = mkdtempSync(join(tmpdir(), "homerail-dsh-read-tools-outside-"));
+    roots.push(escapedRoot);
+    writeFileSync(join(escapedRoot, "secret.txt"), "do not read\n");
+    symlinkSync(escapedRoot, join(workspace, "future-link"), "dir");
+    await expect(available.get("LS")!.handler({ path: "future-link" }))
+      .resolves.toMatchObject({
+        is_error: true,
+        content: [{ text: expect.stringContaining("outside the declared workspace roots") }],
+      });
+  });
+
+  it("bounds model-controlled regular expressions outside the Worker event loop", async () => {
+    const workspace = fixture();
+    writeFileSync(join(workspace, "repository", "pathological.txt"), `${"a".repeat(100_000)}X\n`);
+    const available = tools(workspace, undefined, 100);
+
+    await expect(available.get("Grep")!.handler({ pattern: "[", path: "repository" }))
+      .resolves.toMatchObject({
+        is_error: true,
+        content: [{ text: expect.stringContaining("invalid Grep regular expression") }],
+      });
+
+    const startedAt = Date.now();
+    await expect(available.get("Grep")!.handler({
+      pattern: "^(a+)+$",
+      path: "repository/pathological.txt",
+    })).resolves.toMatchObject({
+      is_error: true,
+      content: [{ text: expect.stringContaining("Grep search timed out after 100ms") }],
+    });
+    expect(Date.now() - startedAt).toBeLessThan(2_000);
   });
 
   it("refuses mutating or shell built-ins", () => {

--- a/homerail_worker/src/__tests__/deepseek-harness-runtime.integration.test.ts
+++ b/homerail_worker/src/__tests__/deepseek-harness-runtime.integration.test.ts
@@ -1,0 +1,158 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import { DeepSeekHarnessAdapter } from "../agent/deepseek-harness.js";
+import type { AgentEvent, DagToolDefinition } from "../agent/types.js";
+
+interface MockProvider {
+  baseUrl: string;
+  requests: Array<{ path: string; body: Record<string, unknown> }>;
+  close(): Promise<void>;
+}
+
+const servers: Server[] = [];
+const runtimeConfigured = Boolean(process.env.HOMERAIL_DSH_RUNTIME_COMMAND?.trim());
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => new Promise<void>((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+  })));
+});
+
+function sse(response: ServerResponse, events: unknown[]): void {
+  response.writeHead(200, { "content-type": "text/event-stream" });
+  for (const event of events) response.write(`data: ${typeof event === "string" ? event : JSON.stringify(event)}\n\n`);
+  response.end();
+}
+
+async function startMockProvider(): Promise<MockProvider> {
+  const requests: MockProvider["requests"] = [];
+  const server = createServer((request: IncomingMessage, response: ServerResponse) => {
+    let rawBody = "";
+    request.setEncoding("utf8");
+    request.on("data", (chunk: string) => { rawBody += chunk; });
+    request.on("end", () => {
+      const body = JSON.parse(rawBody) as Record<string, unknown>;
+      requests.push({ path: request.url ?? "", body });
+      if (requests.length === 1) {
+        sse(response, [
+          { choices: [{ index: 0, delta: { role: "assistant", content: "" }, finish_reason: null }] },
+          {
+            choices: [{
+              index: 0,
+              delta: {
+                tool_calls: [{
+                  index: 0,
+                  id: "handoff-call-1",
+                  type: "function",
+                  function: {
+                    name: "mcp__homerail__handoff",
+                    arguments: "{\"port\":\"done\",\"content\":\"runtime-smoke\"}",
+                  },
+                }],
+              },
+              finish_reason: null,
+            }],
+          },
+          {
+            choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }],
+            usage: { prompt_tokens: 5, completion_tokens: 2 },
+          },
+          "[DONE]",
+        ]);
+        return;
+      }
+      sse(response, [
+        { choices: [{ index: 0, delta: { role: "assistant", content: "" }, finish_reason: null }] },
+        { choices: [{ index: 0, delta: { content: "runtime complete" }, finish_reason: null }] },
+        {
+          choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+          usage: { prompt_tokens: 7, completion_tokens: 3 },
+        },
+        "[DONE]",
+      ]);
+    });
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address() as AddressInfo;
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}/v1/chat/completions`,
+    requests,
+    close: () => new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        const index = servers.indexOf(server);
+        if (index >= 0) servers.splice(index, 1);
+        if (error) reject(error);
+        else resolve();
+      });
+    }),
+  };
+}
+
+describe.skipIf(!runtimeConfigured)("DeepSeek Harness packaged runtime", () => {
+  it("runs the real JSON-RPC runtime through model SSE and MCP handoff", async () => {
+    const provider = await startMockProvider();
+    const calls: Array<{ args: Record<string, unknown>; toolCallId?: string }> = [];
+    const handoff: DagToolDefinition = {
+      name: "handoff",
+      description: "Return the completed work to HomeRail",
+      input_schema: {
+        type: "object",
+        properties: {
+          port: { type: "string" },
+          content: { type: "string" },
+        },
+        required: ["port", "content"],
+      },
+      handler: async (args, metadata) => {
+        calls.push({ args, toolCallId: metadata?.tool_call_id });
+        return { content: [{ type: "text", text: "accepted" }] };
+      },
+    };
+    const events: AgentEvent[] = [];
+    const adapter = new DeepSeekHarnessAdapter();
+
+    for await (const event of adapter.run("Call handoff, then finish.", [handoff], {
+      provider: "local-smoke",
+      protocol: "openai_compatible",
+      model: "mock-model",
+      apiKey: "keyless-smoke",
+      baseUrl: provider.baseUrl,
+      workspace: process.cwd(),
+      sessionId: "dsh-runtime-smoke",
+    })) events.push(event);
+
+    expect(events.some((event) => event.type === "error")).toBe(false);
+    expect(events).toContainEqual({
+      type: "tool_use",
+      id: "handoff-call-1",
+      name: "handoff",
+      input: { port: "done", content: "runtime-smoke" },
+    });
+    expect(events).toContainEqual({
+      type: "tool_result",
+      tool_use_id: "handoff-call-1",
+      content: "accepted",
+      is_error: false,
+    });
+    expect(events).toContainEqual({ type: "text", text: "runtime complete" });
+    expect(events.at(-1)).toMatchObject({
+      type: "done",
+      usage: { input_tokens: 12, output_tokens: 5 },
+      finish_reason: "completed",
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.args).toEqual({ port: "done", content: "runtime-smoke" });
+    expect(calls[0]?.toolCallId).toMatch(/^\d+$/);
+    expect(provider.requests).toHaveLength(2);
+    expect(provider.requests.map((entry) => entry.path)).toEqual([
+      "/v1/chat/completions",
+      "/v1/chat/completions",
+    ]);
+    expect(JSON.stringify(provider.requests[0]?.body)).toContain("mcp__homerail__handoff");
+    expect(JSON.stringify(provider.requests[1]?.body)).toContain("accepted");
+
+    await provider.close();
+  }, 30_000);
+});

--- a/homerail_worker/src/__tests__/deepseek-harness.test.ts
+++ b/homerail_worker/src/__tests__/deepseek-harness.test.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { DeepSeekHarnessAdapter, _deepSeekHarnessForkCommitForTest } from "../agent/deepseek-harness.js";
 import { AgentTurnController } from "../agent/turn-controller.js";
-import type { AgentEvent, AgentRunContext } from "../agent/types.js";
+import type { AgentEvent, AgentRunContext, DagToolDefinition } from "../agent/types.js";
 
 const fakeRuntime = fileURLToPath(new URL("./fixtures/fake-dsh-runtime.mjs", import.meta.url));
 const tempRoots: string[] = [];
@@ -34,9 +34,13 @@ function context(overrides: Partial<AgentRunContext> = {}): AgentRunContext {
   };
 }
 
-async function collect(adapter: DeepSeekHarnessAdapter, runContext: AgentRunContext): Promise<AgentEvent[]> {
+async function collect(
+  adapter: DeepSeekHarnessAdapter,
+  runContext: AgentRunContext,
+  tools: DagToolDefinition[] = [],
+): Promise<AgentEvent[]> {
   const events: AgentEvent[] = [];
-  for await (const event of adapter.run("do the work", [], runContext)) events.push(event);
+  for await (const event of adapter.run("do the work", tools, runContext)) events.push(event);
   return events;
 }
 
@@ -103,6 +107,70 @@ describe("DeepSeekHarnessAdapter", () => {
     expect(recorded.reasoningEfforts).toBeUndefined();
     expect(recorded.apiKeyPresent).toBe(true);
     expect(recorded.params).toMatchObject({ maxTokens: 32_768 });
+  });
+
+  it("runs the generated MCP proxy through the authenticated loopback tool bridge", async () => {
+    const root = tempRoot();
+    const recordFile = join(root, "runtime.jsonl");
+    const calls: Array<{ args: Record<string, unknown>; toolCallId?: string }> = [];
+    const handoffTool: DagToolDefinition = {
+      name: "handoff",
+      description: "Submit a terminal handoff",
+      input_schema: { type: "object" },
+      handler: async (args, metadata) => {
+        calls.push({ args, toolCallId: metadata?.tool_call_id });
+        return { content: [{ type: "text", text: "accepted:done" }] };
+      },
+    };
+    const adapter = new DeepSeekHarnessAdapter({
+      runtimeCommand: process.execPath,
+      runtimeArgs: [fakeRuntime],
+    });
+    const events = await collect(adapter, context({
+      environmentVariables: {
+        DSH_FAKE_RECORD_FILE: recordFile,
+        DSH_FAKE_EXERCISE_MCP: "1",
+      },
+    }), [handoffTool]);
+
+    const records = readFileSync(recordFile, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    const exercised = records.find((record) => record.mcp) as {
+      mcp: {
+        initialized: { serverInfo: { name: string } };
+        listed: { tools: Array<{ name: string }> };
+        called: { content: Array<{ text: string }>; isError: boolean };
+        unknown: { content: Array<{ text: string }>; isError: boolean };
+        composite: { content: Array<{ text: string }>; isError: boolean };
+        unauthorized: { status: number; body: { error: string } };
+      };
+    };
+
+    expect(events.some((event) => event.type === "error")).toBe(false);
+    expect(exercised.mcp.initialized.serverInfo.name).toBe("homerail-tools");
+    expect(exercised.mcp.listed.tools.map((tool) => tool.name)).toEqual(["handoff"]);
+    expect(exercised.mcp.called).toEqual({
+      content: [{ type: "text", text: "accepted:done" }],
+      isError: false,
+    });
+    expect(exercised.mcp.unknown).toEqual({
+      content: [{ type: "text", text: "Unknown tool: missing" }],
+      isError: true,
+    });
+    expect(exercised.mcp.composite).toEqual({
+      content: [{ type: "text", text: "Unknown tool: mcp__homerail__handoff" }],
+      isError: true,
+    });
+    expect(exercised.mcp.unauthorized).toEqual({
+      status: 403,
+      body: { error: "forbidden" },
+    });
+    expect(calls).toEqual([{
+      args: { port: "done", content: { ok: true } },
+      toolCallId: "3",
+    }]);
   });
 
   it("passes a model-declared reasoning selector and wire mapping to DSH", async () => {
@@ -256,6 +324,13 @@ describe("DeepSeekHarnessAdapter", () => {
       },
     }));
     await vi.waitFor(() => expect(existsSync(readyFile)).toBe(true));
+    const bindingProbe = controller.steer({
+      commandId: "cancel-binding-probe",
+      content: "remain active until cancelled",
+    });
+    expect(bindingProbe.status).toBe("accepted");
+    if (bindingProbe.status !== "accepted") throw new Error("binding probe was not accepted");
+    await expect(bindingProbe.applied).resolves.toEqual({ status: "applied" });
 
     await expect(controller.interrupt("stop now")).resolves.toEqual({ status: "interrupted" });
     const events = await eventsPromise;

--- a/homerail_worker/src/__tests__/deepseek-harness.test.ts
+++ b/homerail_worker/src/__tests__/deepseek-harness.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { DeepSeekHarness } from "@deepseek-ai/dsh-sdk-client";
 import { DeepSeekHarnessAdapter, _deepSeekHarnessForkCommitForTest } from "../agent/deepseek-harness.js";
 import { AgentTurnController } from "../agent/turn-controller.js";
 import type { AgentEvent, AgentRunContext, DagToolDefinition } from "../agent/types.js";
@@ -336,5 +337,50 @@ describe("DeepSeekHarnessAdapter", () => {
     const events = await eventsPromise;
     expect(events.at(-1)).toMatchObject({ type: "done", finish_reason: "cancelled" });
     await controller.close({ outcome: "failed", reason: "cancelled" });
+  });
+
+  it("does not leak a close rejection when abort cancellation fails", async () => {
+    const root = tempRoot();
+    const readyFile = join(root, "ready");
+    const abortController = new AbortController();
+    const adapter = new DeepSeekHarnessAdapter({
+      runtimeCommand: process.execPath,
+      runtimeArgs: [fakeRuntime],
+    });
+    const originalClose = DeepSeekHarness.prototype.close;
+    const closeSpy = vi.spyOn(DeepSeekHarness.prototype, "close")
+      .mockImplementationOnce(async () => {
+        throw new Error("simulated close failure");
+      })
+      .mockImplementation(function (this: DeepSeekHarness) {
+        return originalClose.call(this);
+      });
+    const unhandled: unknown[] = [];
+    const captureUnhandled = (reason: unknown): void => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", captureUnhandled);
+
+    try {
+      const eventsPromise = collect(adapter, context({
+        abortSignal: abortController.signal,
+        environmentVariables: {
+          DSH_FAKE_WAIT_FOR: "cancel",
+          DSH_FAKE_CANCEL_ERROR: "cancel transport failed",
+          DSH_FAKE_READY_FILE: readyFile,
+        },
+      }));
+      await vi.waitFor(() => expect(existsSync(readyFile)).toBe(true));
+      abortController.abort();
+
+      const events = await eventsPromise;
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(events.at(-1)).toMatchObject({ type: "done", finish_reason: "cancelled" });
+      expect(closeSpy).toHaveBeenCalled();
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", captureUnhandled);
+      closeSpy.mockRestore();
+    }
   });
 });

--- a/homerail_worker/src/__tests__/deepseek-harness.test.ts
+++ b/homerail_worker/src/__tests__/deepseek-harness.test.ts
@@ -137,6 +137,22 @@ describe("DeepSeekHarnessAdapter", () => {
     }));
   });
 
+  it("surfaces structured DSH turn failures as actionable agent errors", async () => {
+    const adapter = new DeepSeekHarnessAdapter({
+      runtimeCommand: process.execPath,
+      runtimeArgs: [fakeRuntime],
+    });
+    const events = await collect(adapter, context({
+      environmentVariables: { DSH_FAKE_TURN_ERROR: "provider connection refused" },
+    }));
+
+    expect(events).toContainEqual({
+      type: "error",
+      message: "DeepSeek Harness turn failed [UPSTREAM_REJECTED] (HTTP 502): provider connection refused",
+    });
+    expect(events.at(-1)).toMatchObject({ type: "done", finish_reason: "error" });
+  });
+
   it("uses cooperative session cancellation for an active DSH turn", async () => {
     const root = tempRoot();
     const readyFile = join(root, "ready");

--- a/homerail_worker/src/__tests__/deepseek-harness.test.ts
+++ b/homerail_worker/src/__tests__/deepseek-harness.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -109,6 +109,32 @@ describe("DeepSeekHarnessAdapter", () => {
     const events = await eventsPromise;
     expect(events.at(-1)?.type).toBe("done");
     await controller.close({ outcome: "completed" });
+  });
+
+  it("projects only the explicitly allowed HomeRail-managed read tools into DSH MCP", async () => {
+    const workspace = tempRoot();
+    mkdirSync(join(workspace, "repository"));
+    writeFileSync(join(workspace, "repository", "README.md"), "fixture\n");
+    const adapter = new DeepSeekHarnessAdapter({
+      runtimeCommand: process.execPath,
+      runtimeArgs: [fakeRuntime],
+    });
+    const events = await collect(adapter, context({
+      workspace,
+      allowedBuiltinTools: ["Read", "Grep", "Glob", "LS"],
+      workspaceAccess: { writable_paths: [], readonly_paths: ["repository"] },
+      maxBuiltinToolCalls: 12,
+    }));
+
+    expect(events).toContainEqual(expect.objectContaining({
+      type: "debug",
+      source: "deepseek-harness",
+      message: "runtime_prepared",
+      data: expect.objectContaining({
+        tool_count: 4,
+        builtin_tools: ["Read", "Grep", "Glob", "LS"],
+      }),
+    }));
   });
 
   it("uses cooperative session cancellation for an active DSH turn", async () => {

--- a/homerail_worker/src/__tests__/deepseek-harness.test.ts
+++ b/homerail_worker/src/__tests__/deepseek-harness.test.ts
@@ -197,7 +197,7 @@ describe("DeepSeekHarnessAdapter", () => {
     }));
   });
 
-  it("applies a DSH-only default built-in read budget", async () => {
+  it("does not impose a built-in read budget unless the workflow requests one", async () => {
     const workspace = tempRoot();
     mkdirSync(join(workspace, "repository"));
     const adapter = new DeepSeekHarnessAdapter({
@@ -213,7 +213,7 @@ describe("DeepSeekHarnessAdapter", () => {
     expect(events).toContainEqual(expect.objectContaining({
       type: "debug",
       source: "deepseek-harness",
-      data: expect.objectContaining({ max_builtin_tool_calls: 24 }),
+      data: expect.objectContaining({ max_builtin_tool_calls: null }),
     }));
   });
 

--- a/homerail_worker/src/__tests__/deepseek-harness.test.ts
+++ b/homerail_worker/src/__tests__/deepseek-harness.test.ts
@@ -121,7 +121,7 @@ describe("DeepSeekHarnessAdapter", () => {
     const calls: Array<{ args: Record<string, unknown>; toolCallId?: string }> = [];
     const handoffTool: DagToolDefinition = {
       name: "handoff",
-      description: "Submit a terminal handoff",
+      description: "Submit a `handoff` without evaluating ${process.exit(99)}",
       input_schema: { type: "object" },
       handler: async (args, metadata) => {
         calls.push({ args, toolCallId: metadata?.tool_call_id });
@@ -146,7 +146,7 @@ describe("DeepSeekHarnessAdapter", () => {
     const exercised = records.find((record) => record.mcp) as {
       mcp: {
         initialized: { serverInfo: { name: string } };
-        listed: { tools: Array<{ name: string }> };
+        listed: { tools: Array<{ name: string; description: string }> };
         called: { content: Array<{ text: string }>; isError: boolean };
         unknown: { content: Array<{ text: string }>; isError: boolean };
         composite: { content: Array<{ text: string }>; isError: boolean };
@@ -157,6 +157,9 @@ describe("DeepSeekHarnessAdapter", () => {
     expect(events.some((event) => event.type === "error")).toBe(false);
     expect(exercised.mcp.initialized.serverInfo.name).toBe("homerail-tools");
     expect(exercised.mcp.listed.tools.map((tool) => tool.name)).toEqual(["handoff"]);
+    expect(exercised.mcp.listed.tools[0]?.description).toBe(
+      "Submit a `handoff` without evaluating ${process.exit(99)}",
+    );
     expect(exercised.mcp.called).toEqual({
       content: [{ type: "text", text: "accepted:done" }],
       isError: false,

--- a/homerail_worker/src/__tests__/deepseek-harness.test.ts
+++ b/homerail_worker/src/__tests__/deepseek-harness.test.ts
@@ -41,6 +41,15 @@ async function collect(adapter: DeepSeekHarnessAdapter, runContext: AgentRunCont
 }
 
 describe("DeepSeekHarnessAdapter", () => {
+  it("pins the compatible fork revision and selects the local model effort vocabulary", () => {
+    const dockerfile = readFileSync(new URL("../../Dockerfile", import.meta.url), "utf8");
+    const composition = readFileSync(new URL("../../dsh/homerail.cordis.yml", import.meta.url), "utf8");
+    const dockerCommit = /^ARG HOMERAIL_DSH_FORK_COMMIT=([a-f0-9]{40})$/m.exec(dockerfile)?.[1];
+
+    expect(dockerCommit).toBe(_deepSeekHarnessForkCommitForTest);
+    expect(composition).toMatch(/^\s{4}reasoningEffort: xhigh$/m);
+  });
+
   it("maps DSH streaming, tool, usage, and completion events without leaking the Manager token", async () => {
     const root = tempRoot();
     const recordFile = join(root, "runtime.jsonl");

--- a/homerail_worker/src/__tests__/deepseek-harness.test.ts
+++ b/homerail_worker/src/__tests__/deepseek-harness.test.ts
@@ -1,10 +1,15 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { PassThrough } from "node:stream";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { DeepSeekHarness } from "@deepseek-ai/dsh-sdk-client";
-import { DeepSeekHarnessAdapter, _deepSeekHarnessForkCommitForTest } from "../agent/deepseek-harness.js";
+import {
+  DeepSeekHarnessAdapter,
+  _deepSeekHarnessForkCommitForTest,
+  _readDeepSeekHarnessToolJsonForTest,
+} from "../agent/deepseek-harness.js";
 import { AgentTurnController } from "../agent/turn-controller.js";
 import type { AgentEvent, AgentRunContext, DagToolDefinition } from "../agent/types.js";
 
@@ -172,6 +177,34 @@ describe("DeepSeekHarnessAdapter", () => {
       args: { port: "done", content: { ok: true } },
       toolCallId: "3",
     }]);
+  });
+
+  it("preserves split UTF-8 tool arguments and enforces the bridge limit in bytes", async () => {
+    const body = Buffer.from(JSON.stringify({
+      name: "handoff",
+      args: { content: "中文证据" },
+    }));
+    const multibyteStart = body.indexOf(Buffer.from("中"));
+    expect(multibyteStart).toBeGreaterThan(0);
+
+    const request = new PassThrough();
+    const parsed = _readDeepSeekHarnessToolJsonForTest(
+      request as unknown as Parameters<typeof _readDeepSeekHarnessToolJsonForTest>[0],
+    );
+    request.write(body.subarray(0, multibyteStart + 1));
+    request.end(body.subarray(multibyteStart + 1));
+    await expect(parsed).resolves.toEqual({
+      name: "handoff",
+      args: { content: "中文证据" },
+    });
+
+    const oversizedRequest = new PassThrough();
+    const oversized = _readDeepSeekHarnessToolJsonForTest(
+      oversizedRequest as unknown as Parameters<typeof _readDeepSeekHarnessToolJsonForTest>[0],
+      body.length - 1,
+    );
+    oversizedRequest.end(body);
+    await expect(oversized).rejects.toThrow("request body too large");
   });
 
   it("passes a model-declared reasoning selector and wire mapping to DSH", async () => {

--- a/homerail_worker/src/__tests__/deepseek-harness.test.ts
+++ b/homerail_worker/src/__tests__/deepseek-harness.test.ts
@@ -41,15 +41,15 @@ async function collect(adapter: DeepSeekHarnessAdapter, runContext: AgentRunCont
 }
 
 describe("DeepSeekHarnessAdapter", () => {
-  it("pins the compatible fork revision and projects the selected model effort", () => {
+  it("pins the compatible fork revision and uses the capability-aware pi-ai adapter", () => {
     const dockerfile = readFileSync(new URL("../../Dockerfile", import.meta.url), "utf8");
     const composition = readFileSync(new URL("../../dsh/homerail.cordis.yml", import.meta.url), "utf8");
     const dockerCommit = /^ARG HOMERAIL_DSH_FORK_COMMIT=([a-f0-9]{40})$/m.exec(dockerfile)?.[1];
 
     expect(dockerCommit).toBe(_deepSeekHarnessForkCommitForTest);
-    expect(composition).toMatch(
-      /^\s{4}reasoningEffort: !!js process\.env\.DSH_REASONING_EFFORT \|\| 'high'$/m,
-    );
+    expect(composition).toContain("@deepseek-ai/dsh-llm-pi-ai");
+    expect(composition).toContain("HOMERAIL_DSH_PROVIDERS_JSON");
+    expect(composition).not.toContain("@deepseek-ai/dsh-llm-deepseek");
   });
 
   it("maps DSH streaming, tool, usage, and completion events without leaking the Manager token", async () => {
@@ -99,11 +99,13 @@ describe("DeepSeekHarnessAdapter", () => {
     expect(recorded.managerToken).toBeUndefined();
     expect(recorded.baseUrl).toBe("https://example.invalid/v1");
     expect(recorded.cordisConfig).toBe(customConfig);
-    expect(recorded.reasoningEffort).toBe("high");
+    expect(recorded.reasoningEffort).toBeUndefined();
+    expect(recorded.reasoningEfforts).toBeUndefined();
+    expect(recorded.apiKeyPresent).toBe(true);
     expect(recorded.params).toMatchObject({ maxTokens: 32_768 });
   });
 
-  it("passes an explicit compatible reasoning effort to the DSH composition", async () => {
+  it("passes a model-declared reasoning selector and wire mapping to DSH", async () => {
     const root = tempRoot();
     const recordFile = join(root, "runtime.jsonl");
     const adapter = new DeepSeekHarnessAdapter({
@@ -112,23 +114,28 @@ describe("DeepSeekHarnessAdapter", () => {
     });
     await collect(adapter, context({
       reasoningEffort: "medium",
+      reasoningEffortMap: { off: null, medium: "balanced", high: "deep" },
       environmentVariables: { DSH_FAKE_RECORD_FILE: recordFile },
     }));
 
     const recorded = JSON.parse(readFileSync(recordFile, "utf8").trim()) as Record<string, unknown>;
     expect(recorded.reasoningEffort).toBe("medium");
+    expect(recorded.reasoningEfforts).toEqual({ off: null, medium: "balanced", high: "deep" });
   });
 
-  it("rejects an incompatible reasoning effort before starting DSH", async () => {
+  it("rejects a reasoning selector the selected model did not declare", async () => {
     const adapter = new DeepSeekHarnessAdapter({
       runtimeCommand: process.execPath,
       runtimeArgs: [fakeRuntime],
     });
 
-    const events = await collect(adapter, context({ reasoningEffort: "ultra" }));
+    const events = await collect(adapter, context({
+      reasoningEffort: "ultra",
+      reasoningEffortMap: { off: null, medium: "balanced" },
+    }));
     expect(events).toContainEqual({
       type: "error",
-      message: expect.stringContaining("DeepSeek Harness reasoning effort must be one of"),
+      message: "DeepSeek Harness failed: DeepSeek Harness model does not declare reasoning effort 'ultra'",
     });
     expect(events.at(-1)).toMatchObject({ type: "done" });
   });

--- a/homerail_worker/src/__tests__/deepseek-harness.test.ts
+++ b/homerail_worker/src/__tests__/deepseek-harness.test.ts
@@ -41,13 +41,15 @@ async function collect(adapter: DeepSeekHarnessAdapter, runContext: AgentRunCont
 }
 
 describe("DeepSeekHarnessAdapter", () => {
-  it("pins the compatible fork revision and selects the local model effort vocabulary", () => {
+  it("pins the compatible fork revision and projects the selected model effort", () => {
     const dockerfile = readFileSync(new URL("../../Dockerfile", import.meta.url), "utf8");
     const composition = readFileSync(new URL("../../dsh/homerail.cordis.yml", import.meta.url), "utf8");
     const dockerCommit = /^ARG HOMERAIL_DSH_FORK_COMMIT=([a-f0-9]{40})$/m.exec(dockerfile)?.[1];
 
     expect(dockerCommit).toBe(_deepSeekHarnessForkCommitForTest);
-    expect(composition).toMatch(/^\s{4}reasoningEffort: xhigh$/m);
+    expect(composition).toMatch(
+      /^\s{4}reasoningEffort: !!js process\.env\.DSH_REASONING_EFFORT \|\| 'high'$/m,
+    );
   });
 
   it("maps DSH streaming, tool, usage, and completion events without leaking the Manager token", async () => {
@@ -97,7 +99,38 @@ describe("DeepSeekHarnessAdapter", () => {
     expect(recorded.managerToken).toBeUndefined();
     expect(recorded.baseUrl).toBe("https://example.invalid/v1");
     expect(recorded.cordisConfig).toBe(customConfig);
+    expect(recorded.reasoningEffort).toBe("high");
     expect(recorded.params).toMatchObject({ maxTokens: 32_768 });
+  });
+
+  it("passes an explicit compatible reasoning effort to the DSH composition", async () => {
+    const root = tempRoot();
+    const recordFile = join(root, "runtime.jsonl");
+    const adapter = new DeepSeekHarnessAdapter({
+      runtimeCommand: process.execPath,
+      runtimeArgs: [fakeRuntime],
+    });
+    await collect(adapter, context({
+      reasoningEffort: "medium",
+      environmentVariables: { DSH_FAKE_RECORD_FILE: recordFile },
+    }));
+
+    const recorded = JSON.parse(readFileSync(recordFile, "utf8").trim()) as Record<string, unknown>;
+    expect(recorded.reasoningEffort).toBe("medium");
+  });
+
+  it("rejects an incompatible reasoning effort before starting DSH", async () => {
+    const adapter = new DeepSeekHarnessAdapter({
+      runtimeCommand: process.execPath,
+      runtimeArgs: [fakeRuntime],
+    });
+
+    const events = await collect(adapter, context({ reasoningEffort: "ultra" }));
+    expect(events).toContainEqual({
+      type: "error",
+      message: expect.stringContaining("DeepSeek Harness reasoning effort must be one of"),
+    });
+    expect(events.at(-1)).toMatchObject({ type: "done" });
   });
 
   it("allows an explicit bounded per-request output token limit", async () => {
@@ -159,7 +192,28 @@ describe("DeepSeekHarnessAdapter", () => {
       data: expect.objectContaining({
         tool_count: 4,
         builtin_tools: ["Read", "Grep", "Glob", "LS"],
+        max_builtin_tool_calls: 12,
       }),
+    }));
+  });
+
+  it("applies a DSH-only default built-in read budget", async () => {
+    const workspace = tempRoot();
+    mkdirSync(join(workspace, "repository"));
+    const adapter = new DeepSeekHarnessAdapter({
+      runtimeCommand: process.execPath,
+      runtimeArgs: [fakeRuntime],
+    });
+    const events = await collect(adapter, context({
+      workspace,
+      allowedBuiltinTools: ["Read"],
+      workspaceAccess: { writable_paths: [], readonly_paths: ["repository"] },
+    }));
+
+    expect(events).toContainEqual(expect.objectContaining({
+      type: "debug",
+      source: "deepseek-harness",
+      data: expect.objectContaining({ max_builtin_tool_calls: 24 }),
     }));
   });
 

--- a/homerail_worker/src/__tests__/deepseek-harness.test.ts
+++ b/homerail_worker/src/__tests__/deepseek-harness.test.ts
@@ -88,6 +88,23 @@ describe("DeepSeekHarnessAdapter", () => {
     expect(recorded.managerToken).toBeUndefined();
     expect(recorded.baseUrl).toBe("https://example.invalid/v1");
     expect(recorded.cordisConfig).toBe(customConfig);
+    expect(recorded.params).toMatchObject({ maxTokens: 32_768 });
+  });
+
+  it("allows an explicit bounded per-request output token limit", async () => {
+    const root = tempRoot();
+    const recordFile = join(root, "runtime.jsonl");
+    const adapter = new DeepSeekHarnessAdapter({
+      runtimeCommand: process.execPath,
+      runtimeArgs: [fakeRuntime],
+      maxTokens: 16_384,
+    });
+    await collect(adapter, context({
+      environmentVariables: { DSH_FAKE_RECORD_FILE: recordFile },
+    }));
+
+    const recorded = JSON.parse(readFileSync(recordFile, "utf8").trim()) as Record<string, unknown>;
+    expect(recorded.params).toMatchObject({ maxTokens: 16_384 });
   });
 
   it("routes queued live steering through the fork session/steer method", async () => {

--- a/homerail_worker/src/__tests__/deepseek-harness.test.ts
+++ b/homerail_worker/src/__tests__/deepseek-harness.test.ts
@@ -1,0 +1,136 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DeepSeekHarnessAdapter, _deepSeekHarnessForkCommitForTest } from "../agent/deepseek-harness.js";
+import { AgentTurnController } from "../agent/turn-controller.js";
+import type { AgentEvent, AgentRunContext } from "../agent/types.js";
+
+const fakeRuntime = fileURLToPath(new URL("./fixtures/fake-dsh-runtime.mjs", import.meta.url));
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  for (const root of tempRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function tempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "homerail-dsh-test-"));
+  tempRoots.push(root);
+  return root;
+}
+
+function context(overrides: Partial<AgentRunContext> = {}): AgentRunContext {
+  return {
+    provider: "deepseek",
+    protocol: "openai_compatible",
+    model: "test-model",
+    apiKey: "test-secret",
+    baseUrl: "https://example.invalid/v1/chat/completions/",
+    workspace: process.cwd(),
+    sessionId: "session-under-test",
+    ...overrides,
+  };
+}
+
+async function collect(adapter: DeepSeekHarnessAdapter, runContext: AgentRunContext): Promise<AgentEvent[]> {
+  const events: AgentEvent[] = [];
+  for await (const event of adapter.run("do the work", [], runContext)) events.push(event);
+  return events;
+}
+
+describe("DeepSeekHarnessAdapter", () => {
+  it("maps DSH streaming, tool, usage, and completion events without leaking the Manager token", async () => {
+    const root = tempRoot();
+    const recordFile = join(root, "runtime.jsonl");
+    const customConfig = join(root, "fork-homerail.cordis.yml");
+    vi.stubEnv("HOMERAIL_WORKER_TOKEN", "manager-secret");
+    vi.stubEnv("HOMERAIL_DSH_CORDIS_CONFIG", customConfig);
+    const adapter = new DeepSeekHarnessAdapter({
+      runtimeCommand: process.execPath,
+      runtimeArgs: [fakeRuntime],
+    });
+    const events = await collect(adapter, context({
+      environmentVariables: {
+        DSH_FAKE_RECORD_FILE: recordFile,
+        HOMERAIL_WORKER_TOKEN: "context-manager-secret",
+      },
+    }));
+
+    expect(events).toContainEqual({ type: "thinking", text: "checking" });
+    expect(events).toContainEqual({ type: "text", text: "finished" });
+    expect(events).toContainEqual({
+      type: "tool_use",
+      id: "call-1",
+      name: "handoff",
+      input: { port: "done", content: "ok" },
+    });
+    expect(events).toContainEqual({
+      type: "tool_result",
+      tool_use_id: "call-1",
+      content: "accepted",
+      is_error: false,
+    });
+    expect(events).toContainEqual({
+      type: "usage",
+      usage: {
+        input_tokens: 7,
+        output_tokens: 3,
+        cache_read_input_tokens: 2,
+        cache_creation_input_tokens: 0,
+      },
+    });
+    expect(events.at(-1)).toMatchObject({ type: "done", finish_reason: "completed" });
+    expect(_deepSeekHarnessForkCommitForTest).toMatch(/^[a-f0-9]{40}$/);
+
+    const recorded = JSON.parse(readFileSync(recordFile, "utf8").trim()) as Record<string, unknown>;
+    expect(recorded.managerToken).toBeUndefined();
+    expect(recorded.baseUrl).toBe("https://example.invalid/v1");
+    expect(recorded.cordisConfig).toBe(customConfig);
+  });
+
+  it("routes queued live steering through the fork session/steer method", async () => {
+    const controller = new AgentTurnController({ capabilities: { liveSteer: true } });
+    const adapter = new DeepSeekHarnessAdapter({
+      runtimeCommand: process.execPath,
+      runtimeArgs: [fakeRuntime],
+    });
+    const eventsPromise = collect(adapter, context({
+      turnController: controller,
+      environmentVariables: { DSH_FAKE_WAIT_FOR: "steer" },
+    }));
+    const receipt = controller.steer({ commandId: "redirect", content: "change direction" });
+    expect(receipt.status).toBe("accepted");
+    if (receipt.status !== "accepted") throw new Error("steer was not accepted");
+
+    await expect(receipt.accepted).resolves.toEqual({ status: "accepted" });
+    await expect(receipt.applied).resolves.toEqual({ status: "applied" });
+    const events = await eventsPromise;
+    expect(events.at(-1)?.type).toBe("done");
+    await controller.close({ outcome: "completed" });
+  });
+
+  it("uses cooperative session cancellation for an active DSH turn", async () => {
+    const root = tempRoot();
+    const readyFile = join(root, "ready");
+    const controller = new AgentTurnController({ capabilities: { liveSteer: true } });
+    const adapter = new DeepSeekHarnessAdapter({
+      runtimeCommand: process.execPath,
+      runtimeArgs: [fakeRuntime],
+    });
+    const eventsPromise = collect(adapter, context({
+      turnController: controller,
+      environmentVariables: {
+        DSH_FAKE_WAIT_FOR: "cancel",
+        DSH_FAKE_READY_FILE: readyFile,
+      },
+    }));
+    await vi.waitFor(() => expect(existsSync(readyFile)).toBe(true));
+
+    await expect(controller.interrupt("stop now")).resolves.toEqual({ status: "interrupted" });
+    const events = await eventsPromise;
+    expect(events.at(-1)).toMatchObject({ type: "done", finish_reason: "cancelled" });
+    await controller.close({ outcome: "failed", reason: "cancelled" });
+  });
+});

--- a/homerail_worker/src/__tests__/fixtures/fake-dsh-runtime.mjs
+++ b/homerail_worker/src/__tests__/fixtures/fake-dsh-runtime.mjs
@@ -88,11 +88,15 @@ lines.on("line", (line) => {
   const request = JSON.parse(line);
   if (request.method === "initialize") {
     if (process.env.DSH_FAKE_RECORD_FILE) {
+      const providerProfiles = JSON.parse(process.env.HOMERAIL_DSH_PROVIDERS_JSON ?? "{}");
+      const providerProfile = providerProfiles[request.params.provider];
       appendFileSync(process.env.DSH_FAKE_RECORD_FILE, `${JSON.stringify({
         params: request.params,
         cordisConfig: process.env.DSH_CORDIS_CONFIG,
-        baseUrl: process.env.DEEPSEEK_BASE_URL,
-        reasoningEffort: process.env.DSH_REASONING_EFFORT,
+        baseUrl: providerProfile?.baseURL,
+        reasoningEffort: providerProfile?.reasoning,
+        reasoningEfforts: providerProfile?.models?.[0]?.reasoningEfforts,
+        apiKeyPresent: Boolean(process.env.HOMERAIL_DSH_API_KEY),
         managerToken: process.env.HOMERAIL_WORKER_TOKEN,
       })}\n`);
     }

--- a/homerail_worker/src/__tests__/fixtures/fake-dsh-runtime.mjs
+++ b/homerail_worker/src/__tests__/fixtures/fake-dsh-runtime.mjs
@@ -235,6 +235,15 @@ lines.on("line", async (line) => {
     return;
   }
   if (request.method === "session/cancel") {
+    if (process.env.DSH_FAKE_CANCEL_ERROR) {
+      write({
+        jsonrpc: "2.0",
+        id: request.id,
+        error: { code: -32000, message: process.env.DSH_FAKE_CANCEL_ERROR },
+      });
+      if (process.env.DSH_FAKE_WAIT_FOR === "cancel") setTimeout(() => finish("cancelled"), 20);
+      return;
+    }
     response(request.id, { accepted: true });
     if (process.env.DSH_FAKE_WAIT_FOR === "cancel") finish("cancelled");
     return;

--- a/homerail_worker/src/__tests__/fixtures/fake-dsh-runtime.mjs
+++ b/homerail_worker/src/__tests__/fixtures/fake-dsh-runtime.mjs
@@ -1,4 +1,5 @@
 import { appendFileSync } from "node:fs";
+import { spawn } from "node:child_process";
 import { createInterface } from "node:readline";
 
 const lines = createInterface({ input: process.stdin });
@@ -13,6 +14,92 @@ function write(value) {
 
 function response(id, result) {
   write({ jsonrpc: "2.0", id, result });
+}
+
+async function exerciseMcpBridge() {
+  const script = process.env.HOMERAIL_DSH_MCP_SCRIPT;
+  const bridgeUrl = process.env.HOMERAIL_MCP_BRIDGE_URL;
+  const bridgeToken = process.env.HOMERAIL_MCP_BRIDGE_TOKEN;
+  if (!script || !bridgeUrl || !bridgeToken) throw new Error("DSH MCP bridge environment is incomplete");
+
+  const child = spawn(process.execPath, [script], {
+    env: {
+      HOMERAIL_MCP_BRIDGE_URL: bridgeUrl,
+      HOMERAIL_MCP_BRIDGE_TOKEN: bridgeToken,
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  const childLines = createInterface({ input: child.stdout });
+  const pending = new Map();
+  let requestId = 0;
+  let stderr = "";
+  child.stderr.on("data", (chunk) => { stderr += chunk.toString("utf8"); });
+  childLines.on("line", (line) => {
+    const message = JSON.parse(line);
+    const waiter = pending.get(message.id);
+    if (!waiter) return;
+    pending.delete(message.id);
+    clearTimeout(waiter.timeout);
+    if (message.error) waiter.reject(new Error(message.error.message));
+    else waiter.resolve(message.result);
+  });
+  child.on("error", (error) => {
+    for (const waiter of pending.values()) {
+      clearTimeout(waiter.timeout);
+      waiter.reject(error);
+    }
+    pending.clear();
+  });
+  const request = (method, params = {}) => new Promise((resolve, reject) => {
+    const id = ++requestId;
+    const timeout = setTimeout(() => {
+      if (!pending.delete(id)) return;
+      reject(new Error(`DSH MCP request timed out: ${method}; stderr=${stderr}`));
+    }, 5_000);
+    pending.set(id, { resolve, reject, timeout });
+    child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`);
+  });
+
+  try {
+    const initialized = await request("initialize", {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+    });
+    child.stdin.write(`${JSON.stringify({
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+      params: {},
+    })}\n`);
+    const listed = await request("tools/list");
+    const called = await request("tools/call", {
+      name: "handoff",
+      arguments: { port: "done", content: { ok: true } },
+    });
+    const unknown = await request("tools/call", { name: "missing", arguments: {} });
+    const composite = await request("tools/call", {
+      name: "mcp__homerail__handoff",
+      arguments: { port: "done" },
+    });
+    const unauthorizedResponse = await fetch(`${bridgeUrl}/tool`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "handoff", args: {} }),
+    });
+    return {
+      initialized,
+      listed,
+      called,
+      unknown,
+      composite,
+      unauthorized: {
+        status: unauthorizedResponse.status,
+        body: await unauthorizedResponse.json(),
+      },
+    };
+  } finally {
+    childLines.close();
+    child.kill("SIGTERM");
+  }
 }
 
 function event(sessionId, type, data) {
@@ -83,7 +170,7 @@ function startPrompt(params) {
   return activeMessage;
 }
 
-lines.on("line", (line) => {
+lines.on("line", async (line) => {
   if (!line.trim()) return;
   const request = JSON.parse(line);
   if (request.method === "initialize") {
@@ -105,6 +192,21 @@ lines.on("line", (line) => {
   }
   if (request.method === "session/prompt") {
     const messageId = startPrompt(request.params);
+    if (process.env.DSH_FAKE_EXERCISE_MCP) {
+      try {
+        const mcp = await exerciseMcpBridge();
+        if (process.env.DSH_FAKE_RECORD_FILE) {
+          appendFileSync(process.env.DSH_FAKE_RECORD_FILE, `${JSON.stringify({ mcp })}\n`);
+        }
+      } catch (error) {
+        write({
+          jsonrpc: "2.0",
+          id: request.id,
+          error: { code: -32000, message: error instanceof Error ? error.message : String(error) },
+        });
+        return;
+      }
+    }
     response(request.id, { messageId });
     event(activeSession, "agent/inbox/spliced", {
       target: "next-turn",

--- a/homerail_worker/src/__tests__/fixtures/fake-dsh-runtime.mjs
+++ b/homerail_worker/src/__tests__/fixtures/fake-dsh-runtime.mjs
@@ -108,7 +108,18 @@ lines.on("line", (line) => {
     });
     status(activeSession, "running");
     if (process.env.DSH_FAKE_READY_FILE) appendFileSync(process.env.DSH_FAKE_READY_FILE, "ready\n");
-    if (!process.env.DSH_FAKE_WAIT_FOR) finish();
+    if (!process.env.DSH_FAKE_WAIT_FOR) {
+      finish(process.env.DSH_FAKE_TURN_ERROR
+        ? {
+            kind: "error",
+            error: {
+              code: "UPSTREAM_REJECTED",
+              message: process.env.DSH_FAKE_TURN_ERROR,
+              status: 502,
+            },
+          }
+        : "completed");
+    }
     return;
   }
   if (request.method === "session/steer") {

--- a/homerail_worker/src/__tests__/fixtures/fake-dsh-runtime.mjs
+++ b/homerail_worker/src/__tests__/fixtures/fake-dsh-runtime.mjs
@@ -92,6 +92,7 @@ lines.on("line", (line) => {
         params: request.params,
         cordisConfig: process.env.DSH_CORDIS_CONFIG,
         baseUrl: process.env.DEEPSEEK_BASE_URL,
+        reasoningEffort: process.env.DSH_REASONING_EFFORT,
         managerToken: process.env.HOMERAIL_WORKER_TOKEN,
       })}\n`);
     }

--- a/homerail_worker/src/__tests__/fixtures/fake-dsh-runtime.mjs
+++ b/homerail_worker/src/__tests__/fixtures/fake-dsh-runtime.mjs
@@ -1,0 +1,130 @@
+import { appendFileSync } from "node:fs";
+import { createInterface } from "node:readline";
+
+const lines = createInterface({ input: process.stdin });
+let sequence = 0;
+let activeSession = "";
+let activeMessage = "";
+let activePrompt = [];
+
+function write(value) {
+  process.stdout.write(`${JSON.stringify(value)}\n`);
+}
+
+function response(id, result) {
+  write({ jsonrpc: "2.0", id, result });
+}
+
+function event(sessionId, type, data) {
+  write({
+    jsonrpc: "2.0",
+    method: "session.event",
+    params: { sessionId, event: { type, seq: sequence++, time: Date.now(), data } },
+  });
+}
+
+function status(sessionId, value) {
+  write({ jsonrpc: "2.0", method: "session.status", params: { sessionId, status: value } });
+}
+
+function finish(reason = "completed") {
+  const sessionId = activeSession;
+  event(sessionId, "assistant/chunk", {
+    turn: 1,
+    step: 1,
+    chunk: { type: "reasoning-delta", index: 0, text: "checking" },
+  });
+  event(sessionId, "tool/call", {
+    turn: 1,
+    step: 1,
+    callId: "call-1",
+    name: "mcp__homerail__handoff",
+    arguments: JSON.stringify({ port: "done", content: "ok" }),
+  });
+  event(sessionId, "tool/result", {
+    turn: 1,
+    step: 1,
+    message: {
+      id: "tool-result-1",
+      role: "user",
+      content: [{
+        type: "tool-result",
+        toolCallId: "call-1",
+        content: [{ type: "text", text: "accepted" }],
+        isError: false,
+      }],
+      source: { kind: "tool", callId: "call-1" },
+    },
+  });
+  event(sessionId, "assistant/chunk", {
+    turn: 1,
+    step: 1,
+    chunk: { type: "text-delta", index: 1, text: "finished" },
+  });
+  event(sessionId, "assistant/message", {
+    turn: 1,
+    step: 1,
+    message: {
+      id: "assistant-1",
+      role: "assistant",
+      content: [{ type: "text", text: "finished" }],
+      source: { kind: "model", provider: "deepseek-official", model: "test-model" },
+    },
+    usage: { inputTokens: 7, outputTokens: 3, cacheReadTokens: 2 },
+  });
+  event(sessionId, "turn/end", { turn: 1, reason });
+  status(sessionId, "idle");
+}
+
+function startPrompt(params) {
+  activeSession = String(params.sessionId);
+  activeMessage = `message-${Date.now()}`;
+  activePrompt = Array.isArray(params.contentBlocks) ? params.contentBlocks : [];
+  return activeMessage;
+}
+
+lines.on("line", (line) => {
+  if (!line.trim()) return;
+  const request = JSON.parse(line);
+  if (request.method === "initialize") {
+    if (process.env.DSH_FAKE_RECORD_FILE) {
+      appendFileSync(process.env.DSH_FAKE_RECORD_FILE, `${JSON.stringify({
+        params: request.params,
+        cordisConfig: process.env.DSH_CORDIS_CONFIG,
+        baseUrl: process.env.DEEPSEEK_BASE_URL,
+        managerToken: process.env.HOMERAIL_WORKER_TOKEN,
+      })}\n`);
+    }
+    response(request.id, { serverInfo: { name: "deepseek-harness-sdk-runtime", version: "fake" } });
+    return;
+  }
+  if (request.method === "session/prompt") {
+    const messageId = startPrompt(request.params);
+    response(request.id, { messageId });
+    event(activeSession, "agent/inbox/spliced", {
+      target: "next-turn",
+      start: 0,
+      inserted: [{ id: messageId, role: "user", content: activePrompt, source: { kind: "user" } }],
+    });
+    status(activeSession, "running");
+    if (process.env.DSH_FAKE_READY_FILE) appendFileSync(process.env.DSH_FAKE_READY_FILE, "ready\n");
+    if (!process.env.DSH_FAKE_WAIT_FOR) finish();
+    return;
+  }
+  if (request.method === "session/steer") {
+    response(request.id, { messageId: "steer-1" });
+    if (process.env.DSH_FAKE_WAIT_FOR === "steer") finish();
+    return;
+  }
+  if (request.method === "session/cancel") {
+    response(request.id, { accepted: true });
+    if (process.env.DSH_FAKE_WAIT_FOR === "cancel") finish("cancelled");
+    return;
+  }
+  if (request.method === "shutdown") {
+    response(request.id, {});
+    setImmediate(() => process.exit(0));
+    return;
+  }
+  write({ jsonrpc: "2.0", id: request.id, error: { code: -32601, message: "unknown method" } });
+});

--- a/homerail_worker/src/__tests__/kimi-code.test.ts
+++ b/homerail_worker/src/__tests__/kimi-code.test.ts
@@ -243,7 +243,10 @@ describe("KimiCodeAdapter", () => {
           apiKey: "my-api-key",
           baseUrl: "https://api.moonshot.cn/v1",
           model: "kimi-latest",
-          environmentVariables: { SERVICE_TEST_TOKEN: "turn-scoped-value" },
+          environmentVariables: {
+            SERVICE_TEST_TOKEN: "turn-scoped-value",
+            HOMERAIL_WORKER_TOKEN: "reserved-turn-value",
+          },
         },
         "/tmp/kimi-home-123",
       );
@@ -255,6 +258,7 @@ describe("KimiCodeAdapter", () => {
       expect(env.KIMI_MODEL_NAME).toBe("kimi-latest");
       expect(env.KIMI_MODEL_BASE_URL).toBe("https://api.moonshot.cn/v1");
       expect(env.SERVICE_TEST_TOKEN).toBe("turn-scoped-value");
+      expect(env.HOMERAIL_WORKER_TOKEN).toBeUndefined();
     });
 
     it("does not leak secrets in the returned env object debug output", () => {

--- a/homerail_worker/src/__tests__/manager-agent-server.test.ts
+++ b/homerail_worker/src/__tests__/manager-agent-server.test.ts
@@ -429,6 +429,20 @@ class NoToolAgent implements AgentClient {
   }
 }
 
+class ContextCaptureAgent implements AgentClient {
+  context?: AgentRunContext;
+
+  async *run(
+    _prompt: string,
+    _tools: DagToolDefinition[],
+    context: AgentRunContext,
+  ): AsyncIterable<AgentEvent> {
+    this.context = context;
+    yield { type: "text", text: "context captured" };
+    yield { type: "done" };
+  }
+}
+
 class NoTextAgent implements AgentClient {
   async *run(): AsyncIterable<AgentEvent> {
     yield { type: "done" };
@@ -763,6 +777,52 @@ describe("manager-agent server", () => {
     } finally {
       await close(server);
       await close(managerApi);
+    }
+  });
+
+  it("forwards provider-owned DSH runtime fields into AgentRunContext", async () => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-manager-agent-workspace-"));
+    tmpDirs.push(workspace);
+    const agent = new ContextCaptureAgent();
+    registerAgentBackend("manager-agent-context-capture-test", () => agent);
+    vi.stubEnv("PROJECT_WORKSPACE", workspace);
+
+    const server = startManagerAgentServer(0);
+    await new Promise<void>((resolve) => server.once("listening", resolve));
+    const address = server.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/chat`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          message: "capture",
+          agent_config: {
+            agent_type: "manager-agent-context-capture-test",
+            provider_name: "glm",
+            protocol: "openai_compatible",
+            model: "glm-5.3",
+            api_key: "secret",
+            base_url: "https://glm.example/v1",
+            reasoning_effort: "deep",
+            reasoning_effort_map: { off: null, deep: "deep" },
+            service_tier: "priority",
+          },
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(agent.context).toMatchObject({
+        provider: "glm",
+        protocol: "openai_compatible",
+        model: "glm-5.3",
+        reasoningEffort: "deep",
+        reasoningEffortMap: { off: null, deep: "deep" },
+        serviceTier: "priority",
+      });
+    } finally {
+      await close(server);
     }
   });
 

--- a/homerail_worker/src/__tests__/prompt-runner.test.ts
+++ b/homerail_worker/src/__tests__/prompt-runner.test.ts
@@ -929,6 +929,30 @@ describe("prompt runner", () => {
     expect(parsed.map((msg) => msg.type)).toContain("SESSION_END");
   });
 
+  it("fails DeepSeek Harness before execution for a non-OpenAI protocol", async () => {
+    const sent: string[] = [];
+    await runPrompt(
+      {
+        task: "test",
+        sender: "test",
+        runId: "run-dsh-protocol-invalid",
+        llmProtocol: "anthropic_compatible",
+        dagConfig: makeConfigWith({ agent_type: "deepseek_harness" }),
+      },
+      {
+        wsSend: (data) => sent.push(data),
+        agentBackend: "dsh",
+      },
+    );
+
+    expect(sent.map((message) => JSON.parse(message))).toContainEqual(expect.objectContaining({
+      type: "node_error",
+      data: expect.objectContaining({
+        message: expect.stringContaining("OpenAI-compatible Chat Completions endpoint"),
+      }),
+    }));
+  });
+
   it("streams agent debug events without sending them as content", async () => {
     const mockAgent: AgentClient = {
       run() {

--- a/homerail_worker/src/__tests__/prompt-runner.test.ts
+++ b/homerail_worker/src/__tests__/prompt-runner.test.ts
@@ -747,6 +747,38 @@ describe("prompt runner", () => {
     }));
   });
 
+  it("limits DeepSeek Harness built-ins to HomeRail-managed read-only tools", async () => {
+    for (const dagConfig of [
+      makeConfigWith({
+        agent_type: "deepseek_harness",
+        allowed_builtin_tools: ["Write"],
+        workspace_access: { writable_paths: ["repository"], readonly_paths: [] },
+      }),
+      makeConfigWith({
+        agent_type: "deepseek_harness",
+        allowed_builtin_tools: ["Read"],
+      }),
+    ]) {
+      const sent: string[] = [];
+      await runPrompt({
+        task: "reject unsupported DSH filesystem policy",
+        sender: "test",
+        runId: "run-dsh-builtin-policy",
+        llmProtocol: "openai_compatible",
+        dagConfig,
+      }, {
+        wsSend: (data) => sent.push(data),
+        agentBackend: "deepseek_harness",
+      });
+      expect(sent.map((message) => JSON.parse(message))).toContainEqual(expect.objectContaining({
+        type: "node_error",
+        data: expect.objectContaining({
+          message: expect.stringMatching(/read-only built-in tools|require workspace_access/),
+        }),
+      }));
+    }
+  });
+
   it("allows explicit backend-native tools only for sandboxed Codex DAG turns", async () => {
     let called = false;
     const mockAgent: AgentClient = {

--- a/homerail_worker/src/__tests__/runtime-version.test.ts
+++ b/homerail_worker/src/__tests__/runtime-version.test.ts
@@ -63,9 +63,9 @@ describe("Worker runtime version identity", () => {
   it("keeps Worker build source overrides optional, build-only Docker arguments", () => {
     const dockerfile = readFileSync(new URL("../../Dockerfile", import.meta.url), "utf8")
       .replace(/\r\n/g, "\n");
-    expect(dockerfile.match(/^ARG HOMERAIL_WORKER_BUILD_APT_MIRROR$/gm)).toHaveLength(2);
-    expect(dockerfile.match(/^ARG HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR$/gm)).toHaveLength(2);
-    expect(dockerfile.match(/^ARG NPM_CONFIG_REGISTRY$/gm)).toHaveLength(1);
+    expect(dockerfile.match(/^ARG HOMERAIL_WORKER_BUILD_APT_MIRROR$/gm)).toHaveLength(3);
+    expect(dockerfile.match(/^ARG HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR$/gm)).toHaveLength(3);
+    expect(dockerfile.match(/^ARG NPM_CONFIG_REGISTRY$/gm)).toHaveLength(2);
     expect(dockerfile).not.toMatch(/ARG HOMERAIL_WORKER_BUILD_APT_MIRROR=/);
     expect(dockerfile).not.toMatch(/ARG HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR=/);
     expect(dockerfile).not.toMatch(/ARG NPM_CONFIG_REGISTRY=/);

--- a/homerail_worker/src/__tests__/runtime-version.test.ts
+++ b/homerail_worker/src/__tests__/runtime-version.test.ts
@@ -66,6 +66,8 @@ describe("Worker runtime version identity", () => {
     expect(dockerfile.match(/^ARG HOMERAIL_WORKER_BUILD_APT_MIRROR$/gm)).toHaveLength(3);
     expect(dockerfile.match(/^ARG HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR$/gm)).toHaveLength(3);
     expect(dockerfile.match(/^ARG NPM_CONFIG_REGISTRY$/gm)).toHaveLength(2);
+    expect(dockerfile.match(/^ARG HOMERAIL_DSH_FORK_REPOSITORY=https:\/\/github\.com\/xiaotianfotos\/deepseek-harness\.git$/gm))
+      .toHaveLength(1);
     expect(dockerfile).not.toMatch(/ARG HOMERAIL_WORKER_BUILD_APT_MIRROR=/);
     expect(dockerfile).not.toMatch(/ARG HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR=/);
     expect(dockerfile).not.toMatch(/ARG NPM_CONFIG_REGISTRY=/);

--- a/homerail_worker/src/__tests__/turn-controller.test.ts
+++ b/homerail_worker/src/__tests__/turn-controller.test.ts
@@ -122,6 +122,8 @@ describe("AgentTurnController", () => {
       KIMI_AGENT_SDK_EXECUTABLE: "kimi-sdk",
     }).capabilities.liveSteer).toBe(false);
     expect(agentTurnControllerOptionsForBackend("deterministic", {}).capabilities.liveSteer).toBe(false);
+    expect(agentTurnControllerOptionsForBackend("deepseek_harness", {}).capabilities.liveSteer).toBe(true);
+    expect(agentTurnControllerOptionsForBackend("dsh", {}).capabilities.liveSteer).toBe(true);
   });
 
   it("reports synchronous and asynchronous driver failures deterministically", async () => {

--- a/homerail_worker/src/agent/claude-sdk.ts
+++ b/homerail_worker/src/agent/claude-sdk.ts
@@ -1056,8 +1056,10 @@ export class ClaudeSdkAdapter implements AgentClient {
     const fromAnthropicBaseUrl = process.env.ANTHROPIC_BASE_URL ?? "";
     const fromLlmBaseUrl = process.env.LLM_BASE_URL ?? "";
     const baseUrl = fromContextBaseUrl || fromAnthropicBaseUrl || fromLlmBaseUrl;
-    const env = sanitizedAgentChildEnv();
-    Object.assign(env, context.environmentVariables ?? {});
+    const env = sanitizedAgentChildEnv({
+      ...process.env,
+      ...context.environmentVariables,
+    });
     if (apiKey) {
       if (context.anthropicAuthMode === "auth_token") {
         delete env.ANTHROPIC_API_KEY;

--- a/homerail_worker/src/agent/deepseek-harness-read-tools.ts
+++ b/homerail_worker/src/agent/deepseek-harness-read-tools.ts
@@ -1,11 +1,11 @@
 import {
-  lstatSync,
   readFileSync,
   readdirSync,
   realpathSync,
   statSync,
 } from "node:fs";
 import path from "node:path";
+import { Worker } from "node:worker_threads";
 import type { AgentBuiltinToolName, DagWorkspaceAccess } from "homerail-protocol";
 import type { DagToolDefinition } from "./types.js";
 
@@ -16,12 +16,15 @@ const MAX_GREP_RESULTS = 500;
 const MAX_FILE_BYTES = 2 * 1024 * 1024;
 const MAX_READ_LINES = 2_000;
 const MAX_RESULT_CHARS = 120_000;
+const DEFAULT_GREP_TIMEOUT_MS = 2_000;
+const MAX_GREP_TIMEOUT_MS = 30_000;
 
 interface ReadToolOptions {
   workspace: string;
   workspaceAccess: DagWorkspaceAccess;
   allowedTools: AgentBuiltinToolName[];
   maxCalls?: number;
+  grepTimeoutMs?: number;
 }
 
 interface PolicyRoots {
@@ -65,11 +68,19 @@ function policyRoots(options: ReadToolOptions): PolicyRoots {
     if (!isWithin(workspace, lexical)) {
       throw new Error(`DSH workspace read policy root escapes workspace: ${entry}`);
     }
-    const resolved = realpathSync(lexical);
-    if (!isWithin(workspace, resolved)) {
-      throw new Error(`DSH workspace read policy root escapes workspace: ${entry}`);
+    try {
+      const resolved = realpathSync(lexical);
+      if (!isWithin(workspace, resolved)) {
+        throw new Error(`DSH workspace read policy root escapes workspace: ${entry}`);
+      }
+    } catch (error) {
+      if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) {
+        throw error;
+      }
+      // A declared root may be staged after the turn starts. Preserve its
+      // lexical location now and resolve it again for every tool call.
     }
-    return resolved;
+    return lexical;
   });
   return { workspace, roots: [...new Set(roots)] };
 }
@@ -101,7 +112,15 @@ function resolveTarget(policy: PolicyRoots, requested: string): string {
     throw new Error(`path must be relative and traversal-free: ${requested}`);
   }
   const resolved = realpathSync(path.resolve(policy.workspace, requested));
-  if (!isWithin(policy.workspace, resolved) || !policy.roots.some((root) => isWithin(root, resolved))) {
+  const insideRoot = policy.roots.some((rootPath) => {
+    try {
+      const root = realpathSync(rootPath);
+      return isWithin(policy.workspace, root) && isWithin(root, resolved);
+    } catch {
+      return false;
+    }
+  });
+  if (!isWithin(policy.workspace, resolved) || !insideRoot) {
     throw new Error(`path is outside the declared workspace roots: ${requested}`);
   }
   return resolved;
@@ -119,7 +138,7 @@ function result(text: string, isError = false): Awaited<ReturnType<DagToolDefini
   };
 }
 
-function globRegex(pattern: string): RegExp {
+function globMatcher(pattern: string): (candidate: string) => boolean {
   if (!pattern.trim() || pattern.length > 2_000 || pattern.includes("\0") || path.isAbsolute(pattern)) {
     throw new Error("pattern must be a relative glob of at most 2000 characters");
   }
@@ -127,28 +146,172 @@ function globRegex(pattern: string): RegExp {
   if (normalized.split("/").includes("..")) {
     throw new Error("pattern must not traverse outside the search path");
   }
-  let source = "";
-  for (let index = 0; index < normalized.length; index += 1) {
-    const character = normalized[index];
-    if (character === "*") {
-      if (normalized[index + 1] === "*") {
-        index += 1;
-        if (normalized[index + 1] === "/") {
-          index += 1;
-          source += "(?:.*/)?";
-        } else {
-          source += ".*";
-        }
+  const patternSegments = normalized.split("/");
+  if (patternSegments.some((segment) => !segment || (segment.includes("**") && segment !== "**"))) {
+    throw new Error("globstar must occupy a complete, non-empty path segment");
+  }
+
+  const matchSegment = (segmentPattern: string, value: string): boolean => {
+    let patternIndex = 0;
+    let valueIndex = 0;
+    let starIndex = -1;
+    let retryIndex = -1;
+    while (valueIndex < value.length) {
+      const character = segmentPattern[patternIndex];
+      if (character === "?" || character === value[valueIndex]) {
+        patternIndex += 1;
+        valueIndex += 1;
+      } else if (character === "*") {
+        starIndex = patternIndex;
+        retryIndex = valueIndex;
+        patternIndex += 1;
+      } else if (starIndex >= 0) {
+        patternIndex = starIndex + 1;
+        retryIndex += 1;
+        valueIndex = retryIndex;
       } else {
-        source += "[^/]*";
+        return false;
       }
-    } else if (character === "?") {
-      source += "[^/]";
-    } else {
-      source += character.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
+    }
+    while (segmentPattern[patternIndex] === "*") patternIndex += 1;
+    return patternIndex === segmentPattern.length;
+  };
+
+  return (candidate: string): boolean => {
+    const valueSegments = candidate.split("/");
+    let states = new Set<number>([0]);
+    const closeGlobstars = (input: Set<number>): Set<number> => {
+      const closed = new Set(input);
+      for (const state of closed) {
+        if (patternSegments[state] === "**") closed.add(state + 1);
+      }
+      return closed;
+    };
+    states = closeGlobstars(states);
+    for (const value of valueSegments) {
+      const next = new Set<number>();
+      for (const state of states) {
+        const segment = patternSegments[state];
+        if (segment === "**") next.add(state);
+        else if (segment !== undefined && matchSegment(segment, value)) next.add(state + 1);
+      }
+      states = closeGlobstars(next);
+      if (states.size === 0) return false;
+    }
+    return closeGlobstars(states).has(patternSegments.length);
+  };
+}
+
+const GREP_WORKER_SOURCE = String.raw`
+const { parentPort, workerData } = require("node:worker_threads");
+const { lstatSync, readFileSync } = require("node:fs");
+
+function run(expression) {
+  const matches = [];
+  let outputChars = 0;
+  for (const entry of workerData.files) {
+    const stats = lstatSync(entry.path);
+    if (!stats.isFile() || stats.size > workerData.maxFileBytes) continue;
+    const content = readFileSync(entry.path);
+    if (content.includes(0)) continue;
+    const lines = content.toString("utf8").split(/\r?\n/);
+    for (let index = 0; index < lines.length; index += 1) {
+      expression.lastIndex = 0;
+      if (!expression.test(lines[index])) continue;
+      const rendered = entry.display + ":" + (index + 1) + ":" + lines[index];
+      const separatorChars = matches.length > 0 ? 1 : 0;
+      if (outputChars + separatorChars + rendered.length > workerData.maxResultChars) {
+        const remaining = workerData.maxResultChars - outputChars - separatorChars;
+        if (remaining > 0) matches.push(rendered.slice(0, remaining));
+        return matches.join("\n") + "\n[output truncated at " + workerData.maxResultChars + " characters]";
+      }
+      matches.push(rendered);
+      outputChars += separatorChars + rendered.length;
+      if (matches.length >= workerData.maxResults) {
+        return matches.join("\n") + "\n[results truncated at " + workerData.maxResults + " matches]";
+      }
     }
   }
-  return new RegExp(`^${source}$`);
+  return matches.join("\n");
+}
+
+let expression;
+try {
+  expression = new RegExp(workerData.pattern, workerData.flags);
+} catch (error) {
+  parentPort.postMessage({
+    errorType: "invalid_regex",
+    error: error instanceof Error ? error.message : String(error),
+  });
+}
+if (expression) {
+  try {
+    parentPort.postMessage({ text: run(expression) });
+  } catch (error) {
+    parentPort.postMessage({
+      errorType: "runtime",
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+`;
+
+interface GrepWorkerFile {
+  path: string;
+  display: string;
+}
+
+function grepInWorker(
+  files: GrepWorkerFile[],
+  pattern: string,
+  caseInsensitive: boolean,
+  timeoutMs: number,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(GREP_WORKER_SOURCE, {
+      eval: true,
+      workerData: {
+        files,
+        pattern,
+        flags: caseInsensitive ? "i" : "",
+        maxFileBytes: MAX_FILE_BYTES,
+        maxResults: MAX_GREP_RESULTS,
+        maxResultChars: MAX_RESULT_CHARS,
+      },
+    });
+    let settled = false;
+    const finish = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      worker.removeAllListeners();
+      void worker.terminate();
+      callback();
+    };
+    const timer = setTimeout(() => {
+      finish(() => reject(new Error(`Grep search timed out after ${timeoutMs}ms`)));
+    }, timeoutMs);
+    worker.once("message", (message: unknown) => {
+      finish(() => {
+        if (!isRecord(message)) {
+          reject(new Error("Grep worker returned an invalid response"));
+        } else if (message.errorType === "invalid_regex" && typeof message.error === "string") {
+          reject(new Error(`invalid Grep regular expression: ${message.error}`));
+        } else if (typeof message.error === "string") {
+          reject(new Error(`Grep worker failed: ${message.error}`));
+        } else if (typeof message.text === "string") {
+          resolve(message.text);
+        } else {
+          reject(new Error("Grep worker returned an invalid response"));
+        }
+      });
+    });
+    worker.once("error", (error) => finish(() => reject(error)));
+    worker.once("exit", (code) => {
+      if (code !== 0) finish(() => reject(new Error(`Grep worker exited with code ${code}`)));
+      else finish(() => reject(new Error("Grep worker exited without a response")));
+    });
+  });
 }
 
 function enumerateFiles(root: string): string[] {
@@ -210,10 +373,10 @@ function globHandler(policy: PolicyRoots, args: Record<string, unknown>) {
   const requested = stringArg(args, "path");
   const root = resolveTarget(policy, requested);
   if (!statSync(root).isDirectory()) throw new Error(`Glob path is not a directory: ${requested}`);
-  const matches = globRegex(stringArg(args, "pattern"));
+  const matches = globMatcher(stringArg(args, "pattern"));
   const paths = enumerateFiles(root)
     .map((candidate) => relativeToSearchRoot(root, candidate))
-    .filter((candidate) => matches.test(candidate))
+    .filter((candidate) => matches(candidate))
     .sort();
   if (paths.length > MAX_GLOB_RESULTS) {
     return `${paths.slice(0, MAX_GLOB_RESULTS).join("\n")}\n[${paths.length - MAX_GLOB_RESULTS} additional paths omitted]`;
@@ -221,40 +384,23 @@ function globHandler(policy: PolicyRoots, args: Record<string, unknown>) {
   return paths.join("\n");
 }
 
-function grepHandler(policy: PolicyRoots, args: Record<string, unknown>) {
+async function grepHandler(policy: PolicyRoots, args: Record<string, unknown>, timeoutMs: number): Promise<string> {
   const requested = stringArg(args, "path");
   const target = resolveTarget(policy, requested);
   const pattern = stringArg(args, "pattern");
   if (pattern.length > 2_000) throw new Error("pattern must be at most 2000 characters");
-  let expression: RegExp;
-  try {
-    expression = new RegExp(pattern, args.case_insensitive === true ? "i" : "");
-  } catch (error) {
-    throw new Error(`invalid Grep regular expression: ${error instanceof Error ? error.message : String(error)}`);
-  }
   const include = typeof args.glob === "string" && args.glob.trim()
-    ? globRegex(args.glob.trim())
+    ? globMatcher(args.glob.trim())
     : undefined;
-  const files = statSync(target).isFile() ? [target] : enumerateFiles(target);
-  const matches: string[] = [];
+  const targetIsFile = statSync(target).isFile();
+  const files = targetIsFile ? [target] : enumerateFiles(target);
+  const workerFiles: GrepWorkerFile[] = [];
   for (const file of files) {
-    const relative = statSync(target).isFile() ? path.basename(file) : relativeToSearchRoot(target, file);
-    if (include && !include.test(relative)) continue;
-    const stats = lstatSync(file);
-    if (!stats.isFile() || stats.size > MAX_FILE_BYTES) continue;
-    const content = readFileSync(file);
-    if (content.includes(0)) continue;
-    const lines = content.toString("utf8").split(/\r?\n/);
-    for (let index = 0; index < lines.length; index += 1) {
-      expression.lastIndex = 0;
-      if (!expression.test(lines[index])) continue;
-      matches.push(`${relative}:${index + 1}:${lines[index]}`);
-      if (matches.length >= MAX_GREP_RESULTS) {
-        return `${matches.join("\n")}\n[results truncated at ${MAX_GREP_RESULTS} matches]`;
-      }
-    }
+    const relative = targetIsFile ? path.basename(file) : relativeToSearchRoot(target, file);
+    if (include && !include(relative)) continue;
+    workerFiles.push({ path: file, display: relative });
   }
-  return matches.join("\n");
+  return grepInWorker(workerFiles, pattern, args.case_insensitive === true, timeoutMs);
 }
 
 function schemaFor(name: AgentBuiltinToolName): Record<string, unknown> {
@@ -322,6 +468,10 @@ export function createDeepSeekHarnessReadTools(options: ReadToolOptions): DagToo
   if (options.maxCalls !== undefined && (!Number.isInteger(options.maxCalls) || options.maxCalls < 1)) {
     throw new Error("built-in tool budget must be a positive integer");
   }
+  const grepTimeoutMs = options.grepTimeoutMs ?? DEFAULT_GREP_TIMEOUT_MS;
+  if (!Number.isInteger(grepTimeoutMs) || grepTimeoutMs < 1 || grepTimeoutMs > MAX_GREP_TIMEOUT_MS) {
+    throw new Error(`Grep timeout must be an integer from 1 through ${MAX_GREP_TIMEOUT_MS}`);
+  }
   const policy = policyRoots(options);
   let calls = 0;
   return options.allowedTools.map((name) => ({
@@ -341,7 +491,7 @@ export function createDeepSeekHarnessReadTools(options: ReadToolOptions): DagToo
         const text = name === "Read"
           ? readHandler(policy, args)
           : name === "Grep"
-            ? grepHandler(policy, args)
+            ? await grepHandler(policy, args, grepTimeoutMs)
             : name === "Glob"
               ? globHandler(policy, args)
               : lsHandler(policy, args);

--- a/homerail_worker/src/agent/deepseek-harness-read-tools.ts
+++ b/homerail_worker/src/agent/deepseek-harness-read-tools.ts
@@ -1,0 +1,354 @@
+import {
+  lstatSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  statSync,
+} from "node:fs";
+import path from "node:path";
+import type { AgentBuiltinToolName, DagWorkspaceAccess } from "homerail-protocol";
+import type { DagToolDefinition } from "./types.js";
+
+const SUPPORTED_READ_TOOLS = new Set<string>(["Read", "Grep", "Glob", "LS"]);
+const MAX_DIRECTORY_ENTRIES = 20_000;
+const MAX_GLOB_RESULTS = 1_000;
+const MAX_GREP_RESULTS = 500;
+const MAX_FILE_BYTES = 2 * 1024 * 1024;
+const MAX_READ_LINES = 2_000;
+const MAX_RESULT_CHARS = 120_000;
+
+interface ReadToolOptions {
+  workspace: string;
+  workspaceAccess: DagWorkspaceAccess;
+  allowedTools: AgentBuiltinToolName[];
+  maxCalls?: number;
+}
+
+interface PolicyRoots {
+  workspace: string;
+  roots: string[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function safeRelativePath(value: string): boolean {
+  const normalized = value.replace(/\\/g, "/").replace(/^\.\//, "").replace(/\/$/, "");
+  return Boolean(normalized)
+    && !path.posix.isAbsolute(normalized)
+    && !/^[A-Za-z]:\//.test(normalized)
+    && !normalized.split("/").includes("..")
+    && !normalized.includes("\0");
+}
+
+function isWithin(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative === "" || (
+    relative !== ".."
+    && !relative.startsWith(`..${path.sep}`)
+    && !path.isAbsolute(relative)
+  );
+}
+
+function policyRoots(options: ReadToolOptions): PolicyRoots {
+  const workspace = realpathSync(path.resolve(options.workspace));
+  const configured = [
+    ...options.workspaceAccess.writable_paths,
+    ...(options.workspaceAccess.readonly_paths ?? []),
+  ];
+  const roots = configured.map((entry) => {
+    if (!safeRelativePath(entry)) {
+      throw new Error(`DSH workspace read policy path must be relative and traversal-free: ${entry}`);
+    }
+    const lexical = path.resolve(workspace, entry);
+    if (!isWithin(workspace, lexical)) {
+      throw new Error(`DSH workspace read policy root escapes workspace: ${entry}`);
+    }
+    const resolved = realpathSync(lexical);
+    if (!isWithin(workspace, resolved)) {
+      throw new Error(`DSH workspace read policy root escapes workspace: ${entry}`);
+    }
+    return resolved;
+  });
+  return { workspace, roots: [...new Set(roots)] };
+}
+
+function stringArg(args: Record<string, unknown>, key: string, fallback?: string): string {
+  const value = args[key] ?? fallback;
+  if (typeof value !== "string" || !value.trim() || value.includes("\0")) {
+    throw new Error(`${key} must be a non-empty path or pattern`);
+  }
+  return value.trim();
+}
+
+function positiveIntegerArg(
+  args: Record<string, unknown>,
+  key: string,
+  fallback: number,
+  maximum: number,
+): number {
+  const value = args[key];
+  if (value === undefined) return fallback;
+  if (!Number.isInteger(value) || Number(value) < 1 || Number(value) > maximum) {
+    throw new Error(`${key} must be an integer from 1 through ${maximum}`);
+  }
+  return Number(value);
+}
+
+function resolveTarget(policy: PolicyRoots, requested: string): string {
+  if (!safeRelativePath(requested)) {
+    throw new Error(`path must be relative and traversal-free: ${requested}`);
+  }
+  const resolved = realpathSync(path.resolve(policy.workspace, requested));
+  if (!isWithin(policy.workspace, resolved) || !policy.roots.some((root) => isWithin(root, resolved))) {
+    throw new Error(`path is outside the declared workspace roots: ${requested}`);
+  }
+  return resolved;
+}
+
+function bounded(text: string): string {
+  if (text.length <= MAX_RESULT_CHARS) return text;
+  return `${text.slice(0, MAX_RESULT_CHARS)}\n[output truncated at ${MAX_RESULT_CHARS} characters]`;
+}
+
+function result(text: string, isError = false): Awaited<ReturnType<DagToolDefinition["handler"]>> {
+  return {
+    content: [{ type: "text", text: bounded(text) }],
+    ...(isError ? { is_error: true } : {}),
+  };
+}
+
+function globRegex(pattern: string): RegExp {
+  if (!pattern.trim() || pattern.length > 2_000 || pattern.includes("\0") || path.isAbsolute(pattern)) {
+    throw new Error("pattern must be a relative glob of at most 2000 characters");
+  }
+  const normalized = pattern.replace(/\\/g, "/").replace(/^\.\//, "");
+  if (normalized.split("/").includes("..")) {
+    throw new Error("pattern must not traverse outside the search path");
+  }
+  let source = "";
+  for (let index = 0; index < normalized.length; index += 1) {
+    const character = normalized[index];
+    if (character === "*") {
+      if (normalized[index + 1] === "*") {
+        index += 1;
+        if (normalized[index + 1] === "/") {
+          index += 1;
+          source += "(?:.*/)?";
+        } else {
+          source += ".*";
+        }
+      } else {
+        source += "[^/]*";
+      }
+    } else if (character === "?") {
+      source += "[^/]";
+    } else {
+      source += character.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
+    }
+  }
+  return new RegExp(`^${source}$`);
+}
+
+function enumerateFiles(root: string): string[] {
+  const files: string[] = [];
+  const pending = [root];
+  let entries = 0;
+  while (pending.length > 0) {
+    const directory = pending.pop()!;
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      entries += 1;
+      if (entries > MAX_DIRECTORY_ENTRIES) {
+        throw new Error(`workspace search exceeded ${MAX_DIRECTORY_ENTRIES} directory entries`);
+      }
+      const candidate = path.join(directory, entry.name);
+      if (entry.isSymbolicLink()) continue;
+      if (entry.isDirectory()) pending.push(candidate);
+      else if (entry.isFile()) files.push(candidate);
+    }
+  }
+  return files;
+}
+
+function relativeToSearchRoot(root: string, candidate: string): string {
+  return path.relative(root, candidate).split(path.sep).join("/");
+}
+
+function readHandler(policy: PolicyRoots, args: Record<string, unknown>) {
+  const requested = stringArg(args, "file_path");
+  const target = resolveTarget(policy, requested);
+  const stats = statSync(target);
+  if (!stats.isFile()) throw new Error(`Read target is not a file: ${requested}`);
+  if (stats.size > MAX_FILE_BYTES) {
+    throw new Error(`Read target exceeds ${MAX_FILE_BYTES} bytes: ${requested}`);
+  }
+  const offset = positiveIntegerArg(args, "offset", 1, 10_000_000);
+  const limit = positiveIntegerArg(args, "limit", 400, MAX_READ_LINES);
+  const lines = readFileSync(target, "utf8").split(/\r?\n/);
+  const selected = lines.slice(offset - 1, offset - 1 + limit);
+  const width = String(Math.min(lines.length, offset + selected.length)).length;
+  return selected.map((line, index) => `${String(offset + index).padStart(width)}\t${line}`).join("\n");
+}
+
+function lsHandler(policy: PolicyRoots, args: Record<string, unknown>) {
+  const requested = stringArg(args, "path");
+  const target = resolveTarget(policy, requested);
+  const stats = statSync(target);
+  if (!stats.isDirectory()) throw new Error(`LS target is not a directory: ${requested}`);
+  const entries = readdirSync(target, { withFileTypes: true });
+  if (entries.length > MAX_GLOB_RESULTS) {
+    throw new Error(`LS target exceeds ${MAX_GLOB_RESULTS} entries: ${requested}`);
+  }
+  return entries
+    .sort((left, right) => left.name.localeCompare(right.name))
+    .map((entry) => `${entry.name}${entry.isDirectory() ? "/" : entry.isSymbolicLink() ? "@" : ""}`)
+    .join("\n");
+}
+
+function globHandler(policy: PolicyRoots, args: Record<string, unknown>) {
+  const requested = stringArg(args, "path");
+  const root = resolveTarget(policy, requested);
+  if (!statSync(root).isDirectory()) throw new Error(`Glob path is not a directory: ${requested}`);
+  const matches = globRegex(stringArg(args, "pattern"));
+  const paths = enumerateFiles(root)
+    .map((candidate) => relativeToSearchRoot(root, candidate))
+    .filter((candidate) => matches.test(candidate))
+    .sort();
+  if (paths.length > MAX_GLOB_RESULTS) {
+    return `${paths.slice(0, MAX_GLOB_RESULTS).join("\n")}\n[${paths.length - MAX_GLOB_RESULTS} additional paths omitted]`;
+  }
+  return paths.join("\n");
+}
+
+function grepHandler(policy: PolicyRoots, args: Record<string, unknown>) {
+  const requested = stringArg(args, "path");
+  const target = resolveTarget(policy, requested);
+  const pattern = stringArg(args, "pattern");
+  if (pattern.length > 2_000) throw new Error("pattern must be at most 2000 characters");
+  let expression: RegExp;
+  try {
+    expression = new RegExp(pattern, args.case_insensitive === true ? "i" : "");
+  } catch (error) {
+    throw new Error(`invalid Grep regular expression: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  const include = typeof args.glob === "string" && args.glob.trim()
+    ? globRegex(args.glob.trim())
+    : undefined;
+  const files = statSync(target).isFile() ? [target] : enumerateFiles(target);
+  const matches: string[] = [];
+  for (const file of files) {
+    const relative = statSync(target).isFile() ? path.basename(file) : relativeToSearchRoot(target, file);
+    if (include && !include.test(relative)) continue;
+    const stats = lstatSync(file);
+    if (!stats.isFile() || stats.size > MAX_FILE_BYTES) continue;
+    const content = readFileSync(file);
+    if (content.includes(0)) continue;
+    const lines = content.toString("utf8").split(/\r?\n/);
+    for (let index = 0; index < lines.length; index += 1) {
+      expression.lastIndex = 0;
+      if (!expression.test(lines[index])) continue;
+      matches.push(`${relative}:${index + 1}:${lines[index]}`);
+      if (matches.length >= MAX_GREP_RESULTS) {
+        return `${matches.join("\n")}\n[results truncated at ${MAX_GREP_RESULTS} matches]`;
+      }
+    }
+  }
+  return matches.join("\n");
+}
+
+function schemaFor(name: AgentBuiltinToolName): Record<string, unknown> {
+  const pathProperty = { type: "string", description: "Workspace-relative path inside a declared HomeRail root." };
+  if (name === "Read") {
+    return {
+      type: "object",
+      additionalProperties: false,
+      required: ["file_path"],
+      properties: {
+        file_path: pathProperty,
+        offset: { type: "integer", minimum: 1 },
+        limit: { type: "integer", minimum: 1, maximum: MAX_READ_LINES },
+      },
+    };
+  }
+  if (name === "Grep") {
+    return {
+      type: "object",
+      additionalProperties: false,
+      required: ["pattern", "path"],
+      properties: {
+        pattern: { type: "string", description: "JavaScript regular expression." },
+        path: pathProperty,
+        glob: { type: "string", description: "Optional relative glob limiting searched files." },
+        case_insensitive: { type: "boolean" },
+      },
+    };
+  }
+  if (name === "Glob") {
+    return {
+      type: "object",
+      additionalProperties: false,
+      required: ["pattern", "path"],
+      properties: {
+        pattern: { type: "string", description: "Relative glob such as **/*.ts." },
+        path: pathProperty,
+      },
+    };
+  }
+  return {
+    type: "object",
+    additionalProperties: false,
+    required: ["path"],
+    properties: { path: pathProperty },
+  };
+}
+
+function descriptionFor(name: AgentBuiltinToolName): string {
+  if (name === "Read") return "Read a bounded line range from one file inside the HomeRail-declared workspace roots.";
+  if (name === "Grep") return "Search file contents inside the HomeRail-declared workspace roots with bounded results.";
+  if (name === "Glob") return "Find files by relative glob inside one HomeRail-declared workspace root.";
+  return "List one directory inside the HomeRail-declared workspace roots.";
+}
+
+export function supportsDeepSeekHarnessReadTools(tools: readonly string[]): boolean {
+  return tools.every((tool) => SUPPORTED_READ_TOOLS.has(tool));
+}
+
+export function createDeepSeekHarnessReadTools(options: ReadToolOptions): DagToolDefinition[] {
+  if (!supportsDeepSeekHarnessReadTools(options.allowedTools)) {
+    const unsupported = options.allowedTools.filter((tool) => !SUPPORTED_READ_TOOLS.has(tool));
+    throw new Error(`DeepSeek Harness only supports HomeRail-managed read tools; unsupported: ${unsupported.join(", ")}`);
+  }
+  if (options.maxCalls !== undefined && (!Number.isInteger(options.maxCalls) || options.maxCalls < 1)) {
+    throw new Error("built-in tool budget must be a positive integer");
+  }
+  const policy = policyRoots(options);
+  let calls = 0;
+  return options.allowedTools.map((name) => ({
+    name,
+    description: descriptionFor(name),
+    input_schema: schemaFor(name),
+    handler: async (args) => {
+      if (!isRecord(args)) return result(`${name} arguments must be an object`, true);
+      if (options.maxCalls !== undefined && calls >= options.maxCalls) {
+        return result(
+          `Built-in tool budget exhausted (${options.maxCalls}/${options.maxCalls}). Stop inspecting and call an allowed HomeRail DAG handoff tool now.`,
+          true,
+        );
+      }
+      calls += 1;
+      try {
+        const text = name === "Read"
+          ? readHandler(policy, args)
+          : name === "Grep"
+            ? grepHandler(policy, args)
+            : name === "Glob"
+              ? globHandler(policy, args)
+              : lsHandler(policy, args);
+        return result(text || "No results.");
+      } catch (error) {
+        return result(error instanceof Error ? error.message : String(error), true);
+      }
+    },
+  }));
+}

--- a/homerail_worker/src/agent/deepseek-harness.ts
+++ b/homerail_worker/src/agent/deepseek-harness.ts
@@ -33,9 +33,11 @@ import { WORKER_RUNTIME_VERSION } from "../runtime-version.js";
 
 const DEFAULT_DSH_RUNTIME_COMMAND = "dsh-jsonrpc-agent-pkg";
 const DEFAULT_DSH_MAX_TOKENS = 32_768;
+const DEFAULT_DSH_MAX_BUILTIN_TOOL_CALLS = 24;
 const DSH_FORK_COMMIT = "ec75587a05bf0cc3f29dd0d5f875d3235f7deae6";
 const MCP_TOOL_PREFIX = "mcp__homerail__";
 const DEFAULT_SYSTEM_PROMPT = "You are a HomeRail DAG worker. Complete the assigned task and call the provided handoff tool exactly once.";
+const DSH_REASONING_EFFORTS = new Set(["off", "low", "medium", "high", "xhigh", "max"]);
 
 interface DeepSeekHarnessAdapterOptions {
   runtimeCommand?: string;
@@ -117,6 +119,14 @@ function parseMaxTokens(value: number | string | undefined): number {
     throw new Error("HOMERAIL_DSH_MAX_TOKENS must be a positive integer");
   }
   return parsed;
+}
+
+function dshReasoningEffort(value: string | undefined): string {
+  const effort = value?.trim() || "high";
+  if (!DSH_REASONING_EFFORTS.has(effort)) {
+    throw new Error(`DeepSeek Harness reasoning effort must be one of: ${[...DSH_REASONING_EFFORTS].join(", ")}`);
+  }
+  return effort;
 }
 
 function defaultCordisConfigPath(): string {
@@ -343,13 +353,15 @@ export class DeepSeekHarnessAdapter implements AgentClient {
     const queue = new AsyncQueue<AgentEvent>();
 
     try {
+      const reasoningEffort = dshReasoningEffort(context.reasoningEffort);
+      const maxBuiltinToolCalls = context.maxBuiltinToolCalls ?? DEFAULT_DSH_MAX_BUILTIN_TOOL_CALLS;
       const builtinTools = context.handoffOnly || !context.allowedBuiltinTools?.length
         ? []
         : createDeepSeekHarnessReadTools({
             workspace: context.workspace ?? process.cwd(),
             workspaceAccess: context.workspaceAccess!,
             allowedTools: context.allowedBuiltinTools,
-            maxCalls: context.maxBuiltinToolCalls,
+            maxCalls: maxBuiltinToolCalls,
           });
       const names = new Set<string>();
       const bridgeTools = [...builtinTools, ...tools].filter((tool) => {
@@ -368,6 +380,7 @@ export class DeepSeekHarnessAdapter implements AgentClient {
         DSH_CORDIS_CONFIG: this.cordisConfigPath,
         DSH_CWD: context.workspace ?? process.cwd(),
         DSH_MODEL: context.model,
+        DSH_REASONING_EFFORT: reasoningEffort,
         DSH_SESSION_ROOT: join(runtimeRoot, "sessions"),
         DSH_SYSTEM_PROMPT: projectedSystemPrompt(context),
         DEEPSEEK_API_KEY: context.apiKey,
@@ -400,7 +413,9 @@ export class DeepSeekHarnessAdapter implements AgentClient {
           session_id: sessionId,
           tool_count: bridgeTools.length,
           builtin_tools: builtinTools.map((tool) => tool.name),
+          max_builtin_tool_calls: builtinTools.length > 0 ? maxBuiltinToolCalls : null,
           max_tokens: this.maxTokens,
+          reasoning_effort: reasoningEffort,
           workspace: context.workspace ?? process.cwd(),
           process_isolation: true,
           resume_supported: false,

--- a/homerail_worker/src/agent/deepseek-harness.ts
+++ b/homerail_worker/src/agent/deepseek-harness.ts
@@ -28,6 +28,7 @@ import type {
   DagToolDefinition,
 } from "./types.js";
 import type { AgentTurnDriverBindingResult } from "./turn-controller.js";
+import { createDeepSeekHarnessReadTools } from "./deepseek-harness-read-tools.js";
 import { WORKER_RUNTIME_VERSION } from "../runtime-version.js";
 
 const DEFAULT_DSH_RUNTIME_COMMAND = "dsh-jsonrpc-agent-pkg";
@@ -311,7 +312,23 @@ export class DeepSeekHarnessAdapter implements AgentClient {
     const queue = new AsyncQueue<AgentEvent>();
 
     try {
-      bridge = await createToolBridge(tools, runtimeRoot);
+      const builtinTools = context.handoffOnly || !context.allowedBuiltinTools?.length
+        ? []
+        : createDeepSeekHarnessReadTools({
+            workspace: context.workspace ?? process.cwd(),
+            workspaceAccess: context.workspaceAccess!,
+            allowedTools: context.allowedBuiltinTools,
+            maxCalls: context.maxBuiltinToolCalls,
+          });
+      const names = new Set<string>();
+      const bridgeTools = [...builtinTools, ...tools].filter((tool) => {
+        if (names.has(tool.name)) {
+          throw new Error(`DeepSeek Harness tool name collision: ${tool.name}`);
+        }
+        names.add(tool.name);
+        return true;
+      });
+      bridge = await createToolBridge(bridgeTools, runtimeRoot);
       const childEnv = {
         ...sanitizedAgentChildEnv({
           ...process.env,
@@ -349,7 +366,8 @@ export class DeepSeekHarnessAdapter implements AgentClient {
           runtime_command: this.runtimeCommand,
           runtime_args_count: this.runtimeArgs.length,
           session_id: sessionId,
-          tool_count: tools.length,
+          tool_count: bridgeTools.length,
+          builtin_tools: builtinTools.map((tool) => tool.name),
           workspace: context.workspace ?? process.cwd(),
           process_isolation: true,
           resume_supported: false,

--- a/homerail_worker/src/agent/deepseek-harness.ts
+++ b/homerail_worker/src/agent/deepseek-harness.ts
@@ -33,7 +33,7 @@ import { WORKER_RUNTIME_VERSION } from "../runtime-version.js";
 
 const DEFAULT_DSH_RUNTIME_COMMAND = "dsh-jsonrpc-agent-pkg";
 const DEFAULT_DSH_MAX_TOKENS = 32_768;
-const DSH_FORK_COMMIT = "559cd23cc2f1b96da2fde230064da2dc3781b126";
+const DSH_FORK_COMMIT = "ec75587a05bf0cc3f29dd0d5f875d3235f7deae6";
 const MCP_TOOL_PREFIX = "mcp__homerail__";
 const DEFAULT_SYSTEM_PROMPT = "You are a HomeRail DAG worker. Complete the assigned task and call the provided handoff tool exactly once.";
 

--- a/homerail_worker/src/agent/deepseek-harness.ts
+++ b/homerail_worker/src/agent/deepseek-harness.ts
@@ -174,6 +174,18 @@ function finishReason(value: unknown): string | null {
   return isRecord(value) && typeof value.kind === "string" ? value.kind : null;
 }
 
+function turnEndError(value: unknown): AgentEvent | null {
+  if (!isRecord(value) || value.kind !== "error") return null;
+  const failure = isRecord(value.error) ? value.error : undefined;
+  const code = typeof failure?.code === "string" ? failure.code : "UNKNOWN";
+  const message = typeof failure?.message === "string" ? failure.message : "Unknown DSH turn failure";
+  const status = typeof failure?.status === "number" ? ` (HTTP ${failure.status})` : "";
+  return {
+    type: "error",
+    message: `DeepSeek Harness turn failed [${code}]${status}: ${message}`,
+  };
+}
+
 function notificationEvents(
   notification: HarnessNotification,
   aggregateUsage: AgentUsage,
@@ -237,12 +249,16 @@ function notificationEvents(
         finish: null,
       };
     }
-    case "turn/end":
+    case "turn/end": {
+      const error = turnEndError(event.data.reason);
       return {
-        events: [{ type: "turn_complete" }],
+        events: [...(error ? [error] : []), { type: "turn_complete" }],
         usage: aggregateUsage,
-        finish: typeof event.data.reason === "string" ? event.data.reason : null,
+        finish: typeof event.data.reason === "string"
+          ? event.data.reason
+          : finishReason(event.data.reason),
       };
+    }
     default:
       return { events: [], usage: aggregateUsage, finish: null };
   }

--- a/homerail_worker/src/agent/deepseek-harness.ts
+++ b/homerail_worker/src/agent/deepseek-harness.ts
@@ -1,0 +1,598 @@
+/**
+ * DeepSeek Harness adapter — drives a forked DSH JSON-RPC runtime in a child
+ * process and exposes HomeRail DAG tools through a turn-local MCP bridge.
+ */
+
+import { randomUUID } from "node:crypto";
+import {
+  chmodSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  DeepSeekHarness,
+  type HarnessNotification,
+} from "@deepseek-ai/dsh-sdk-client";
+import { sanitizedAgentChildEnv } from "./child-env.js";
+import type {
+  AgentClient,
+  AgentEvent,
+  AgentRunContext,
+  AgentUsage,
+  DagToolDefinition,
+} from "./types.js";
+import type { AgentTurnDriverBindingResult } from "./turn-controller.js";
+import { WORKER_RUNTIME_VERSION } from "../runtime-version.js";
+
+const DEFAULT_DSH_RUNTIME_COMMAND = "dsh-jsonrpc-agent-pkg";
+const DSH_FORK_COMMIT = "559cd23cc2f1b96da2fde230064da2dc3781b126";
+const MCP_TOOL_PREFIX = "mcp__homerail__";
+const DEFAULT_SYSTEM_PROMPT = "You are a HomeRail DAG worker. Complete the assigned task and call the provided handoff tool exactly once.";
+
+interface DeepSeekHarnessAdapterOptions {
+  runtimeCommand?: string;
+  runtimeArgs?: string[];
+  cordisConfigPath?: string;
+}
+
+interface ToolBridge {
+  scriptPath: string;
+  url: string;
+  token: string;
+  close(): Promise<void>;
+}
+
+interface QueueWaiter<T> {
+  resolve(value: IteratorResult<T>): void;
+  reject(error: unknown): void;
+}
+
+class AsyncQueue<T> implements AsyncIterable<T> {
+  private readonly items: T[] = [];
+  private readonly waiters: QueueWaiter<T>[] = [];
+  private ended = false;
+  private failure: unknown;
+
+  push(item: T): void {
+    if (this.ended) return;
+    const waiter = this.waiters.shift();
+    if (waiter) waiter.resolve({ done: false, value: item });
+    else this.items.push(item);
+  }
+
+  end(): void {
+    if (this.ended) return;
+    this.ended = true;
+    for (const waiter of this.waiters.splice(0)) waiter.resolve({ done: true, value: undefined });
+  }
+
+  fail(error: unknown): void {
+    if (this.ended) return;
+    this.failure = error;
+    this.ended = true;
+    for (const waiter of this.waiters.splice(0)) waiter.reject(error);
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<T> {
+    return {
+      next: () => {
+        const item = this.items.shift();
+        if (item !== undefined) return Promise.resolve({ done: false, value: item });
+        if (this.failure !== undefined) return Promise.reject(this.failure);
+        if (this.ended) return Promise.resolve({ done: true, value: undefined });
+        return new Promise<IteratorResult<T>>((resolveNext, rejectNext) => {
+          this.waiters.push({ resolve: resolveNext, reject: rejectNext });
+        });
+      },
+    };
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function parseRuntimeArgs(value: string | undefined): string[] {
+  if (!value?.trim()) return [];
+  const parsed: unknown = JSON.parse(value);
+  if (!Array.isArray(parsed) || !parsed.every((entry) => typeof entry === "string")) {
+    throw new Error("HOMERAIL_DSH_RUNTIME_ARGS must be a JSON array of strings");
+  }
+  return parsed;
+}
+
+function defaultCordisConfigPath(): string {
+  return fileURLToPath(new URL("../../dsh/homerail.cordis.yml", import.meta.url));
+}
+
+function normalizeBaseUrl(value: string): string {
+  return value.trim().replace(/\/+$/, "").replace(/\/chat\/completions$/i, "");
+}
+
+function redactSecret(value: string, secret: string): string {
+  return secret ? value.split(secret).join("***") : value;
+}
+
+function projectedSystemPrompt(context: AgentRunContext): string {
+  const skills = context.skillProjection?.definitions?.map((skill) => [
+    `HomeRail Skill: ${skill.name ?? skill.id}`,
+    skill.description?.trim() ?? "",
+    skill.content.trim(),
+  ].filter(Boolean).join("\n")) ?? [];
+  return [context.systemPrompt?.trim() || DEFAULT_SYSTEM_PROMPT, ...skills]
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+function safeToolName(name: string): string {
+  return name.startsWith(MCP_TOOL_PREFIX) ? name.slice(MCP_TOOL_PREFIX.length) : name;
+}
+
+function parseToolArguments(value: unknown): Record<string, unknown> {
+  if (typeof value !== "string") return {};
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function contentText(value: unknown): string {
+  if (!Array.isArray(value)) return "";
+  return value.map((block) => {
+    if (!isRecord(block)) return "";
+    if ((block.type === "text" || block.type === "reasoning") && typeof block.text === "string") {
+      return block.text;
+    }
+    return `[${String(block.type ?? "content")}]`;
+  }).filter(Boolean).join("\n");
+}
+
+function addUsage(total: AgentUsage, value: unknown): AgentUsage {
+  if (!isRecord(value)) return { ...total };
+  return {
+    input_tokens: (total.input_tokens ?? 0) + numberOrZero(value.inputTokens),
+    output_tokens: (total.output_tokens ?? 0) + numberOrZero(value.outputTokens),
+    cache_read_input_tokens: (total.cache_read_input_tokens ?? 0) + numberOrZero(value.cacheReadTokens),
+    cache_creation_input_tokens: (total.cache_creation_input_tokens ?? 0) + numberOrZero(value.cacheWriteTokens),
+  };
+}
+
+function numberOrZero(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function finishReason(value: unknown): string | null {
+  return isRecord(value) && typeof value.kind === "string" ? value.kind : null;
+}
+
+function notificationEvents(
+  notification: HarnessNotification,
+  aggregateUsage: AgentUsage,
+): { events: AgentEvent[]; usage: AgentUsage; finish: string | null } {
+  if (notification.method !== "session.event") {
+    return { events: [], usage: aggregateUsage, finish: null };
+  }
+  const event = notification.params.event;
+  if (!isRecord(event) || typeof event.type !== "string" || !isRecord(event.data)) {
+    return { events: [], usage: aggregateUsage, finish: null };
+  }
+  switch (event.type) {
+    case "assistant/chunk": {
+      const chunk = event.data.chunk;
+      if (!isRecord(chunk)) return { events: [], usage: aggregateUsage, finish: null };
+      if (chunk.type === "text-delta" && typeof chunk.text === "string") {
+        return { events: [{ type: "text", text: chunk.text }], usage: aggregateUsage, finish: null };
+      }
+      if (chunk.type === "reasoning-delta" && typeof chunk.text === "string") {
+        return { events: [{ type: "thinking", text: chunk.text }], usage: aggregateUsage, finish: null };
+      }
+      return {
+        events: [],
+        usage: aggregateUsage,
+        finish: chunk.type === "finish" ? finishReason(chunk.reason) : null,
+      };
+    }
+    case "assistant/message": {
+      const usage = addUsage(aggregateUsage, event.data.usage);
+      return {
+        events: event.data.usage === undefined ? [] : [{ type: "usage", usage }],
+        usage,
+        finish: null,
+      };
+    }
+    case "tool/call": {
+      const callId = typeof event.data.callId === "string" ? event.data.callId : randomUUID();
+      const name = typeof event.data.name === "string" ? safeToolName(event.data.name) : "unknown";
+      return {
+        events: [{ type: "tool_use", id: callId, name, input: parseToolArguments(event.data.arguments) }],
+        usage: aggregateUsage,
+        finish: null,
+      };
+    }
+    case "tool/result": {
+      const message = event.data.message;
+      const source = isRecord(message) ? message.source : undefined;
+      const blocks = isRecord(message) ? message.content : undefined;
+      const resultBlock = Array.isArray(blocks) && isRecord(blocks[0]) ? blocks[0] : undefined;
+      const callId = isRecord(source) && typeof source.callId === "string"
+        ? source.callId
+        : typeof resultBlock?.toolCallId === "string" ? resultBlock.toolCallId : randomUUID();
+      return {
+        events: [{
+          type: "tool_result",
+          tool_use_id: callId,
+          content: contentText(resultBlock?.content),
+          is_error: resultBlock?.isError === true || event.data.error !== undefined,
+        }],
+        usage: aggregateUsage,
+        finish: null,
+      };
+    }
+    case "turn/end":
+      return {
+        events: [{ type: "turn_complete" }],
+        usage: aggregateUsage,
+        finish: typeof event.data.reason === "string" ? event.data.reason : null,
+      };
+    default:
+      return { events: [], usage: aggregateUsage, finish: null };
+  }
+}
+
+function validateReceipt(value: unknown, field: "messageId" | "accepted"): void {
+  if (!isRecord(value)) throw new Error(`DSH ${field} receipt was not an object`);
+  if (field === "messageId" && typeof value.messageId !== "string") {
+    throw new Error("DSH session/steer returned no messageId");
+  }
+  if (field === "accepted" && typeof value.accepted !== "boolean") {
+    throw new Error("DSH session/cancel returned no accepted flag");
+  }
+}
+
+function isPromptReceipt(
+  notification: HarnessNotification,
+  sessionId: string,
+  messageId: string,
+): boolean {
+  if (notification.method !== "session.event" || notification.params.sessionId !== sessionId) return false;
+  const event = notification.params.event;
+  if (!isRecord(event) || event.type !== "agent/inbox/spliced" || !isRecord(event.data)) return false;
+  return Array.isArray(event.data.inserted) && event.data.inserted.some((message) => (
+    isRecord(message) && message.id === messageId
+  ));
+}
+
+function isIdleStatus(notification: HarnessNotification, sessionId: string): boolean {
+  return notification.method === "session.status" &&
+    notification.params.sessionId === sessionId &&
+    notification.params.status === "idle";
+}
+
+export class DeepSeekHarnessAdapter implements AgentClient {
+  private readonly runtimeCommand: string;
+  private readonly runtimeArgs: string[];
+  private readonly cordisConfigPath: string;
+
+  constructor(options: DeepSeekHarnessAdapterOptions = {}) {
+    this.runtimeCommand = options.runtimeCommand
+      ?? process.env.HOMERAIL_DSH_RUNTIME_COMMAND?.trim()
+      ?? DEFAULT_DSH_RUNTIME_COMMAND;
+    this.runtimeArgs = options.runtimeArgs
+      ?? parseRuntimeArgs(process.env.HOMERAIL_DSH_RUNTIME_ARGS);
+    this.cordisConfigPath = resolve(
+      options.cordisConfigPath
+        ?? process.env.HOMERAIL_DSH_CORDIS_CONFIG?.trim()
+        ?? defaultCordisConfigPath(),
+    );
+  }
+
+  async *run(
+    prompt: string,
+    tools: DagToolDefinition[],
+    context: AgentRunContext,
+  ): AsyncIterable<AgentEvent> {
+    const startedAt = Date.now();
+    const runtimeRoot = mkdtempSync(join(tmpdir(), "homerail-dsh-"));
+    const sessionId = context.sessionId?.trim() || `homerail-${randomUUID()}`;
+    let bridge: ToolBridge | null = null;
+    let harness: DeepSeekHarness | null = null;
+    let abortHandler: (() => void) | null = null;
+    let controllerBinding: AgentTurnDriverBindingResult | null = null;
+    let aggregateUsage: AgentUsage = {};
+    let latestFinishReason: string | null = null;
+    const queue = new AsyncQueue<AgentEvent>();
+
+    try {
+      bridge = await createToolBridge(tools, runtimeRoot);
+      const childEnv = {
+        ...sanitizedAgentChildEnv({
+          ...process.env,
+          ...context.environmentVariables,
+        }),
+        DSH_CORDIS_CONFIG: this.cordisConfigPath,
+        DSH_CWD: context.workspace ?? process.cwd(),
+        DSH_MODEL: context.model,
+        DSH_SESSION_ROOT: join(runtimeRoot, "sessions"),
+        DSH_SYSTEM_PROMPT: projectedSystemPrompt(context),
+        DEEPSEEK_API_KEY: context.apiKey,
+        DEEPSEEK_BASE_URL: normalizeBaseUrl(context.baseUrl),
+        HOMERAIL_DSH_MCP_SCRIPT: bridge.scriptPath,
+        HOMERAIL_MCP_BRIDGE_URL: bridge.url,
+        HOMERAIL_MCP_BRIDGE_TOKEN: bridge.token,
+      };
+      harness = new DeepSeekHarness({
+        launch: {
+          command: this.runtimeCommand,
+          args: this.runtimeArgs,
+          cwd: context.workspace ?? process.cwd(),
+          env: childEnv,
+        },
+        cwd: context.workspace,
+        provider: "deepseek-official",
+        model: context.model,
+      });
+
+      yield {
+        type: "debug",
+        source: "deepseek-harness",
+        message: "runtime_prepared",
+        data: {
+          fork_commit: DSH_FORK_COMMIT,
+          runtime_command: this.runtimeCommand,
+          runtime_args_count: this.runtimeArgs.length,
+          session_id: sessionId,
+          tool_count: tools.length,
+          workspace: context.workspace ?? process.cwd(),
+          process_isolation: true,
+          resume_supported: false,
+        },
+      };
+
+      await harness.start();
+      const bindController = (): void => {
+        if (!context.turnController || controllerBinding) return;
+        controllerBinding = context.turnController.bindDriver({
+          steer: async (command) => {
+            const receipt = await harness!.client.request("session/steer", {
+              sessionId,
+              contentBlocks: [{ type: "text", text: command.content }],
+            });
+            validateReceipt(receipt, "messageId");
+          },
+          interrupt: async () => {
+            const receipt = await harness!.client.request("session/cancel", { sessionId });
+            validateReceipt(receipt, "accepted");
+            if ((receipt as { accepted: boolean }).accepted !== true) await harness!.close();
+          },
+          close: () => harness!.close(),
+        });
+      };
+
+      abortHandler = (): void => {
+        void harness!.client.request("session/cancel", { sessionId }).then((receipt) => {
+          if (!isRecord(receipt) || receipt.accepted !== true) return harness!.close();
+        }).catch(() => harness!.close());
+      };
+      if (context.abortSignal?.aborted) abortHandler();
+      else context.abortSignal?.addEventListener("abort", abortHandler, { once: true });
+
+      const runTask = (async (): Promise<void> => {
+        const subscription = harness!.client.subscribeSessionTree(sessionId);
+        try {
+          const messageId = await harness!.client.prompt(sessionId, [{ type: "text", text: prompt }]);
+          bindController();
+          let receivedPrompt = false;
+          while (true) {
+            const notification = await subscription.next();
+            if (!receivedPrompt) {
+              if (!isPromptReceipt(notification, sessionId, messageId)) continue;
+              receivedPrompt = true;
+            }
+            const mapped = notificationEvents(notification, aggregateUsage);
+            aggregateUsage = mapped.usage;
+            if (mapped.finish !== null) latestFinishReason = mapped.finish;
+            for (const event of mapped.events) queue.push(event);
+            if (isIdleStatus(notification, sessionId)) break;
+          }
+        } finally {
+          subscription.close();
+        }
+      })().then(() => queue.end(), (error: unknown) => queue.fail(error));
+
+      for await (const event of queue) yield event;
+      await runTask;
+      yield {
+        type: "done",
+        usage: aggregateUsage,
+        duration_ms: Date.now() - startedAt,
+        finish_reason: latestFinishReason,
+      };
+    } catch (error) {
+      const message = redactSecret(error instanceof Error ? error.message : String(error), context.apiKey);
+      yield { type: "error", message: `DeepSeek Harness failed: ${message}` };
+      yield { type: "done", usage: aggregateUsage, duration_ms: Date.now() - startedAt };
+    } finally {
+      if (context.abortSignal && abortHandler) {
+        context.abortSignal.removeEventListener("abort", abortHandler);
+      }
+      await harness?.close().catch(() => undefined);
+      await bridge?.close().catch(() => undefined);
+      rmSync(runtimeRoot, { recursive: true, force: true });
+    }
+  }
+}
+
+async function createToolBridge(tools: DagToolDefinition[], root: string): Promise<ToolBridge> {
+  const token = randomUUID();
+  const toolMap = new Map(tools.map((tool) => [tool.name, tool]));
+  const server = createServer((request, response) => {
+    void handleToolRequest(request, response, token, toolMap);
+  });
+  const address = await listenOnLoopback(server);
+  const scriptPath = join(root, "homerail-tools-mcp-server.mjs");
+  writeFileSync(scriptPath, buildMcpProxyScript(tools), { encoding: "utf8", mode: 0o700 });
+  try {
+    chmodSync(scriptPath, 0o700);
+  } catch {
+    // Windows and restrictive filesystems may not expose POSIX modes.
+  }
+  return {
+    scriptPath,
+    url: `http://127.0.0.1:${address.port}`,
+    token,
+    close: () => closeHttpServer(server),
+  };
+}
+
+async function handleToolRequest(
+  request: IncomingMessage,
+  response: ServerResponse,
+  token: string,
+  tools: Map<string, DagToolDefinition>,
+): Promise<void> {
+  if (request.method !== "POST" || request.url !== "/tool") {
+    writeJson(response, 404, { error: "not_found" });
+    return;
+  }
+  if (request.headers.authorization !== `Bearer ${token}`) {
+    writeJson(response, 403, { error: "forbidden" });
+    return;
+  }
+  try {
+    const body = await readJson(request);
+    const name = typeof body.name === "string" ? body.name : "";
+    const tool = tools.get(name);
+    if (!tool) {
+      writeJson(response, 404, { content: `Unknown tool: ${name}`, is_error: true });
+      return;
+    }
+    const args = isRecord(body.args) ? body.args : {};
+    const result = await tool.handler(
+      args,
+      typeof body.tool_call_id === "string" ? { tool_call_id: body.tool_call_id } : undefined,
+    );
+    writeJson(response, 200, {
+      content: result.content.map((block) => block.text).join(""),
+      is_error: result.is_error === true,
+    });
+  } catch (error) {
+    writeJson(response, 500, {
+      content: error instanceof Error ? error.message : String(error),
+      is_error: true,
+    });
+  }
+}
+
+function buildMcpProxyScript(tools: DagToolDefinition[]): string {
+  const descriptors = tools.map((tool) => ({
+    name: tool.name,
+    description: tool.description,
+    inputSchema: tool.input_schema,
+  }));
+  return `#!/usr/bin/env node
+import { createInterface } from "node:readline";
+
+const TOOLS = ${JSON.stringify(descriptors)};
+const BRIDGE_URL = process.env.HOMERAIL_MCP_BRIDGE_URL;
+const BRIDGE_TOKEN = process.env.HOMERAIL_MCP_BRIDGE_TOKEN;
+const lines = createInterface({ input: process.stdin });
+const write = (value) => process.stdout.write(JSON.stringify(value) + "\\n");
+const result = (id, value) => write({ jsonrpc: "2.0", id, result: value });
+const failure = (id, code, message) => write({ jsonrpc: "2.0", id, error: { code, message } });
+
+lines.on("line", async (line) => {
+  if (!line.trim()) return;
+  let request;
+  try { request = JSON.parse(line); }
+  catch { failure(null, -32700, "Parse error"); return; }
+  const id = request.id;
+  try {
+    if (request.method === "initialize") {
+      result(id, {
+        protocolVersion: request.params?.protocolVersion || "2024-11-05",
+        capabilities: { tools: { listChanged: false } },
+        serverInfo: { name: "homerail-tools", version: ${JSON.stringify(WORKER_RUNTIME_VERSION)} }
+      });
+    } else if (request.method === "notifications/initialized") {
+      return;
+    } else if (request.method === "ping") {
+      result(id, {});
+    } else if (request.method === "tools/list") {
+      result(id, { tools: TOOLS });
+    } else if (request.method === "tools/call") {
+      const toolResponse = await fetch(BRIDGE_URL + "/tool", {
+        method: "POST",
+        headers: { authorization: "Bearer " + BRIDGE_TOKEN, "content-type": "application/json" },
+        body: JSON.stringify({
+          name: String(request.params?.name || ""),
+          args: request.params?.arguments ?? {},
+          tool_call_id: String(id)
+        })
+      });
+      const body = await toolResponse.json().catch(() => ({}));
+      result(id, {
+        content: [{ type: "text", text: String(body.content ?? body.error ?? "") }],
+        isError: !toolResponse.ok || body.is_error === true
+      });
+    } else {
+      failure(id, -32601, "Method not found: " + request.method);
+    }
+  } catch (error) {
+    failure(id, -32000, error instanceof Error ? error.message : String(error));
+  }
+});
+`;
+}
+
+function listenOnLoopback(server: Server): Promise<AddressInfo> {
+  return new Promise((resolveAddress, rejectAddress) => {
+    const onError = (error: Error): void => rejectAddress(error);
+    server.once("error", onError);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", onError);
+      const address = server.address();
+      if (!address || typeof address === "string") rejectAddress(new Error("DSH MCP bridge did not bind"));
+      else resolveAddress(address);
+    });
+  });
+}
+
+function closeHttpServer(server: Server): Promise<void> {
+  return new Promise((resolveClose) => server.close(() => resolveClose()));
+}
+
+function readJson(request: IncomingMessage, maxBytes = 1_000_000): Promise<Record<string, unknown>> {
+  return new Promise((resolveBody, rejectBody) => {
+    let body = "";
+    request.on("data", (chunk: Buffer) => {
+      body += chunk.toString("utf8");
+      if (body.length > maxBytes) request.destroy(new Error("request body too large"));
+    });
+    request.on("end", () => {
+      try {
+        const parsed: unknown = JSON.parse(body || "{}");
+        if (!isRecord(parsed)) throw new Error("request body must be an object");
+        resolveBody(parsed);
+      } catch (error) {
+        rejectBody(error);
+      }
+    });
+    request.on("error", rejectBody);
+  });
+}
+
+function writeJson(response: ServerResponse, status: number, body: Record<string, unknown>): void {
+  response.statusCode = status;
+  response.setHeader("content-type", "application/json");
+  response.end(JSON.stringify(body));
+}
+
+export const _deepSeekHarnessForkCommitForTest = DSH_FORK_COMMIT;

--- a/homerail_worker/src/agent/deepseek-harness.ts
+++ b/homerail_worker/src/agent/deepseek-harness.ts
@@ -34,7 +34,7 @@ import { WORKER_RUNTIME_VERSION } from "../runtime-version.js";
 const DEFAULT_DSH_RUNTIME_COMMAND = "dsh-jsonrpc-agent-pkg";
 const DEFAULT_DSH_MAX_TOKENS = 32_768;
 const DEFAULT_DSH_CONTEXT_WINDOW = 200_000;
-const DSH_FORK_COMMIT = "554b7b931a503f8af98614dc8002862f13eb9298";
+const DSH_FORK_COMMIT = "dc04fa3dbdcedc512322fff199b5cfef9169ea21";
 const MCP_TOOL_PREFIX = "mcp__homerail__";
 const DEFAULT_SYSTEM_PROMPT = "You are a HomeRail DAG worker. Complete the assigned task and call the provided handoff tool exactly once.";
 

--- a/homerail_worker/src/agent/deepseek-harness.ts
+++ b/homerail_worker/src/agent/deepseek-harness.ts
@@ -33,7 +33,6 @@ import { WORKER_RUNTIME_VERSION } from "../runtime-version.js";
 
 const DEFAULT_DSH_RUNTIME_COMMAND = "dsh-jsonrpc-agent-pkg";
 const DEFAULT_DSH_MAX_TOKENS = 32_768;
-const DEFAULT_DSH_MAX_BUILTIN_TOOL_CALLS = 24;
 const DSH_FORK_COMMIT = "ec75587a05bf0cc3f29dd0d5f875d3235f7deae6";
 const MCP_TOOL_PREFIX = "mcp__homerail__";
 const DEFAULT_SYSTEM_PROMPT = "You are a HomeRail DAG worker. Complete the assigned task and call the provided handoff tool exactly once.";
@@ -354,7 +353,7 @@ export class DeepSeekHarnessAdapter implements AgentClient {
 
     try {
       const reasoningEffort = dshReasoningEffort(context.reasoningEffort);
-      const maxBuiltinToolCalls = context.maxBuiltinToolCalls ?? DEFAULT_DSH_MAX_BUILTIN_TOOL_CALLS;
+      const maxBuiltinToolCalls = context.maxBuiltinToolCalls;
       const builtinTools = context.handoffOnly || !context.allowedBuiltinTools?.length
         ? []
         : createDeepSeekHarnessReadTools({
@@ -413,7 +412,7 @@ export class DeepSeekHarnessAdapter implements AgentClient {
           session_id: sessionId,
           tool_count: bridgeTools.length,
           builtin_tools: builtinTools.map((tool) => tool.name),
-          max_builtin_tool_calls: builtinTools.length > 0 ? maxBuiltinToolCalls : null,
+          max_builtin_tool_calls: builtinTools.length > 0 ? maxBuiltinToolCalls ?? null : null,
           max_tokens: this.maxTokens,
           reasoning_effort: reasoningEffort,
           workspace: context.workspace ?? process.cwd(),

--- a/homerail_worker/src/agent/deepseek-harness.ts
+++ b/homerail_worker/src/agent/deepseek-harness.ts
@@ -33,10 +33,10 @@ import { WORKER_RUNTIME_VERSION } from "../runtime-version.js";
 
 const DEFAULT_DSH_RUNTIME_COMMAND = "dsh-jsonrpc-agent-pkg";
 const DEFAULT_DSH_MAX_TOKENS = 32_768;
-const DSH_FORK_COMMIT = "ec75587a05bf0cc3f29dd0d5f875d3235f7deae6";
+const DEFAULT_DSH_CONTEXT_WINDOW = 200_000;
+const DSH_FORK_COMMIT = "554b7b931a503f8af98614dc8002862f13eb9298";
 const MCP_TOOL_PREFIX = "mcp__homerail__";
 const DEFAULT_SYSTEM_PROMPT = "You are a HomeRail DAG worker. Complete the assigned task and call the provided handoff tool exactly once.";
-const DSH_REASONING_EFFORTS = new Set(["off", "low", "medium", "high", "xhigh", "max"]);
 
 interface DeepSeekHarnessAdapterOptions {
   runtimeCommand?: string;
@@ -120,12 +120,52 @@ function parseMaxTokens(value: number | string | undefined): number {
   return parsed;
 }
 
-function dshReasoningEffort(value: string | undefined): string {
-  const effort = value?.trim() || "high";
-  if (!DSH_REASONING_EFFORTS.has(effort)) {
-    throw new Error(`DeepSeek Harness reasoning effort must be one of: ${[...DSH_REASONING_EFFORTS].join(", ")}`);
+function dshReasoningEffort(
+  value: string | undefined,
+  effortMap: Record<string, string | null> | false | undefined,
+): string | undefined {
+  const effort = value?.trim() || undefined;
+  if (!effort) return undefined;
+  if (effortMap === undefined || effortMap === false
+    || !Object.prototype.hasOwnProperty.call(effortMap, effort)) {
+    throw new Error(`DeepSeek Harness model does not declare reasoning effort '${effort}'`);
   }
   return effort;
+}
+
+function dshProviderProfile(
+  context: AgentRunContext,
+  maxTokens: number,
+): { provider: string; reasoningEffort?: string; providersJson: string } {
+  const provider = context.provider?.trim();
+  if (!provider) throw new Error("DeepSeek Harness requires the selected model provider");
+  if (context.protocol !== "openai_compatible") {
+    throw new Error(`DeepSeek Harness pi-ai route requires openai_compatible, got ${context.protocol ?? "unknown"}`);
+  }
+  const reasoningEffort = dshReasoningEffort(context.reasoningEffort, context.reasoningEffortMap);
+  const model = {
+    id: context.model,
+    contextWindow: DEFAULT_DSH_CONTEXT_WINDOW,
+    maxTokens,
+    ...(context.reasoningEffortMap === undefined
+      ? {}
+      : { reasoningEfforts: context.reasoningEffortMap }),
+  };
+  return {
+    provider,
+    reasoningEffort,
+    providersJson: JSON.stringify({
+      [provider]: {
+        displayName: provider,
+        apiKeyEnv: "HOMERAIL_DSH_API_KEY",
+        api: "openai-completions",
+        baseURL: normalizeBaseUrl(context.baseUrl),
+        streamIdleTimeoutMs: 172_800_000,
+        models: [model],
+        ...(reasoningEffort ? { reasoning: reasoningEffort } : {}),
+      },
+    }),
+  };
 }
 
 function defaultCordisConfigPath(): string {
@@ -352,7 +392,7 @@ export class DeepSeekHarnessAdapter implements AgentClient {
     const queue = new AsyncQueue<AgentEvent>();
 
     try {
-      const reasoningEffort = dshReasoningEffort(context.reasoningEffort);
+      const providerProfile = dshProviderProfile(context, this.maxTokens);
       const maxBuiltinToolCalls = context.maxBuiltinToolCalls;
       const builtinTools = context.handoffOnly || !context.allowedBuiltinTools?.length
         ? []
@@ -378,12 +418,10 @@ export class DeepSeekHarnessAdapter implements AgentClient {
         }),
         DSH_CORDIS_CONFIG: this.cordisConfigPath,
         DSH_CWD: context.workspace ?? process.cwd(),
-        DSH_MODEL: context.model,
-        DSH_REASONING_EFFORT: reasoningEffort,
         DSH_SESSION_ROOT: join(runtimeRoot, "sessions"),
         DSH_SYSTEM_PROMPT: projectedSystemPrompt(context),
-        DEEPSEEK_API_KEY: context.apiKey,
-        DEEPSEEK_BASE_URL: normalizeBaseUrl(context.baseUrl),
+        HOMERAIL_DSH_API_KEY: context.apiKey,
+        HOMERAIL_DSH_PROVIDERS_JSON: providerProfile.providersJson,
         HOMERAIL_DSH_MCP_SCRIPT: bridge.scriptPath,
         HOMERAIL_MCP_BRIDGE_URL: bridge.url,
         HOMERAIL_MCP_BRIDGE_TOKEN: bridge.token,
@@ -396,7 +434,7 @@ export class DeepSeekHarnessAdapter implements AgentClient {
           env: childEnv,
         },
         cwd: context.workspace,
-        provider: "deepseek-official",
+        provider: providerProfile.provider,
         model: context.model,
         maxTokens: this.maxTokens,
       });
@@ -414,7 +452,10 @@ export class DeepSeekHarnessAdapter implements AgentClient {
           builtin_tools: builtinTools.map((tool) => tool.name),
           max_builtin_tool_calls: builtinTools.length > 0 ? maxBuiltinToolCalls ?? null : null,
           max_tokens: this.maxTokens,
-          reasoning_effort: reasoningEffort,
+          reasoning_effort: providerProfile.reasoningEffort ?? null,
+          reasoning_efforts: context.reasoningEffortMap !== undefined && context.reasoningEffortMap !== false
+            ? Object.keys(context.reasoningEffortMap)
+            : [],
           workspace: context.workspace ?? process.cwd(),
           process_isolation: true,
           resume_supported: false,

--- a/homerail_worker/src/agent/deepseek-harness.ts
+++ b/homerail_worker/src/agent/deepseek-harness.ts
@@ -680,13 +680,19 @@ function closeHttpServer(server: Server): Promise<void> {
 
 function readJson(request: IncomingMessage, maxBytes = 1_000_000): Promise<Record<string, unknown>> {
   return new Promise((resolveBody, rejectBody) => {
-    let body = "";
+    const chunks: Buffer[] = [];
+    let bodyBytes = 0;
     request.on("data", (chunk: Buffer) => {
-      body += chunk.toString("utf8");
-      if (body.length > maxBytes) request.destroy(new Error("request body too large"));
+      bodyBytes += chunk.length;
+      if (bodyBytes > maxBytes) {
+        request.destroy(new Error("request body too large"));
+        return;
+      }
+      chunks.push(chunk);
     });
     request.on("end", () => {
       try {
+        const body = Buffer.concat(chunks, bodyBytes).toString("utf8");
         const parsed: unknown = JSON.parse(body || "{}");
         if (!isRecord(parsed)) throw new Error("request body must be an object");
         resolveBody(parsed);
@@ -697,6 +703,8 @@ function readJson(request: IncomingMessage, maxBytes = 1_000_000): Promise<Recor
     request.on("error", rejectBody);
   });
 }
+
+export const _readDeepSeekHarnessToolJsonForTest = readJson;
 
 function writeJson(response: ServerResponse, status: number, body: Record<string, unknown>): void {
   response.statusCode = status;

--- a/homerail_worker/src/agent/deepseek-harness.ts
+++ b/homerail_worker/src/agent/deepseek-harness.ts
@@ -34,7 +34,7 @@ import { WORKER_RUNTIME_VERSION } from "../runtime-version.js";
 const DEFAULT_DSH_RUNTIME_COMMAND = "dsh-jsonrpc-agent-pkg";
 const DEFAULT_DSH_MAX_TOKENS = 32_768;
 const DEFAULT_DSH_CONTEXT_WINDOW = 200_000;
-const DSH_FORK_COMMIT = "dc04fa3dbdcedc512322fff199b5cfef9169ea21";
+const DSH_FORK_COMMIT = "f4fd5f005636cdcbf9d95f70f04d05afa8c0db54";
 const MCP_TOOL_PREFIX = "mcp__homerail__";
 const DEFAULT_SYSTEM_PROMPT = "You are a HomeRail DAG worker. Complete the assigned task and call the provided handoff tool exactly once.";
 

--- a/homerail_worker/src/agent/deepseek-harness.ts
+++ b/homerail_worker/src/agent/deepseek-harness.ts
@@ -32,6 +32,7 @@ import { createDeepSeekHarnessReadTools } from "./deepseek-harness-read-tools.js
 import { WORKER_RUNTIME_VERSION } from "../runtime-version.js";
 
 const DEFAULT_DSH_RUNTIME_COMMAND = "dsh-jsonrpc-agent-pkg";
+const DEFAULT_DSH_MAX_TOKENS = 32_768;
 const DSH_FORK_COMMIT = "559cd23cc2f1b96da2fde230064da2dc3781b126";
 const MCP_TOOL_PREFIX = "mcp__homerail__";
 const DEFAULT_SYSTEM_PROMPT = "You are a HomeRail DAG worker. Complete the assigned task and call the provided handoff tool exactly once.";
@@ -40,6 +41,7 @@ interface DeepSeekHarnessAdapterOptions {
   runtimeCommand?: string;
   runtimeArgs?: string[];
   cordisConfigPath?: string;
+  maxTokens?: number;
 }
 
 interface ToolBridge {
@@ -104,6 +106,15 @@ function parseRuntimeArgs(value: string | undefined): string[] {
   const parsed: unknown = JSON.parse(value);
   if (!Array.isArray(parsed) || !parsed.every((entry) => typeof entry === "string")) {
     throw new Error("HOMERAIL_DSH_RUNTIME_ARGS must be a JSON array of strings");
+  }
+  return parsed;
+}
+
+function parseMaxTokens(value: number | string | undefined): number {
+  if (value === undefined || value === "") return DEFAULT_DSH_MAX_TOKENS;
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error("HOMERAIL_DSH_MAX_TOKENS must be a positive integer");
   }
   return parsed;
 }
@@ -297,6 +308,7 @@ export class DeepSeekHarnessAdapter implements AgentClient {
   private readonly runtimeCommand: string;
   private readonly runtimeArgs: string[];
   private readonly cordisConfigPath: string;
+  private readonly maxTokens: number;
 
   constructor(options: DeepSeekHarnessAdapterOptions = {}) {
     this.runtimeCommand = options.runtimeCommand
@@ -308,6 +320,9 @@ export class DeepSeekHarnessAdapter implements AgentClient {
       options.cordisConfigPath
         ?? process.env.HOMERAIL_DSH_CORDIS_CONFIG?.trim()
         ?? defaultCordisConfigPath(),
+    );
+    this.maxTokens = parseMaxTokens(
+      options.maxTokens ?? process.env.HOMERAIL_DSH_MAX_TOKENS?.trim(),
     );
   }
 
@@ -371,6 +386,7 @@ export class DeepSeekHarnessAdapter implements AgentClient {
         cwd: context.workspace,
         provider: "deepseek-official",
         model: context.model,
+        maxTokens: this.maxTokens,
       });
 
       yield {
@@ -384,6 +400,7 @@ export class DeepSeekHarnessAdapter implements AgentClient {
           session_id: sessionId,
           tool_count: bridgeTools.length,
           builtin_tools: builtinTools.map((tool) => tool.name),
+          max_tokens: this.maxTokens,
           workspace: context.workspace ?? process.cwd(),
           process_isolation: true,
           resume_supported: false,

--- a/homerail_worker/src/agent/deepseek-harness.ts
+++ b/homerail_worker/src/agent/deepseek-harness.ts
@@ -483,9 +483,12 @@ export class DeepSeekHarnessAdapter implements AgentClient {
       };
 
       abortHandler = (): void => {
-        void harness!.client.request("session/cancel", { sessionId }).then((receipt) => {
-          if (!isRecord(receipt) || receipt.accepted !== true) return harness!.close();
-        }).catch(() => harness!.close());
+        const closeAfterAbort = async (): Promise<void> => {
+          await harness!.close().catch(() => undefined);
+        };
+        void harness!.client.request("session/cancel", { sessionId }).then(async (receipt) => {
+          if (!isRecord(receipt) || receipt.accepted !== true) await closeAfterAbort();
+        }, closeAfterAbort);
       };
       if (context.abortSignal?.aborted) abortHandler();
       else context.abortSignal?.addEventListener("abort", abortHandler, { once: true });

--- a/homerail_worker/src/agent/factory.ts
+++ b/homerail_worker/src/agent/factory.ts
@@ -9,6 +9,7 @@ import { DeterministicClient } from "./deterministic.js";
 import { ClaudeSdkAdapter } from "./claude-sdk.js";
 import { KimiCodeAdapter } from "./kimi-code.js";
 import { CodexAppServerAdapter } from "./codex-appserver.js";
+import { DeepSeekHarnessAdapter } from "./deepseek-harness.js";
 import { ManagerAgentSmokeClient } from "./manager-agent-smoke.js";
 import {
   DEFAULT_MANAGER_AGENT_RUNTIME_AGENT_TYPE,
@@ -19,6 +20,7 @@ import {
 const PRODUCTION_REGISTRY: Record<ManagerAgentRuntimeAgentType, () => AgentClient> = {
   "claude-sdk": () => new ClaudeSdkAdapter(),
   codex_appserver: () => new CodexAppServerAdapter(),
+  deepseek_harness: () => new DeepSeekHarnessAdapter(),
   kimi_code: () => new KimiCodeAdapter(),
 };
 

--- a/homerail_worker/src/agent/kimi-code.ts
+++ b/homerail_worker/src/agent/kimi-code.ts
@@ -928,8 +928,10 @@ export class KimiCodeAdapter implements AgentClient {
    * Must NOT expose KIMI_MODEL_API_KEY in any debug output.
    */
   buildKimiEnv(context: AgentRunContext, kimiHome: string): Record<string, string | undefined> {
-    const env = sanitizedAgentChildEnv();
-    Object.assign(env, context.environmentVariables ?? {});
+    const env = sanitizedAgentChildEnv({
+      ...process.env,
+      ...context.environmentVariables,
+    });
 
     // Isolated KIMI_CODE_HOME
     env.KIMI_CODE_HOME = kimiHome;

--- a/homerail_worker/src/agent/turn-controller.ts
+++ b/homerail_worker/src/agent/turn-controller.ts
@@ -150,6 +150,9 @@ export function agentTurnControllerOptionsForBackend(
   if (normalized === "claude-sdk") {
     return { capabilities: { liveSteer: true } };
   }
+  if (normalized === "deepseek_harness" || normalized === "deepseek-harness" || normalized === "dsh") {
+    return { capabilities: { liveSteer: true } };
+  }
   if (normalized === "kimi_code" || normalized === "kimi-code" || normalized === "kimi") {
     const configuredTransport = env.HOMERAIL_KIMI_AGENT_TRANSPORT?.trim().toLowerCase();
     const explicitlySdk = configuredTransport === "sdk"

--- a/homerail_worker/src/agent/types.ts
+++ b/homerail_worker/src/agent/types.ts
@@ -114,8 +114,10 @@ export interface AgentRunContext {
   model: string;
   apiKey: string;
   baseUrl: string;
-  /** Codex Responses reasoning effort selected by the runtime profile. */
+  /** Provider-owned reasoning selector chosen by the runtime profile. */
   reasoningEffort?: string;
+  /** Selectable reasoning ids mapped to the configured provider's wire values. */
+  reasoningEffortMap?: Record<string, string | null> | false;
   /** Explicit command sandbox selected by the trusted DAG runtime policy. */
   codexSandbox?: "read-only" | "workspace-write" | "danger-full-access";
   /** Optional provider service tier; null means provider default. */

--- a/homerail_worker/src/index.ts
+++ b/homerail_worker/src/index.ts
@@ -176,6 +176,12 @@ client.on("task", async (msg) => {
   const reasoningEffort = typeof llmConfig.reasoning_effort === "string"
     ? llmConfig.reasoning_effort
     : undefined;
+  const reasoningEffortMap = llmConfig.reasoning_effort_map === false
+    ? false
+    : llmConfig.reasoning_effort_map && typeof llmConfig.reasoning_effort_map === "object"
+      && !Array.isArray(llmConfig.reasoning_effort_map)
+    ? llmConfig.reasoning_effort_map as Record<string, string | null>
+    : undefined;
   const serviceTier = typeof llmConfig.service_tier === "string"
     ? llmConfig.service_tier
     : llmConfig.service_tier === null ? null : undefined;
@@ -211,6 +217,7 @@ client.on("task", async (msg) => {
         agent_type: agentType,
         model,
         reasoning_effort: reasoningEffort,
+        reasoning_effort_map: reasoningEffortMap,
         service_tier: serviceTier,
         outgoing_edges: ((envelope.outgoingEdges ?? []) as Array<Record<string, unknown>>).map((e) => ({
           from_port: String(e.from_port ?? ""),

--- a/homerail_worker/src/manager-agent/server.ts
+++ b/homerail_worker/src/manager-agent/server.ts
@@ -66,6 +66,7 @@ import {
 
 interface ManagerAgentConfig {
   provider_name?: string;
+  protocol?: string;
   model?: string;
   model_name?: string;
   api_key?: string;
@@ -74,6 +75,7 @@ interface ManagerAgentConfig {
   agent_type?: string;
   project_workspace?: string;
   reasoning_effort?: string;
+  reasoning_effort_map?: Record<string, string | null> | false;
   service_tier?: string | null;
 }
 
@@ -1882,9 +1884,13 @@ async function handleChat(
     ].filter(Boolean).join("\n\n"),
     systemPromptMode: "append",
     provider: config.provider_name,
+    protocol: config.protocol,
     model,
     apiKey: String(config.api_key || ""),
     baseUrl: String(config.base_url || ""),
+    reasoningEffort: config.reasoning_effort,
+    reasoningEffortMap: config.reasoning_effort_map,
+    serviceTier: config.service_tier,
     anthropicAuthMode: config.anthropic_auth_mode,
     workspace: projectWorkspace(),
     claudePermissionMode: "dontAsk",

--- a/homerail_worker/src/prompt-runner.ts
+++ b/homerail_worker/src/prompt-runner.ts
@@ -579,6 +579,7 @@ export async function runPrompt(
       apiKey: job.llmApiKey ?? process.env.LLM_API_KEY ?? "",
       baseUrl: resolveAgentBaseUrl(job, agentBackend),
       reasoningEffort: job.dagConfig.reasoning_effort,
+      reasoningEffortMap: job.dagConfig.reasoning_effort_map,
       codexSandbox: job.dagConfig.codex_sandbox,
       serviceTier: job.dagConfig.service_tier,
       anthropicAuthMode: job.llmAnthropicAuthMode,

--- a/homerail_worker/src/prompt-runner.ts
+++ b/homerail_worker/src/prompt-runner.ts
@@ -136,6 +136,11 @@ function assertAgentRuntimeProtocol(agentBackend: string | undefined, protocol: 
       "Codex app-server requires a Responses-compatible endpoint; Chat Completions and Anthropic protocols are not valid Codex wire transports.",
     );
   }
+  if (backend === "deepseek_harness" && protocol !== "openai_compatible") {
+    throw new Error(
+      "DeepSeek Harness requires an OpenAI-compatible Chat Completions endpoint.",
+    );
+  }
 }
 
 function assertBuiltinToolPolicySupported(

--- a/homerail_worker/src/prompt-runner.ts
+++ b/homerail_worker/src/prompt-runner.ts
@@ -25,6 +25,7 @@ import {
   type ReviewFailureCategory,
 } from "homerail-protocol";
 import { createAgentClient } from "./agent/factory.js";
+import { supportsDeepSeekHarnessReadTools } from "./agent/deepseek-harness-read-tools.js";
 import type {
   AgentEvent,
   AgentRunContext,
@@ -169,6 +170,18 @@ function assertBuiltinToolPolicySupported(
   }
   if (allowedTools === undefined) return;
   if (backend === "claude-sdk" || backend === "deterministic") return;
+  if (backend === "deepseek_harness") {
+    if (!Array.isArray(allowedTools) || !allowedTools.every((tool) => typeof tool === "string")) {
+      throw new Error("DeepSeek Harness allowed_builtin_tools must be an array");
+    }
+    if (!supportsDeepSeekHarnessReadTools(allowedTools)) {
+      throw new Error("DeepSeek Harness only enforces the read-only built-in tools Read, Grep, Glob, and LS");
+    }
+    if (allowedTools.length > 0 && (!workspaceAccess || typeof workspaceAccess !== "object" || Array.isArray(workspaceAccess))) {
+      throw new Error("DeepSeek Harness read-only built-in tools require workspace_access");
+    }
+    return;
+  }
   throw new Error(
     `allowed_builtin_tools is not enforced by agent backend '${backend ?? "unknown"}'`,
   );

--- a/scripts/configure-pr-review-runtime-profile.mjs
+++ b/scripts/configure-pr-review-runtime-profile.mjs
@@ -30,6 +30,16 @@ function normalizedAgentType(value) {
   return agentType;
 }
 
+export function resolvePrReviewProfileId(value, agentType) {
+  agentType = normalizedAgentType(agentType);
+  const profileId = nonEmpty(value)
+    ?? (agentType === "deepseek_harness" ? "pr-review-dsh" : "pr-review-mixed");
+  if (agentType === "deepseek_harness" && profileId === "pr-review-mixed") {
+    throw new Error("DeepSeek Harness PR Review must not overwrite the pr-review-mixed profile");
+  }
+  return profileId;
+}
+
 function normalizedDshReasoningEffort(value, agentType) {
   if (agentType !== "deepseek_harness") return undefined;
   const effort = nonEmpty(value) ?? "medium";
@@ -128,7 +138,7 @@ async function request(managerUrl, pathname, init) {
 
 export async function configurePrReviewRuntimeProfile({
   managerUrl = process.env.HOMERAIL_MANAGER_URL ?? "http://127.0.0.1:29191",
-  profileId = process.env.HOMERAIL_PR_REVIEW_PROFILE_ID ?? "pr-review-mixed",
+  profileId = process.env.HOMERAIL_PR_REVIEW_PROFILE_ID,
   workflowId = process.env.HOMERAIL_PR_REVIEW_WORKFLOW_ID ?? "pr-review",
   agentType = process.env.HOMERAIL_PR_REVIEW_AGENT_TYPE ?? "claude-sdk",
   modelSelector = process.env.HOMERAIL_PR_REVIEW_MODEL,
@@ -138,9 +148,9 @@ export async function configurePrReviewRuntimeProfile({
   reasoningEffort = process.env.HOMERAIL_PR_REVIEW_REASONING_EFFORT,
 } = {}) {
   const normalizedManagerUrl = managerUrl.replace(/\/+$/, "");
-  profileId = nonEmpty(profileId) ?? "pr-review-mixed";
   workflowId = nonEmpty(workflowId) ?? "pr-review";
   agentType = normalizedAgentType(agentType);
+  profileId = resolvePrReviewProfileId(profileId, agentType);
   modelSelector = nonEmpty(modelSelector);
   const listed = await request(normalizedManagerUrl, "/api/llm/settings");
   const settings = Array.isArray(listed?.settings) ? listed.settings : [];

--- a/scripts/configure-pr-review-runtime-profile.mjs
+++ b/scripts/configure-pr-review-runtime-profile.mjs
@@ -114,13 +114,13 @@ export function prReviewRuntimeProfileYaml({
     "default:",
     `  llm_setting_id: ${yamlString(primary.id)}`,
     `  agent_type: ${agentType}`,
-    ...(reasoningEffort ? [`  reasoning_effort: ${reasoningEffort}`] : []),
+    ...(reasoningEffort ? [`  reasoning_effort: ${yamlString(reasoningEffort)}`] : []),
     "agents:",
     ...Object.entries(PR_REVIEW_MODEL_AGENTS).flatMap(([agentId, role]) => [
       `  ${agentId}:`,
       `    llm_setting_id: ${yamlString(settingsByRole[role].id)}`,
       `    agent_type: ${agentType}`,
-      ...(reasoningEffort ? [`    reasoning_effort: ${reasoningEffort}`] : []),
+      ...(reasoningEffort ? [`    reasoning_effort: ${yamlString(reasoningEffort)}`] : []),
     ]),
     "",
   ].join("\n");

--- a/scripts/configure-pr-review-runtime-profile.mjs
+++ b/scripts/configure-pr-review-runtime-profile.mjs
@@ -44,7 +44,11 @@ function normalizedDshReasoningEffort(value, agentType, settings) {
   if (!effort) return undefined;
   for (const setting of new Set(settings)) {
     const effortMap = setting?.reasoning_effort_map;
-    if (!effortMap || typeof effortMap !== "object" || !(effort in effortMap)) {
+    if (
+      !effortMap
+      || typeof effortMap !== "object"
+      || !Object.prototype.hasOwnProperty.call(effortMap, effort)
+    ) {
       throw new Error(
         `DeepSeek Harness model setting ${setting?.id ?? "unknown"} does not declare reasoning effort: ${effort}`,
       );

--- a/scripts/configure-pr-review-runtime-profile.mjs
+++ b/scripts/configure-pr-review-runtime-profile.mjs
@@ -8,8 +8,6 @@ export const PR_REVIEW_MODEL_AGENTS = Object.freeze({
   glm_reviewer: "third",
 });
 
-const DSH_REASONING_EFFORTS = new Set(["off", "low", "medium", "high", "xhigh", "max"]);
-
 function nonEmpty(value) {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
@@ -30,11 +28,17 @@ function normalizedAgentType(value) {
   return agentType;
 }
 
-function normalizedDshReasoningEffort(value, agentType) {
+function normalizedDshReasoningEffort(value, agentType, settings) {
   if (agentType !== "deepseek_harness") return undefined;
-  const effort = nonEmpty(value) ?? "medium";
-  if (!DSH_REASONING_EFFORTS.has(effort)) {
-    throw new Error(`Unsupported DeepSeek Harness reasoning effort: ${effort}`);
+  const effort = nonEmpty(value);
+  if (!effort) return undefined;
+  for (const setting of new Set(settings)) {
+    const effortMap = setting?.reasoning_effort_map;
+    if (!effortMap || typeof effortMap !== "object" || !(effort in effortMap)) {
+      throw new Error(
+        `DeepSeek Harness model setting ${setting?.id ?? "unknown"} does not declare reasoning effort: ${effort}`,
+      );
+    }
   }
   return effort;
 }
@@ -81,7 +85,7 @@ export function prReviewRuntimeProfileYaml({
   reasoningEffort,
 }) {
   agentType = normalizedAgentType(agentType);
-  reasoningEffort = normalizedDshReasoningEffort(reasoningEffort, agentType);
+  reasoningEffort = normalizedDshReasoningEffort(reasoningEffort, agentType, [primary, arbiter, third]);
   if (agentType === "claude-sdk" && new Set([primary.id, arbiter.id, third.id]).size !== 3) {
     throw new Error("PR Review requires three distinct LLM settings");
   }

--- a/scripts/configure-pr-review-runtime-profile.mjs
+++ b/scripts/configure-pr-review-runtime-profile.mjs
@@ -8,6 +8,8 @@ export const PR_REVIEW_MODEL_AGENTS = Object.freeze({
   glm_reviewer: "third",
 });
 
+const DSH_REASONING_EFFORTS = new Set(["off", "low", "medium", "high", "xhigh", "max"]);
+
 function nonEmpty(value) {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
@@ -26,6 +28,15 @@ function normalizedAgentType(value) {
     throw new Error(`Unsupported PR Review agent type: ${agentType}`);
   }
   return agentType;
+}
+
+function normalizedDshReasoningEffort(value, agentType) {
+  if (agentType !== "deepseek_harness") return undefined;
+  const effort = nonEmpty(value) ?? "medium";
+  if (!DSH_REASONING_EFFORTS.has(effort)) {
+    throw new Error(`Unsupported DeepSeek Harness reasoning effort: ${effort}`);
+  }
+  return effort;
 }
 
 export function selectRuntimeSetting(settings, selector, role, agentType = "claude-sdk") {
@@ -67,8 +78,10 @@ export function prReviewRuntimeProfileYaml({
   arbiter,
   third,
   agentType = "claude-sdk",
+  reasoningEffort,
 }) {
   agentType = normalizedAgentType(agentType);
+  reasoningEffort = normalizedDshReasoningEffort(reasoningEffort, agentType);
   if (agentType === "claude-sdk" && new Set([primary.id, arbiter.id, third.id]).size !== 3) {
     throw new Error("PR Review requires three distinct LLM settings");
   }
@@ -83,11 +96,13 @@ export function prReviewRuntimeProfileYaml({
     "default:",
     `  llm_setting_id: ${yamlString(primary.id)}`,
     `  agent_type: ${agentType}`,
+    ...(reasoningEffort ? [`  reasoning_effort: ${reasoningEffort}`] : []),
     "agents:",
     ...Object.entries(PR_REVIEW_MODEL_AGENTS).flatMap(([agentId, role]) => [
       `  ${agentId}:`,
       `    llm_setting_id: ${yamlString(settingsByRole[role].id)}`,
       `    agent_type: ${agentType}`,
+      ...(reasoningEffort ? [`    reasoning_effort: ${reasoningEffort}`] : []),
     ]),
     "",
   ].join("\n");
@@ -120,6 +135,7 @@ export async function configurePrReviewRuntimeProfile({
   primarySelector = process.env.HOMERAIL_PR_REVIEW_PRIMARY_MODEL,
   arbiterSelector = process.env.HOMERAIL_PR_REVIEW_ARBITER_MODEL,
   thirdSelector = process.env.HOMERAIL_PR_REVIEW_THIRD_MODEL,
+  reasoningEffort = process.env.HOMERAIL_PR_REVIEW_REASONING_EFFORT,
 } = {}) {
   const normalizedManagerUrl = managerUrl.replace(/\/+$/, "");
   profileId = nonEmpty(profileId) ?? "pr-review-mixed";
@@ -131,7 +147,15 @@ export async function configurePrReviewRuntimeProfile({
   const primary = selectRuntimeSetting(settings, modelSelector ?? primarySelector, "primary", agentType);
   const arbiter = selectRuntimeSetting(settings, modelSelector ?? arbiterSelector, "arbiter", agentType);
   const third = selectRuntimeSetting(settings, modelSelector ?? thirdSelector, "third", agentType);
-  const yamlText = prReviewRuntimeProfileYaml({ profileId, workflowId, primary, arbiter, third, agentType });
+  const yamlText = prReviewRuntimeProfileYaml({
+    profileId,
+    workflowId,
+    primary,
+    arbiter,
+    third,
+    agentType,
+    reasoningEffort,
+  });
   const synced = await request(normalizedManagerUrl, "/api/dag/profiles/sync", {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/scripts/configure-pr-review-runtime-profile.mjs
+++ b/scripts/configure-pr-review-runtime-profile.mjs
@@ -20,7 +20,16 @@ function yamlString(value) {
   return JSON.stringify(String(value));
 }
 
-export function selectRuntimeSetting(settings, selector, role) {
+function normalizedAgentType(value) {
+  const agentType = nonEmpty(value) ?? "claude-sdk";
+  if (agentType !== "claude-sdk" && agentType !== "deepseek_harness") {
+    throw new Error(`Unsupported PR Review agent type: ${agentType}`);
+  }
+  return agentType;
+}
+
+export function selectRuntimeSetting(settings, selector, role, agentType = "claude-sdk") {
+  agentType = normalizedAgentType(agentType);
   const wanted = nonEmpty(selector);
   if (!wanted) throw new Error(`HOMERAIL_PR_REVIEW_${role.toUpperCase()}_MODEL is required for stable review`);
   const matches = settings.filter((setting) => (
@@ -35,8 +44,18 @@ export function selectRuntimeSetting(settings, selector, role) {
   if (!bool(setting.is_active) || !bool(setting.supports_llm)) {
     throw new Error(`PR Review ${role} model is not an active LLM setting: ${wanted}`);
   }
-  if (!nonEmpty(setting.anthropic_base_url)) {
+  if (agentType === "claude-sdk" && !nonEmpty(setting.anthropic_base_url)) {
     throw new Error(`PR Review ${role} model has no Anthropic-compatible endpoint: ${wanted}`);
+  }
+  if (agentType === "deepseek_harness" && setting.protocol !== "openai_compatible") {
+    throw new Error(`PR Review ${role} model is not OpenAI-compatible for DeepSeek Harness: ${wanted}`);
+  }
+  if (
+    agentType === "deepseek_harness"
+    && !nonEmpty(setting.chat_completions_base_url)
+    && !nonEmpty(setting.base_url)
+  ) {
+    throw new Error(`PR Review ${role} model has no Chat Completions endpoint: ${wanted}`);
   }
   return setting;
 }
@@ -47,23 +66,28 @@ export function prReviewRuntimeProfileYaml({
   primary,
   arbiter,
   third,
+  agentType = "claude-sdk",
 }) {
-  if (new Set([primary.id, arbiter.id, third.id]).size !== 3) {
+  agentType = normalizedAgentType(agentType);
+  if (agentType === "claude-sdk" && new Set([primary.id, arbiter.id, third.id]).size !== 3) {
     throw new Error("PR Review requires three distinct LLM settings");
   }
   const settingsByRole = { primary, arbiter, third };
+  const description = agentType === "deepseek_harness"
+    ? "Three independent DeepSeek Harness reviewer processes; model settings may intentionally be shared."
+    : "Three-model PR review with one independent vote per model.";
   return [
     `profile_id: ${yamlString(profileId)}`,
     `workflow_id: ${yamlString(workflowId)}`,
-    "description: Three-model PR review with one independent vote per model.",
+    `description: ${description}`,
     "default:",
     `  llm_setting_id: ${yamlString(primary.id)}`,
-    "  agent_type: claude-sdk",
+    `  agent_type: ${agentType}`,
     "agents:",
     ...Object.entries(PR_REVIEW_MODEL_AGENTS).flatMap(([agentId, role]) => [
       `  ${agentId}:`,
       `    llm_setting_id: ${yamlString(settingsByRole[role].id)}`,
-      "    agent_type: claude-sdk",
+      `    agent_type: ${agentType}`,
     ]),
     "",
   ].join("\n");
@@ -91,17 +115,23 @@ export async function configurePrReviewRuntimeProfile({
   managerUrl = process.env.HOMERAIL_MANAGER_URL ?? "http://127.0.0.1:29191",
   profileId = process.env.HOMERAIL_PR_REVIEW_PROFILE_ID ?? "pr-review-mixed",
   workflowId = process.env.HOMERAIL_PR_REVIEW_WORKFLOW_ID ?? "pr-review",
+  agentType = process.env.HOMERAIL_PR_REVIEW_AGENT_TYPE ?? "claude-sdk",
+  modelSelector = process.env.HOMERAIL_PR_REVIEW_MODEL,
   primarySelector = process.env.HOMERAIL_PR_REVIEW_PRIMARY_MODEL,
   arbiterSelector = process.env.HOMERAIL_PR_REVIEW_ARBITER_MODEL,
   thirdSelector = process.env.HOMERAIL_PR_REVIEW_THIRD_MODEL,
 } = {}) {
   const normalizedManagerUrl = managerUrl.replace(/\/+$/, "");
+  profileId = nonEmpty(profileId) ?? "pr-review-mixed";
+  workflowId = nonEmpty(workflowId) ?? "pr-review";
+  agentType = normalizedAgentType(agentType);
+  modelSelector = nonEmpty(modelSelector);
   const listed = await request(normalizedManagerUrl, "/api/llm/settings");
   const settings = Array.isArray(listed?.settings) ? listed.settings : [];
-  const primary = selectRuntimeSetting(settings, primarySelector, "primary");
-  const arbiter = selectRuntimeSetting(settings, arbiterSelector, "arbiter");
-  const third = selectRuntimeSetting(settings, thirdSelector, "third");
-  const yamlText = prReviewRuntimeProfileYaml({ profileId, workflowId, primary, arbiter, third });
+  const primary = selectRuntimeSetting(settings, modelSelector ?? primarySelector, "primary", agentType);
+  const arbiter = selectRuntimeSetting(settings, modelSelector ?? arbiterSelector, "arbiter", agentType);
+  const third = selectRuntimeSetting(settings, modelSelector ?? thirdSelector, "third", agentType);
+  const yamlText = prReviewRuntimeProfileYaml({ profileId, workflowId, primary, arbiter, third, agentType });
   const synced = await request(normalizedManagerUrl, "/api/dag/profiles/sync", {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/scripts/lib/worker-build-network.sh
+++ b/scripts/lib/worker-build-network.sh
@@ -8,6 +8,7 @@
 #   HOMERAIL_WORKER_BUILD_APT_MIRROR           optional Debian main repository URL
 #   HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR  optional Debian security repository URL
 #   HOMERAIL_WORKER_BUILD_NPM_REGISTRY         optional npm registry URL
+#   HOMERAIL_WORKER_BUILD_DSH_GIT_REMOTE       optional DeepSeek Harness Git mirror URL
 #
 # Unset or whitespace-only values leave the corresponding source unchanged.
 # Normalization and validation are delegated to the Worker WHATWG URL helper
@@ -77,22 +78,29 @@ homerail_worker_build_network_normalize_source() {
 #   --build-arg HOMERAIL_WORKER_BUILD_APT_MIRROR=<url>
 #   --build-arg HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR=<url>
 #   --build-arg NPM_CONFIG_REGISTRY=<url>
+#   --build-arg HOMERAIL_DSH_FORK_REPOSITORY=<url>
 # plus one value-less --build-arg NAME entry for every recognized proxy variable
 # containing a non-whitespace character. Returns 1 before any Docker invocation
 # when a value is invalid.
 homerail_worker_build_network_args() {
   HOMERAIL_WORKER_BUILD_NETWORK_ARGS=()
   local name normalized proxy_name
-  for name in HOMERAIL_WORKER_BUILD_APT_MIRROR HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR HOMERAIL_WORKER_BUILD_NPM_REGISTRY; do
+  for name in HOMERAIL_WORKER_BUILD_APT_MIRROR HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR HOMERAIL_WORKER_BUILD_NPM_REGISTRY HOMERAIL_WORKER_BUILD_DSH_GIT_REMOTE; do
     if ! normalized="$(homerail_worker_build_network_normalize_source "$name")"; then
       return 1
     fi
     if [ -n "$normalized" ]; then
-      if [ "$name" = "HOMERAIL_WORKER_BUILD_NPM_REGISTRY" ]; then
-        HOMERAIL_WORKER_BUILD_NETWORK_ARGS+=("--build-arg" "NPM_CONFIG_REGISTRY=$normalized")
-      else
-        HOMERAIL_WORKER_BUILD_NETWORK_ARGS+=("--build-arg" "$name=$normalized")
-      fi
+      case "$name" in
+        HOMERAIL_WORKER_BUILD_NPM_REGISTRY)
+          HOMERAIL_WORKER_BUILD_NETWORK_ARGS+=("--build-arg" "NPM_CONFIG_REGISTRY=$normalized")
+          ;;
+        HOMERAIL_WORKER_BUILD_DSH_GIT_REMOTE)
+          HOMERAIL_WORKER_BUILD_NETWORK_ARGS+=("--build-arg" "HOMERAIL_DSH_FORK_REPOSITORY=$normalized")
+          ;;
+        *)
+          HOMERAIL_WORKER_BUILD_NETWORK_ARGS+=("--build-arg" "$name=$normalized")
+          ;;
+      esac
     fi
   done
   for proxy_name in HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy; do

--- a/scripts/live-runner-isolation.test.mjs
+++ b/scripts/live-runner-isolation.test.mjs
@@ -295,6 +295,7 @@ exec "${process.execPath}" "$@"
     HOMERAIL_WORKER_BUILD_APT_MIRROR: "",
     HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR: "",
     HOMERAIL_WORKER_BUILD_NPM_REGISTRY: "",
+    HOMERAIL_WORKER_BUILD_DSH_GIT_REMOTE: "",
     HTTP_PROXY: "",
     HTTPS_PROXY: "",
     NO_PROXY: "",
@@ -333,11 +334,13 @@ exec "${process.execPath}" "$@"
   const custom = runRunner({
     HOMERAIL_WORKER_BUILD_APT_MIRROR: "https://deb.live.example/debian/",
     HOMERAIL_WORKER_BUILD_NPM_REGISTRY: "https://npm.live.example",
+    HOMERAIL_WORKER_BUILD_DSH_GIT_REMOTE: "https://git.live.example/deepseek-harness.git",
   });
   assert.equal(custom.status, 3, custom.stderr);
   const customArgs = fs.readFileSync(capturePath, "utf8");
   assert.match(customArgs, /--build-arg\nHOMERAIL_WORKER_BUILD_APT_MIRROR=https:\/\/deb\.live\.example\/debian\n/);
   assert.match(customArgs, /--build-arg\nNPM_CONFIG_REGISTRY=https:\/\/npm\.live\.example\n/);
+  assert.match(customArgs, /--build-arg\nHOMERAIL_DSH_FORK_REPOSITORY=https:\/\/git\.live\.example\/deepseek-harness\.git\n/);
   assert.doesNotMatch(customArgs, /HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR/);
 
   const proxy = runRunner({
@@ -366,12 +369,14 @@ exec "${process.execPath}" "$@"
     "HOMERAIL_WORKER_BUILD_APT_MIRROR",
     "HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR",
     "HOMERAIL_WORKER_BUILD_NPM_REGISTRY",
+    "HOMERAIL_WORKER_BUILD_DSH_GIT_REMOTE",
   ]) {
     assert.ok(capturedArgv.includes(expected), `delegation must name ${expected} only`);
   }
   for (const prohibited of [
     "https://deb.live.example/debian/",
     "https://npm.live.example",
+    "https://git.live.example/deepseek-harness.git",
     "http://proxy.live.example:3128",
     "http://user:pass@deb.live.example",
   ]) {

--- a/scripts/pr-review-runtime-profile.test.mjs
+++ b/scripts/pr-review-runtime-profile.test.mjs
@@ -217,6 +217,10 @@ test("formal PR Review submits to the durable stable Manager", () => {
     workflow,
     /HOMERAIL_PR_REVIEW_AGENT_TYPE: \$\{\{ inputs\.agent_type \|\| 'claude-sdk' \}\}/,
   );
+  assert.match(
+    workflow,
+    /HOMERAIL_PR_REVIEW_REASONING_EFFORT: \$\{\{ inputs\.reasoning_effort \}\}/,
+  );
   assert.doesNotMatch(workflow, /install:all|build:packages|run-pr-review-live-runner/);
   assert.doesNotMatch(workflow, /vars\.HOMERAIL_PR_REVIEW_(?:HOME_TEMPLATE|PRIMARY_MODEL|ARBITER_MODEL|THIRD_MODEL)/);
 });

--- a/scripts/pr-review-runtime-profile.test.mjs
+++ b/scripts/pr-review-runtime-profile.test.mjs
@@ -9,6 +9,7 @@ import {
   PR_REVIEW_MODEL_AGENTS,
   configurePrReviewRuntimeProfile,
   prReviewRuntimeProfileYaml,
+  resolvePrReviewProfileId,
   selectRuntimeSetting,
 } from "./configure-pr-review-runtime-profile.mjs";
 
@@ -131,6 +132,16 @@ test("binds three independent DSH reviewers to one OpenAI-compatible Qwen settin
   );
 });
 
+test("keeps omitted DSH profile ids isolated from the mixed-model profile", () => {
+  assert.equal(resolvePrReviewProfileId(undefined, "claude-sdk"), "pr-review-mixed");
+  assert.equal(resolvePrReviewProfileId(undefined, "deepseek_harness"), "pr-review-dsh");
+  assert.equal(resolvePrReviewProfileId("pr-review-qwen38-dsh", "deepseek_harness"), "pr-review-qwen38-dsh");
+  assert.throws(
+    () => resolvePrReviewProfileId("pr-review-mixed", "deepseek_harness"),
+    /must not overwrite the pr-review-mixed profile/,
+  );
+});
+
 test("authenticates profile sync with the isolated DAG mutation token", async () => {
   const previousToken = process.env.HOMERAIL_DAG_MUTATION_TOKEN;
   const previousAdminToken = process.env.HOMERAIL_MANAGER_ADMIN_TOKEN;
@@ -187,8 +198,9 @@ test("formal PR Review submits to the durable stable Manager", () => {
   assert.match(workflow, /homerail-pr-review/);
   assert.match(
     workflow,
-    /HOMERAIL_PR_REVIEW_PROFILE_ID: \$\{\{ inputs\.profile_id \|\| 'pr-review-mixed' \}\}/,
+    /HOMERAIL_PR_REVIEW_PROFILE_ID: \$\{\{ inputs\.profile_id \|\| \(inputs\.agent_type == 'deepseek_harness' && 'pr-review-dsh' \|\| 'pr-review-mixed'\) \}\}/,
   );
+  assert.doesNotMatch(workflow, /inputs\.profile_id \|\| 'pr-review-mixed'/);
   assert.match(
     workflow,
     /HOMERAIL_PR_REVIEW_AGENT_TYPE: \$\{\{ inputs\.agent_type \|\| 'claude-sdk' \}\}/,

--- a/scripts/pr-review-runtime-profile.test.mjs
+++ b/scripts/pr-review-runtime-profile.test.mjs
@@ -102,6 +102,29 @@ test("binds three independent DSH reviewers to one OpenAI-compatible Qwen settin
   assert.match(yaml, /description: Three independent DeepSeek Harness reviewer processes/);
   assert.equal((yaml.match(/llm_setting_id: "setting-qwen38-local"/g) ?? []).length, 4);
   assert.equal((yaml.match(/agent_type: deepseek_harness/g) ?? []).length, 4);
+  assert.equal((yaml.match(/reasoning_effort: medium/g) ?? []).length, 4);
+  assert.match(
+    prReviewRuntimeProfileYaml({
+      profileId: "pr-review-qwen38-dsh-xhigh",
+      primary: qwenLocal,
+      arbiter: qwenLocal,
+      third: qwenLocal,
+      agentType: "deepseek_harness",
+      reasoningEffort: "xhigh",
+    }),
+    /reasoning_effort: xhigh/,
+  );
+  assert.throws(
+    () => prReviewRuntimeProfileYaml({
+      profileId: "pr-review-qwen38-dsh-invalid",
+      primary: qwenLocal,
+      arbiter: qwenLocal,
+      third: qwenLocal,
+      agentType: "deepseek_harness",
+      reasoningEffort: "ultra",
+    }),
+    /Unsupported DeepSeek Harness reasoning effort/,
+  );
   assert.throws(
     () => selectRuntimeSetting([{ ...qwenLocal, protocol: "anthropic_compatible" }], qwenLocal.id, "primary", "deepseek_harness"),
     /not OpenAI-compatible/,

--- a/scripts/pr-review-runtime-profile.test.mjs
+++ b/scripts/pr-review-runtime-profile.test.mjs
@@ -128,6 +128,17 @@ test("binds three independent DSH reviewers to one OpenAI-compatible Qwen settin
     /does not declare reasoning effort: ultra/,
   );
   assert.throws(
+    () => prReviewRuntimeProfileYaml({
+      profileId: "pr-review-qwen38-dsh-inherited-selector",
+      primary: qwenLocal,
+      arbiter: qwenLocal,
+      third: qwenLocal,
+      agentType: "deepseek_harness",
+      reasoningEffort: "toString",
+    }),
+    /does not declare reasoning effort: toString/,
+  );
+  assert.throws(
     () => selectRuntimeSetting([{ ...qwenLocal, protocol: "anthropic_compatible" }], qwenLocal.id, "primary", "deepseek_harness"),
     /not OpenAI-compatible/,
   );

--- a/scripts/pr-review-runtime-profile.test.mjs
+++ b/scripts/pr-review-runtime-profile.test.mjs
@@ -185,6 +185,14 @@ test("formal PR Review submits to the durable stable Manager", () => {
   assert.match(runner, /--profile "\$PROFILE_ID"/);
   assert.match(workflow, /run-pr-review-stable-runner\.sh/);
   assert.match(workflow, /homerail-pr-review/);
+  assert.match(
+    workflow,
+    /HOMERAIL_PR_REVIEW_PROFILE_ID: \$\{\{ inputs\.profile_id \|\| 'pr-review-mixed' \}\}/,
+  );
+  assert.match(
+    workflow,
+    /HOMERAIL_PR_REVIEW_AGENT_TYPE: \$\{\{ inputs\.agent_type \|\| 'claude-sdk' \}\}/,
+  );
   assert.doesNotMatch(workflow, /install:all|build:packages|run-pr-review-live-runner/);
   assert.doesNotMatch(workflow, /vars\.HOMERAIL_PR_REVIEW_(?:HOME_TEMPLATE|PRIMARY_MODEL|ARBITER_MODEL|THIRD_MODEL)/);
 });

--- a/scripts/pr-review-runtime-profile.test.mjs
+++ b/scripts/pr-review-runtime-profile.test.mjs
@@ -77,6 +77,37 @@ test("binds the three review votes to three distinct models", () => {
   );
 });
 
+test("binds three independent DSH reviewers to one OpenAI-compatible Qwen setting", () => {
+  const qwenLocal = {
+    id: "setting-qwen38-local",
+    display_name: "Qwen3.8 27B Local · DSH",
+    model_name: "qwen3.8",
+    protocol: "openai_compatible",
+    base_url: "http://192.168.100.10:5000/v1",
+    chat_completions_base_url: "http://192.168.100.10:5000/v1",
+    is_active: true,
+    supports_llm: true,
+  };
+  assert.equal(
+    selectRuntimeSetting([qwenLocal], qwenLocal.display_name, "primary", "deepseek_harness"),
+    qwenLocal,
+  );
+  const yaml = prReviewRuntimeProfileYaml({
+    profileId: "pr-review-qwen38-dsh",
+    primary: qwenLocal,
+    arbiter: qwenLocal,
+    third: qwenLocal,
+    agentType: "deepseek_harness",
+  });
+  assert.match(yaml, /description: Three independent DeepSeek Harness reviewer processes/);
+  assert.equal((yaml.match(/llm_setting_id: "setting-qwen38-local"/g) ?? []).length, 4);
+  assert.equal((yaml.match(/agent_type: deepseek_harness/g) ?? []).length, 4);
+  assert.throws(
+    () => selectRuntimeSetting([{ ...qwenLocal, protocol: "anthropic_compatible" }], qwenLocal.id, "primary", "deepseek_harness"),
+    /not OpenAI-compatible/,
+  );
+});
+
 test("authenticates profile sync with the isolated DAG mutation token", async () => {
   const previousToken = process.env.HOMERAIL_DAG_MUTATION_TOKEN;
   const previousAdminToken = process.env.HOMERAIL_MANAGER_ADMIN_TOKEN;

--- a/scripts/pr-review-runtime-profile.test.mjs
+++ b/scripts/pr-review-runtime-profile.test.mjs
@@ -85,6 +85,7 @@ test("binds three independent DSH reviewers to one OpenAI-compatible Qwen settin
     protocol: "openai_compatible",
     base_url: "http://192.168.100.10:5000/v1",
     chat_completions_base_url: "http://192.168.100.10:5000/v1",
+    reasoning_effort_map: { medium: "medium", xhigh: "xhigh" },
     is_active: true,
     supports_llm: true,
   };
@@ -102,7 +103,7 @@ test("binds three independent DSH reviewers to one OpenAI-compatible Qwen settin
   assert.match(yaml, /description: Three independent DeepSeek Harness reviewer processes/);
   assert.equal((yaml.match(/llm_setting_id: "setting-qwen38-local"/g) ?? []).length, 4);
   assert.equal((yaml.match(/agent_type: deepseek_harness/g) ?? []).length, 4);
-  assert.equal((yaml.match(/reasoning_effort: medium/g) ?? []).length, 4);
+  assert.doesNotMatch(yaml, /reasoning_effort:/);
   assert.match(
     prReviewRuntimeProfileYaml({
       profileId: "pr-review-qwen38-dsh-xhigh",
@@ -123,7 +124,7 @@ test("binds three independent DSH reviewers to one OpenAI-compatible Qwen settin
       agentType: "deepseek_harness",
       reasoningEffort: "ultra",
     }),
-    /Unsupported DeepSeek Harness reasoning effort/,
+    /does not declare reasoning effort: ultra/,
   );
   assert.throws(
     () => selectRuntimeSetting([{ ...qwenLocal, protocol: "anthropic_compatible" }], qwenLocal.id, "primary", "deepseek_harness"),

--- a/scripts/pr-review-runtime-profile.test.mjs
+++ b/scripts/pr-review-runtime-profile.test.mjs
@@ -114,7 +114,25 @@ test("binds three independent DSH reviewers to one OpenAI-compatible Qwen settin
       agentType: "deepseek_harness",
       reasoningEffort: "xhigh",
     }),
-    /reasoning_effort: xhigh/,
+    /reasoning_effort: "xhigh"/,
+  );
+
+  const yamlSensitiveEffort = "medium: fast # operator choice\nretained";
+  const yamlSensitiveSetting = {
+    ...qwenLocal,
+    reasoning_effort_map: { [yamlSensitiveEffort]: "balanced" },
+  };
+  const yamlWithSensitiveEffort = prReviewRuntimeProfileYaml({
+    profileId: "pr-review-qwen38-dsh-sensitive-effort",
+    primary: yamlSensitiveSetting,
+    arbiter: yamlSensitiveSetting,
+    third: yamlSensitiveSetting,
+    agentType: "deepseek_harness",
+    reasoningEffort: yamlSensitiveEffort,
+  });
+  assert.equal(
+    (yamlWithSensitiveEffort.match(/reasoning_effort: "medium: fast # operator choice\\nretained"/g) ?? []).length,
+    4,
   );
   assert.throws(
     () => prReviewRuntimeProfileYaml({

--- a/scripts/production-deploy-contracts.test.mjs
+++ b/scripts/production-deploy-contracts.test.mjs
@@ -736,6 +736,8 @@ exec "${process.execPath}" "$@"
     HOMERAIL_WORKER_BUILD_DSH_GIT_REMOTE: [
       "ssh://git.example.com/deepseek-harness.git",
       "https://user:secret@git.example.com/deepseek-harness.git",
+      "https://git.example.com/deepseek-harness$(touch).git",
+      "https://git.example.com/deepseek-harness(test).git",
     ],
   };
   for (const [name, values] of Object.entries(invalidValues)) {

--- a/scripts/production-deploy-contracts.test.mjs
+++ b/scripts/production-deploy-contracts.test.mjs
@@ -392,6 +392,7 @@ test("production deployment preserves database compatibility across success and 
         HOMERAIL_WORKER_BUILD_APT_MIRROR: "",
         HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR: "",
         HOMERAIL_WORKER_BUILD_NPM_REGISTRY: "",
+        HOMERAIL_WORKER_BUILD_DSH_GIT_REMOTE: "",
         HTTP_PROXY: "",
         HTTPS_PROXY: "",
         NO_PROXY: "",
@@ -480,6 +481,7 @@ test("production deployment preserves database compatibility across success and 
     assert.match(dockerBuildArgs, new RegExp(`HOMERAIL_WORKER_IMAGE_REVISION=${revision}`));
     assert.doesNotMatch(dockerBuildArgs, /HOMERAIL_WORKER_BUILD_APT/);
     assert.doesNotMatch(dockerBuildArgs, /NPM_CONFIG_REGISTRY/);
+    assert.doesNotMatch(dockerBuildArgs, /HOMERAIL_DSH_FORK_REPOSITORY/);
     assert.doesNotMatch(dockerBuildArgs, /(?:HTTP|HTTPS|NO)_PROXY/i);
     const unit = fs.readFileSync(passed.unitPath, "utf8");
     assert.match(unit, /StartLimitIntervalSec=0/);
@@ -498,6 +500,7 @@ test("production deployment preserves database compatibility across success and 
       HOMERAIL_WORKER_BUILD_APT_MIRROR: "https://deb.fn.example/debian/",
       HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR: "https://deb.fn.example/debian-security",
       HOMERAIL_WORKER_BUILD_NPM_REGISTRY: "https://npm.fn.example",
+      HOMERAIL_WORKER_BUILD_DSH_GIT_REMOTE: "https://git.fn.example/deepseek-harness.git",
     },
   });
   try {
@@ -506,6 +509,7 @@ test("production deployment preserves database compatibility across success and 
     assert.match(customBuildArgs, /--build-arg\nHOMERAIL_WORKER_BUILD_APT_MIRROR=https:\/\/deb\.fn\.example\/debian\n/);
     assert.match(customBuildArgs, /--build-arg\nHOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR=https:\/\/deb\.fn\.example\/debian-security\n/);
     assert.match(customBuildArgs, /--build-arg\nNPM_CONFIG_REGISTRY=https:\/\/npm\.fn\.example\n/);
+    assert.match(customBuildArgs, /--build-arg\nHOMERAIL_DSH_FORK_REPOSITORY=https:\/\/git\.fn\.example\/deepseek-harness\.git\n/);
     assert.match(customBuildArgs, new RegExp(`HOMERAIL_WORKER_SOURCE_FINGERPRINT=${workerFingerprint}`));
   } finally {
     fs.rmSync(customSources.tempRoot, { recursive: true, force: true });
@@ -586,6 +590,7 @@ test("worker build network contract is shared by production and live entry point
     "HOMERAIL_WORKER_BUILD_APT_MIRROR",
     "HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR",
     "HOMERAIL_WORKER_BUILD_NPM_REGISTRY",
+    "HOMERAIL_WORKER_BUILD_DSH_GIT_REMOTE",
   ]) {
     assert.ok(helper.includes(name), `helper must consume ${name}`);
   }
@@ -594,6 +599,7 @@ test("worker build network contract is shared by production and live entry point
     "helper must forward every recognized proxy variable name in a fixed order",
   );
   assert.match(helper, /NPM_CONFIG_REGISTRY=/);
+  assert.match(helper, /HOMERAIL_DSH_FORK_REPOSITORY=/);
 });
 
 test("worker build network helper validates sources and forwards proxy names only", { skip: process.platform === "win32" }, () => {
@@ -630,6 +636,7 @@ test("worker build network helper validates sources and forwards proxy names onl
     HOMERAIL_WORKER_BUILD_APT_MIRROR: "HTTPS://DEB.example.com:8443/debian/",
     HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR: "  https://deb.example.com/debian-security  ",
     HOMERAIL_WORKER_BUILD_NPM_REGISTRY: "https://npm.example.com/",
+    HOMERAIL_WORKER_BUILD_DSH_GIT_REMOTE: "https://git.example.com/deepseek-harness.git/",
     HTTP_PROXY: "http://proxy.example:3128",
     no_proxy: "localhost",
     HTTPS_PROXY: "",
@@ -642,6 +649,8 @@ test("worker build network helper validates sources and forwards proxy names onl
     "HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR=https://deb.example.com/debian-security",
     "--build-arg",
     "NPM_CONFIG_REGISTRY=https://npm.example.com",
+    "--build-arg",
+    "HOMERAIL_DSH_FORK_REPOSITORY=https://git.example.com/deepseek-harness.git",
     "--build-arg",
     "HTTP_PROXY",
     "--build-arg",
@@ -668,6 +677,7 @@ exec "${process.execPath}" "$@"
       ARGV_LOG: argvLog,
       HOMERAIL_WORKER_BUILD_APT_MIRROR: "https://deb.example.com/debian/",
       HOMERAIL_WORKER_BUILD_NPM_REGISTRY: "https://npm.example.com/",
+      HOMERAIL_WORKER_BUILD_DSH_GIT_REMOTE: "https://git.example.com/deepseek-harness.git/",
       HTTPS_PROXY: "http://proxy.example:3128",
     });
     assert.equal(shimmed.status, 0, shimmed.stderr);
@@ -676,6 +686,8 @@ exec "${process.execPath}" "$@"
       "HOMERAIL_WORKER_BUILD_APT_MIRROR=https://deb.example.com/debian",
       "--build-arg",
       "NPM_CONFIG_REGISTRY=https://npm.example.com",
+      "--build-arg",
+      "HOMERAIL_DSH_FORK_REPOSITORY=https://git.example.com/deepseek-harness.git",
       "--build-arg",
       "HTTPS_PROXY",
     ]);
@@ -686,12 +698,14 @@ exec "${process.execPath}" "$@"
       "HOMERAIL_WORKER_BUILD_APT_MIRROR",
       "HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR",
       "HOMERAIL_WORKER_BUILD_NPM_REGISTRY",
+      "HOMERAIL_WORKER_BUILD_DSH_GIT_REMOTE",
     ]) {
       assert.ok(capturedArgv.includes(expected), `delegation must name ${expected} only`);
     }
     for (const prohibited of [
       "https://deb.example.com/debian/",
       "https://npm.example.com/",
+      "https://git.example.com/deepseek-harness.git/",
       "http://proxy.example:3128",
     ]) {
       assert.ok(!capturedArgv.includes(prohibited), "source and proxy values must never reach argv");
@@ -718,6 +732,10 @@ exec "${process.execPath}" "$@"
     HOMERAIL_WORKER_BUILD_NPM_REGISTRY: [
       "ftp://npm.example.com",
       "https://npm.example.com/<script>",
+    ],
+    HOMERAIL_WORKER_BUILD_DSH_GIT_REMOTE: [
+      "ssh://git.example.com/deepseek-harness.git",
+      "https://user:secret@git.example.com/deepseek-harness.git",
     ],
   };
   for (const [name, values] of Object.entries(invalidValues)) {


### PR DESCRIPTION
## Summary

- add an independent per-turn `deepseek_harness` Worker backend driven through the published DSH TypeScript SDK
- expose HomeRail DAG tools plus the exact DAG-authorized `Read`, `Grep`, `Glob`, and `LS` subset through a loopback bearer-token MCP bridge
- confine managed read tools to `workspace_access` roots with traversal/symlink checks and bounded I/O; enforce a call budget only when the workflow explicitly requests one
- support `session/steer` and cooperative `session/cancel` through the owner-maintained DSH fork
- package runtime commit `f4fd5f005636cdcbf9d95f70f04d05afa8c0db54` into the standard Worker image
- add runtime selection aliases, OpenAI-compatible model resolution, CLI doctor checks, PR Review profile selection, tests, and integration documentation

Fork: https://github.com/xiaotianfotos/deepseek-harness/tree/agent/homerail-sdk-control

The owner-maintained fork branch `agent/homerail-sdk-control` now pins merge commit `f4fd5f005636cdcbf9d95f70f04d05afa8c0db54`, whose upstream parent is official `dsh-v0.1.1-rc.2` (`b150a551b8d465e31e418e1b2eaf5e79bbb7d28e`). HomeRail fetches that immutable fork commit during Worker image builds.

## Isolation

Claude, Codex, and Kimi adapters retain their existing implementations and selection paths. DSH is selected only through its own registry/protocol value. Its Cordis composition mounts no shell, ambient filesystem, Skills, runtime-context, or job tools. HomeRail mounts only the turn's DAG tools and explicitly authorized managed read tools. Manager/Worker control-plane secrets are stripped before the child starts.

Reasoning effort is selected by the runtime profile and passed through DSH. HomeRail deliberately does not add a global read-call or reasoning cap to compensate for the observed behavior of one local model. `max_builtin_tool_calls` remains available as an explicit workflow policy, and `HOMERAIL_DSH_MAX_TOKENS` remains an operator setting.

## Validation

- HomeRail full `npm run ci` passed after merging current `main`; standard Worker suite: 36 files / 434 passed / 2 skipped, plus the opt-in packaged-runtime integration test passed separately in the final container
- full Worker image build and real keyless container smoke with the packaged DSH runtime and a local OpenAI-compatible SSE server
- model tool discovery, `mcp__homerail__handoff`, second model round, usage/error/event mapping, steering, cancellation, and clean completion covered by runtime/integration tests
- DSH fork at official `dsh-v0.1.1-rc.2`: pre-push build/typecheck, lint, docs-sync, focused 100% SDK coverage, Python SDK tests, runtime-closure verification, and packaged runtime smoke
- deployed diagnostic HomeRail `1ee5ec284eb42b3c65f3cc4b5f4761ddded6d5bf` to 112: https://github.com/xiaotianfotos/homerail/actions/runs/32029873742
- deployed final no-default-budget HomeRail `4b617fffac76eba23770b0004f3af50340630688` to 112 without starting another model-specific long run: https://github.com/xiaotianfotos/homerail/actions/runs/32034776227

### Qwen3.8 27B FP8 PR Review runs

All historical qwen/kimi/glm node labels below used the same `Qwen3.8 27B Local · DSH` model setting in three independent DSH processes.

1. Raw `xhigh`, no read-call budget: https://github.com/xiaotianfotos/homerail/actions/runs/32023994801 (`d40c93aa-d9ff-4b57-a97c-e1c98c8d3e14`). The stable runner ended it at 70 minutes. One reviewer completed through a handoff-only correction; two were still inspecting after 32 and 37 tool calls. The model service reported zero errors. KV stayed around 93–99.7% with 18 preemptions.
2. Diagnostic `medium` run using the temporary 24-call experiment: https://github.com/xiaotianfotos/homerail/actions/runs/32030182632 (`1ee15bc9-db13-47ca-8d71-c55dda6a9dea`). It completed successfully in about 47m35s with a 9/9 scorecard: 3 approve, 0 request changes, 0 abstain, 0 findings, and 33/33-file coverage from every reviewer. There were no correction turns or automatic handoff fallbacks. Final DSH totals were about 5.54M input tokens, 133,526 output tokens, and 66 tool calls. The first two reviewers finished in about 23 and 24 minutes after 17 and 21 built-in calls. The slow reviewer took about 47 minutes, emitted 72,938 output tokens, attempted 25 built-in calls, received one denial from the experimental limit, and then handed off.

The raw run processed about 8.16M prompt tokens: about 4.96M local prefix-cache hits and 3.20M local recomputation. Cache was working; it could not accelerate roughly 166k generated tokens, newly appended tool results, or private session tails evicted under concurrent KV pressure. The diagnostic run also showed multi-minute 6k–17k-token reasoning rounds with no new prefill, including while only one review request was active. No DSH compaction plugin or compaction event was present.

Conclusion: the DSH transport/tool/handoff path works and completed a real review, but this local Qwen3.8 27B FP8 configuration reasons too long and converges too late for a practical unattended three-reviewer DAG. This is documented as model behavior, not converted into a global DSH enforcement rule.

Live DAG steering was not exercised on 112 because remote mutations require a local request or `HOMERAIL_DAG_MUTATION_TOKEN`; the SDK/runtime steering path is covered by adapter and fork tests.

`npm audit --json` still reports the six existing Worker transitive findings (three moderate, three high) through the existing Claude MCP/Vitest dependency paths; `npm explain` shows none are introduced through DSH.

## WIP / follow-ups

- choose and qualify a model with more reliable tool-loop convergence before recommending DSH for unattended review
- persistent DSH session resume/reuse is not implemented; the adapter starts one process per turn
- Manager Agent UI/onboarding is not yet polished
- Worker image size/build overhead needs optimization