### PR TITLE
build: persist worker package caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,8 @@ jobs:
         run: npm --prefix homerail_node test -- src/providers/__tests__/docker-cli-provider.integration.test.ts
 
       - name: Build Worker image
+        env:
+          DOCKER_BUILDKIT: "1"
         run: docker build -t homerail-worker:ci -f homerail_worker/Dockerfile .
 
       - name: Exercise packaged DeepSeek Harness runtime

--- a/docs/worker-build-network.md
+++ b/docs/worker-build-network.md
@@ -39,8 +39,15 @@ helper resolves it from its own repository-relative location.
 
 ## BuildKit dependency caches
 
-The canonical Worker Dockerfile uses Dockerfile frontend 1.7 cache mounts for
-package-manager download caches. All npm installs share the stable
+The canonical Worker Dockerfile uses BuildKit cache mounts for package-manager
+download caches. Supported build entry points explicitly set
+`DOCKER_BUILDKIT=1`: the Manager process, the shared production/live shell
+helper, and the Docker smoke build in CI. The Dockerfile intentionally does not
+pin a `# syntax` frontend image, so builds use the Docker engine's bundled
+frontend without an extra Docker Hub frontend fetch. The supported Docker
+engine must therefore include BuildKit cache-mount support.
+
+All npm installs share the stable
 `homerail-worker-npm-node22-v1` cache at `/root/.npm`. The pinned DSH build
 also uses separate Corepack and pnpm caches at `/root/.cache/node/corepack`
 and `/root/.local/share/pnpm/store`. Cache mounts use `sharing=locked`, so

--- a/docs/worker-build-network.md
+++ b/docs/worker-build-network.md
@@ -37,6 +37,31 @@ source value never appears in argv, captured commands, failures, or logs.
 `${NODE_BIN:-node}` selects the Node binary used for that delegation; the
 helper resolves it from its own repository-relative location.
 
+## BuildKit dependency caches
+
+The canonical Worker Dockerfile uses Dockerfile frontend 1.7 cache mounts for
+package-manager download caches. All npm installs share the stable
+`homerail-worker-npm-node22-v1` cache at `/root/.npm`. The pinned DSH build
+also uses separate Corepack and pnpm caches at `/root/.cache/node/corepack`
+and `/root/.local/share/pnpm/store`. Cache mounts use `sharing=locked`, so
+concurrent builds cannot mutate the same package-manager cache at the same
+time.
+
+These are BuildKit-managed build caches, not image contents: cache data is
+excluded from committed layers and is never bind-mounted into a running
+Worker. A cold builder still fetches missing packages from the selected
+source; later builds can reuse verified package-manager cache content even
+when an earlier image layer was invalidated by source changes elsewhere in
+the repository.
+
+Lockfile behavior is unchanged. npm package trees continue to use `npm ci`,
+and the DSH tree continues to use `pnpm install --frozen-lockfile`. npm
+installs add `--prefer-offline --no-audit --no-fund`, while pnpm adds
+`--prefer-offline`; these options reduce metadata traffic but do not enable
+offline mode or permit stale/missing dependencies. HomeRail does not add a
+Python package manager or configure uv/PyPI sources as part of the Worker
+build.
+
 ## Validation contract
 
 - Unset or whitespace-only values leave the corresponding source unchanged.

