### PR TITLE
ci: make production deployment manual only

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,9 +1,6 @@
 name: Deploy Production
 
 on:
-  schedule:
-    # GitHub cron is UTC. 19:30 UTC is 03:30 Asia/Shanghai.
-    - cron: "30 19 * * *"
   workflow_dispatch:
     inputs:
       revision:
@@ -21,9 +18,7 @@ concurrency:
 jobs:
   deploy:
     name: Deploy persistent HomeRail service
-    if: >-
-      github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && github.actor == 'xiaotianfotos')
+    if: github.event_name == 'workflow_dispatch' && github.actor == 'xiaotianfotos'
     runs-on: [self-hosted, Linux, X64, homerail-deploy]
     timeout-minutes: 45
     steps:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -21,6 +21,10 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && github.actor == 'xiaotianfotos'
     runs-on: [self-hosted, Linux, X64, homerail-deploy]
     timeout-minutes: 45
+    env:
+      HOMERAIL_WORKER_BUILD_APT_MIRROR: ${{ vars.HOMERAIL_WORKER_BUILD_APT_MIRROR }}
+      HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR: ${{ vars.HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR }}
+      HOMERAIL_WORKER_BUILD_NPM_REGISTRY: ${{ vars.HOMERAIL_WORKER_BUILD_NPM_REGISTRY }}
     steps:
       - name: Check out the validated revision
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -105,8 +105,14 @@ Debian sources and npm registry. Standard proxy variables are forwarded to
 Docker by name only; their values never enter deployment argv or logs. See
 [Worker build network sources](worker-build-network.md).
 
-The workflow also has a maintainer-only manual dispatch for immediate recovery
-or an explicitly selected revision. Scheduled and default manual deployments
-resolve `main` at job start. The release switch never changes
+The production workflow reads those three public source overrides from GitHub
+Actions repository variables and maps them explicitly into the deploy job.
+This keeps the self-hosted runner independent of whether its systemd process
+has reloaded a machine-local environment file. Other Worker build entry points
+may continue to receive the same variables from their process environment.
+
+The workflow has a maintainer-only manual dispatch for immediate recovery or
+an explicitly selected revision. A manual deployment without a revision
+resolves `main` at job start. The release switch never changes
 `HOMERAIL_PRODUCTION_HOME`; database, settings, sessions, certificates, and
 external Skills continue to live in the persistent Home across deployments.

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -1,11 +1,10 @@
 # Persistent production deployment
 
 `.github/workflows/deploy-production.yml` deploys the latest `main` revision
-once per day at 03:30 Asia/Shanghai (19:30 UTC), and also supports an
-owner-only manual dispatch for an immediate deployment. Merging a pull request
-does not start a second deployment workflow. It runs on a dedicated self-hosted
-runner labeled `homerail-deploy`; the live DAG, PR Review, and Auto Fix labels
-must stay on separate runners.
+only through an owner-initiated manual dispatch. Merging a pull request does
+not start a deployment workflow. It runs on a dedicated self-hosted runner
+labeled `homerail-deploy`; the live DAG, PR Review, and Auto Fix labels must
+stay on separate runners.
 
 Each deployment runner keeps its machine-specific paths and public address in
 `~/.config/homerail/production.env` with mode `0600`. The tracked workflow does

--- a/scripts/production-deploy-contracts.test.mjs
+++ b/scripts/production-deploy-contracts.test.mjs
@@ -18,6 +18,18 @@ test("deploys an owner-dispatched revision on the isolated deploy runner", () =>
   assert.doesNotMatch(workflow, /cron:/);
   assert.doesNotMatch(workflow, /workflow_run:/);
   assert.match(workflow, /runs-on: \[self-hosted, Linux, X64, homerail-deploy\]/);
+  assert.match(
+    workflow,
+    /HOMERAIL_WORKER_BUILD_APT_MIRROR: \$\{\{ vars\.HOMERAIL_WORKER_BUILD_APT_MIRROR \}\}/,
+  );
+  assert.match(
+    workflow,
+    /HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR: \$\{\{ vars\.HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR \}\}/,
+  );
+  assert.match(
+    workflow,
+    /HOMERAIL_WORKER_BUILD_NPM_REGISTRY: \$\{\{ vars\.HOMERAIL_WORKER_BUILD_NPM_REGISTRY \}\}/,
+  );
   assert.match(workflow, /ref: \$\{\{ inputs\.revision \|\| 'main' \}\}/);
   assert.match(workflow, /revision="\$\(git rev-parse HEAD\)"/);
   assert.match(workflow, /persist-credentials: false/);

--- a/scripts/production-deploy-contracts.test.mjs
+++ b/scripts/production-deploy-contracts.test.mjs
@@ -8,15 +8,14 @@ import { fileURLToPath } from "node:url";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
-test("deploys main daily or an owner-dispatched revision on the isolated deploy runner", () => {
+test("deploys an owner-dispatched revision on the isolated deploy runner", () => {
   const workflow = fs
     .readFileSync(path.join(repoRoot, ".github", "workflows", "deploy-production.yml"), "utf8")
     .replace(/\r\n/g, "\n");
-  assert.match(workflow, /schedule:\n\s+# GitHub cron is UTC/);
-  assert.match(workflow, /cron: "30 19 \* \* \*"/);
   assert.match(workflow, /workflow_dispatch:/);
-  assert.match(workflow, /github\.event_name == 'schedule'/);
   assert.match(workflow, /github\.event_name == 'workflow_dispatch' && github\.actor == 'xiaotianfotos'/);
+  assert.doesNotMatch(workflow, /schedule:/);
+  assert.doesNotMatch(workflow, /cron:/);
   assert.doesNotMatch(workflow, /workflow_run:/);
   assert.match(workflow, /runs-on: \[self-hosted, Linux, X64, homerail-deploy\]/);
   assert.match(workflow, /ref: \$\{\{ inputs\.revision \|\| 'main' \}\}/);


### PR DESCRIPTION
## Summary
- remove the scheduled production deployment trigger
- retain owner-only manual deployment with an optional revision
- update deployment documentation and contract coverage

## Verification
- `node --test scripts/production-deploy-contracts.test.mjs`
- `git diff --check`