### PR TITLE
fix(dag): enforce WorkflowSpec policies.max_parallelism at runtime

### DIFF
--- a/homerail_manager/src/orchestration/workflow-spec-v1.ts
+++ b/homerail_manager/src/orchestration/workflow-spec-v1.ts
@@ -1750,6 +1750,7 @@ export function projectCanonicalWorkflowToParsedDAG(canonical: CanonicalWorkflow
       workspace: canonical.workspace,
       limits: {
         max_nodes: canonical.policies.max_nodes,
+        max_parallelism: canonical.policies.max_parallelism,
         max_dispatches: canonical.policies.max_dispatches,
         max_handoffs: canonical.policies.max_handoffs,
         max_corrections_per_node: canonical.policies.max_corrections_per_node,

--- a/homerail_manager/src/runtime/active-runs.ts
+++ b/homerail_manager/src/runtime/active-runs.ts
@@ -357,6 +357,7 @@ export interface ResumeWaitingRunResult {
 
 export interface DAGRunLimits {
   max_nodes: number;
+  max_parallelism: number;
   max_dispatches: number;
   max_handoffs: number;
   max_corrections_per_node: number;
@@ -399,6 +400,7 @@ const store = new Map<string, ActiveRun>();
 
 const DEFAULT_LIMITS: DAGRunLimits = {
   max_nodes: 1000,
+  max_parallelism: 32,
   max_dispatches: 30,
   max_handoffs: 50,
   max_corrections_per_node: 2,
@@ -431,6 +433,7 @@ function _resolveLimits(raw: unknown): DAGRunLimits {
     : undefined;
   return {
     max_nodes: _limitValue(value, "max_nodes", DEFAULT_LIMITS.max_nodes),
+    max_parallelism: Math.max(1, _limitValue(value, "max_parallelism", DEFAULT_LIMITS.max_parallelism)),
     max_dispatches: _limitValue(value, "max_dispatches", DEFAULT_LIMITS.max_dispatches),
     max_handoffs: _limitValue(value, "max_handoffs", DEFAULT_LIMITS.max_handoffs),
     max_corrections_per_node: _limitValue(value, "max_corrections_per_node", DEFAULT_LIMITS.max_corrections_per_node),
@@ -1286,7 +1289,7 @@ export function restoreActiveRun(
     createdAt: metadata.createdAt,
     status: metadata.status,
     currentRound,
-    limits: metadata.limits ?? { ...DEFAULT_LIMITS },
+    limits: _resolveLimits(metadata.limits),
     counters: _restoreCounters(metadata.counters),
     nodeIndex: _buildNodeIndex(nodes),
     nodeSessions: new Map(),
@@ -6315,6 +6318,34 @@ function _markRoundCommandsDelivered(run: ActiveRun, nodeId: string): void {
   for (const command of commands) markDagActorCommandDelivered(command.command_id);
 }
 
+/**
+ * Return the logical Actor dispatches that currently occupy workflow-level
+ * parallelism. Gateway execution has its own lifecycle and fan-out has an
+ * independent node-local bound, so neither is folded into this Actor limit.
+ * A READY node being provisioned reserves capacity before its asynchronous
+ * Worker send transitions it to RUNNING.
+ */
+function _activeDispatchNodeIds(run: ActiveRun): Set<string> {
+  const active = new Set<string>();
+  for (const node of run.dagRun.graph.nodes) {
+    if (_isGatewayNode(node)) continue;
+    const state = run.dagRun.nodeStates.get(node.node_id);
+    if (state === "RUNNING") {
+      active.add(node.node_id);
+      continue;
+    }
+    if (state === "READY" && findDispatchTarget(run.runId, node.node_id)?.state === "provisioning") {
+      active.add(node.node_id);
+    }
+  }
+  return active;
+}
+
+function _hasDispatchCapacity(run: ActiveRun, nodeId: string): boolean {
+  const active = _activeDispatchNodeIds(run);
+  return active.has(nodeId) || active.size < run.limits.max_parallelism;
+}
+
 export function dispatchReadyNodes(
   runId: string,
   dispatcher: DAGDispatcher,
@@ -6349,6 +6380,8 @@ export function dispatchReadyNodes(
       if (run.status !== "active") break;
       continue;
     }
+
+    if (!_hasDispatchCapacity(run, nodeId)) continue;
 
     _prepareNodeSessionForDispatch(run, node);
 
@@ -6444,6 +6477,7 @@ export function markNodeDispatched(
   if (getNodeState(run.dagRun, nodeId) !== "READY") return false;
   const node = run.dagRun.graph.nodes.find((n) => n.node_id === nodeId);
   if (!node) return false;
+  if (_isGatewayNode(node) || !_hasDispatchCapacity(run, nodeId)) return false;
 
   const before = _snapshotNodeStates(run);
   _prepareNodeSessionForDispatch(run, node);
@@ -6463,6 +6497,8 @@ export function recordProvisionedNodeDispatchAttempt(
 ): boolean {
   const run = store.get(runId);
   if (!run || run.status !== "active" || getNodeState(run.dagRun, nodeId) !== "READY") return false;
+  const node = run.dagRun.graph.nodes.find((candidate) => candidate.node_id === nodeId);
+  if (!node || _isGatewayNode(node) || !_hasDispatchCapacity(run, nodeId)) return false;
   if (run.counters.dispatches >= run.limits.max_dispatches) {
     abortActiveRun(runId, `max_dispatches (${run.limits.max_dispatches}) exceeded`, nodeId);
     return false;

--- a/homerail_manager/tests/dag-parallelism.test.ts
+++ b/homerail_manager/tests/dag-parallelism.test.ts
@@ -8,7 +8,12 @@ import type {
   DispatchEnvelope,
   DispatchResult,
 } from "../src/orchestration/dag-dispatcher.js";
-import { _clearAllDispatches } from "../src/orchestration/dispatch-tracker.js";
+import { GraphExecutor } from "../src/orchestration/graph-executor.js";
+import {
+  _clearAllDispatches,
+  clearDispatchTarget,
+  recordProvisioning,
+} from "../src/orchestration/dispatch-tracker.js";
 import { parseDAGYaml } from "../src/orchestration/yaml-loader.js";
 import { parseWorkflowSource } from "../src/orchestration/workflow-spec-v1.js";
 import { closeDb } from "../src/persistence/db.js";
@@ -55,6 +60,23 @@ nodes:
   gamma:
     agent: worker
     outputs: { done: { to: "" } }
+`);
+}
+
+function fiveEntryDag(maxParallelism = 2) {
+  return parseDAGYaml(`
+name: workflow-parallelism-five
+workflow_id: workflow-parallelism-five
+limits:
+  max_parallelism: ${maxParallelism}
+agents:
+  worker: { agent_type: deterministic }
+nodes:
+  alpha: { agent: worker, outputs: { done: { to: "" } } }
+  beta: { agent: worker, outputs: { done: { to: "" } } }
+  gamma: { agent: worker, outputs: { done: { to: "" } } }
+  delta: { agent: worker, outputs: { done: { to: "" } } }
+  epsilon: { agent: worker, outputs: { done: { to: "" } } }
 `);
 }
 
@@ -172,6 +194,93 @@ spec:
     createActiveRun("bounded-after-cancel", threeEntryDag());
     expect(dispatchReadyNodes("bounded-after-cancel", afterCancel)).toBe(1);
     expect(afterCancel.dispatched.map((entry) => entry.nodeId)).toEqual(["alpha"]);
+  });
+
+  it("never admits more than two of five ready entry nodes", () => {
+    const runId = "bounded-five-entry";
+    const dispatcher = new CaptureDispatcher();
+    createActiveRun(runId, fiveEntryDag());
+
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(2);
+    expect(dispatcher.dispatched.map((entry) => entry.nodeId)).toEqual(["alpha", "beta"]);
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(0);
+
+    handoffActiveRun(runId, "alpha", "done", { ok: true });
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+    expect(dispatcher.dispatched.map((entry) => entry.nodeId)).toEqual(["alpha", "beta", "delta"]);
+    expect(Array.from(getActiveRun(runId)!.dagRun.nodeStates.values()).filter((state) => state === "RUNNING"))
+      .toHaveLength(2);
+  });
+
+  it("reserves workflow capacity while an asynchronous Worker is provisioning", () => {
+    const runId = "bounded-provisioning";
+    const dispatcher = new CaptureDispatcher();
+    createActiveRun(runId, threeEntryDag());
+    recordProvisioning(runId, "alpha");
+
+    const provisioningAwareDispatcher: DAGDispatcher = {
+      dispatch(envelope) {
+        if (envelope.nodeId === "alpha") {
+          return { status: "skipped", reason: "provisioning_in_progress" };
+        }
+        return dispatcher.dispatch(envelope);
+      },
+    };
+    expect(dispatchReadyNodes(runId, provisioningAwareDispatcher)).toBe(0);
+    expect(dispatcher.dispatched).toEqual([]);
+
+    clearDispatchTarget(runId, "alpha");
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+    expect(dispatcher.dispatched.map((entry) => entry.nodeId)).toEqual(["alpha"]);
+  });
+
+  it("composes the workflow limit with a larger fan-out-local limit", () => {
+    const parsed = parseWorkflowSource(`
+api_version: homerail.ai/v1
+kind: Workflow
+metadata: { id: layered-runtime, name: Layered Runtime }
+spec:
+  policies: { max_parallelism: 1 }
+  contracts:
+    Items: { type: array }
+    WorkerResult: { type: object }
+  agents: { worker: { system: Work. } }
+  nodes:
+    fan:
+      kind: fanout
+      inputs: { items: { contract: Items } }
+      outputs: { passed: {}, failed: {} }
+      config:
+        input: items
+        worker_agent: worker
+        max_items: 3
+        max_parallelism: 2
+        completion: all
+        result_contract: WorkerResult
+        result_port: passed
+        failed_port: failed
+    done: { kind: terminal, outcome: success, inputs: { result: {} } }
+    failed: { kind: terminal, outcome: failure, inputs: { result: {} } }
+  edges:
+    - { from: $run.input, to: fan.items }
+    - { from: fan.passed, to: done.result }
+    - { from: fan.failed, to: failed.result, condition: on_failure }
+`);
+    parsed.meta.agents!.worker.agent_type = "deterministic";
+    const dispatcher = new CaptureDispatcher();
+    const executor = new GraphExecutor(dispatcher);
+    executor.createRun("layered-runtime-run", parsed, JSON.stringify(["a", "b", "c"]));
+
+    expect(executor.tick("layered-runtime-run")).toBe(2);
+    expect(dispatcher.dispatched.map((entry) => entry.nodeId)).toEqual(["fan__item_0001"]);
+    expect(getActiveRun("layered-runtime-run")?.dagRun.nodeStates.get("fan__item_0002")).toBe("READY");
+
+    handoffActiveRun("layered-runtime-run", "fan__item_0001", "result", { ok: true });
+    expect(executor.tick("layered-runtime-run")).toBe(1);
+    expect(dispatcher.dispatched.map((entry) => entry.nodeId)).toEqual([
+      "fan__item_0001",
+      "fan__item_0002",
+    ]);
   });
 
   it("enforces the same limit for direct dispatch admission", () => {

--- a/homerail_manager/tests/dag-parallelism.test.ts
+++ b/homerail_manager/tests/dag-parallelism.test.ts
@@ -1,0 +1,205 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type {
+  DAGDispatcher,
+  DispatchEnvelope,
+  DispatchResult,
+} from "../src/orchestration/dag-dispatcher.js";
+import { _clearAllDispatches } from "../src/orchestration/dispatch-tracker.js";
+import { parseDAGYaml } from "../src/orchestration/yaml-loader.js";
+import { parseWorkflowSource } from "../src/orchestration/workflow-spec-v1.js";
+import { closeDb } from "../src/persistence/db.js";
+import { _clearAllPersistence } from "../src/persistence/store.js";
+import {
+  _clearActiveRuns,
+  cancelActiveRun,
+  createActiveRun,
+  dispatchReadyNodes,
+  dispatchRecoveredRuns,
+  failActiveRun,
+  getActiveRun,
+  handoffActiveRun,
+  markNodeDispatched,
+  recoverAllActiveRuns,
+  requestNodeCorrection,
+} from "../src/runtime/active-runs.js";
+
+class CaptureDispatcher implements DAGDispatcher {
+  readonly dispatched: DispatchEnvelope[] = [];
+
+  dispatch(envelope: DispatchEnvelope): DispatchResult {
+    this.dispatched.push(envelope);
+    return { status: "dispatched", targetType: "fake", targetId: "fake" };
+  }
+}
+
+function threeEntryDag(maxParallelism = 1) {
+  return parseDAGYaml(`
+name: workflow-parallelism
+workflow_id: workflow-parallelism
+limits:
+  max_parallelism: ${maxParallelism}
+  max_corrections_per_node: 1
+agents:
+  worker: { agent_type: deterministic }
+nodes:
+  alpha:
+    agent: worker
+    outputs: { done: { to: "" } }
+  beta:
+    agent: worker
+    outputs: { done: { to: "" } }
+  gamma:
+    agent: worker
+    outputs: { done: { to: "" } }
+`);
+}
+
+describe("workflow max_parallelism", () => {
+  let tmpHome: string;
+  let previousHome: string | undefined;
+
+  beforeEach(() => {
+    previousHome = process.env.HOMERAIL_HOME;
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-parallelism-"));
+    process.env.HOMERAIL_HOME = tmpHome;
+    closeDb();
+    _clearActiveRuns();
+    _clearAllDispatches();
+    _clearAllPersistence();
+  });
+
+  afterEach(() => {
+    _clearActiveRuns();
+    _clearAllDispatches();
+    closeDb();
+    if (previousHome === undefined) delete process.env.HOMERAIL_HOME;
+    else process.env.HOMERAIL_HOME = previousHome;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("projects WorkflowSpec policies.max_parallelism into runtime limits", () => {
+    const parsed = parseWorkflowSource(`
+api_version: homerail.ai/v1
+kind: Workflow
+metadata: { id: projected-parallelism, name: Projected Parallelism }
+spec:
+  policies: { max_parallelism: 1 }
+  contracts: { Task: { type: string } }
+  agents: { worker: { system: Work. } }
+  nodes:
+    work:
+      kind: agent
+      agent: worker
+      inputs: { task: { contract: Task } }
+      outputs: { result: {} }
+    done: { kind: terminal, outcome: success, inputs: { result: {} } }
+  edges:
+    - { from: $run.input, to: work.task }
+    - { from: work.result, to: done.result }
+`);
+
+    expect(parsed.meta.limits).toMatchObject({ max_parallelism: 1 });
+  });
+
+  it("keeps workflow and fan-out parallelism as independent limits", () => {
+    const parsed = parseWorkflowSource(`
+api_version: homerail.ai/v1
+kind: Workflow
+metadata: { id: layered-parallelism, name: Layered Parallelism }
+spec:
+  policies: { max_parallelism: 1 }
+  contracts: { Items: { type: array } }
+  agents: { worker: { system: Work. } }
+  nodes:
+    fan:
+      kind: fanout
+      inputs: { items: { contract: Items } }
+      outputs: { passed: {}, failed: {} }
+      config:
+        input: items
+        worker_agent: worker
+        max_items: 3
+        max_parallelism: 3
+        completion: all
+        result_port: passed
+        failed_port: failed
+    done: { kind: terminal, outcome: success, inputs: { result: {} } }
+    failed: { kind: terminal, outcome: failure, inputs: { result: {} } }
+  edges:
+    - { from: $run.input, to: fan.items }
+    - { from: fan.passed, to: done.result }
+    - { from: fan.failed, to: failed.result, condition: on_failure }
+`);
+
+    expect(parsed.meta.limits).toMatchObject({ max_parallelism: 1 });
+    expect(parsed.graph.nodes.find((node) => node.node_id === "fan")?.gateway_config)
+      .toMatchObject({ max_parallelism: 3 });
+  });
+
+  it("admits only one of three ready entry nodes and releases capacity on retry, terminal, and cancellation", () => {
+    const runId = "bounded-three-entry";
+    const dispatcher = new CaptureDispatcher();
+    createActiveRun(runId, threeEntryDag());
+
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+    expect(dispatcher.dispatched.map((entry) => entry.nodeId)).toEqual(["alpha"]);
+    expect(Array.from(getActiveRun(runId)!.dagRun.nodeStates.values()).filter((state) => state === "RUNNING"))
+      .toHaveLength(1);
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(0);
+
+    expect(requestNodeCorrection(runId, "alpha", "retry the same actor")).toMatchObject({ status: "scheduled" });
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+    expect(dispatcher.dispatched.map((entry) => entry.nodeId)).toEqual(["alpha", "alpha"]);
+    expect(Array.from(getActiveRun(runId)!.dagRun.nodeStates.values()).filter((state) => state === "RUNNING"))
+      .toHaveLength(1);
+
+    handoffActiveRun(runId, "alpha", "done", { ok: true });
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+    expect(dispatcher.dispatched.at(-1)?.nodeId).toBe("beta");
+
+    failActiveRun(runId, "beta", "expected test failure");
+    expect(dispatchReadyNodes(runId, dispatcher)).toBe(1);
+    expect(dispatcher.dispatched.at(-1)?.nodeId).toBe("gamma");
+    expect(Array.from(getActiveRun(runId)!.dagRun.nodeStates.values()).filter((state) => state === "RUNNING"))
+      .toHaveLength(1);
+
+    expect(cancelActiveRun(runId)?.status).toBe("cancelled");
+    const afterCancel = new CaptureDispatcher();
+    createActiveRun("bounded-after-cancel", threeEntryDag());
+    expect(dispatchReadyNodes("bounded-after-cancel", afterCancel)).toBe(1);
+    expect(afterCancel.dispatched.map((entry) => entry.nodeId)).toEqual(["alpha"]);
+  });
+
+  it("enforces the same limit for direct dispatch admission", () => {
+    const runId = "bounded-direct-admission";
+    createActiveRun(runId, threeEntryDag());
+
+    expect(markNodeDispatched(runId, "alpha")).toBe(true);
+    expect(markNodeDispatched(runId, "beta")).toBe(false);
+
+    handoffActiveRun(runId, "alpha", "done", { ok: true });
+    expect(markNodeDispatched(runId, "beta")).toBe(true);
+  });
+
+  it("restores the limit without leaking an orphaned running slot", () => {
+    const runId = "bounded-recovery";
+    const beforeRestart = new CaptureDispatcher();
+    createActiveRun(runId, threeEntryDag());
+    expect(dispatchReadyNodes(runId, beforeRestart)).toBe(1);
+
+    _clearActiveRuns();
+    const recovery = recoverAllActiveRuns();
+    expect(recovery.recovered).toEqual([runId]);
+    expect(getActiveRun(runId)).toMatchObject({ limits: { max_parallelism: 1 } });
+
+    const afterRestart = new CaptureDispatcher();
+    expect(dispatchRecoveredRuns(afterRestart)).toBe(1);
+    expect(afterRestart.dispatched.map((entry) => entry.nodeId)).toEqual(["beta"]);
+    expect(Array.from(getActiveRun(runId)!.dagRun.nodeStates.values()).filter((state) => state === "RUNNING"))
+      .toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Implements #246

## Summary

Compile WorkflowSpec `policies.max_parallelism` into the per-run limits and enforce it at every Actor admission path.

The scheduler derives occupied capacity from logical non-gateway `RUNNING` Actors plus `READY` nodes with asynchronous provisioning reservations. It does not maintain a separate release-token counter, avoiding terminal/cancel/retry slot leaks. Fanout gateways do not consume an Actor slot; fanout-local `config.max_parallelism` remains independent while dynamic children still obey the workflow-wide bound.

## Owned paths

- `homerail_manager/src/orchestration/workflow-spec-v1.ts`
- `homerail_manager/src/runtime/active-runs.ts`
- `homerail_manager/tests/dag-parallelism.test.ts`

## Verification

- `npm exec vitest -- run tests/dag-parallelism.test.ts --maxWorkers=1`
  - 1 file passed; 5 tests passed; exit 0.
- `npm exec vitest -- run tests/dag-parallelism.test.ts tests/workflow-spec-v1.test.ts tests/workflow-spec-runtime.test.ts tests/cold-recovery.test.ts tests/dispatch-capabilities.test.ts --maxWorkers=1`
  - 5 files passed; 108 tests passed; exit 0.
- root `npm run typecheck`
  - all seven packages passed; exit 0.
- root `npm run build:packages`
  - all seven packages built; exit 0 (existing Vite chunk/browser-data warnings only).
- Full Manager serial rerun
  - 156 files passed / 1 skipped; 1426 tests passed / 2 skipped; exit 0.
  - The Docker daemon also printed the pre-existing diagnostic `No such image: homerail-plugin-runtime:m6`; the suite still completed successfully.
- Full root `npm run ci` under an isolated Node.js 22.23.2 runtime
  - protocol, SDK, Manager, Node, Worker, CLI, Agent UI, and live-validator stages passed; exit 0.
  - Manager: 156 files passed / 1 skipped; 1426 tests passed / 2 skipped.
- `git diff HEAD^ HEAD --check`
  - exit 0.

## Residual limits

This is logical admission inside one authoritative Manager process. It is not a distributed semaphore across multiple Managers. Existing workflows that omit the policy resolve to the maintained default of 32.
