### PR TITLE
fix(manager): pin Codex Live Voice realtime model

### DIFF
--- a/homerail_manager/src/server/codex-live-voice-runtime.ts
+++ b/homerail_manager/src/server/codex-live-voice-runtime.ts
@@ -11,6 +11,11 @@ import {
 } from "./codex-appserver-client.js";
 import { acquireCodexThreadLease } from "./codex-thread-lease.js";
 
+// Codex app-server releases before the upstream default-model fix select a V3
+// realtime model that the ChatGPT-authenticated backend no longer accepts.
+// Keep this explicit until HomeRail's minimum Codex version includes that fix.
+const CODEX_LIVE_VOICE_REALTIME_MODEL = "gpt-live-1-codex";
+
 export type CodexLiveVoiceRuntimeEvent =
   | { type: "session.started"; thread_id: string; realtime_session_id?: string; version: string }
   | { type: "session.sdp"; sdp: string }
@@ -168,6 +173,7 @@ export class CodexLiveVoiceRuntime {
       await this.client.request("thread/realtime/start", {
         threadId,
         version: "v3",
+        model: CODEX_LIVE_VOICE_REALTIME_MODEL,
         outputModality: "audio",
         transport: { type: "webrtc", sdp: offerSdp },
         includeStartupContext: true,

--- a/homerail_manager/tests/codex-live-voice-runtime.test.ts
+++ b/homerail_manager/tests/codex-live-voice-runtime.test.ts
@@ -82,6 +82,7 @@ describe("CodexLiveVoiceRuntime", () => {
     expect(realtime?.params).toMatchObject({
       threadId: "thread-live-1",
       version: "v3",
+      model: "gpt-live-1-codex",
       outputModality: "audio",
       transport: { type: "webrtc", sdp: "offer-sdp" },
       includeStartupContext: true,


### PR DESCRIPTION
## Summary

- explicitly select `gpt-live-1-codex` for Codex Realtime V3 starts
- retain the existing WebRTC, startup-context, voice, and handoff contract
- cover the realtime model in the runtime request test

## Context

Codex app-server versions released before openai/codex#40321 select a default V3 model that the ChatGPT-authenticated realtime backend no longer accepts. The upstream workaround in openai/codex#40140 is to pass `model: "gpt-live-1-codex"` at the top level of `thread/realtime/start`.

Fixes #239.

## Validation

- `npm exec -- vitest run tests/codex-live-voice-runtime.test.ts` — 6 tests passed
- `npm test` in `homerail_manager` — 155 files passed, 1 skipped; 1421 tests passed, 2 skipped
- `npm run build` in `homerail_manager`
- live local smoke with ChatGPT-authenticated `codex-cli 0.147.0`: received a 1681-byte SDP answer, WebRTC reached `connected`, and the `oai-events` data channel reached `open`
