### PR TITLE
fix(kimi): reconcile K3 Manager tool completion with authoritative run IDs

### DIFF
--- a/homerail_worker/src/__tests__/kimi-code.test.ts
+++ b/homerail_worker/src/__tests__/kimi-code.test.ts
@@ -745,7 +745,7 @@ if (process.argv.includes("acp")) {
       }
     });
 
-    it("uses prompt-mode tool markers for Manager Agent tools only when explicitly enabled", async () => {
+    it("reconciles K3 Manager completion with the authoritative nested run ID", async () => {
       const tempDir = mkdtempSync(join(tmpdir(), "homerail-kimi-manager-tool-bridge-"));
       const kimiBin = join(tempDir, "kimi");
       const promptPath = join(tempDir, "prompt.txt");
@@ -777,7 +777,7 @@ if (process.argv.includes("--prompt")) {
   const finishMarker = JSON.stringify({
     name: "finish",
     input: {
-      text: "The run id will be assigned later."
+      text: "任务已经启动，运行 ID：fabricated-kimi-run。"
     }
   });
   console.log(JSON.stringify({
@@ -817,7 +817,12 @@ process.exit(2);
           },
           handler: async (args) => {
             calls.push(args);
-            return { content: [{ type: "text", text: JSON.stringify({ run_id: "run-kimi-manager" }) }] };
+            return {
+              content: [{
+                type: "text",
+                text: JSON.stringify({ success: true, data: { runId: "run-kimi-manager" } }),
+              }],
+            };
           },
         };
         const finishTool: DagToolDefinition = {
@@ -859,7 +864,7 @@ process.exit(2);
             ...ctx,
             systemPrompt: "You are the HomeRail Manager Agent. Never invent run IDs.",
             provider: "kimi",
-            model: "kimi-k2.7-code",
+            model: "k3",
             baseUrl: "https://api.kimi.com/coding/v1",
             skillProjection: { mode: "explicit", definitions: [] },
           },
@@ -881,6 +886,8 @@ process.exit(2);
         expect(prompt).toContain("Attempt the matching entry instead of speculating about availability");
         expect(prompt).toContain("name only the visible action that did not complete and offer to retry");
         expect(prompt).toContain("always add one concise user-facing summary in the user's language");
+        expect(prompt).toContain("exactly one finish marker whose text is non-empty and user-facing");
+        expect(prompt).toContain("Do not put any guessed, placeholder, or fabricated run ID");
         expect(prompt).toContain('"name":"upsert_generated_view"');
         expect(prompt).toContain('"component":"Text"');
         expect(prompt).toContain("<homerail_tool_call>");
@@ -900,18 +907,27 @@ process.exit(2);
         }));
         expect(events).toContainEqual(expect.objectContaining({
           type: "tool_result",
-          content: JSON.stringify({ run_id: "run-kimi-manager" }),
+          content: JSON.stringify({ success: true, data: { runId: "run-kimi-manager" } }),
         }));
         expect(events).toContainEqual(expect.objectContaining({
           type: "debug",
-          message: "prompt_mode_finish_ignored_after_create_and_run",
+          message: "prompt_mode_finish_reconciled_with_authoritative_run_id",
+          data: { run_id: "run-kimi-manager" },
         }));
-        expect(events).toContainEqual({ type: "text", text: "已启动。" });
+        expect(events).toContainEqual(expect.objectContaining({
+          type: "tool_use",
+          name: "finish",
+          input: { text: "任务已经启动，运行 ID：run-kimi-manager。" },
+        }));
+        expect(events).not.toContainEqual(expect.objectContaining({ type: "text" }));
         expect(events).not.toContainEqual(expect.objectContaining({ text: expect.stringContaining("内部前言") }));
+        expect(JSON.stringify(events)).not.toContain("fabricated-kimi-run");
         expect(calls).toEqual([{
           yamlPath: "assets/orchestrations/public-two-node.yaml.template",
           profile: "offline-deterministic",
           prompt: "smoke",
+        }, {
+          finish: { text: "任务已经启动，运行 ID：run-kimi-manager。" },
         }]);
       } finally {
         if (previousCapturePromptPath === undefined) delete process.env.CAPTURE_PROMPT_PATH;
@@ -925,6 +941,265 @@ process.exit(2);
         rmSync(tempDir, { recursive: true, force: true });
       }
     });