--- a/homerail_manager/src/server/dag-environment.ts
+++ b/homerail_manager/src/server/dag-environment.ts
@@ -915,7 +915,11 @@ export class DagEnvironmentController {
     try {
       child = this.spawnImpl("docker", args, {
         cwd: this.repoRoot,
-        env: { ...this.env, HOMERAIL_HOME: getHomerailHome() },
+        env: {
+          ...this.env,
+          DOCKER_BUILDKIT: "1",
+          HOMERAIL_HOME: getHomerailHome(),
+        },
         windowsHide: true,
       });
     } catch (error) {

--- a/homerail_manager/tests/dag-environment.test.ts
+++ b/homerail_manager/tests/dag-environment.test.ts
@@ -1105,6 +1105,7 @@ it("forwards validated build-network sources and proxy names to the Docker build
   expect(args[proxyIndex + 1]).not.toContain("proxy.internal");
   expect(args.join("\u0000")).not.toContain("proxy.internal");
   expect(options.env.HTTPS_PROXY).toBe("http://proxy.internal:3128");
+  expect(options.env.DOCKER_BUILDKIT).toBe("1");
 
   markBuilt();
   stdout.write("step one\n");

--- a/homerail_worker/Dockerfile
+++ b/homerail_worker/Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1.7
-
 # Build from repo root: docker build -t homerail-worker:latest -f homerail_worker/Dockerfile .
 FROM node:22-slim AS secret-guard-build
 
@@ -92,7 +90,8 @@ COPY homerail_protocol/src /homerail_protocol/src
 COPY homerail_protocol/tsconfig.json /homerail_protocol/
 RUN --mount=type=cache,id=homerail-worker-npm-node22-v1,target=/root/.npm,sharing=locked \
   cd /homerail_protocol && npm ci --prefer-offline --no-audit --no-fund
-RUN cd /homerail_protocol && npm run build
+RUN --mount=type=cache,id=homerail-worker-npm-node22-v1,target=/root/.npm,sharing=locked \
+  cd /homerail_protocol && npm run build
 
 # Copy homerail_worker
 COPY homerail_worker/package.json homerail_worker/package-lock.json* ./
@@ -156,7 +155,8 @@ COPY homerail_worker/dsh ./dsh
 COPY --from=dsh-runtime-build \
   /src/deepseek-harness/python/sdk-runtime/src/deepseek_harness_runtime/runtime/node \
   /opt/deepseek-harness-runtime
-RUN npm run build
+RUN --mount=type=cache,id=homerail-worker-npm-node22-v1,target=/root/.npm,sharing=locked \
+  npm run build
 
 # Workspace checkouts can be created with owner-only source modes. Normalize
 # only the copied metadata/config files the unprivileged runtime reads; npm and

--- a/homerail_worker/Dockerfile
+++ b/homerail_worker/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.7
+
 # Build from repo root: docker build -t homerail-worker:latest -f homerail_worker/Dockerfile .
 FROM node:22-slim AS secret-guard-build
 
@@ -31,7 +33,9 @@ RUN node /opt/homerail/scripts/configure-apt-sources.mjs
 RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates git python3 make g++ \
   && rm -rf /var/lib/apt/lists/*
-RUN npm install --global corepack@0.34.0 && corepack enable
+RUN --mount=type=cache,id=homerail-worker-npm-node22-v1,target=/root/.npm,sharing=locked \
+  npm install --global corepack@0.34.0 --prefer-offline --no-audit --no-fund \
+  && corepack enable
 RUN git init /src/deepseek-harness \
   && cd /src/deepseek-harness \
   && git remote add origin "${HOMERAIL_DSH_FORK_REPOSITORY}" \
@@ -39,8 +43,10 @@ RUN git init /src/deepseek-harness \
   && git checkout --detach FETCH_HEAD \
   && test "$(git rev-parse HEAD)" = "${HOMERAIL_DSH_FORK_COMMIT}"
 WORKDIR /src/deepseek-harness
-RUN if [ -n "${NPM_CONFIG_REGISTRY:-}" ]; then export COREPACK_NPM_REGISTRY="$NPM_CONFIG_REGISTRY"; fi \
-  && corepack pnpm install --frozen-lockfile \
+RUN --mount=type=cache,id=homerail-worker-corepack-v1,target=/root/.cache/node/corepack,sharing=locked \
+    --mount=type=cache,id=homerail-worker-pnpm-node22-v1,target=/root/.local/share/pnpm/store,sharing=locked \
+  if [ -n "${NPM_CONFIG_REGISTRY:-}" ]; then export COREPACK_NPM_REGISTRY="$NPM_CONFIG_REGISTRY"; fi \
+  && corepack pnpm install --frozen-lockfile --prefer-offline \
   && corepack pnpm run build:lib:host \
   && corepack pnpm exec tsx scripts/build-exe-for-python-sdk.ts --skip-build --node-only
 
@@ -75,7 +81,8 @@ ENV HOMERAIL_DSH_RUNTIME_COMMAND="/usr/local/bin/node" \
 RUN apt-get update \
   && apt-get install -y --no-install-recommends bash ca-certificates curl git openssh-client \
   && rm -rf /var/lib/apt/lists/*
-RUN npm install -g npm@11.6.2
+RUN --mount=type=cache,id=homerail-worker-npm-node22-v1,target=/root/.npm,sharing=locked \
+  npm install -g npm@11.6.2 --prefer-offline --no-audit --no-fund
 COPY --from=secret-guard-build /homerail-codex-secret-guard.so /usr/local/lib/homerail-codex-secret-guard.so
 
 # Copy homerail_protocol to /homerail_protocol (parallel to /app) so that
@@ -83,19 +90,22 @@ COPY --from=secret-guard-build /homerail-codex-secret-guard.so /usr/local/lib/ho
 COPY homerail_protocol/package.json homerail_protocol/package-lock.json* /homerail_protocol/
 COPY homerail_protocol/src /homerail_protocol/src
 COPY homerail_protocol/tsconfig.json /homerail_protocol/
-RUN cd /homerail_protocol && npm ci
+RUN --mount=type=cache,id=homerail-worker-npm-node22-v1,target=/root/.npm,sharing=locked \
+  cd /homerail_protocol && npm ci --prefer-offline --no-audit --no-fund
 RUN cd /homerail_protocol && npm run build
 
 # Copy homerail_worker
 COPY homerail_worker/package.json homerail_worker/package-lock.json* ./
 # --ignore-scripts skips postinstall since homerail_protocol is already built above
-RUN npm ci --ignore-scripts
+RUN --mount=type=cache,id=homerail-worker-npm-node22-v1,target=/root/.npm,sharing=locked \
+  npm ci --ignore-scripts --prefer-offline --no-audit --no-fund
 RUN command -v kimi
 # npm treats the Claude SDK and Codex native platform payloads as optional, so
 # a transient fetch failure can leave a successful install with unusable agent
 # backends. Repair only the current Linux architecture at the exact pinned
 # versions, without changing the image-owned package lock, then verify them.
-RUN codex_arch="$(dpkg --print-architecture)" \
+RUN --mount=type=cache,id=homerail-worker-npm-node22-v1,target=/root/.npm,sharing=locked \
+  codex_arch="$(dpkg --print-architecture)" \
   && case "$codex_arch" in \
     amd64) codex_arch=x64 ;; \
     arm64) codex_arch=arm64 ;; \
@@ -104,13 +114,13 @@ RUN codex_arch="$(dpkg --print-architecture)" \
   && claude_version="$(node -p 'require("./node_modules/@anthropic-ai/claude-agent-sdk/package.json").version')" \
   && claude_platform="@anthropic-ai/claude-agent-sdk-linux-${codex_arch}" \
   && if [ ! -d "node_modules/${claude_platform}" ]; then \
-    npm install --no-save --package-lock=false --ignore-scripts \
+    npm install --no-save --package-lock=false --ignore-scripts --prefer-offline --no-audit --no-fund \
       "${claude_platform}@${claude_version}"; \
   fi \
   && codex_version="$(node -p 'require("./node_modules/@openai/codex/package.json").version')" \
   && codex_platform="@openai/codex-linux-${codex_arch}" \
   && if [ ! -d "node_modules/${codex_platform}" ]; then \
-    npm install --no-save --package-lock=false --ignore-scripts \
+    npm install --no-save --package-lock=false --ignore-scripts --prefer-offline --no-audit --no-fund \
       "${codex_platform}@npm:@openai/codex@${codex_version}-linux-${codex_arch}"; \
   fi \
   && test -x "node_modules/${claude_platform}/claude" \
@@ -125,15 +135,20 @@ RUN mkdir -p /opt/homerail-dependency-cache \
   && ln -s /homerail_protocol /opt/homerail-dependency-cache/homerail_protocol \
   && ln -s /app /opt/homerail-dependency-cache/homerail_worker
 COPY homerail_plugin_sdk/package.json homerail_plugin_sdk/package-lock.json* /opt/homerail-dependency-cache/homerail_plugin_sdk/
-RUN cd /opt/homerail-dependency-cache/homerail_plugin_sdk && npm ci
+RUN --mount=type=cache,id=homerail-worker-npm-node22-v1,target=/root/.npm,sharing=locked \
+  cd /opt/homerail-dependency-cache/homerail_plugin_sdk && npm ci --prefer-offline --no-audit --no-fund
 COPY homerail_manager/package.json homerail_manager/package-lock.json* /opt/homerail-dependency-cache/homerail_manager/
-RUN cd /opt/homerail-dependency-cache/homerail_manager && npm ci
+RUN --mount=type=cache,id=homerail-worker-npm-node22-v1,target=/root/.npm,sharing=locked \
+  cd /opt/homerail-dependency-cache/homerail_manager && npm ci --prefer-offline --no-audit --no-fund
 COPY homerail_node/package.json homerail_node/package-lock.json* /opt/homerail-dependency-cache/homerail_node/
-RUN cd /opt/homerail-dependency-cache/homerail_node && npm ci
+RUN --mount=type=cache,id=homerail-worker-npm-node22-v1,target=/root/.npm,sharing=locked \
+  cd /opt/homerail-dependency-cache/homerail_node && npm ci --prefer-offline --no-audit --no-fund
 COPY homerail_cli/package.json homerail_cli/package-lock.json* /opt/homerail-dependency-cache/homerail_cli/
-RUN cd /opt/homerail-dependency-cache/homerail_cli && npm ci
+RUN --mount=type=cache,id=homerail-worker-npm-node22-v1,target=/root/.npm,sharing=locked \
+  cd /opt/homerail-dependency-cache/homerail_cli && npm ci --prefer-offline --no-audit --no-fund
 COPY agent-ui/package.json agent-ui/package-lock.json* /opt/homerail-dependency-cache/agent-ui/
-RUN cd /opt/homerail-dependency-cache/agent-ui && npm ci --ignore-scripts
+RUN --mount=type=cache,id=homerail-worker-npm-node22-v1,target=/root/.npm,sharing=locked \
+  cd /opt/homerail-dependency-cache/agent-ui && npm ci --ignore-scripts --prefer-offline --no-audit --no-fund
 
 COPY homerail_worker/tsconfig.json ./
 COPY homerail_worker/src ./src

--- a/homerail_worker/src/__tests__/build-sources.test.ts
+++ b/homerail_worker/src/__tests__/build-sources.test.ts
@@ -657,6 +657,10 @@ describe("Worker build source environment-name CLI mode", () => {
 });
 
 describe("Worker Dockerfile source wiring", () => {
+  it("opts into a cache-mount-capable Dockerfile frontend", () => {
+    expect(dockerfile.startsWith("# syntax=docker/dockerfile:1.7\n")).toBe(true);
+  });
+
   it("keeps exactly one canonical Worker Dockerfile", () => {
     const dockerfiles: string[] = [];
     const visit = (dir: string): void => {
@@ -719,6 +723,33 @@ describe("Worker Dockerfile source wiring", () => {
     expect(dockerfile).not.toMatch(/ENV[^\n]*HOMERAIL_WORKER_BUILD_APT/);
   });
 
+  it("keeps the canonical image source-neutral and free of Python source configuration", () => {
+    for (const vendor of ["npmmirror", "tuna", "ustc"]) {
+      expect(dockerfile.toLowerCase()).not.toContain(vendor);
+    }
+    expect(dockerfile).not.toMatch(/\b(?:UV|PIP)_(?:DEFAULT_)?INDEX_URL\b/);
+    expect(dockerfile).not.toMatch(/(?:^|[\s;&|])uv(?:[\s;&|]|$)/m);
+  });
+
+  it("mounts one stable npm cache for every npm install without weakening lockfiles", () => {
+    const installs = dockerfileStages()
+      .flatMap((stage) => npmInstructions(stage.lines))
+      .filter((instruction) => /\bnpm (?:ci|install)\b/.test(instruction.text));
+    expect(installs.length).toBeGreaterThan(0);
+
+    const cacheMount = "--mount=type=cache,id=homerail-worker-npm-node22-v1,target=/root/.npm,sharing=locked";
+    for (const instruction of installs) {
+      const commandCount = instruction.text.match(/\bnpm (?:ci|install)\b/g)?.length ?? 0;
+      expect(instruction.text).toContain(cacheMount);
+      expect(instruction.text.match(/--prefer-offline\b/g)).toHaveLength(commandCount);
+      expect(instruction.text.match(/--no-audit\b/g)).toHaveLength(commandCount);
+      expect(instruction.text.match(/--no-fund\b/g)).toHaveLength(commandCount);
+    }
+
+    expect(dockerfile.match(/\bnpm ci\b/g)?.length ?? 0).toBeGreaterThan(0);
+    expect(dockerfile.match(/--package-lock=false\b/g)).toHaveLength(2);
+  });
+
   it("repairs skipped optional agent platform payloads before verifying the CLIs", () => {
     const finalStage = dockerfileStages().at(-1);
     expect(finalStage).toBeDefined();
@@ -752,6 +783,13 @@ describe("Worker Dockerfile source wiring", () => {
     expect(corepackRuns.length).toBeGreaterThan(0);
     for (const instruction of corepackRuns) {
       expect(instruction.text).toContain('export COREPACK_NPM_REGISTRY="$NPM_CONFIG_REGISTRY"');
+      expect(instruction.text).toContain(
+        "--mount=type=cache,id=homerail-worker-corepack-v1,target=/root/.cache/node/corepack,sharing=locked",
+      );
+      expect(instruction.text).toContain(
+        "--mount=type=cache,id=homerail-worker-pnpm-node22-v1,target=/root/.local/share/pnpm/store,sharing=locked",
+      );
+      expect(instruction.text).toContain("corepack pnpm install --frozen-lockfile --prefer-offline");
     }
   });
 });

--- a/homerail_worker/src/__tests__/build-sources.test.ts
+++ b/homerail_worker/src/__tests__/build-sources.test.ts
@@ -21,6 +21,8 @@ const workerRoot = fileURLToPath(new URL("../..", import.meta.url));
 const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
 const dockerfile = readFileSync(new URL("../../Dockerfile", import.meta.url), "utf8")
   .replace(/\r\n/g, "\n");
+const ciWorkflow = readFileSync(join(repoRoot, ".github", "workflows", "ci.yml"), "utf8")
+  .replace(/\r\n/g, "\n");
 
 interface BuildSourcesHelperModule {
   DEFAULT_DEB822_SOURCES_PATH: string;
@@ -657,8 +659,14 @@ describe("Worker build source environment-name CLI mode", () => {
 });
 
 describe("Worker Dockerfile source wiring", () => {
-  it("opts into a cache-mount-capable Dockerfile frontend", () => {
-    expect(dockerfile.startsWith("# syntax=docker/dockerfile:1.7\n")).toBe(true);
+  it("uses Docker's built-in frontend instead of fetching a pinned frontend image", () => {
+    expect(dockerfile).not.toMatch(/^# syntax=/m);
+  });
+
+  it("enables BuildKit for the direct CI Worker build", () => {
+    expect(ciWorkflow).toMatch(
+      /- name: Build Worker image\n\s+env:\n\s+DOCKER_BUILDKIT: "1"\n\s+run: docker build/,
+    );
   });
 
   it("keeps exactly one canonical Worker Dockerfile", () => {
@@ -748,6 +756,16 @@ describe("Worker Dockerfile source wiring", () => {
 
     expect(dockerfile.match(/\bnpm ci\b/g)?.length ?? 0).toBeGreaterThan(0);
     expect(dockerfile.match(/--package-lock=false\b/g)).toHaveLength(2);
+  });
+
+  it("keeps npm command metadata out of committed image layers", () => {
+    const npmRuns = dockerfileStages().flatMap((stage) => npmInstructions(stage.lines));
+    expect(npmRuns.length).toBeGreaterThan(0);
+    for (const instruction of npmRuns) {
+      expect(instruction.text).toContain(
+        "--mount=type=cache,id=homerail-worker-npm-node22-v1,target=/root/.npm,sharing=locked",
+      );
+    }
   });
 
   it("repairs skipped optional agent platform payloads before verifying the CLIs", () => {

--- a/scripts/lib/worker-build-network.sh
+++ b/scripts/lib/worker-build-network.sh
@@ -27,7 +27,9 @@
 # The helper populates the global HOMERAIL_WORKER_BUILD_NETWORK_ARGS argv
 # array. This avoids Bash 4.3 namerefs so the contract also works with the
 # Bash 3.2 runtime shipped by macOS. It never evaluates or executes validated
-# input. Callers must use `set -euo pipefail`.
+# input. It also forces Docker's built-in BuildKit frontend so the canonical
+# Dockerfile cache mounts are interpreted without fetching a separately pinned
+# frontend image. Callers must use `set -euo pipefail`.
 
 # homerail_worker_build_network_helper_path
 #
@@ -83,6 +85,8 @@ homerail_worker_build_network_normalize_source() {
 # containing a non-whitespace character. Returns 1 before any Docker invocation
 # when a value is invalid.
 homerail_worker_build_network_args() {
+  DOCKER_BUILDKIT=1
+  export DOCKER_BUILDKIT
   HOMERAIL_WORKER_BUILD_NETWORK_ARGS=()
   local name normalized proxy_name
   for name in HOMERAIL_WORKER_BUILD_APT_MIRROR HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR HOMERAIL_WORKER_BUILD_NPM_REGISTRY HOMERAIL_WORKER_BUILD_DSH_GIT_REMOTE; do

--- a/scripts/production-deploy-contracts.test.mjs
+++ b/scripts/production-deploy-contracts.test.mjs
@@ -611,6 +611,7 @@ test("worker build network contract is shared by production and live entry point
   );
   assert.match(helper, /NPM_CONFIG_REGISTRY=/);
   assert.match(helper, /HOMERAIL_DSH_FORK_REPOSITORY=/);
+  assert.match(helper, /DOCKER_BUILDKIT=1\s+export DOCKER_BUILDKIT/);
 });
 
 test("worker build network helper validates sources and forwards proxy names only", { skip: process.platform === "win32" }, () => {


### PR DESCRIPTION
Summary:
- add stable BuildKit cache mounts for npm, Corepack, and pnpm downloads
- keep lockfile determinism and source-neutral runtime/defaults while reducing metadata traffic
- extend Dockerfile source/cache contracts and document cache ownership

Validation:
- Worker: 437 passed, 2 skipped; typecheck passed
- production deployment contracts: 8/8 passed
- two complete local Worker builds and packaged DSH runtime integration passed
- cold/reuse pnpm: 929 downloaded -> 0, 28s -> 12.7s
- final image contains no npm/uv/PyPI source environment variables