### PR TITLE
feat(llm-settings): catalog Kimi K3 capabilities and reasoning levels

### DIFF
--- a/agent-ui/src/api/types/orchestration-v2.types.ts
+++ b/agent-ui/src/api/types/orchestration-v2.types.ts
@@ -240,6 +240,8 @@ export interface ProviderModelPreset {
   description?: string
   recommended?: boolean
   resource_id?: string
+  reasoning_effort_map?: Record<string, string | null> | false
+  default_reasoning_effort?: string
   supports_llm?: boolean
   supports_asr?: boolean
   supports_tts?: boolean

--- a/agent-ui/src/components/agent/settings/ModelForms.test.ts
+++ b/agent-ui/src/components/agent/settings/ModelForms.test.ts
@@ -219,7 +219,7 @@ describe('model purpose forms', () => {
     let submitted: ModelFormPayload | undefined
     const providerWithAnotherModel: Provider = {
       ...provider,
-      endpoints: provider.endpoints.map(endpoint => ({
+      endpoints: provider.endpoints!.map(endpoint => ({
         ...endpoint,
         models: [
           ...endpoint.models,
@@ -301,7 +301,7 @@ describe('model purpose forms', () => {
         id: 'kimi_cn',
         name: 'Kimi / Moonshot CN',
         endpoints: [{
-          ...provider.endpoints[0],
+          ...provider.endpoints![0],
           id: 'kimi_coding_plan',
           provider_id: 'kimi_cn',
           name: 'Kimi Coding Plan',

--- a/agent-ui/src/components/agent/settings/ModelForms.test.ts
+++ b/agent-ui/src/components/agent/settings/ModelForms.test.ts
@@ -290,6 +290,115 @@ describe('model purpose forms', () => {
     }
   })
 
+  it('lists both K3 catalog variants once when provider probing returns the same model ids', async () => {
+    vi.useFakeTimers()
+    try {
+      vi.mocked(probeModels).mockResolvedValueOnce({
+        models: ['k3', 'k3-256k', 'k3-experimental']
+      })
+      const k3Provider: Provider = {
+        ...provider,
+        id: 'kimi_cn',
+        name: 'Kimi / Moonshot CN',
+        endpoints: [{
+          ...provider.endpoints[0],
+          id: 'kimi_coding_plan',
+          provider_id: 'kimi_cn',
+          name: 'Kimi Coding Plan',
+          plan_type: 'coding_plan',
+          base_url: 'https://api.kimi.com/coding/v1',
+          default_model: 'kimi-for-coding',
+          models: [
+            { id: 'kimi-for-coding', display_name: 'Kimi K2.7 Code', supports_llm: true },
+            {
+              id: 'k3',
+              display_name: 'Kimi K3',
+              supports_llm: true,
+              supports_image_input: true,
+              supports_video_input: true,
+              reasoning_effort_map: { low: 'low', high: 'high', max: 'max' },
+              default_reasoning_effort: 'high'
+            },
+            {
+              id: 'k3-256k',
+              display_name: 'Kimi K3 256K',
+              supports_llm: true,
+              supports_image_input: true,
+              supports_video_input: false,
+              reasoning_effort_map: { low: 'low', high: 'high', max: 'max' },
+              default_reasoning_effort: 'high'
+            }
+          ]
+        }]
+      }
+      const k3Setting: LLMSetting = {
+        ...setting,
+        provider_id: k3Provider.id,
+        provider_name: k3Provider.name,
+        endpoint_id: 'kimi_coding_plan',
+        endpoint_name: 'Kimi Coding Plan',
+        plan_type: 'coding_plan',
+        model_name: 'kimi-for-coding',
+        display_name: 'Kimi K2.7 Code'
+      }
+      let submitted: ModelFormPayload | undefined
+      const root = await mount(ModelForm, {
+        providers: [k3Provider],
+        settings: [k3Setting],
+        purpose: 'llm',
+        onSubmit: (payload: ModelFormPayload) => {
+          submitted = payload
+        }
+      })
+
+      const credential = Array.from(root.querySelectorAll('button')).find(button =>
+        button.textContent?.includes('Coding Plan')
+      )!
+      credential.click()
+      await nextTick()
+      await vi.advanceTimersByTimeAsync(600)
+      await nextTick()
+
+      expect(probeModels).toHaveBeenCalledWith({ settingId: k3Setting.id })
+      const modelButton = (label: string) => Array.from(root.querySelectorAll('button')).filter(
+        button => button.querySelector('.block.truncate')?.textContent?.trim() === label
+      )
+      expect(modelButton('Kimi K3')).toHaveLength(1)
+      expect(modelButton('Kimi K3 256K')).toHaveLength(1)
+      expect(modelButton('k3-experimental')).toHaveLength(1)
+
+      modelButton('Kimi K3')[0].click()
+      await nextTick()
+      modelButton('Kimi K3 256K')[0].click()
+      await nextTick()
+      const submit = Array.from(root.querySelectorAll('button')).find(
+        button => button.textContent?.trim() === '添加'
+      )!
+      submit.click()
+      await nextTick()
+
+      expect(submitted?.models).toEqual(['k3', 'k3-256k'])
+      expect(submitted?.modelConfigs).toEqual([
+        expect.objectContaining({
+          modelName: 'k3',
+          capabilities: expect.objectContaining({
+            supports_image_input: true,
+            supports_video_input: true
+          })
+        }),
+        expect.objectContaining({
+          modelName: 'k3-256k',
+          capabilities: expect.objectContaining({
+            supports_image_input: true,
+            supports_video_input: false
+          })
+        })
+      ])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('cancels a pending credential probe when the form unmounts', async () => {
     vi.useFakeTimers()
     try {

--- a/homerail_manager/src/persistence/provider-catalog.ts
+++ b/homerail_manager/src/persistence/provider-catalog.ts
@@ -320,6 +320,29 @@ export const DEFAULT_PROVIDER_CATALOG: CatalogProviderInfo[] = [
         models: [
           model("kimi-for-coding", {}, { recommended: true }),
           model("kimi-for-coding-highspeed"),
+          model("k3", {
+            supports_image_input: true,
+            supports_video_input: true,
+          }, {
+            display_name: "Kimi K3",
+            reasoning_effort_map: {
+              low: "low",
+              high: "high",
+              max: "max",
+            },
+            default_reasoning_effort: "high",
+          }),
+          model("k3-256k", {
+            supports_image_input: true,
+          }, {
+            display_name: "Kimi K3 256K",
+            reasoning_effort_map: {
+              low: "low",
+              high: "high",
+              max: "max",
+            },
+            default_reasoning_effort: "high",
+          }),
         ],
       }),
     ],

--- a/homerail_manager/tests/llm-providers.test.ts
+++ b/homerail_manager/tests/llm-providers.test.ts
@@ -64,11 +64,44 @@ describe("custom LLM providers", () => {
       base_url: "https://api.moonshot.cn/v1",
       default_model: "kimi-k2.7-code",
     }));
-    expect(kimiCn?.endpoints).toContainEqual(expect.objectContaining({
+    const codingPlan = kimiCn?.endpoints.find((endpoint) => endpoint.id === "kimi_coding_plan");
+    expect(codingPlan).toMatchObject({
       id: "kimi_coding_plan",
       base_url: "https://api.kimi.com/coding/v1",
       default_model: "kimi-for-coding",
-    }));
+    });
+    expect(codingPlan?.models.map((candidate) => candidate.id)).toHaveLength(4);
+    expect(codingPlan?.models.map((candidate) => candidate.id)).toEqual(expect.arrayContaining([
+      "kimi-for-coding",
+      "kimi-for-coding-highspeed",
+      "k3",
+      "k3-256k",
+    ]));
+    expect(codingPlan?.models.find((candidate) => candidate.id === "kimi-for-coding")).toMatchObject({
+      recommended: true,
+    });
+    expect(codingPlan?.models.find((candidate) => candidate.id === "k3")).toMatchObject({
+      display_name: "Kimi K3",
+      supports_image_input: true,
+      supports_video_input: true,
+      reasoning_effort_map: {
+        low: "low",
+        high: "high",
+        max: "max",
+      },
+      default_reasoning_effort: "high",
+    });
+    expect(codingPlan?.models.find((candidate) => candidate.id === "k3-256k")).toMatchObject({
+      display_name: "Kimi K3 256K",
+      supports_image_input: true,
+      supports_video_input: false,
+      reasoning_effort_map: {
+        low: "low",
+        high: "high",
+        max: "max",
+      },
+      default_reasoning_effort: "high",
+    });
     expect(kimiInternational).toMatchObject({
       name: "Kimi / Moonshot",
       base_url: "https://api.moonshot.ai/v1",
@@ -89,6 +122,28 @@ describe("custom LLM providers", () => {
       model_name: "kimi-for-coding",
       base_url: "https://api.kimi.com/coding/v1",
     });
+
+    for (const modelName of ["k3", "k3-256k"]) {
+      const k3Setting = createSetting({
+        provider_id: "kimi_cn",
+        endpoint_id: "kimi_coding_plan",
+        model_name: modelName,
+        api_key: `pk-${modelName}-fixture`,
+        is_active: true,
+        is_default: false,
+      });
+      expect(k3Setting).toMatchObject({
+        provider_id: "kimi_cn",
+        endpoint_id: "kimi_coding_plan",
+        model_name: modelName,
+        reasoning_effort_map: {
+          low: "low",
+          high: "high",
+          max: "max",
+        },
+        default_reasoning_effort: "high",
+      });
+    }
   });
 
   it("catalogs the released Qwen3.8-Max Token Plan model instead of its preview", () => {

--- a/homerail_manager/tests/llm-providers.test.ts
+++ b/homerail_manager/tests/llm-providers.test.ts
@@ -50,7 +50,7 @@ describe("custom LLM providers", () => {
     server = createServer(0, undefined, undefined, false);
   });
 
-  it("separates Kimi CN and international credentials and migrates the legacy Coding Plan", () => {
+  it("separates Kimi CN and international credentials and migrates the legacy Coding Plan", async () => {
     const providers = listProviders();
     const kimiCn = providers.find((provider) => provider.id === "kimi_cn");
     const kimiInternational = providers.find((provider) => provider.id === "kimi");
@@ -102,6 +102,46 @@ describe("custom LLM providers", () => {
       },
       default_reasoning_effort: "high",
     });
+
+    const port = await listen(server);
+    const catalogResponse = await fetch(`http://127.0.0.1:${port}/api/llm/providers`);
+    const catalogBody = await catalogResponse.json() as {
+      data: {
+        providers: Array<{
+          id: string;
+          endpoints?: Array<{
+            id: string;
+            models: Array<{
+              id: string;
+              reasoning_effort_map?: Record<string, string | null> | false;
+              default_reasoning_effort?: string;
+              supports_image_input?: boolean;
+              supports_video_input?: boolean;
+            }>;
+          }>;
+        }>;
+      };
+    };
+    expect(catalogResponse.status).toBe(200);
+    const apiCodingPlan = catalogBody.data.providers
+      .find((provider) => provider.id === "kimi_cn")
+      ?.endpoints?.find((endpoint) => endpoint.id === "kimi_coding_plan");
+    expect(apiCodingPlan?.models.filter((candidate) => candidate.id === "k3")).toEqual([
+      expect.objectContaining({
+        reasoning_effort_map: { low: "low", high: "high", max: "max" },
+        default_reasoning_effort: "high",
+        supports_image_input: true,
+        supports_video_input: true,
+      }),
+    ]);
+    expect(apiCodingPlan?.models.filter((candidate) => candidate.id === "k3-256k")).toEqual([
+      expect.objectContaining({
+        reasoning_effort_map: { low: "low", high: "high", max: "max" },
+        default_reasoning_effort: "high",
+        supports_image_input: true,
+        supports_video_input: false,
+      }),
+    ]);
     expect(kimiInternational).toMatchObject({
       name: "Kimi / Moonshot",
       base_url: "https://api.moonshot.ai/v1",


### PR DESCRIPTION
Implements #247

## Summary

Add current Kimi K3 catalog metadata without changing HomeRail's existing default/recommended Kimi model.

- adds `k3` and `k3-256k`;
- exposes `low`, `high`, and `max` reasoning choices;
- uses provider default `high`;
- records the documented multimodal differences;
- keeps `kimi-for-coding` as the endpoint default and recommended preset.

## Owned paths

- `homerail_manager/src/persistence/provider-catalog.ts`
- `homerail_manager/tests/llm-providers.test.ts`

## Verification

- `npm test -- tests/llm-providers.test.ts`
  - TypeScript check passed; 1 file passed; 38 tests passed; exit 0.
- `npm run build`
  - `tsc`; exit 0.
- Full Manager suite
  - 155 files passed / 1 skipped; 1421 tests passed / 2 skipped; exit 0.
- Full root `npm run ci` under an isolated Node.js 22.23.2 runtime
  - protocol, SDK, Manager, Node, Worker, CLI, Agent UI, and live-validator stages passed; exit 0.
  - Manager: 155 files passed / 1 skipped; 1421 tests passed / 2 skipped.
- Diff and credential/local-path scans
  - clean; no credential or machine-specific configuration included.

## Residual limits

This PR only updates code-authoritative catalog metadata. Runtime ACP permission semantics and long-turn cancellation remain #249. Manager completion reconciliation remains #250. Account entitlement can still affect observed context/capability availability.