+
+    it("finishes a K3 Manager run at most once and preserves failure-path summaries", async () => {
+      const cases = [
+        {
+          id: "top-level-duplicate",
+          model: "k3",
+          createFails: false,
+          createContent: JSON.stringify({ run_id: "run-top-level" }),
+          finishFails: false,
+          markerOrder: ["create", "finish", "finish"],
+          finishText: "Commit 0123456789abcdef0123456789abcdef01234567 completed.",
+          visibleText: "Top-level run created.",
+        },
+        {
+          id: "duplicate-create-before-finish",
+          model: "k3",
+          createFails: false,
+          createContent: JSON.stringify({ run_id: "run-duplicate-before" }),
+          finishFails: false,
+          markerOrder: ["create", "create", "finish"],
+          finishText: "Duplicate create was ignored.",
+          visibleText: "Duplicate create marker ignored.",
+        },
+        {
+          id: "duplicate-create-after-finish",
+          model: "k3",
+          createFails: false,
+          createContent: JSON.stringify({ run_id: "run-duplicate-after" }),
+          finishFails: false,
+          markerOrder: ["create", "finish", "create"],
+          finishText: "Create after finish was ignored.",
+          visibleText: "Create after finish marker ignored.",
+        },
+        {
+          id: "failed-create",
+          model: "k3",
+          createFails: true,
+          createContent: "create rejected",
+          finishFails: false,
+          markerOrder: ["create", "finish"],
+          finishText: "Original finish summary.",
+          visibleText: "Creation failed; retry is available.",
+        },
+        {
+          id: "missing-finish",
+          model: "k3-256k",
+          createFails: false,
+          createContent: JSON.stringify({ runId: "run-missing-finish" }),
+          finishFails: false,
+          markerOrder: ["create"],
+          finishText: "Original finish summary.",
+          visibleText: "The run started without a finish marker.",
+        },
+        {
+          id: "failed-finish",
+          model: "k3",
+          createFails: false,
+          createContent: JSON.stringify({ data: { run_id: "run-failed-finish" } }),
+          finishFails: true,
+          markerOrder: ["create", "finish"],
+          finishText: "Original finish summary.",
+          visibleText: "Finishing failed; retry is available.",
+        },
+        {
+          id: "missing-run-id",
+          model: "k3",
+          createFails: false,
+          createContent: JSON.stringify({ success: true, data: { accepted: true } }),
+          finishFails: false,
+          markerOrder: ["create", "finish"],
+          finishText: "Original finish summary.",
+          visibleText: "The run response did not contain an ID.",
+        },
+        {
+          id: "legacy-non-k3",
+          model: "kimi-k2.7-code",
+          createFails: false,
+          createContent: JSON.stringify({ run_id: "run-legacy" }),
+          finishFails: false,
+          markerOrder: ["create", "finish"],
+          finishText: "Original finish summary.",
+          visibleText: "Legacy visible summary.",
+        },
+      ] as const;
+
+      const previousMarkerOrder = process.env.KIMI_TEST_MARKER_ORDER;
+      const previousFinishText = process.env.KIMI_TEST_FINISH_TEXT;
+      const previousVisibleText = process.env.KIMI_TEST_VISIBLE_TEXT;
+      const previousPromptToolBridge = process.env.HOMERAIL_KIMI_PROMPT_TOOL_BRIDGE;
+      try {
+        for (const testCase of cases) {
+          const tempDir = mkdtempSync(join(tmpdir(), `homerail-kimi-${testCase.id}-`));
+          const kimiBin = join(tempDir, "kimi");
+          writeFileSync(kimiBin, `#!/usr/bin/env node
+if (process.argv.includes("--version")) {
+  console.log("kimi-code fixture 0.0.0");
+  process.exit(0);
+}
+if (process.argv.includes("acp")) {
+  console.error("prompt bridge fixture must not use ACP");
+  process.exit(9);
+}
+if (process.argv.includes("--prompt")) {
+  const createMarker = JSON.stringify({
+    name: "create_and_run",
+    input: { yamlPath: "assets/orchestrations/public-two-node.yaml.template" }
+  });
+  const finishMarker = JSON.stringify({
+    name: "finish",
+    input: { text: process.env.KIMI_TEST_FINISH_TEXT }
+  });
+  const markerOrder = (process.env.KIMI_TEST_MARKER_ORDER || "")
+    .split(",")
+    .filter(Boolean);
+  const markers = markerOrder.map((marker) => {
+    const payload = marker === "create" ? createMarker : finishMarker;
+    return "<homerail_tool_call>" + payload + "</homerail_tool_call>";
+  }).join("");
+  console.log(JSON.stringify({
+    role: "assistant",
+    content: markers + "\\n" + process.env.KIMI_TEST_VISIBLE_TEXT
+  }));
+  process.exit(0);
+}
+process.exit(2);
+`, "utf-8");
+          chmodSync(kimiBin, 0o755);
+          process.env.KIMI_TEST_MARKER_ORDER = testCase.markerOrder.join(",");
+          process.env.KIMI_TEST_FINISH_TEXT = testCase.finishText;
+          process.env.KIMI_TEST_VISIBLE_TEXT = testCase.visibleText;
+          process.env.HOMERAIL_KIMI_PROMPT_TOOL_BRIDGE = "1";
+
+          try {
+            const calls: Array<{ name: string; input: Record<string, unknown> }> = [];
+            const createAndRunTool: DagToolDefinition = {
+              name: "create_and_run",
+              description: "Create and run a DAG",
+              input_schema: {
+                type: "object",
+                properties: { yamlPath: { type: "string" } },
+                required: ["yamlPath"],
+                additionalProperties: false,
+              },
+              handler: async (input) => {
+                calls.push({ name: "create_and_run", input });
+                return testCase.createFails
+                  ? { content: [{ type: "text" as const, text: testCase.createContent }], is_error: true }
+                  : { content: [{ type: "text" as const, text: testCase.createContent }] };
+              },
+            };
+            const finishTool: DagToolDefinition = {
+              name: "finish",
+              description: "Finish the turn",
+              input_schema: {
+                type: "object",
+                properties: { text: { type: "string" } },
+                required: ["text"],
+                additionalProperties: false,
+              },
+              handler: async (input) => {
+                calls.push({ name: "finish", input });
+                return testCase.finishFails
+                  ? { content: [{ type: "text" as const, text: "finish rejected" }], is_error: true }
+                  : { content: [{ type: "text" as const, text: "finished" }] };
+              },
+            };
+            const events: AgentEvent[] = [];
+            const scenarioAdapter = new KimiCodeAdapter(kimiBin);
+            for await (const event of scenarioAdapter.run(
+              "Run the isolated Manager scenario.",
+              [createAndRunTool, finishTool],
+              {
+                ...ctx,
+                model: testCase.model,
+                provider: "kimi",
+                baseUrl: "https://api.kimi.com/coding/v1",
+              },
+            )) {
+              events.push(event);
+            }
+
+            if (testCase.id === "top-level-duplicate") {
+              expect(calls.map((call) => call.name)).toEqual(["create_and_run", "finish"]);
+              expect(calls[1].input).toEqual({
+                text: "Commit 0123456789abcdef0123456789abcdef01234567 completed.\nRun ID: run-top-level.",
+              });
+              expect(events).toContainEqual(expect.objectContaining({
+                message: "prompt_mode_duplicate_finish_ignored",
+              }));
+              expect(events).not.toContainEqual(expect.objectContaining({ type: "text" }));
+            } else if (testCase.id === "duplicate-create-before-finish") {
+              expect(calls.map((call) => call.name)).toEqual(["create_and_run", "finish"]);
+              expect(calls[1].input).toEqual({
+                text: "Duplicate create was ignored.\nRun ID: run-duplicate-before.",
+              });
+              expect(events).toContainEqual(expect.objectContaining({
+                message: "prompt_mode_duplicate_create_and_run_ignored",
+                data: { run_id: "run-duplicate-before" },
+              }));
+              expect(events).not.toContainEqual(expect.objectContaining({ type: "text" }));
+            } else if (testCase.id === "duplicate-create-after-finish") {
+              expect(calls.map((call) => call.name)).toEqual(["create_and_run", "finish"]);
+              expect(calls[1].input).toEqual({
+                text: "Create after finish was ignored.\nRun ID: run-duplicate-after.",
+              });
+              expect(events).toContainEqual(expect.objectContaining({
+                message: "prompt_mode_duplicate_create_and_run_ignored",
+                data: { run_id: "run-duplicate-after" },
+              }));
+              expect(events).not.toContainEqual(expect.objectContaining({ type: "text" }));
+            } else if (testCase.id === "failed-create") {
+              expect(calls.map((call) => call.name)).toEqual(["create_and_run"]);
+              expect(events).toContainEqual(expect.objectContaining({
+                message: "prompt_mode_finish_skipped_without_authoritative_run_id",
+              }));
+              expect(events).toContainEqual({ type: "text", text: testCase.visibleText });
+            } else if (testCase.id === "missing-finish") {
+              expect(calls.map((call) => call.name)).toEqual(["create_and_run"]);
+              expect(events).not.toContainEqual(expect.objectContaining({ type: "tool_use", name: "finish" }));
+              expect(events).toContainEqual({ type: "text", text: testCase.visibleText });
+            } else if (testCase.id === "failed-finish") {
+              expect(calls.map((call) => call.name)).toEqual(["create_and_run", "finish"]);
+              expect(calls[1].input).toEqual({
+                text: "Original finish summary.\nRun ID: run-failed-finish.",
+              });
+              expect(events).toContainEqual(expect.objectContaining({
+                type: "tool_result",
+                content: "finish rejected",
+                is_error: true,
+              }));
+              expect(events).toContainEqual({ type: "text", text: testCase.visibleText });
+            } else if (testCase.id === "missing-run-id") {
+              expect(calls.map((call) => call.name)).toEqual(["create_and_run"]);
+              expect(events).toContainEqual(expect.objectContaining({
+                message: "prompt_mode_authoritative_run_id_missing",
+              }));
+              expect(events).toContainEqual({ type: "text", text: testCase.visibleText });
+            } else {
+              expect(calls.map((call) => call.name)).toEqual(["create_and_run"]);
+              expect(events).toContainEqual(expect.objectContaining({
+                message: "prompt_mode_finish_ignored_after_create_and_run",
+              }));
+              expect(events).toContainEqual({ type: "text", text: testCase.visibleText });
+            }
+          } finally {
+            rmSync(tempDir, { recursive: true, force: true });
+          }
+        }
+      } finally {
+        if (previousMarkerOrder === undefined) delete process.env.KIMI_TEST_MARKER_ORDER;
+        else process.env.KIMI_TEST_MARKER_ORDER = previousMarkerOrder;
+        if (previousFinishText === undefined) delete process.env.KIMI_TEST_FINISH_TEXT;
+        else process.env.KIMI_TEST_FINISH_TEXT = previousFinishText;
+        if (previousVisibleText === undefined) delete process.env.KIMI_TEST_VISIBLE_TEXT;
+        else process.env.KIMI_TEST_VISIBLE_TEXT = previousVisibleText;
+        if (previousPromptToolBridge === undefined) delete process.env.HOMERAIL_KIMI_PROMPT_TOOL_BRIDGE;
+        else process.env.HOMERAIL_KIMI_PROMPT_TOOL_BRIDGE = previousPromptToolBridge;
+      }
+    }, 20_000);
 
     it("registers Manager Agent tools through a local MCP bridge for ACP sessions", async () => {
       const tempDir = mkdtempSync(join(tmpdir(), "homerail-kimi-acp-mcp-"));
@@ -1092,7 +1367,7 @@ rl.on("line", async (line) => {
           ...ctx,
           systemPrompt: "You are the HomeRail Manager Agent. Use registered tools directly.",
           provider: "kimi",
-          model: "kimi-k2.7-code",
+          model: "k3",
           baseUrl: "https://api.kimi.com/coding/v1",
           skillProjection: { mode: "explicit", definitions: [] },
         })) {
@@ -1147,6 +1422,9 @@ rl.on("line", async (line) => {
           type: "debug",
           message: "acp_session_created",
           data: expect.objectContaining({ mcp_server_count: 1, mcp_tool_count: 2 }),
+        }));
+        expect(events).not.toContainEqual(expect.objectContaining({
+          message: "prompt_mode_tool_bridge_selected",
         }));
       } finally {
         if (previousCapturePath === undefined) delete process.env.CAPTURE_PATH;

--- a/homerail_worker/src/__tests__/kimi-code.test.ts
+++ b/homerail_worker/src/__tests__/kimi-code.test.ts
@@ -886,7 +886,7 @@ process.exit(2);
         expect(prompt).toContain("Attempt the matching entry instead of speculating about availability");
         expect(prompt).toContain("name only the visible action that did not complete and offer to retry");
         expect(prompt).toContain("always add one concise user-facing summary in the user's language");
-        expect(prompt).toContain("exactly one finish marker whose text is non-empty and user-facing");
+        expect(prompt).toContain("exactly one finish marker after all create markers");
         expect(prompt).toContain("Do not put any guessed, placeholder, or fabricated run ID");
         expect(prompt).toContain('"name":"upsert_generated_view"');
         expect(prompt).toContain('"component":"Text"');
@@ -982,7 +982,7 @@ process.exit(2);
           finishFails: false,
           markerOrder: ["create", "finish"],
           finishText: "Original finish summary.",
-          visibleText: "Creation failed; retry is available.",
+          visibleText: "",
         },
         {
           id: "missing-finish",
@@ -993,6 +993,26 @@ process.exit(2);
           markerOrder: ["create"],
           finishText: "Original finish summary.",
           visibleText: "The run started without a finish marker.",
+        },
+        {
+          id: "synthesized-secret-redaction",
+          model: "k3",
+          createFails: false,
+          createContent: JSON.stringify({ run_id: "run-redacted" }),
+          finishFails: false,
+          markerOrder: ["create"],
+          finishText: "unused",
+          visibleText: "Started with test-secret-key.",
+        },
+        {
+          id: "finish-only",
+          model: "k3",
+          createFails: false,
+          createContent: "unused",
+          finishFails: false,
+          markerOrder: ["finish"],
+          finishText: "No DAG was needed; the request is clearly blocked.",
+          visibleText: "",
         },
         {
           id: "finish-before-create",
@@ -1015,6 +1035,46 @@ process.exit(2);
           visibleText: "Authoritative run ID was appended.",
         },
         {
+          id: "task-id-label",
+          model: "k3",
+          createFails: false,
+          createContent: JSON.stringify({ run_id: "run-task-label" }),
+          finishFails: false,
+          markerOrder: ["create", "finish"],
+          finishText: "Task ID: task-42 is ready.",
+          visibleText: "Task label was preserved.",
+        },
+        {
+          id: "english-run-id-is",
+          model: "k3",
+          createFails: false,
+          createContent: JSON.stringify({ run_id: "run-english-is" }),
+          finishFails: false,
+          markerOrder: ["create", "finish"],
+          finishText: "The Run ID is placeholder-run.",
+          visibleText: "English label was reconciled.",
+        },
+        {
+          id: "historical-run-id",
+          model: "k3",
+          createFails: false,
+          createContent: JSON.stringify({ run_id: "run-current" }),
+          finishFails: false,
+          markerOrder: ["create", "finish"],
+          finishText: "Previous Run ID: 0123456789abcdef01234567 completed.",
+          visibleText: "Historical identity was preserved.",
+        },
+        {
+          id: "distinct-creates",
+          model: "k3",
+          createFails: false,
+          createContent: "unused",
+          finishFails: false,
+          markerOrder: ["create", "finish", "create-distinct", "finish"],
+          finishText: "Started both requested runs.",
+          visibleText: "Both runs were started.",
+        },
+        {
           id: "failed-finish",
           model: "k3",
           createFails: false,
@@ -1022,7 +1082,7 @@ process.exit(2);
           finishFails: true,
           markerOrder: ["create", "finish"],
           finishText: "Original finish summary.",
-          visibleText: "Finishing failed; retry is available.",
+          visibleText: "",
         },
         {
           id: "missing-run-id",
@@ -1032,7 +1092,7 @@ process.exit(2);
           finishFails: false,
           markerOrder: ["create", "finish"],
           finishText: "Original finish summary.",
-          visibleText: "The run response did not contain an ID.",
+          visibleText: "",
         },
         {
           id: "legacy-non-k3",
@@ -1068,6 +1128,10 @@ if (process.argv.includes("--prompt")) {
     name: "create_and_run",
     input: { yamlPath: "assets/orchestrations/public-two-node.yaml.template" }
   });
+  const distinctCreateMarker = JSON.stringify({
+    name: "create_and_run",
+    input: { yamlPath: "assets/orchestrations/public-second-two-node.yaml.template" }
+  });
   const finishMarker = JSON.stringify({
     name: "finish",
     input: { text: process.env.KIMI_TEST_FINISH_TEXT }
@@ -1076,7 +1140,11 @@ if (process.argv.includes("--prompt")) {
     .split(",")
     .filter(Boolean);
   const markers = markerOrder.map((marker) => {
-    const payload = marker === "create" ? createMarker : finishMarker;
+    const payload = marker === "create"
+      ? createMarker
+      : marker === "create-distinct"
+        ? distinctCreateMarker
+        : finishMarker;
     return "<homerail_tool_call>" + payload + "</homerail_tool_call>";
   }).join("");
   console.log(JSON.stringify({
@@ -1106,9 +1174,16 @@ process.exit(2);
               },
               handler: async (input) => {
                 calls.push({ name: "create_and_run", input });
+                const createContent = testCase.id === "distinct-creates"
+                  ? JSON.stringify({
+                      run_id: input.yamlPath === "assets/orchestrations/public-second-two-node.yaml.template"
+                        ? "run-second"
+                        : "run-first",
+                    })
+                  : testCase.createContent;
                 return testCase.createFails
-                  ? { content: [{ type: "text" as const, text: testCase.createContent }], is_error: true }
-                  : { content: [{ type: "text" as const, text: testCase.createContent }] };
+                  ? { content: [{ type: "text" as const, text: createContent }], is_error: true }
+                  : { content: [{ type: "text" as const, text: createContent }] };
               },
             };
             const finishTool: DagToolDefinition = {
@@ -1176,7 +1251,10 @@ process.exit(2);
               expect(events).toContainEqual(expect.objectContaining({
                 message: "prompt_mode_finish_skipped_without_authoritative_run_id",
               }));
-              expect(events).toContainEqual({ type: "text", text: testCase.visibleText });
+              expect(events).toContainEqual({
+                type: "text",
+                text: "The DAG start did not return a verifiable run ID; I can retry.",
+              });
             } else if (testCase.id === "missing-finish") {
               expect(calls.map((call) => call.name)).toEqual(["create_and_run", "finish"]);
               expect(calls[1].input).toEqual({
@@ -1185,6 +1263,24 @@ process.exit(2);
               expect(events).toContainEqual(expect.objectContaining({
                 message: "prompt_mode_finish_synthesized_after_create_and_run",
                 data: { run_id: "run-missing-finish" },
+              }));
+              expect(events).not.toContainEqual(expect.objectContaining({ type: "text" }));
+            } else if (testCase.id === "synthesized-secret-redaction") {
+              expect(calls.map((call) => call.name)).toEqual(["create_and_run", "finish"]);
+              expect(calls[1].input).toEqual({
+                text: "Started with ***.\nRun ID: run-redacted.",
+              });
+              expect(JSON.stringify(events)).not.toContain("test-secret-key");
+              expect(events).not.toContainEqual(expect.objectContaining({ type: "text" }));
+            } else if (testCase.id === "finish-only") {
+              expect(calls.map((call) => call.name)).toEqual(["finish"]);
+              expect(calls[0].input).toEqual({ text: testCase.finishText });
+              expect(events).toContainEqual(expect.objectContaining({
+                message: "prompt_mode_finish_executed_without_create_and_run",
+                data: { success: true },
+              }));
+              expect(events).not.toContainEqual(expect.objectContaining({
+                message: "prompt_mode_tool_marker_missing",
               }));
               expect(events).not.toContainEqual(expect.objectContaining({ type: "text" }));
             } else if (testCase.id === "finish-before-create") {
@@ -1203,6 +1299,41 @@ process.exit(2);
                 text: "Tracking provisional token run-10.\nRun ID: run-1.",
               });
               expect(events).not.toContainEqual(expect.objectContaining({ type: "text" }));
+            } else if (testCase.id === "task-id-label") {
+              expect(calls.map((call) => call.name)).toEqual(["create_and_run", "finish"]);
+              expect(calls[1].input).toEqual({
+                text: "Task ID: task-42 is ready.\nRun ID: run-task-label.",
+              });
+              expect(events).not.toContainEqual(expect.objectContaining({ type: "text" }));
+            } else if (testCase.id === "english-run-id-is") {
+              expect(calls.map((call) => call.name)).toEqual(["create_and_run", "finish"]);
+              expect(calls[1].input).toEqual({ text: "The Run ID is run-english-is." });
+              expect(events).not.toContainEqual(expect.objectContaining({ type: "text" }));
+            } else if (testCase.id === "historical-run-id") {
+              expect(calls.map((call) => call.name)).toEqual(["create_and_run", "finish"]);
+              expect(calls[1].input).toEqual({
+                text: "Previous Run ID: 0123456789abcdef01234567 completed.\nRun ID: run-current.",
+              });
+              expect(events).not.toContainEqual(expect.objectContaining({ type: "text" }));
+            } else if (testCase.id === "distinct-creates") {
+              expect(calls.map((call) => call.name)).toEqual([
+                "create_and_run",
+                "create_and_run",
+                "finish",
+              ]);
+              expect(calls[0].input).toEqual({
+                yamlPath: "assets/orchestrations/public-two-node.yaml.template",
+              });
+              expect(calls[1].input).toEqual({
+                yamlPath: "assets/orchestrations/public-second-two-node.yaml.template",
+              });
+              expect(calls[2].input).toEqual({
+                text: "Started both requested runs.\nRun IDs: run-first, run-second.",
+              });
+              expect(events).toContainEqual(expect.objectContaining({
+                message: "prompt_mode_duplicate_finish_ignored",
+              }));
+              expect(events).not.toContainEqual(expect.objectContaining({ type: "text" }));
             } else if (testCase.id === "failed-finish") {
               expect(calls.map((call) => call.name)).toEqual(["create_and_run", "finish"]);
               expect(calls[1].input).toEqual({
@@ -1213,13 +1344,19 @@ process.exit(2);
                 content: "finish rejected",
                 is_error: true,
               }));
-              expect(events).toContainEqual({ type: "text", text: testCase.visibleText });
+              expect(events).toContainEqual({
+                type: "text",
+                text: "Original finish summary.\nRun ID: run-failed-finish.",
+              });
             } else if (testCase.id === "missing-run-id") {
               expect(calls.map((call) => call.name)).toEqual(["create_and_run"]);
               expect(events).toContainEqual(expect.objectContaining({
                 message: "prompt_mode_authoritative_run_id_missing",
               }));
-              expect(events).toContainEqual({ type: "text", text: testCase.visibleText });
+              expect(events).toContainEqual({
+                type: "text",
+                text: "The DAG start did not return a verifiable run ID; I can retry.",
+              });
             } else {
               expect(calls.map((call) => call.name)).toEqual(["create_and_run"]);
               expect(events).toContainEqual(expect.objectContaining({

--- a/homerail_worker/src/__tests__/kimi-code.test.ts
+++ b/homerail_worker/src/__tests__/kimi-code.test.ts
@@ -995,6 +995,16 @@ process.exit(2);
           visibleText: "The run started without a finish marker.",
         },
         {
+          id: "empty-finish-text",
+          model: "k3",
+          createFails: false,
+          createContent: JSON.stringify({ run_id: "run-empty-finish" }),
+          finishFails: false,
+          markerOrder: ["create", "finish"],
+          finishText: "",
+          visibleText: "The run started from the trailing summary.",
+        },
+        {
           id: "synthesized-secret-redaction",
           model: "k3",
           createFails: false,
@@ -1264,6 +1274,12 @@ process.exit(2);
                 message: "prompt_mode_finish_synthesized_after_create_and_run",
                 data: { run_id: "run-missing-finish" },
               }));
+              expect(events).not.toContainEqual(expect.objectContaining({ type: "text" }));
+            } else if (testCase.id === "empty-finish-text") {
+              expect(calls.map((call) => call.name)).toEqual(["create_and_run", "finish"]);
+              expect(calls[1].input).toEqual({
+                text: "The run started from the trailing summary.\nRun ID: run-empty-finish.",
+              });
               expect(events).not.toContainEqual(expect.objectContaining({ type: "text" }));
             } else if (testCase.id === "synthesized-secret-redaction") {
               expect(calls.map((call) => call.name)).toEqual(["create_and_run", "finish"]);

--- a/homerail_worker/src/__tests__/kimi-code.test.ts
+++ b/homerail_worker/src/__tests__/kimi-code.test.ts
@@ -995,6 +995,26 @@ process.exit(2);
           visibleText: "The run started without a finish marker.",
         },
         {
+          id: "finish-before-create",
+          model: "k3",
+          createFails: false,
+          createContent: JSON.stringify({ data: { runId: "run-out-of-order" } }),
+          finishFails: false,
+          markerOrder: ["finish", "create"],
+          finishText: "任务已经启动，运行 ID：placeholder-run。",
+          visibleText: "Out-of-order markers were reconciled.",
+        },
+        {
+          id: "run-id-prefix",
+          model: "k3",
+          createFails: false,
+          createContent: JSON.stringify({ run_id: "run-1" }),
+          finishFails: false,
+          markerOrder: ["create", "finish"],
+          finishText: "Tracking provisional token run-10.",
+          visibleText: "Authoritative run ID was appended.",
+        },
+        {
           id: "failed-finish",
           model: "k3",
           createFails: false,
@@ -1158,9 +1178,31 @@ process.exit(2);
               }));
               expect(events).toContainEqual({ type: "text", text: testCase.visibleText });
             } else if (testCase.id === "missing-finish") {
-              expect(calls.map((call) => call.name)).toEqual(["create_and_run"]);
-              expect(events).not.toContainEqual(expect.objectContaining({ type: "tool_use", name: "finish" }));
-              expect(events).toContainEqual({ type: "text", text: testCase.visibleText });
+              expect(calls.map((call) => call.name)).toEqual(["create_and_run", "finish"]);
+              expect(calls[1].input).toEqual({
+                text: "The run started without a finish marker.\nRun ID: run-missing-finish.",
+              });
+              expect(events).toContainEqual(expect.objectContaining({
+                message: "prompt_mode_finish_synthesized_after_create_and_run",
+                data: { run_id: "run-missing-finish" },
+              }));
+              expect(events).not.toContainEqual(expect.objectContaining({ type: "text" }));
+            } else if (testCase.id === "finish-before-create") {
+              expect(calls.map((call) => call.name)).toEqual(["create_and_run", "finish"]);
+              expect(calls[1].input).toEqual({
+                text: "任务已经启动，运行 ID：run-out-of-order。",
+              });
+              expect(events).toContainEqual(expect.objectContaining({
+                message: "prompt_mode_finish_reconciled_with_authoritative_run_id",
+                data: { run_id: "run-out-of-order" },
+              }));
+              expect(events).not.toContainEqual(expect.objectContaining({ type: "text" }));
+            } else if (testCase.id === "run-id-prefix") {
+              expect(calls.map((call) => call.name)).toEqual(["create_and_run", "finish"]);
+              expect(calls[1].input).toEqual({
+                text: "Tracking provisional token run-10.\nRun ID: run-1.",
+              });
+              expect(events).not.toContainEqual(expect.objectContaining({ type: "text" }));
             } else if (testCase.id === "failed-finish") {
               expect(calls.map((call) => call.name)).toEqual(["create_and_run", "finish"]);
               expect(calls[1].input).toEqual({

--- a/homerail_worker/src/agent/kimi-code.ts
+++ b/homerail_worker/src/agent/kimi-code.ts
@@ -1287,6 +1287,7 @@ export class KimiCodeAdapter implements AgentClient {
     let promptModeCreatedRun = false;
     let authoritativeCreateAttempted = false;
     let authoritativeRunId: string | null = null;
+    let authoritativeFinishMarkerInput: Record<string, unknown> | null = null;
     let authoritativeFinishAttempted = false;
     let authoritativeFinishCompleted = false;
 
@@ -1371,10 +1372,8 @@ export class KimiCodeAdapter implements AgentClient {
           };
           continue;
         }
-        let markerInput = marker.input;
-        let reconciledFinishText: string | null = null;
         if (marker.name === "finish" && reconcileK3ManagerFinish) {
-          if (authoritativeFinishAttempted) {
+          if (authoritativeFinishMarkerInput) {
             yield {
               type: "debug",
               source: "kimi-code",
@@ -1383,27 +1382,15 @@ export class KimiCodeAdapter implements AgentClient {
             };
             continue;
           }
-          if (!authoritativeRunId) {
-            yield {
-              type: "debug",
-              source: "kimi-code",
-              message: "prompt_mode_finish_skipped_without_authoritative_run_id",
-              data: {
-                reason: authoritativeCreateAttempted ? "create_failed_or_run_id_missing" : "create_not_executed",
-              },
-            };
-            continue;
-          }
-          authoritativeFinishAttempted = true;
-          markerInput = {
-            ...marker.input,
-            text: authoritativeManagerRunFinishText(marker.input.text, authoritativeRunId),
-          };
-          reconciledFinishText = String(markerInput.text);
+          // K3 may emit the final marker before create_and_run or omit it
+          // entirely. Defer finalization until every create marker has been
+          // reconciled, then execute exactly one finish with the trusted ID.
+          authoritativeFinishMarkerInput = marker.input;
+          continue;
         }
         const toolId = randomUUID();
-        yield { type: "tool_use", id: toolId, name: marker.name, input: markerInput };
-        const result = await this.executeTool(toolMap, marker.name, markerInput, toolId);
+        yield { type: "tool_use", id: toolId, name: marker.name, input: marker.input };
+        const result = await this.executeTool(toolMap, marker.name, marker.input, toolId);
         toolMarkerEmitted = true;
         if (marker.name === "create_and_run" && reconcileK3ManagerFinish) {
           authoritativeCreateAttempted = true;
@@ -1413,9 +1400,6 @@ export class KimiCodeAdapter implements AgentClient {
         }
         if (marker.name === "create_and_run" && !reconcileK3ManagerFinish && result.is_error !== true) {
           promptModeCreatedRun = true;
-        }
-        if (marker.name === "finish" && reconciledFinishText && result.is_error !== true) {
-          authoritativeFinishCompleted = true;
         }
         yield {
           type: "tool_result",
@@ -1432,7 +1416,40 @@ export class KimiCodeAdapter implements AgentClient {
             data: {},
           };
         }
-        if (marker.name === "finish" && reconciledFinishText && result.is_error !== true) {
+      }
+
+      const handoff = parseHomeRailPromptHandoff(accumulatedText);
+      const visibleText = visiblePromptModeText(
+        accumulatedText,
+        toolMarkers.length > 0 || Boolean(handoff),
+      );
+      if (reconcileK3ManagerFinish && authoritativeRunId && !authoritativeFinishAttempted) {
+        const finishInput = authoritativeFinishMarkerInput ?? { text: visibleText };
+        if (!authoritativeFinishMarkerInput) {
+          yield {
+            type: "debug",
+            source: "kimi-code",
+            message: "prompt_mode_finish_synthesized_after_create_and_run",
+            data: { run_id: authoritativeRunId },
+          };
+        }
+        const reconciledInput = {
+          ...finishInput,
+          text: authoritativeManagerRunFinishText(finishInput.text, authoritativeRunId),
+        };
+        const toolId = randomUUID();
+        authoritativeFinishAttempted = true;
+        yield { type: "tool_use", id: toolId, name: "finish", input: reconciledInput };
+        const result = await this.executeTool(toolMap, "finish", reconciledInput, toolId);
+        toolMarkerEmitted = true;
+        authoritativeFinishCompleted = result.is_error !== true;
+        yield {
+          type: "tool_result",
+          tool_use_id: toolId,
+          content: result.content,
+          is_error: result.is_error,
+        };
+        if (authoritativeFinishCompleted) {
           yield {
             type: "debug",
             source: "kimi-code",
@@ -1440,9 +1457,16 @@ export class KimiCodeAdapter implements AgentClient {
             data: { run_id: authoritativeRunId },
           };
         }
+      } else if (reconcileK3ManagerFinish && authoritativeFinishMarkerInput && !authoritativeRunId) {
+        yield {
+          type: "debug",
+          source: "kimi-code",
+          message: "prompt_mode_finish_skipped_without_authoritative_run_id",
+          data: {
+            reason: authoritativeCreateAttempted ? "create_failed_or_run_id_missing" : "create_not_executed",
+          },
+        };
       }
-
-      const handoff = parseHomeRailPromptHandoff(accumulatedText);
       if (handoff && toolMap.has("handoff")) {
         const toolId = randomUUID();
         const input = {
@@ -1476,7 +1500,6 @@ export class KimiCodeAdapter implements AgentClient {
           data: { expected_marker: `<${HOMERAIL_PROMPT_TOOL_CALL_PROTOCOL}>{...}</${HOMERAIL_PROMPT_TOOL_CALL_PROTOCOL}>` },
         };
       }
-      const visibleText = visiblePromptModeText(accumulatedText, toolMarkers.length > 0 || Boolean(handoff));
       if (!authoritativeFinishCompleted && visibleText) {
         yield { type: "text", text: redactSecrets(visibleText, secret) };
       }
@@ -1876,14 +1899,16 @@ function authoritativeManagerRunFinishText(modelText: unknown, runId: string): s
   const fallback = usesChinese ? "DAG 已启动。" : "The DAG has started.";
   const canonicalRunId = usesChinese ? `运行 ID：${runId}。` : `Run ID: ${runId}.`;
   const labelledRunId = /((?:\brun[\s_-]*id\b|运行\s*(?:id|编号)|任务\s*(?:id|编号))\s*(?:[:：=#]|为|是)\s*)(["'`]?)([A-Za-z0-9](?:[A-Za-z0-9._:-]*[A-Za-z0-9])?)(["'`]?)/giu;
+  let reconciledLabel = false;
   let corrected = original
     .replace(labelledRunId, (_match, prefix: string, open: string, _candidate: string, close: string) => {
+      reconciledLabel = true;
       const quote = open && close === open ? open : "";
       return `${prefix}${quote}${runId}${quote}`;
     })
     .trim();
   if (!corrected) corrected = fallback;
-  return corrected.includes(runId) ? corrected : `${corrected}\n${canonicalRunId}`;
+  return reconciledLabel ? corrected : `${corrected}\n${canonicalRunId}`;
 }
 
 function toMcpToolDescriptors(tools: DagToolDefinition[]): KimiMcpToolDescriptor[] {

--- a/homerail_worker/src/agent/kimi-code.ts
+++ b/homerail_worker/src/agent/kimi-code.ts
@@ -1286,6 +1286,8 @@ export class KimiCodeAdapter implements AgentClient {
     let toolMarkerEmitted = false;
     let promptModeCreatedRun = false;
     let authoritativeCreateAttempted = false;
+    const authoritativeCreateInputs = new Set<string>();
+    const authoritativeRunIds: string[] = [];
     let authoritativeRunId: string | null = null;
     let authoritativeFinishMarkerInput: Record<string, unknown> | null = null;
     let authoritativeFinishAttempted = false;
@@ -1315,6 +1317,7 @@ export class KimiCodeAdapter implements AgentClient {
             continue;
           }
           if (event.type === "tool_use") {
+            toolMarkerEmitted = true;
             yield event;
             const result = await this.executeTool(toolMap, event.name, event.input, event.id);
             yield {
@@ -1354,14 +1357,19 @@ export class KimiCodeAdapter implements AgentClient {
           };
           continue;
         }
-        if (marker.name === "create_and_run" && reconcileK3ManagerFinish && authoritativeCreateAttempted) {
-          yield {
-            type: "debug",
-            source: "kimi-code",
-            message: "prompt_mode_duplicate_create_and_run_ignored",
-            data: { run_id: authoritativeRunId },
-          };
-          continue;
+        toolMarkerEmitted = true;
+        if (marker.name === "create_and_run" && reconcileK3ManagerFinish) {
+          const inputKey = toolEventKey(marker.name, marker.input);
+          if (authoritativeCreateInputs.has(inputKey)) {
+            yield {
+              type: "debug",
+              source: "kimi-code",
+              message: "prompt_mode_duplicate_create_and_run_ignored",
+              data: { run_id: authoritativeRunId },
+            };
+            continue;
+          }
+          authoritativeCreateInputs.add(inputKey);
         }
         if (marker.name === "finish" && !reconcileK3ManagerFinish && promptModeCreatedRun) {
           yield {
@@ -1391,12 +1399,18 @@ export class KimiCodeAdapter implements AgentClient {
         const toolId = randomUUID();
         yield { type: "tool_use", id: toolId, name: marker.name, input: marker.input };
         const result = await this.executeTool(toolMap, marker.name, marker.input, toolId);
-        toolMarkerEmitted = true;
+        let reconciledCreateRunId: string | null | undefined;
         if (marker.name === "create_and_run" && reconcileK3ManagerFinish) {
           authoritativeCreateAttempted = true;
-          authoritativeRunId = result.is_error === true
+          reconciledCreateRunId = result.is_error === true
             ? null
             : authoritativeRunIdFromToolResult(result.content);
+          if (reconciledCreateRunId) {
+            authoritativeRunId = reconciledCreateRunId;
+            if (!authoritativeRunIds.includes(reconciledCreateRunId)) {
+              authoritativeRunIds.push(reconciledCreateRunId);
+            }
+          }
         }
         if (marker.name === "create_and_run" && !reconcileK3ManagerFinish && result.is_error !== true) {
           promptModeCreatedRun = true;
@@ -1408,7 +1422,7 @@ export class KimiCodeAdapter implements AgentClient {
           is_error: result.is_error,
         };
         if (marker.name === "create_and_run" && reconcileK3ManagerFinish
-          && result.is_error !== true && !authoritativeRunId) {
+          && result.is_error !== true && !reconciledCreateRunId) {
           yield {
             type: "debug",
             source: "kimi-code",
@@ -1423,7 +1437,15 @@ export class KimiCodeAdapter implements AgentClient {
         accumulatedText,
         toolMarkers.length > 0 || Boolean(handoff),
       );
-      if (reconcileK3ManagerFinish && authoritativeRunId && !authoritativeFinishAttempted) {
+      const redactedVisibleText = redactSecrets(visibleText, secret);
+      const deferredFinishText = redactSecrets(
+        typeof authoritativeFinishMarkerInput?.text === "string"
+          ? authoritativeFinishMarkerInput.text
+          : "",
+        secret,
+      ).trim();
+      let fallbackVisibleText = redactedVisibleText;
+      if (reconcileK3ManagerFinish && authoritativeRunIds.length > 0 && !authoritativeFinishAttempted) {
         const finishInput = authoritativeFinishMarkerInput ?? { text: visibleText };
         if (!authoritativeFinishMarkerInput) {
           yield {
@@ -1435,7 +1457,10 @@ export class KimiCodeAdapter implements AgentClient {
         }
         const reconciledInput = {
           ...finishInput,
-          text: authoritativeManagerRunFinishText(finishInput.text, authoritativeRunId),
+          text: authoritativeManagerRunFinishText(
+            redactSecrets(typeof finishInput.text === "string" ? finishInput.text : "", secret),
+            authoritativeRunIds,
+          ),
         };
         const toolId = randomUUID();
         authoritativeFinishAttempted = true;
@@ -1443,6 +1468,9 @@ export class KimiCodeAdapter implements AgentClient {
         const result = await this.executeTool(toolMap, "finish", reconciledInput, toolId);
         toolMarkerEmitted = true;
         authoritativeFinishCompleted = result.is_error !== true;
+        if (!authoritativeFinishCompleted && !fallbackVisibleText) {
+          fallbackVisibleText = reconciledInput.text;
+        }
         yield {
           type: "tool_result",
           tool_use_id: toolId,
@@ -1457,7 +1485,34 @@ export class KimiCodeAdapter implements AgentClient {
             data: { run_id: authoritativeRunId },
           };
         }
+      } else if (reconcileK3ManagerFinish && authoritativeFinishMarkerInput
+        && !authoritativeCreateAttempted && !authoritativeFinishAttempted) {
+        const finishInput = {
+          ...authoritativeFinishMarkerInput,
+          text: deferredFinishText || redactedVisibleText || "No usable summary was produced for this turn.",
+        };
+        const toolId = randomUUID();
+        authoritativeFinishAttempted = true;
+        yield { type: "tool_use", id: toolId, name: "finish", input: finishInput };
+        const result = await this.executeTool(toolMap, "finish", finishInput, toolId);
+        authoritativeFinishCompleted = result.is_error !== true;
+        if (!authoritativeFinishCompleted && !fallbackVisibleText) {
+          fallbackVisibleText = finishInput.text;
+        }
+        yield {
+          type: "tool_result",
+          tool_use_id: toolId,
+          content: result.content,
+          is_error: result.is_error,
+        };
+        yield {
+          type: "debug",
+          source: "kimi-code",
+          message: "prompt_mode_finish_executed_without_create_and_run",
+          data: { success: authoritativeFinishCompleted },
+        };
       } else if (reconcileK3ManagerFinish && authoritativeFinishMarkerInput && !authoritativeRunId) {
+        fallbackVisibleText = redactedVisibleText || managerRunIdentityUnavailableText(deferredFinishText);
         yield {
           type: "debug",
           source: "kimi-code",
@@ -1500,8 +1555,8 @@ export class KimiCodeAdapter implements AgentClient {
           data: { expected_marker: `<${HOMERAIL_PROMPT_TOOL_CALL_PROTOCOL}>{...}</${HOMERAIL_PROMPT_TOOL_CALL_PROTOCOL}>` },
         };
       }
-      if (!authoritativeFinishCompleted && visibleText) {
-        yield { type: "text", text: redactSecrets(visibleText, secret) };
+      if (!authoritativeFinishCompleted && fallbackVisibleText) {
+        yield { type: "text", text: fallbackVisibleText };
       }
     } finally {
       if (context.abortSignal) {
@@ -1547,7 +1602,8 @@ export class KimiCodeAdapter implements AgentClient {
         "Do not claim a DAG/run was created unless you output a create_and_run marker. Do not invent run IDs.",
         ...(reconcileK3ManagerFinish
           ? [
-              "For K3 Manager create_and_run, immediately follow the create marker with exactly one finish marker whose text is non-empty and user-facing.",
+              "For K3 Manager, emit each distinct required create_and_run marker exactly once, then emit exactly one finish marker after all create markers; its text must be non-empty and user-facing.",
+              "Do not repeat an identical create_and_run marker. Distinct requested runs must use distinct marker inputs.",
               "Do not put any guessed, placeholder, or fabricated run ID in that finish text; HomeRail appends the authoritative run ID returned by create_and_run.",
             ]
           : []),
@@ -1893,22 +1949,46 @@ function authoritativeRunIdFromToolResult(content: string): string | null {
   return null;
 }
 
-function authoritativeManagerRunFinishText(modelText: unknown, runId: string): string {
+function authoritativeManagerRunFinishText(modelText: unknown, runIds: readonly string[]): string {
+  const uniqueRunIds = [...new Set(runIds.map((runId) => runId.trim()).filter(Boolean))];
   const original = typeof modelText === "string" ? modelText.trim() : "";
   const usesChinese = /[\u3400-\u9fff]/u.test(original);
   const fallback = usesChinese ? "DAG 已启动。" : "The DAG has started.";
-  const canonicalRunId = usesChinese ? `运行 ID：${runId}。` : `Run ID: ${runId}.`;
-  const labelledRunId = /((?:\brun[\s_-]*id\b|运行\s*(?:id|编号)|任务\s*(?:id|编号))\s*(?:[:：=#]|为|是)\s*)(["'`]?)([A-Za-z0-9](?:[A-Za-z0-9._:-]*[A-Za-z0-9])?)(["'`]?)/giu;
-  let reconciledLabel = false;
+  const currentRunIds = new Set(uniqueRunIds);
+  const reconciledRunIds = new Set<string>();
+  let replacementIndex = 0;
+  const labelledRunId = /((?:\brun[\s_-]*id\b|运行\s*(?:id|编号))\s*(?:[:：=#]|为|是|\bis\b)\s*)(["'`]?)([A-Za-z0-9](?:[A-Za-z0-9._:-]*[A-Za-z0-9])?)(["'`]?)/giu;
   let corrected = original
-    .replace(labelledRunId, (_match, prefix: string, open: string, _candidate: string, close: string) => {
-      reconciledLabel = true;
+    .replace(labelledRunId, (match, prefix: string, open: string, candidate: string, close: string) => {
+      if (currentRunIds.has(candidate)) {
+        reconciledRunIds.add(candidate);
+        return match;
+      }
+      // Manager-generated run IDs are currently 24 hexadecimal characters.
+      // Preserve a different valid ID because it may intentionally reference
+      // an earlier run from the conversation rather than a fabricated value.
+      if (/^[a-f0-9]{24}$/iu.test(candidate)) return match;
+      const runId = uniqueRunIds[Math.min(replacementIndex, uniqueRunIds.length - 1)];
+      replacementIndex += 1;
+      if (!runId) return match;
+      reconciledRunIds.add(runId);
       const quote = open && close === open ? open : "";
       return `${prefix}${quote}${runId}${quote}`;
     })
     .trim();
   if (!corrected) corrected = fallback;
-  return reconciledLabel ? corrected : `${corrected}\n${canonicalRunId}`;
+  const missingRunIds = uniqueRunIds.filter((runId) => !reconciledRunIds.has(runId));
+  if (missingRunIds.length === 0) return corrected;
+  const canonicalRunIds = usesChinese
+    ? `运行 ID：${missingRunIds.join("、")}。`
+    : `Run ID${missingRunIds.length === 1 ? "" : "s"}: ${missingRunIds.join(", ")}.`;
+  return `${corrected}\n${canonicalRunIds}`;
+}
+
+function managerRunIdentityUnavailableText(modelText: string): string {
+  return /[\u3400-\u9fff]/u.test(modelText)
+    ? "DAG 启动结果未返回可确认的运行 ID，我可以继续重试。"
+    : "The DAG start did not return a verifiable run ID; I can retry.";
 }
 
 function toMcpToolDescriptors(tools: DagToolDefinition[]): KimiMcpToolDescriptor[] {

--- a/homerail_worker/src/agent/kimi-code.ts
+++ b/homerail_worker/src/agent/kimi-code.ts
@@ -309,6 +309,11 @@ function requiresAlwaysThinking(model: string): boolean {
   return normalized === "kimi-k2.7-code" || normalized.startsWith("kimi-for-coding");
 }
 
+function isKimiK3Model(model: string): boolean {
+  const normalized = model.trim().toLowerCase();
+  return normalized === "k3" || normalized === "k3-256k";
+}
+
 /** Parsed line from kimi CLI stream-json output. */
 interface StreamJsonLine {
   type?: string;
@@ -1252,7 +1257,14 @@ export class KimiCodeAdapter implements AgentClient {
   ): AsyncIterable<AgentEvent> {
     const cwd = context.workspace ?? process.cwd();
     const toolMap = new Map<string, DagToolDefinition>(tools.map((tool) => [tool.name, tool]));
-    const promptText = this.buildPromptModePrompt(prompt, tools, forceToolBridge);
+    const reconcileK3ManagerFinish = isKimiK3Model(effectiveModel)
+      && this.isManagerAgentToolCatalog(tools);
+    const promptText = this.buildPromptModePrompt(
+      prompt,
+      tools,
+      forceToolBridge,
+      reconcileK3ManagerFinish,
+    );
     const child = this.spawnKimi([
       "--model",
       effectiveModel,
@@ -1273,6 +1285,10 @@ export class KimiCodeAdapter implements AgentClient {
     let handoffEmitted = false;
     let toolMarkerEmitted = false;
     let promptModeCreatedRun = false;
+    let authoritativeCreateAttempted = false;
+    let authoritativeRunId: string | null = null;
+    let authoritativeFinishAttempted = false;
+    let authoritativeFinishCompleted = false;
 
     const abortHandler = (): void => {
       cancelled = true;
@@ -1337,7 +1353,16 @@ export class KimiCodeAdapter implements AgentClient {
           };
           continue;
         }
-        if (marker.name === "finish" && promptModeCreatedRun) {
+        if (marker.name === "create_and_run" && reconcileK3ManagerFinish && authoritativeCreateAttempted) {
+          yield {
+            type: "debug",
+            source: "kimi-code",
+            message: "prompt_mode_duplicate_create_and_run_ignored",
+            data: { run_id: authoritativeRunId },
+          };
+          continue;
+        }
+        if (marker.name === "finish" && !reconcileK3ManagerFinish && promptModeCreatedRun) {
           yield {
             type: "debug",
             source: "kimi-code",
@@ -1346,12 +1371,51 @@ export class KimiCodeAdapter implements AgentClient {
           };
           continue;
         }
+        let markerInput = marker.input;
+        let reconciledFinishText: string | null = null;
+        if (marker.name === "finish" && reconcileK3ManagerFinish) {
+          if (authoritativeFinishAttempted) {
+            yield {
+              type: "debug",
+              source: "kimi-code",
+              message: "prompt_mode_duplicate_finish_ignored",
+              data: { run_id: authoritativeRunId },
+            };
+            continue;
+          }
+          if (!authoritativeRunId) {
+            yield {
+              type: "debug",
+              source: "kimi-code",
+              message: "prompt_mode_finish_skipped_without_authoritative_run_id",
+              data: {
+                reason: authoritativeCreateAttempted ? "create_failed_or_run_id_missing" : "create_not_executed",
+              },
+            };
+            continue;
+          }
+          authoritativeFinishAttempted = true;
+          markerInput = {
+            ...marker.input,
+            text: authoritativeManagerRunFinishText(marker.input.text, authoritativeRunId),
+          };
+          reconciledFinishText = String(markerInput.text);
+        }
         const toolId = randomUUID();
-        yield { type: "tool_use", id: toolId, name: marker.name, input: marker.input };
-        const result = await this.executeTool(toolMap, marker.name, marker.input, toolId);
+        yield { type: "tool_use", id: toolId, name: marker.name, input: markerInput };
+        const result = await this.executeTool(toolMap, marker.name, markerInput, toolId);
         toolMarkerEmitted = true;
-        if (marker.name === "create_and_run" && result.is_error !== true) {
+        if (marker.name === "create_and_run" && reconcileK3ManagerFinish) {
+          authoritativeCreateAttempted = true;
+          authoritativeRunId = result.is_error === true
+            ? null
+            : authoritativeRunIdFromToolResult(result.content);
+        }
+        if (marker.name === "create_and_run" && !reconcileK3ManagerFinish && result.is_error !== true) {
           promptModeCreatedRun = true;
+        }
+        if (marker.name === "finish" && reconciledFinishText && result.is_error !== true) {
+          authoritativeFinishCompleted = true;
         }
         yield {
           type: "tool_result",
@@ -1359,6 +1423,23 @@ export class KimiCodeAdapter implements AgentClient {
           content: result.content,
           is_error: result.is_error,
         };
+        if (marker.name === "create_and_run" && reconcileK3ManagerFinish
+          && result.is_error !== true && !authoritativeRunId) {
+          yield {
+            type: "debug",
+            source: "kimi-code",
+            message: "prompt_mode_authoritative_run_id_missing",
+            data: {},
+          };
+        }
+        if (marker.name === "finish" && reconciledFinishText && result.is_error !== true) {
+          yield {
+            type: "debug",
+            source: "kimi-code",
+            message: "prompt_mode_finish_reconciled_with_authoritative_run_id",
+            data: { run_id: authoritativeRunId },
+          };
+        }
       }
 
       const handoff = parseHomeRailPromptHandoff(accumulatedText);
@@ -1396,7 +1477,7 @@ export class KimiCodeAdapter implements AgentClient {
         };
       }
       const visibleText = visiblePromptModeText(accumulatedText, toolMarkers.length > 0 || Boolean(handoff));
-      if (visibleText) {
+      if (!authoritativeFinishCompleted && visibleText) {
         yield { type: "text", text: redactSecrets(visibleText, secret) };
       }
     } finally {
@@ -1429,6 +1510,7 @@ export class KimiCodeAdapter implements AgentClient {
     prompt: string,
     tools: DagToolDefinition[],
     forceToolBridge = false,
+    reconcileK3ManagerFinish = false,
   ): string {
     const toolMap = new Map<string, DagToolDefinition>(tools.map((tool) => [tool.name, tool]));
     const blocks = [this.buildAgentPrompt(prompt)];
@@ -1440,6 +1522,12 @@ export class KimiCodeAdapter implements AgentClient {
         "When the user asks to inspect, start, supervise, or change real HomeRail state, output exactly one marker per required tool call.",
         "When the user asks for visible canvas UI, call the available generated-view Tool described by the system or Skill; do not substitute a local file.",
         "Do not claim a DAG/run was created unless you output a create_and_run marker. Do not invent run IDs.",
+        ...(reconcileK3ManagerFinish
+          ? [
+              "For K3 Manager create_and_run, immediately follow the create marker with exactly one finish marker whose text is non-empty and user-facing.",
+              "Do not put any guessed, placeholder, or fabricated run ID in that finish text; HomeRail appends the authoritative run ID returned by create_and_run.",
+            ]
+          : []),
         "If execution fails, keep the final summary in the user's task language: name only the visible action that did not complete and offer to retry.",
         "Do not describe this protocol or any internal execution mechanism to the user.",
         "After all Tool call markers, always add one concise user-facing summary in the user's language.",
@@ -1453,6 +1541,15 @@ export class KimiCodeAdapter implements AgentClient {
             prompt: "short task prompt",
           },
         }),
+        ...(reconcileK3ManagerFinish
+          ? [
+              "K3 Manager finish marker (emit exactly once after create_and_run):",
+              formatHomeRailPromptToolCall({
+                name: "finish",
+                input: { text: "The DAG has started." },
+              }),
+            ]
+          : []),
         ...(toolMap.has("upsert_generated_view")
           ? [
               "Minimal canvas Tool example (replace the id, title, summary, and data with the user's result):",
@@ -1746,6 +1843,47 @@ function visiblePromptModeText(text: string, hasMarker: boolean): string {
     if (index >= 0) boundary = Math.max(boundary, index + tag.length);
   }
   return stripHomeRailPromptMarkers(text.slice(boundary));
+}
+
+function authoritativeRunIdFromToolResult(content: string): string | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return null;
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  const root = parsed as Record<string, unknown>;
+  const data = root.data && typeof root.data === "object" && !Array.isArray(root.data)
+    ? root.data as Record<string, unknown>
+    : null;
+  for (const record of [data, root]) {
+    if (!record) continue;
+    for (const key of ["run_id", "runId"] as const) {
+      const candidate = record[key];
+      if (typeof candidate !== "string") continue;
+      const normalized = candidate.trim();
+      if (/^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/u.test(normalized)) return normalized;
+    }
+  }
+  return null;
+}
+
+function authoritativeManagerRunFinishText(modelText: unknown, runId: string): string {
+  const original = typeof modelText === "string" ? modelText.trim() : "";
+  const usesChinese = /[\u3400-\u9fff]/u.test(original);
+  const fallback = usesChinese ? "DAG 已启动。" : "The DAG has started.";
+  const canonicalRunId = usesChinese ? `运行 ID：${runId}。` : `Run ID: ${runId}.`;
+  const labelledRunId = /((?:\brun[\s_-]*id\b|运行\s*(?:id|编号)|任务\s*(?:id|编号))\s*(?:[:：=#]|为|是)\s*)(["'`]?)([A-Za-z0-9](?:[A-Za-z0-9._:-]*[A-Za-z0-9])?)(["'`]?)/giu;
+  let corrected = original
+    .replace(labelledRunId, (_match, prefix: string, open: string, _candidate: string, close: string) => {
+      const quote = open && close === open ? open : "";
+      return `${prefix}${quote}${runId}${quote}`;
+    })
+    .trim();
+  if (!corrected) corrected = fallback;
+  return corrected.includes(runId) ? corrected : `${corrected}\n${canonicalRunId}`;
 }
 
 function toMcpToolDescriptors(tools: DagToolDefinition[]): KimiMcpToolDescriptor[] {

--- a/homerail_worker/src/agent/kimi-code.ts
+++ b/homerail_worker/src/agent/kimi-code.ts
@@ -1446,7 +1446,10 @@ export class KimiCodeAdapter implements AgentClient {
       ).trim();
       let fallbackVisibleText = redactedVisibleText;
       if (reconcileK3ManagerFinish && authoritativeRunIds.length > 0 && !authoritativeFinishAttempted) {
-        const finishInput = authoritativeFinishMarkerInput ?? { text: visibleText };
+        const finishInput = {
+          ...(authoritativeFinishMarkerInput ?? {}),
+          text: deferredFinishText || redactedVisibleText,
+        };
         if (!authoritativeFinishMarkerInput) {
           yield {
             type: "debug",


### PR DESCRIPTION
Implements #250

## Summary

Reconcile K3 Manager prompt-tool completion against the authoritative result returned by `create_and_run`.

- extracts top-level and nested `run_id` / `runId`;
- performs `finish` at most once after successful creation;
- replaces model-authored placeholder IDs with the authoritative ID;
- preserves visible text and a bounded diagnostic when the ID is missing/malformed;
- prevents duplicate `create_and_run` execution for repeated marker orderings;
- keeps ordinary K3 Manager turns on native ACP/MCP unless the prompt bridge was explicitly selected;
- leaves K3 DAG/ACP and non-K3 behavior unchanged.

## Owned paths

- `homerail_worker/src/agent/kimi-code.ts`
- `homerail_worker/src/__tests__/kimi-code.test.ts`

## Verification

- `npm test -- src/__tests__/kimi-code.test.ts`
  - 1 file passed; 43 tests passed / 1 skipped; exit 0.
- `npm run typecheck`
  - `tsc --noEmit`; exit 0.
- `npm run build`
  - `tsc`; exit 0.
- Full Worker suite
  - 36 files passed / 1 skipped; 440 tests passed / 2 skipped; exit 0.
- Full root `npm run ci` under an isolated Node.js 22.23.2 runtime
  - protocol, SDK, Manager, Node, Worker, CLI, Agent UI, and live-validator stages passed; exit 0.
  - Worker: 36 files passed / 1 skipped; 440 tests passed / 2 skipped.
- Diff and credential/local-path scans
  - clean.

## Residual limits

This is deliberately limited to the K3 Manager prompt-tool bridge. It does not change the K3 catalog (#247), ACP permission policy (#249), DAG handoff protocol, or general Manager tool orchestration.
