### PR TITLE
Fix credential broker mutation lifetime fencing

### DIFF
--- a/homerail_manager/src/index.ts
+++ b/homerail_manager/src/index.ts
@@ -12,6 +12,7 @@ import {
 } from "./generative-ui/dag-live-surface-projector.js";
 import { getDagEnvironmentController } from "./server/dag-environment.js";
 import { HOMERAIL_PLUGIN_SDK_ABI_VERSION } from "homerail-plugin-sdk";
+import { recoverCredentialBrokerMutations } from "./runtime/credential-broker.js";
 
 // Precondition: this check itself only runs when the Manager dist is current.
 // A stale Manager dist would not contain this guard at all. The check targets
@@ -36,6 +37,10 @@ const dagEnvironment = getDagEnvironmentController();
 // Cold recovery: replay persisted active runs into the in-memory store before
 // the server accepts traffic. The first-worker hook (wired in createServer)
 // re-dispatches their READY nodes once a worker reconnects.
+// Resolve durable mutation attempts before restoring RUNNING gateways. This
+// lets ActiveRun recovery consume a known completed result instead of
+// replaying an external side effect.
+const brokerRecovery = await recoverCredentialBrokerMutations();
 const recovery = recoverAllActiveRuns();
 // Intervention Inbox rows are replayed only after their logical runs and
 // Actors exist again. Applying is transactionally idempotent.
@@ -59,6 +64,9 @@ server.listen(port, host, () => {
   console.error(`homerail_manager listening on ${host}:${port}`);
   console.error(
     `cold recovery: recovered=${recovery.recovered.length} failed=${recovery.failed.length} skipped=${recovery.skipped.length}`,
+  );
+  console.error(
+    `credential broker recovery: reconciled=${brokerRecovery.reconciled.length} unresolved=${brokerRecovery.unresolved.length} failed=${brokerRecovery.failed.length}`,
   );
   for (const failure of recovery.failed) {
     console.error(

--- a/homerail_manager/src/orchestration/response-bridge.ts
+++ b/homerail_manager/src/orchestration/response-bridge.ts
@@ -29,6 +29,14 @@ export interface DagTransportFenceSource {
   targetId: string;
 }
 
+export interface DagTransportFenceAssessmentOptions {
+  /**
+   * Ordinary streaming traffic may renew the current physical lease. Broker
+   * authority checks must pass false: an expired mutation lease fails closed.
+   */
+  renewExpiredLease?: boolean;
+}
+
 export type ResponseBridgeResult =
   | { status: "handoff_applied"; runId: string; nodeId: string; port: string }
   | {
@@ -88,6 +96,7 @@ function ignored(
 export function assessDagTransportFence(
   payload: unknown,
   source: DagTransportFenceSource,
+  options: DagTransportFenceAssessmentOptions = {},
 ): TransportFenceAssessment {
   if (typeof payload !== "object" || payload === null || Array.isArray(payload)) {
     return { status: "malformed_payload", reason: "payload is not an object" };
@@ -127,7 +136,13 @@ export function assessDagTransportFence(
     target_id: source.targetId,
   };
   let lease = assessDagActorLease(leaseInput);
-  if (!lease.current && lease.reason === "expired" && run.status === "active" && lease.lease) {
+  if (
+    options.renewExpiredLease !== false
+    && !lease.current
+    && lease.reason === "expired"
+    && run.status === "active"
+    && lease.lease
+  ) {
     try {
       acquireDagActorLease({
         run_id: runId,

--- a/homerail_manager/src/persistence/credential-broker-mutations.ts
+++ b/homerail_manager/src/persistence/credential-broker-mutations.ts
@@ -1,0 +1,448 @@
+import type { DagCredentialBrokerCallRequest } from "homerail-protocol";
+import { encodeJson, getDb, parseJsonRow } from "./db.js";
+import { nowIso } from "./time.js";
+
+export type CredentialBrokerMutationState =
+  | "prepared"
+  | "dispatched"
+  | "completed"
+  | "failed_pre_dispatch"
+  | "cancelled"
+  | "cancel_requested"
+  | "indeterminate"
+  | "reconciled";
+
+export type CredentialBrokerMutationResolution = "completed" | "absent" | "failed";
+
+interface MutationAttemptRow {
+  request_id: string;
+  idempotency_key: string;
+  request_digest: string;
+  semantic_target: string;
+  source_type: "worker_actor" | "manager_gateway";
+  source_id: string;
+  run_id: string;
+  node_id: string;
+  session_id: string;
+  round_id: string;
+  actor_id: string | null;
+  generation: number | null;
+  lease_generation: number | null;
+  command_id: string | null;
+  gateway_attempt: number | null;
+  credential_ref: string;
+  broker: string;
+  action: string;
+  state: CredentialBrokerMutationState;
+  request_json: string;
+  provider_state_json: string | null;
+  result_json: string | null;
+  error_message: string | null;
+  resolution: CredentialBrokerMutationResolution | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CredentialBrokerMutationAttempt {
+  request_id: string;
+  idempotency_key: string;
+  request_digest: string;
+  semantic_target: string;
+  source_type: "worker_actor" | "manager_gateway";
+  source_id: string;
+  run_id: string;
+  node_id: string;
+  session_id: string;
+  round_id: string;
+  actor_id?: string;
+  generation?: number;
+  lease_generation?: number;
+  command_id?: string;
+  gateway_attempt?: number;
+  credential_ref: string;
+  broker: string;
+  action: string;
+  state: CredentialBrokerMutationState;
+  request: DagCredentialBrokerCallRequest;
+  provider_state?: Record<string, unknown>;
+  result?: unknown;
+  error_message?: string;
+  resolution?: CredentialBrokerMutationResolution;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PrepareCredentialBrokerMutationInput {
+  request: DagCredentialBrokerCallRequest;
+  request_digest: string;
+  semantic_target: string;
+  source_id: string;
+}
+
+export type PrepareCredentialBrokerMutationResult =
+  | { status: "created"; attempt: CredentialBrokerMutationAttempt }
+  | { status: "duplicate"; attempt: CredentialBrokerMutationAttempt }
+  | { status: "blocked"; attempt: CredentialBrokerMutationAttempt };
+
+const MAX_REQUEST_BYTES = 2_200_000;
+const MAX_PROVIDER_STATE_BYTES = 128 * 1024;
+const MAX_RESULT_BYTES = 256 * 1024;
+
+function boundedJson(value: unknown, maxBytes: number, label: string): string {
+  const encoded = encodeJson(value);
+  if (Buffer.byteLength(encoded, "utf8") > maxBytes) throw new Error(`${label} exceeds ${maxBytes} bytes`);
+  return encoded;
+}
+
+function boundedError(value: string | undefined): string | null {
+  if (!value) return null;
+  return value.replace(/[\u0000-\u001f\u007f]/g, " ").slice(0, 1_000);
+}
+
+function rowByRequestId(requestId: string): MutationAttemptRow | undefined {
+  return getDb().prepare(`
+    SELECT request_id, idempotency_key, request_digest, semantic_target,
+           source_type, source_id, run_id, node_id, session_id, round_id,
+           actor_id, generation, lease_generation, command_id, gateway_attempt,
+           credential_ref, broker, action, state, request_json, provider_state_json,
+           result_json, error_message, resolution, created_at, updated_at
+    FROM credential_broker_mutation_attempts
+    WHERE request_id = ?
+  `).get(requestId) as MutationAttemptRow | undefined;
+}
+
+function decodeRow(row: MutationAttemptRow): CredentialBrokerMutationAttempt {
+  const request = parseJsonRow<DagCredentialBrokerCallRequest>(row.request_json);
+  if (
+    !request
+    || request.request_id !== row.request_id
+    || request.idempotency_key !== row.idempotency_key
+    || request.transport_kind !== row.source_type
+    || request.run_id !== row.run_id
+    || request.node_id !== row.node_id
+    || request.session_id !== row.session_id
+    || request.round_id !== row.round_id
+    || request.credential_ref !== row.credential_ref
+    || request.broker !== row.broker
+    || request.action !== row.action
+  ) throw new Error(`Invalid persisted credential broker mutation attempt: ${row.request_id}`);
+  const providerState = row.provider_state_json === null
+    ? undefined
+    : parseJsonRow<Record<string, unknown>>(row.provider_state_json);
+  const result = row.result_json === null ? undefined : parseJsonRow<unknown>(row.result_json);
+  return {
+    request_id: row.request_id,
+    idempotency_key: row.idempotency_key,
+    request_digest: row.request_digest,
+    semantic_target: row.semantic_target,
+    source_type: row.source_type,
+    source_id: row.source_id,
+    run_id: row.run_id,
+    node_id: row.node_id,
+    session_id: row.session_id,
+    round_id: row.round_id,
+    ...(row.actor_id === null ? {} : { actor_id: row.actor_id }),
+    ...(row.generation === null ? {} : { generation: row.generation }),
+    ...(row.lease_generation === null ? {} : { lease_generation: row.lease_generation }),
+    ...(row.command_id === null ? {} : { command_id: row.command_id }),
+    ...(row.gateway_attempt === null ? {} : { gateway_attempt: row.gateway_attempt }),
+    credential_ref: row.credential_ref,
+    broker: row.broker,
+    action: row.action,
+    state: row.state,
+    request,
+    ...(providerState === undefined ? {} : { provider_state: providerState }),
+    ...(result === undefined ? {} : { result }),
+    ...(row.error_message === null ? {} : { error_message: row.error_message }),
+    ...(row.resolution === null ? {} : { resolution: row.resolution }),
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+function appendEvent(
+  requestId: string,
+  requestDigest: string,
+  state: CredentialBrokerMutationState,
+  detail: Record<string, unknown> = {},
+): void {
+  getDb().prepare(`
+    INSERT INTO credential_broker_mutation_events(
+      request_id, request_digest, state, detail_json, created_at
+    ) VALUES (?, ?, ?, ?, ?)
+  `).run(requestId, requestDigest, state, boundedJson(detail, 32 * 1024, "Broker mutation event"), nowIso());
+}
+
+export function getCredentialBrokerMutationAttempt(
+  requestId: string,
+): CredentialBrokerMutationAttempt | undefined {
+  const row = rowByRequestId(requestId);
+  return row ? decodeRow(row) : undefined;
+}
+
+export function listUnresolvedCredentialBrokerMutations(limit = 64): CredentialBrokerMutationAttempt[] {
+  const boundedLimit = Math.max(1, Math.min(256, Math.floor(limit)));
+  const rows = getDb().prepare(`
+    SELECT request_id, idempotency_key, request_digest, semantic_target,
+           source_type, source_id, run_id, node_id, session_id, round_id,
+           actor_id, generation, lease_generation, command_id, gateway_attempt,
+           credential_ref, broker, action, state, request_json, provider_state_json,
+           result_json, error_message, resolution, created_at, updated_at
+    FROM credential_broker_mutation_attempts
+    WHERE state IN ('prepared', 'dispatched', 'cancel_requested', 'indeterminate')
+    ORDER BY created_at, request_id
+    LIMIT ?
+  `).all(boundedLimit) as MutationAttemptRow[];
+  return rows.map(decodeRow);
+}
+
+export function prepareCredentialBrokerMutation(
+  input: PrepareCredentialBrokerMutationInput,
+): PrepareCredentialBrokerMutationResult {
+  if (!/^[a-f0-9]{64}$/.test(input.request_digest)) throw new Error("Broker request digest must be SHA-256");
+  if (!input.semantic_target || input.semantic_target.length > 1_024) {
+    throw new Error("Broker semantic target must be 1-1024 characters");
+  }
+  if (!input.source_id || input.source_id.length > 256) throw new Error("Broker source id is invalid");
+  const requestJson = boundedJson(input.request, MAX_REQUEST_BYTES, "Broker mutation request");
+  return getDb().transaction(() => {
+    const byRequest = rowByRequestId(input.request.request_id);
+    const byIdempotency = getDb().prepare(`
+      SELECT request_id, idempotency_key, request_digest, semantic_target,
+             source_type, source_id, run_id, node_id, session_id, round_id,
+             actor_id, generation, lease_generation, command_id, gateway_attempt,
+             credential_ref, broker, action, state, request_json, provider_state_json,
+             result_json, error_message, resolution, created_at, updated_at
+      FROM credential_broker_mutation_attempts
+      WHERE credential_ref = ? AND broker = ? AND action = ? AND idempotency_key = ?
+    `).get(
+      input.request.credential_ref,
+      input.request.broker,
+      input.request.action,
+      input.request.idempotency_key,
+    ) as MutationAttemptRow | undefined;
+    const existing = byRequest ?? byIdempotency;
+    if (existing) {
+      if (
+        existing.request_id !== input.request.request_id
+        || existing.request_digest !== input.request_digest
+        || existing.idempotency_key !== input.request.idempotency_key
+      ) throw new Error("Credential broker mutation idempotency collision");
+      return { status: "duplicate" as const, attempt: decodeRow(existing) };
+    }
+    const unresolved = getDb().prepare(`
+      SELECT request_id, idempotency_key, request_digest, semantic_target,
+             source_type, source_id, run_id, node_id, session_id, round_id,
+             actor_id, generation, lease_generation, command_id, gateway_attempt,
+             credential_ref, broker, action, state, request_json, provider_state_json,
+             result_json, error_message, resolution, created_at, updated_at
+      FROM credential_broker_mutation_attempts
+      WHERE credential_ref = ? AND broker = ? AND semantic_target = ?
+        AND state IN ('prepared', 'dispatched', 'cancel_requested', 'indeterminate')
+      ORDER BY created_at, request_id
+      LIMIT 1
+    `).get(
+      input.request.credential_ref,
+      input.request.broker,
+      input.semantic_target,
+    ) as MutationAttemptRow | undefined;
+    if (unresolved) return { status: "blocked" as const, attempt: decodeRow(unresolved) };
+
+    const now = nowIso();
+    getDb().prepare(`
+      INSERT INTO credential_broker_mutation_attempts(
+        request_id, idempotency_key, request_digest, semantic_target,
+        source_type, source_id, run_id, node_id, session_id, round_id,
+        actor_id, generation, lease_generation, command_id, gateway_attempt,
+        credential_ref, broker, action, state, request_json, provider_state_json,
+        result_json, error_message, resolution, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                'prepared', ?, NULL, NULL, NULL, NULL, ?, ?)
+    `).run(
+      input.request.request_id,
+      input.request.idempotency_key,
+      input.request_digest,
+      input.semantic_target,
+      input.request.transport_kind,
+      input.source_id,
+      input.request.run_id,
+      input.request.node_id,
+      input.request.session_id,
+      input.request.round_id,
+      input.request.actor_id ?? null,
+      input.request.generation ?? null,
+      input.request.lease_generation ?? null,
+      input.request.command_id ?? null,
+      input.request.gateway_attempt ?? null,
+      input.request.credential_ref,
+      input.request.broker,
+      input.request.action,
+      requestJson,
+      now,
+      now,
+    );
+    appendEvent(input.request.request_id, input.request_digest, "prepared", {
+      source_type: input.request.transport_kind,
+      semantic_target: input.semantic_target,
+    });
+    return { status: "created" as const, attempt: decodeRow(rowByRequestId(input.request.request_id)!) };
+  }).immediate();
+}
+
+function transition(
+  requestId: string,
+  from: readonly CredentialBrokerMutationState[],
+  to: CredentialBrokerMutationState,
+  options: {
+    result?: unknown;
+    error?: string;
+    resolution?: CredentialBrokerMutationResolution;
+    detail?: Record<string, unknown>;
+  } = {},
+): CredentialBrokerMutationAttempt {
+  return getDb().transaction(() => {
+    const existing = rowByRequestId(requestId);
+    if (!existing) throw new Error(`Unknown credential broker mutation attempt: ${requestId}`);
+    if (!from.includes(existing.state)) {
+      if (existing.state === to) return decodeRow(existing);
+      throw new Error(`Invalid credential broker mutation transition: ${existing.state} -> ${to}`);
+    }
+    const resultJson = options.result === undefined
+      ? existing.result_json
+      : boundedJson(options.result, MAX_RESULT_BYTES, "Broker mutation result");
+    const updatedAt = nowIso();
+    const placeholders = from.map(() => "?").join(", ");
+    const updated = getDb().prepare(`
+      UPDATE credential_broker_mutation_attempts
+      SET state = ?, result_json = ?, error_message = ?, resolution = ?, updated_at = ?
+      WHERE request_id = ? AND state IN (${placeholders})
+    `).run(
+      to,
+      resultJson,
+      boundedError(options.error) ?? existing.error_message,
+      options.resolution ?? existing.resolution,
+      updatedAt,
+      requestId,
+      ...from,
+    );
+    if (updated.changes !== 1) throw new Error("Credential broker mutation status conflict");
+    appendEvent(requestId, existing.request_digest, to, options.detail ?? {
+      ...(options.resolution ? { resolution: options.resolution } : {}),
+    });
+    return decodeRow(rowByRequestId(requestId)!);
+  }).immediate();
+}
+
+export function dispatchCredentialBrokerMutation(requestId: string): CredentialBrokerMutationAttempt {
+  return transition(requestId, ["prepared"], "dispatched");
+}
+
+export function completeCredentialBrokerMutation(
+  requestId: string,
+  result: unknown,
+): CredentialBrokerMutationAttempt {
+  return transition(requestId, ["dispatched"], "completed", { result });
+}
+
+export function failCredentialBrokerMutationBeforeDispatch(
+  requestId: string,
+  error: string,
+): CredentialBrokerMutationAttempt {
+  return transition(requestId, ["prepared"], "failed_pre_dispatch", { error });
+}
+
+export function cancelCredentialBrokerMutationAttempt(
+  requestId: string,
+  reason: string,
+): CredentialBrokerMutationAttempt {
+  const existing = getCredentialBrokerMutationAttempt(requestId);
+  if (!existing) throw new Error(`Unknown credential broker mutation attempt: ${requestId}`);
+  if (existing.state === "prepared") {
+    return transition(requestId, ["prepared"], "cancelled", { error: reason });
+  }
+  if (existing.state === "dispatched") {
+    return transition(requestId, ["dispatched"], "cancel_requested", { error: reason });
+  }
+  return existing;
+}
+
+export function markCredentialBrokerMutationIndeterminate(
+  requestId: string,
+  error: string,
+): CredentialBrokerMutationAttempt {
+  return transition(requestId, ["dispatched", "cancel_requested"], "indeterminate", { error });
+}
+
+export function reconcileCredentialBrokerMutation(
+  requestId: string,
+  resolution: CredentialBrokerMutationResolution,
+  options: { result?: unknown; error?: string } = {},
+): CredentialBrokerMutationAttempt {
+  return transition(
+    requestId,
+    ["dispatched", "cancel_requested", "indeterminate"],
+    "reconciled",
+    { ...options, resolution },
+  );
+}
+
+export function checkpointCredentialBrokerMutation(
+  requestId: string,
+  patch: Record<string, unknown>,
+): CredentialBrokerMutationAttempt {
+  return getDb().transaction(() => {
+    const existing = rowByRequestId(requestId);
+    if (!existing) throw new Error(`Unknown credential broker mutation attempt: ${requestId}`);
+    if (!["prepared", "dispatched", "cancel_requested", "indeterminate"].includes(existing.state)) {
+      throw new Error(`Credential broker mutation ${requestId} is already terminal`);
+    }
+    const current = existing.provider_state_json === null
+      ? {}
+      : parseJsonRow<Record<string, unknown>>(existing.provider_state_json);
+    const providerStateJson = boundedJson(
+      { ...current, ...structuredClone(patch) },
+      MAX_PROVIDER_STATE_BYTES,
+      "Broker provider state",
+    );
+    const updated = getDb().prepare(`
+      UPDATE credential_broker_mutation_attempts
+      SET provider_state_json = ?, updated_at = ?
+      WHERE request_id = ? AND state = ?
+    `).run(providerStateJson, nowIso(), requestId, existing.state);
+    if (updated.changes !== 1) throw new Error("Credential broker mutation checkpoint conflict");
+    appendEvent(requestId, existing.request_digest, existing.state, {
+      checkpoint_fields: Object.keys(patch).sort(),
+    });
+    return decodeRow(rowByRequestId(requestId)!);
+  }).immediate();
+}
+
+/** Terminal known completion for an exact Manager gateway fence during cold recovery. */
+export function findCompletedManagerGatewayMutation(input: {
+  run_id: string;
+  node_id: string;
+  session_id: string;
+  round_id: string;
+  gateway_attempt: number;
+}): CredentialBrokerMutationAttempt | undefined {
+  const row = getDb().prepare(`
+    SELECT request_id, idempotency_key, request_digest, semantic_target,
+           source_type, source_id, run_id, node_id, session_id, round_id,
+           actor_id, generation, lease_generation, command_id, gateway_attempt,
+           credential_ref, broker, action, state, request_json, provider_state_json,
+           result_json, error_message, resolution, created_at, updated_at
+    FROM credential_broker_mutation_attempts
+    WHERE source_type = 'manager_gateway' AND run_id = ? AND node_id = ?
+      AND session_id = ? AND round_id = ? AND gateway_attempt = ?
+      AND (state = 'completed' OR (state = 'reconciled' AND resolution = 'completed'))
+    ORDER BY updated_at DESC, request_id DESC
+    LIMIT 1
+  `).get(
+    input.run_id,
+    input.node_id,
+    input.session_id,
+    input.round_id,
+    input.gateway_attempt,
+  ) as MutationAttemptRow | undefined;
+  return row ? decodeRow(row) : undefined;
+}

--- a/homerail_manager/src/persistence/db.ts
+++ b/homerail_manager/src/persistence/db.ts
@@ -2101,6 +2101,44 @@ function validateDagReviewEvidenceSchemaV36(db: SqliteDatabase): void {
   }
 }
 
+function validateCredentialBrokerMutationSchemaV37(db: SqliteDatabase): void {
+  for (const table of ["credential_broker_mutation_attempts", "credential_broker_mutation_events"]) {
+    if (!hasTable(db, table)) throw new Error(`Schema migration 37 is incomplete: missing table ${table}`);
+  }
+  for (const column of [
+    "request_id", "idempotency_key", "request_digest", "semantic_target",
+    "source_type", "source_id", "run_id", "node_id", "session_id", "round_id",
+    "actor_id", "generation", "lease_generation", "command_id", "gateway_attempt",
+    "credential_ref", "broker", "action", "state", "request_json",
+    "provider_state_json", "result_json", "error_message", "resolution",
+    "created_at", "updated_at",
+  ]) {
+    if (!hasColumn(db, "credential_broker_mutation_attempts", column)) {
+      throw new Error(`Schema migration 37 is incomplete: mutation attempts is missing column ${column}`);
+    }
+  }
+  const indexes = new Map((db.prepare(
+    "PRAGMA index_list(credential_broker_mutation_attempts)",
+  ).all() as Array<{ name: string; unique: number; partial: number }>).map((entry) => [entry.name, entry]));
+  const idempotency = indexes.get("idx_credential_broker_mutation_idempotency");
+  if (!idempotency || idempotency.unique !== 1) {
+    throw new Error("Schema migration 37 is incomplete: mutation idempotency index is missing");
+  }
+  const unresolved = indexes.get("idx_credential_broker_mutation_unresolved_target");
+  if (!unresolved || unresolved.unique !== 1 || unresolved.partial !== 1) {
+    throw new Error("Schema migration 37 is incomplete: unresolved semantic target index is invalid");
+  }
+  for (const trigger of [
+    "trg_credential_broker_mutation_identity_immutable",
+    "trg_credential_broker_mutation_events_no_update",
+    "trg_credential_broker_mutation_events_no_delete",
+  ]) {
+    if (!db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'trigger' AND name = ?").get(trigger)) {
+      throw new Error(`Schema migration 37 is incomplete: missing trigger ${trigger}`);
+    }
+  }
+}
+
 function validateGenerativeUiSchemaV3(db: SqliteDatabase): void {
   const requiredColumns: Record<string, readonly string[]> = {
     generative_ui_documents: [
@@ -4380,6 +4418,99 @@ const SCHEMA_MIGRATIONS: readonly SchemaMigration[] = [
         );
     `),
     validate: validateDagReviewEvidenceSchemaV36,
+  },
+  {
+    version: 37,
+    up: (db) => db.exec(`
+      CREATE TABLE IF NOT EXISTS credential_broker_mutation_attempts (
+        request_id TEXT PRIMARY KEY CHECK(length(request_id) BETWEEN 1 AND 256),
+        idempotency_key TEXT NOT NULL CHECK(length(idempotency_key) BETWEEN 1 AND 256),
+        request_digest TEXT NOT NULL CHECK(
+          length(request_digest) = 64 AND request_digest NOT GLOB '*[^0-9a-f]*'
+        ),
+        semantic_target TEXT NOT NULL CHECK(length(semantic_target) BETWEEN 1 AND 1024),
+        source_type TEXT NOT NULL CHECK(source_type IN ('worker_actor', 'manager_gateway')),
+        source_id TEXT NOT NULL CHECK(length(source_id) BETWEEN 1 AND 256),
+        run_id TEXT NOT NULL CHECK(length(run_id) BETWEEN 1 AND 256),
+        node_id TEXT NOT NULL CHECK(length(node_id) BETWEEN 1 AND 256),
+        session_id TEXT NOT NULL CHECK(length(session_id) BETWEEN 1 AND 256),
+        round_id TEXT NOT NULL CHECK(length(round_id) BETWEEN 1 AND 256),
+        actor_id TEXT CHECK(actor_id IS NULL OR length(actor_id) BETWEEN 1 AND 256),
+        generation INTEGER CHECK(generation IS NULL OR generation >= 1),
+        lease_generation INTEGER CHECK(lease_generation IS NULL OR lease_generation >= 1),
+        command_id TEXT CHECK(command_id IS NULL OR length(command_id) BETWEEN 1 AND 256),
+        gateway_attempt INTEGER CHECK(gateway_attempt IS NULL OR gateway_attempt >= 1),
+        credential_ref TEXT NOT NULL CHECK(length(credential_ref) BETWEEN 1 AND 256),
+        broker TEXT NOT NULL CHECK(length(broker) BETWEEN 1 AND 128),
+        action TEXT NOT NULL CHECK(length(action) BETWEEN 1 AND 128),
+        state TEXT NOT NULL CHECK(state IN (
+          'prepared', 'dispatched', 'completed', 'failed_pre_dispatch', 'cancelled',
+          'cancel_requested', 'indeterminate', 'reconciled'
+        )),
+        request_json TEXT NOT NULL CHECK(length(request_json) BETWEEN 2 AND 2200000),
+        provider_state_json TEXT CHECK(provider_state_json IS NULL OR length(provider_state_json) BETWEEN 2 AND 131072),
+        result_json TEXT CHECK(result_json IS NULL OR length(result_json) BETWEEN 1 AND 262144),
+        error_message TEXT CHECK(error_message IS NULL OR length(error_message) BETWEEN 1 AND 1000),
+        resolution TEXT CHECK(resolution IS NULL OR resolution IN ('completed', 'absent', 'failed')),
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        CHECK(
+          (source_type = 'worker_actor' AND actor_id IS NOT NULL AND generation IS NOT NULL
+            AND lease_generation IS NOT NULL AND gateway_attempt IS NULL)
+          OR
+          (source_type = 'manager_gateway' AND actor_id IS NULL AND generation IS NULL
+            AND lease_generation IS NULL AND command_id IS NULL AND gateway_attempt IS NOT NULL)
+        ),
+        CHECK((state = 'reconciled' AND resolution IS NOT NULL) OR (state != 'reconciled' AND resolution IS NULL))
+      );
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_credential_broker_mutation_idempotency
+        ON credential_broker_mutation_attempts(credential_ref, broker, action, idempotency_key);
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_credential_broker_mutation_unresolved_target
+        ON credential_broker_mutation_attempts(credential_ref, broker, semantic_target)
+        WHERE state IN ('prepared', 'dispatched', 'cancel_requested', 'indeterminate');
+      CREATE INDEX IF NOT EXISTS idx_credential_broker_mutation_run
+        ON credential_broker_mutation_attempts(run_id, node_id, created_at, request_id);
+      CREATE INDEX IF NOT EXISTS idx_credential_broker_mutation_state
+        ON credential_broker_mutation_attempts(state, updated_at, request_id);
+      CREATE TRIGGER IF NOT EXISTS trg_credential_broker_mutation_identity_immutable
+      BEFORE UPDATE OF request_id, idempotency_key, request_digest, semantic_target,
+        source_type, source_id, run_id, node_id, session_id, round_id, actor_id,
+        generation, lease_generation, command_id, gateway_attempt, credential_ref,
+        broker, action, request_json
+      ON credential_broker_mutation_attempts
+      BEGIN
+        SELECT RAISE(ABORT, 'Credential broker mutation identity is immutable');
+      END;
+
+      CREATE TABLE IF NOT EXISTS credential_broker_mutation_events (
+        sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+        request_id TEXT NOT NULL,
+        request_digest TEXT NOT NULL CHECK(
+          length(request_digest) = 64 AND request_digest NOT GLOB '*[^0-9a-f]*'
+        ),
+        state TEXT NOT NULL CHECK(state IN (
+          'prepared', 'dispatched', 'completed', 'failed_pre_dispatch', 'cancelled',
+          'cancel_requested', 'indeterminate', 'reconciled'
+        )),
+        detail_json TEXT NOT NULL CHECK(length(detail_json) BETWEEN 2 AND 32768),
+        created_at TEXT NOT NULL,
+        FOREIGN KEY(request_id) REFERENCES credential_broker_mutation_attempts(request_id)
+          ON UPDATE RESTRICT ON DELETE RESTRICT
+      );
+      CREATE INDEX IF NOT EXISTS idx_credential_broker_mutation_events_request
+        ON credential_broker_mutation_events(request_id, sequence);
+      CREATE TRIGGER IF NOT EXISTS trg_credential_broker_mutation_events_no_update
+      BEFORE UPDATE ON credential_broker_mutation_events
+      BEGIN
+        SELECT RAISE(ABORT, 'Credential broker mutation events are append-only');
+      END;
+      CREATE TRIGGER IF NOT EXISTS trg_credential_broker_mutation_events_no_delete
+      BEFORE DELETE ON credential_broker_mutation_events
+      BEGIN
+        SELECT RAISE(ABORT, 'Credential broker mutation events are append-only');
+      END;
+    `),
+    validate: validateCredentialBrokerMutationSchemaV37,
   },
 ];
 

--- a/homerail_manager/src/runtime/active-runs.ts
+++ b/homerail_manager/src/runtime/active-runs.ts
@@ -1164,12 +1164,21 @@ function _applyRecoveredCredentialBrokerGateways(run: ActiveRun): string[] {
     });
     if (!attempt) continue;
     const config = node.gateway_config;
-    handoffActiveRun(
-      run.runId,
-      node.node_id,
-      config?.result_port || "result",
-      attempt.result,
-    );
+    try {
+      handoffActiveRun(
+        run.runId,
+        node.node_id,
+        config?.result_port || "result",
+        attempt.result,
+      );
+    } catch (error) {
+      failActiveRun(
+        run.runId,
+        node.node_id,
+        `broker gateway recovery handoff failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      break;
+    }
     recovered.push(node.node_id);
     emit("dag:gateway_executed", {
       runId: run.runId,
@@ -1403,6 +1412,10 @@ export function recoverAllActiveRuns(): ColdRecoverySummary {
       }
     } catch (err) {
       // A single corrupt run must not block recovery of the rest.
+      // restoreActiveRun installs the reconstructed run before it applies
+      // recovery projections. Never leave that partially restored value
+      // dispatchable when a later recovery step throws.
+      store.delete(runId);
       console.error(
         `[homerail_manager] cold recovery skipped run ${runId}: ${err instanceof Error ? err.message : String(err)}`,
       );

--- a/homerail_manager/src/runtime/active-runs.ts
+++ b/homerail_manager/src/runtime/active-runs.ts
@@ -92,6 +92,7 @@ import {
 import type { RunWorkspaceRetention } from "../persistence/types.js";
 import { getDagActivitySequenceCursor } from "../persistence/dag-activity-journal.js";
 import { getDagActorSurfaceView } from "../persistence/dag-actor-surface-patches.js";
+import { findCompletedManagerGatewayMutation } from "../persistence/credential-broker-mutations.js";
 import { getDb } from "../persistence/db.js";
 import { getCredential, materializeCredential } from "../persistence/credentials.js";
 import {
@@ -1148,6 +1149,39 @@ function _applyOrphanedNodeDemotion(run: ActiveRun): string[] {
   return demotedFromRunning;
 }
 
+function _applyRecoveredCredentialBrokerGateways(run: ActiveRun): string[] {
+  const recovered: string[] = [];
+  for (const node of run.dagRun.graph.nodes) {
+    if (run.dagRun.nodeStates.get(node.node_id) !== "RUNNING" || node.node_type !== "broker_gateway") continue;
+    const session = run.nodeSessions.get(node.node_id);
+    if (!session) continue;
+    const attempt = findCompletedManagerGatewayMutation({
+      run_id: run.runId,
+      node_id: node.node_id,
+      session_id: session.sessionId,
+      round_id: run.currentRound.round_id,
+      gateway_attempt: session.attempt,
+    });
+    if (!attempt) continue;
+    const config = node.gateway_config;
+    handoffActiveRun(
+      run.runId,
+      node.node_id,
+      config?.result_port || "result",
+      attempt.result,
+    );
+    recovered.push(node.node_id);
+    emit("dag:gateway_executed", {
+      runId: run.runId,
+      nodeId: node.node_id,
+      gatewayType: node.node_type,
+      phase: "completed",
+      port: config?.result_port || "result",
+    });
+  }
+  return recovered;
+}
+
 function _loopSourceHasLiveFeedbackPath(
   run: ActiveRun,
   nodeId: string,
@@ -1302,6 +1336,7 @@ export function restoreActiveRun(
 
   store.set(metadata.runId, run);
 
+  if (run.status === "active") _applyRecoveredCredentialBrokerGateways(run);
   const demotedFromRunning = run.status === "active" ? _applyOrphanedNodeDemotion(run) : [];
   const settledPendingNodes = run.status === "active"
     ? Array.from(reconcileSettledPendingNodes(run.dagRun)).sort()
@@ -4293,17 +4328,24 @@ function _startBrokerGateway(
     throw new Error("broker gateway configuration is incomplete");
   }
   const input = _brokerGatewayInput(run, node);
+  const nodeSession = _prepareNodeSessionForDispatch(run, node);
+  startNode(run.dagRun, node.node_id);
+  _markNodeSessionStatus(run, node.node_id, "running");
+  const requestId = randomUUID();
   const request: DagCredentialBrokerCallRequest = {
-    request_id: randomUUID(),
+    request_id: requestId,
+    idempotency_key: requestId,
+    transport_kind: "manager_gateway",
     run_id: run.runId,
     node_id: node.node_id,
-    session_id: `manager-broker-${node.node_id}-${randomUUID()}`,
+    session_id: nodeSession.sessionId,
+    round_id: run.currentRound.round_id,
+    gateway_attempt: nodeSession.attempt,
     credential_ref: config.credential_ref,
     broker: config.broker,
     action: config.action,
     input,
   };
-  startNode(run.dagRun, node.node_id);
   inFlightBrokerGateways.add(key);
   writeRunMetadata(run.runId, serializeRunMetadata(run));
   emit("dag:gateway_executed", {

--- a/homerail_manager/src/runtime/credential-broker.ts
+++ b/homerail_manager/src/runtime/credential-broker.ts
@@ -1,14 +1,34 @@
+import { createHash } from "node:crypto";
 import type {
+  DagCredentialBrokerCancelRequest,
   DagCredentialBrokerCallRequest,
   DagCredentialBrokerCallResult,
 } from "homerail-protocol";
+import { dagCredentialBrokerCallIdentity } from "homerail-protocol";
 import {
   materializeCredential,
   recordCredentialUseFailure,
   type CredentialRecord,
 } from "../persistence/credentials.js";
 import {
+  cancelCredentialBrokerMutationAttempt,
+  checkpointCredentialBrokerMutation,
+  completeCredentialBrokerMutation,
+  dispatchCredentialBrokerMutation,
+  failCredentialBrokerMutationBeforeDispatch,
+  getCredentialBrokerMutationAttempt,
+  listUnresolvedCredentialBrokerMutations,
+  markCredentialBrokerMutationIndeterminate,
+  prepareCredentialBrokerMutation,
+  reconcileCredentialBrokerMutation,
+  type CredentialBrokerMutationAttempt,
+  type CredentialBrokerMutationResolution,
+} from "../persistence/credential-broker-mutations.js";
+import { subscribe } from "../events/bus.js";
+import { assessDagTransportFence } from "../orchestration/response-bridge.js";
+import {
   getActiveRun,
+  getCurrentNodeSession,
   recordActiveRunBrokerActionSuccess,
 } from "./active-runs.js";
 import {
@@ -16,9 +36,11 @@ import {
   githubChecksSnapshot,
   githubCommitFiles,
   githubCommitWorkspace,
+  githubMutationSemanticTarget,
   githubPullRequestSnapshot,
   githubReadDiff,
   githubReadFile,
+  githubReconcileMutation,
   githubRequiredChecks,
   githubValidateHead,
 } from "./github-pr-broker.js";
@@ -27,13 +49,15 @@ export interface CredentialBrokerContext {
   credential: CredentialRecord;
   secret: Readonly<Record<string, string>>;
   input: Readonly<Record<string, unknown>>;
-  transport?: Readonly<{
-    run_id: string;
-    node_id: string;
-    session_id: string;
-    round_id?: string;
-    actor_id?: string;
-    generation?: number;
+  transport?: Readonly<Omit<DagCredentialBrokerCallRequest, "input">>;
+  /** Turn/run cancellation, combined by provider adapters with their own timeout. */
+  signal?: AbortSignal;
+  /** Present only for mutation handlers after their durable attempt is prepared. */
+  mutation?: Readonly<{
+    request_digest: string;
+    semantic_target: string;
+    checkpoint: (patch: Record<string, unknown>) => void;
+    assert_authority: () => void;
   }>;
 }
 
@@ -43,11 +67,25 @@ export type CredentialBrokerHandler = (
 
 export interface CredentialBrokerRegistrationOptions {
   maxInputBytes?: number;
+  effect?: "read" | "mutation";
+  semanticTarget?: (context: CredentialBrokerContext) => string;
+  reconcile?: (
+    context: CredentialBrokerContext,
+    attempt: CredentialBrokerMutationAttempt,
+  ) => Promise<CredentialBrokerReconciliation>;
 }
+
+export type CredentialBrokerReconciliation =
+  | { resolution: "completed"; result: unknown }
+  | { resolution: "absent" | "failed"; error?: string }
+  | { resolution: "indeterminate"; error?: string };
 
 interface RegisteredCredentialBrokerHandler {
   handler: CredentialBrokerHandler;
   maxInputBytes: number;
+  effect: "read" | "mutation";
+  semanticTarget?: (context: CredentialBrokerContext) => string;
+  reconcile?: CredentialBrokerRegistrationOptions["reconcile"];
 }
 
 const BROKER_NAME = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
@@ -56,6 +94,229 @@ const MAX_INPUT_BYTES = 64 * 1024;
 const MAX_CONFIGURED_INPUT_BYTES = 2 * 1024 * 1024;
 const MAX_RESULT_BYTES = 256 * 1024;
 const handlers = new Map<string, Map<string, RegisteredCredentialBrokerHandler>>();
+
+interface InFlightCredentialBrokerCall {
+  sourceId: string;
+  request: DagCredentialBrokerCallRequest;
+  controller: AbortController;
+  effect: "read" | "mutation";
+}
+
+const inFlightCalls = new Map<string, InFlightCredentialBrokerCall>();
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .filter(([, entry]) => entry !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => [key, canonicalize(entry)]),
+  );
+}
+
+function brokerRequestDigest(sourceId: string, request: DagCredentialBrokerCallRequest): string {
+  return createHash("sha256").update(JSON.stringify(canonicalize({
+    version: 1,
+    source_id: sourceId,
+    request,
+  }))).digest("hex");
+}
+
+function boundedMessage(error: unknown): string {
+  return (error instanceof Error ? error.message : String(error))
+    .replace(/[\u0000-\u001f\u007f]/g, " ")
+    .slice(0, 1_000);
+}
+
+function transportPayload(request: DagCredentialBrokerCallRequest): Record<string, unknown> {
+  return {
+    runId: request.run_id,
+    nodeId: request.node_id,
+    round_id: request.round_id,
+    actor_id: request.actor_id,
+    generation: request.generation,
+    lease_generation: request.lease_generation,
+    command_id: request.command_id,
+  };
+}
+
+function validateRequestContract(
+  expectedKind: DagCredentialBrokerCallRequest["transport_kind"],
+  request: DagCredentialBrokerCallRequest,
+): string | undefined {
+  for (const [label, value] of [
+    ["request_id", request.request_id],
+    ["idempotency_key", request.idempotency_key],
+    ["run_id", request.run_id],
+    ["node_id", request.node_id],
+    ["session_id", request.session_id],
+    ["round_id", request.round_id],
+    ["credential_ref", request.credential_ref],
+  ] as const) {
+    if (typeof value !== "string" || !value.trim() || value.length > 256) return `${label} is invalid`;
+  }
+  if (request.transport_kind !== expectedKind) return `transport_kind must be ${expectedKind}`;
+  if (expectedKind === "worker_actor") {
+    if (typeof request.actor_id !== "string" || !request.actor_id || request.actor_id.length > 256) {
+      return "worker broker actor_id is invalid";
+    }
+    if (!Number.isSafeInteger(request.generation) || Number(request.generation) < 1) {
+      return "worker broker generation is invalid";
+    }
+    if (!Number.isSafeInteger(request.lease_generation) || Number(request.lease_generation) < 1) {
+      return "worker broker lease_generation is invalid";
+    }
+    if (request.gateway_attempt !== undefined) return "worker broker cannot provide gateway_attempt";
+  } else {
+    if (!Number.isSafeInteger(request.gateway_attempt) || Number(request.gateway_attempt) < 1) {
+      return "manager broker gateway_attempt is invalid";
+    }
+    if (
+      request.actor_id !== undefined
+      || request.generation !== undefined
+      || request.lease_generation !== undefined
+      || request.command_id !== undefined
+    ) return "manager broker cannot provide Worker Actor fence fields";
+  }
+  if (!request.input || typeof request.input !== "object" || Array.isArray(request.input)) {
+    return "credential broker input must be an object";
+  }
+  return undefined;
+}
+
+function assertWorkerAuthority(workerId: string, request: DagCredentialBrokerCallRequest): void {
+  const assessment = assessDagTransportFence(
+    transportPayload(request),
+    { targetType: "worker", targetId: workerId },
+    { renewExpiredLease: false },
+  );
+  if (assessment.status !== "current") {
+    const reason = assessment.status === "ignored" || assessment.status === "malformed_payload"
+      ? assessment.reason
+      : assessment.status === "unknown_run"
+        ? `unknown run ${assessment.runId}`
+        : "credential broker transport is not current";
+    throw new Error(reason);
+  }
+  const run = getActiveRun(request.run_id);
+  if (!run || run.status !== "active" || run.dagRun.nodeStates.get(request.node_id) !== "RUNNING") {
+    throw new Error("Credential broker Worker node is not running");
+  }
+  const session = getCurrentNodeSession(request.run_id, request.node_id);
+  if (!session || session.sessionId !== request.session_id || session.status !== "running") {
+    throw new Error("Credential broker Worker session is stale");
+  }
+}
+
+function assertManagerAuthority(request: DagCredentialBrokerCallRequest): void {
+  const run = getActiveRun(request.run_id);
+  if (!run || run.status !== "active") throw new Error("Credential broker run is not active");
+  if (run.currentRound.round_id !== request.round_id) throw new Error("Credential broker Manager round is stale");
+  if (run.dagRun.nodeStates.get(request.node_id) !== "RUNNING") {
+    throw new Error("Credential broker Manager gateway is not running");
+  }
+  const session = getCurrentNodeSession(request.run_id, request.node_id);
+  if (
+    !session
+    || session.sessionId !== request.session_id
+    || session.attempt !== request.gateway_attempt
+    || session.status !== "running"
+  ) throw new Error("Credential broker Manager gateway fence is stale");
+}
+
+function resultForFailure(
+  request: DagCredentialBrokerCallRequest,
+  outcome: DagCredentialBrokerCallResult["outcome"],
+  error: string,
+  requestDigest?: string,
+  reconciliation?: DagCredentialBrokerCallResult["reconciliation"],
+): DagCredentialBrokerCallResult {
+  return {
+    request_id: request.request_id,
+    identity: dagCredentialBrokerCallIdentity(request),
+    ok: false,
+    outcome,
+    ...(requestDigest ? { request_digest: requestDigest } : {}),
+    error,
+    ...(reconciliation ? { reconciliation } : {}),
+  };
+}
+
+function sameCancellationFence(
+  request: DagCredentialBrokerCallRequest,
+  cancel: DagCredentialBrokerCancelRequest,
+): boolean {
+  return request.transport_kind === "worker_actor"
+    && cancel.transport_kind === "worker_actor"
+    && request.request_id === cancel.request_id
+    && request.idempotency_key === cancel.idempotency_key
+    && request.run_id === cancel.run_id
+    && request.node_id === cancel.node_id
+    && request.session_id === cancel.session_id
+    && request.round_id === cancel.round_id
+    && request.actor_id === cancel.actor_id
+    && request.generation === cancel.generation
+    && request.lease_generation === cancel.lease_generation
+    && request.command_id === cancel.command_id;
+}
+
+function abortInFlightWhere(
+  predicate: (call: InFlightCredentialBrokerCall) => boolean,
+  reason: string,
+): void {
+  for (const call of inFlightCalls.values()) {
+    if (!predicate(call) || call.controller.signal.aborted) continue;
+    if (call.effect === "mutation") {
+      const attempt = getCredentialBrokerMutationAttempt(call.request.request_id);
+      if (attempt) {
+        try { cancelCredentialBrokerMutationAttempt(attempt.request_id, reason); } catch { /* Completion won the race. */ }
+      }
+    }
+    call.controller.abort(new Error(reason));
+  }
+}
+
+export function cancelCredentialBrokerCall(
+  workerId: string,
+  cancel: DagCredentialBrokerCancelRequest,
+): boolean {
+  const call = inFlightCalls.get(cancel.request_id);
+  if (!call || call.sourceId !== workerId || !sameCancellationFence(call.request, cancel)) return false;
+  abortInFlightWhere((candidate) => candidate === call, "Credential broker caller cancelled the Actor turn");
+  return true;
+}
+
+subscribe("dag:run_cancelled", (payload) => {
+  const runId = (payload as { runId?: unknown }).runId;
+  if (typeof runId === "string") abortInFlightWhere((call) => call.request.run_id === runId, "DAG run cancelled");
+});
+subscribe("dag:run_failed", (payload) => {
+  const runId = (payload as { runId?: unknown }).runId;
+  if (typeof runId === "string") abortInFlightWhere((call) => call.request.run_id === runId, "DAG run failed");
+});
+subscribe("dag:run_completed", (payload) => {
+  const runId = (payload as { runId?: unknown }).runId;
+  if (typeof runId === "string") abortInFlightWhere((call) => call.request.run_id === runId, "DAG run completed");
+});
+subscribe("dag:actor_intervention_applied", (payload) => {
+  const data = payload as { runId?: unknown; actorId?: unknown };
+  if (typeof data.runId === "string" && typeof data.actorId === "string") {
+    abortInFlightWhere(
+      (call) => call.request.run_id === data.runId && call.request.actor_id === data.actorId,
+      "DAG Actor generation superseded",
+    );
+  }
+});
+subscribe("dag:actor_lease_released", (payload) => {
+  const data = payload as { runId?: unknown; actorId?: unknown };
+  if (typeof data.runId === "string" && typeof data.actorId === "string") {
+    abortInFlightWhere(
+      (call) => call.request.run_id === data.runId && call.request.actor_id === data.actorId,
+      "DAG Actor lease released",
+    );
+  }
+});
 
 function safeJsonSize(value: unknown): number {
   const encoded = JSON.stringify(value);
@@ -97,8 +358,21 @@ export function registerCredentialBroker(
   if (!Number.isSafeInteger(maxInputBytes) || maxInputBytes < 1 || maxInputBytes > MAX_CONFIGURED_INPUT_BYTES) {
     throw new Error(`Credential broker input limit must be 1-${MAX_CONFIGURED_INPUT_BYTES} bytes`);
   }
+  const effect = options.effect ?? "read";
+  if (effect === "mutation" && (!options.semanticTarget || !options.reconcile)) {
+    throw new Error("Credential broker mutation handlers require semanticTarget and reconcile contracts");
+  }
+  if (effect === "read" && (options.semanticTarget || options.reconcile)) {
+    throw new Error("Credential broker read handlers cannot declare mutation reconciliation contracts");
+  }
   const actions = handlers.get(broker) ?? new Map<string, RegisteredCredentialBrokerHandler>();
-  actions.set(action, { handler, maxInputBytes });
+  actions.set(action, {
+    handler,
+    maxInputBytes,
+    effect,
+    ...(options.semanticTarget ? { semanticTarget: options.semanticTarget } : {}),
+    ...(options.reconcile ? { reconcile: options.reconcile } : {}),
+  });
   handlers.set(broker, actions);
 }
 
@@ -112,7 +386,10 @@ export async function invokeCredentialBroker(
   if (safeJsonSize(context.input) > registered.maxInputBytes) {
     throw new Error(`Credential broker input exceeds ${registered.maxInputBytes} bytes`);
   }
-  const result = await registered.handler(context);
+  const result = await registered.handler({
+    ...context,
+    signal: context.signal ?? new AbortController().signal,
+  });
   assertResultDoesNotRevealSecrets(result, context.secret);
   if (safeJsonSize(result) > MAX_RESULT_BYTES) {
     throw new Error("Credential broker result exceeds 256 KiB");
@@ -159,25 +436,44 @@ function managerBrokerBinding(
 
 async function executeDeclaredCredentialBrokerCall(
   actor: string,
+  sourceId: string,
+  expectedKind: DagCredentialBrokerCallRequest["transport_kind"],
+  assertAuthority: (request: DagCredentialBrokerCallRequest) => void,
   request: DagCredentialBrokerCallRequest,
 ): Promise<DagCredentialBrokerCallResult> {
-  const fail = (error: string): DagCredentialBrokerCallResult => ({
-    request_id: request.request_id,
-    ok: false,
-    error,
-  });
-  if (!request.request_id || !request.run_id || !request.node_id || !request.session_id) {
-    return fail("Credential broker transport identity is incomplete");
-  }
+  const contractError = validateRequestContract(expectedKind, request);
+  if (contractError) return resultForFailure(request, "failed_pre_dispatch", contractError);
   if (!BROKER_NAME.test(request.broker) || !ACTION_NAME.test(request.action)) {
-    return fail("Credential broker or action is invalid");
+    return resultForFailure(request, "failed_pre_dispatch", "Credential broker or action is invalid");
   }
+  const registered = handlers.get(request.broker)?.get(request.action);
+  if (inFlightCalls.has(request.request_id)) {
+    return resultForFailure(request, "failed_pre_dispatch", "Credential broker request is already in flight");
+  }
+  const requestDigest = brokerRequestDigest(sourceId, request);
+  const controller = new AbortController();
+  const inFlight: InFlightCredentialBrokerCall = {
+    sourceId,
+    request: structuredClone(request),
+    controller,
+    effect: registered?.effect ?? "read",
+  };
+  inFlightCalls.set(request.request_id, inFlight);
   let binding;
   let materializedSecret: Readonly<Record<string, string>> | undefined;
+  let mutationAttempt: CredentialBrokerMutationAttempt | undefined;
+  const ensureAuthority = () => {
+    if (controller.signal.aborted) throw controller.signal.reason ?? new Error("Credential broker call cancelled");
+    assertAuthority(request);
+  };
   try {
+    ensureAuthority();
     binding = managerBrokerBinding(request.run_id, request.node_id, request.credential_ref);
     if (binding.broker !== request.broker || !binding.allowed_actions.includes(request.action)) {
       throw new Error("Credential broker action is not permitted by the WorkflowSpec");
+    }
+    if (!registered) {
+      throw new Error(`Unsupported credential broker action: ${request.broker}/${request.action}`);
     }
     const useContext = {
       actor,
@@ -189,19 +485,122 @@ async function executeDeclaredCredentialBrokerCall(
     };
     const materialized = materializeCredential(request.credential_ref, useContext);
     materializedSecret = materialized.secret;
-    const result = await invokeCredentialBroker(request.broker, request.action, {
+    const transport = Object.fromEntries(
+      Object.entries(request).filter(([key]) => key !== "input"),
+    ) as unknown as Omit<DagCredentialBrokerCallRequest, "input">;
+    const baseContext: CredentialBrokerContext = {
       credential: materialized.record,
       secret: materialized.secret,
       input: request.input,
-      transport: {
+      transport,
+      signal: controller.signal,
+    };
+
+    if (registered.effect === "read") {
+      const result = await invokeCredentialBroker(request.broker, request.action, baseContext);
+      ensureAuthority();
+      recordActiveRunBrokerActionSuccess({
         run_id: request.run_id,
         node_id: request.node_id,
         session_id: request.session_id,
-        ...(request.round_id ? { round_id: request.round_id } : {}),
-        ...(request.actor_id ? { actor_id: request.actor_id } : {}),
-        ...(request.generation === undefined ? {} : { generation: request.generation }),
-      },
+        credential_ref: request.credential_ref,
+        broker: request.broker,
+        action: request.action,
+        result,
+      });
+      return {
+        request_id: request.request_id,
+        identity: dagCredentialBrokerCallIdentity(request),
+        request_digest: requestDigest,
+        ok: true,
+        outcome: "completed",
+        result,
+      };
+    }
+
+    const semanticTarget = registered.semanticTarget!(baseContext).trim();
+    let prepared = prepareCredentialBrokerMutation({
+      request,
+      request_digest: requestDigest,
+      semantic_target: semanticTarget,
+      source_id: sourceId,
     });
+    if (prepared.status === "blocked") {
+      const blocker = await reconcilePersistedCredentialBrokerMutation(prepared.attempt);
+      if (blocker.state === "reconciled" && blocker.resolution !== "completed") {
+        prepared = prepareCredentialBrokerMutation({
+          request,
+          request_digest: requestDigest,
+          semantic_target: semanticTarget,
+          source_id: sourceId,
+        });
+      } else {
+        return resultForFailure(
+          request,
+          blocker.state === "reconciled" ? "reconciled" : "indeterminate",
+          `Credential broker semantic target is owned by unresolved request ${blocker.request_id}`,
+          requestDigest,
+          blocker.state === "reconciled" ? blocker.resolution : undefined,
+        );
+      }
+    }
+    mutationAttempt = prepared.attempt;
+    if (prepared.status === "duplicate") {
+      const duplicate = ["prepared", "dispatched", "cancel_requested", "indeterminate"].includes(mutationAttempt.state)
+        ? await reconcilePersistedCredentialBrokerMutation(mutationAttempt)
+        : mutationAttempt;
+      if (
+        duplicate.state === "completed"
+        || (duplicate.state === "reconciled" && duplicate.resolution === "completed")
+      ) {
+        ensureAuthority();
+        recordActiveRunBrokerActionSuccess({
+          run_id: request.run_id,
+          node_id: request.node_id,
+          session_id: request.session_id,
+          credential_ref: request.credential_ref,
+          broker: request.broker,
+          action: request.action,
+          result: duplicate.result,
+        });
+        return {
+          request_id: request.request_id,
+          identity: dagCredentialBrokerCallIdentity(request),
+          request_digest: requestDigest,
+          ok: true,
+          outcome: duplicate.state === "completed" ? "completed" : "reconciled",
+          ...(duplicate.state === "reconciled" ? { reconciliation: "completed" as const } : {}),
+          result: duplicate.result,
+        };
+      }
+      return attemptFailureResult(duplicate, requestDigest);
+    }
+
+    ensureAuthority();
+    mutationAttempt = dispatchCredentialBrokerMutation(request.request_id);
+    const mutationContext: CredentialBrokerContext = {
+      ...baseContext,
+      mutation: {
+        request_digest: requestDigest,
+        semantic_target: semanticTarget,
+        checkpoint: (patch) => { checkpointCredentialBrokerMutation(request.request_id, patch); },
+        assert_authority: ensureAuthority,
+      },
+    };
+    const result = await invokeCredentialBroker(request.broker, request.action, mutationContext);
+    try {
+      ensureAuthority();
+    } catch (authorityError) {
+      mutationAttempt = reconcileCredentialBrokerMutation(request.request_id, "completed", { result });
+      return resultForFailure(
+        request,
+        "reconciled",
+        `Credential broker mutation completed after authority was revoked: ${boundedMessage(authorityError)}`,
+        requestDigest,
+        "completed",
+      );
+    }
+    mutationAttempt = completeCredentialBrokerMutation(request.request_id, result);
     recordActiveRunBrokerActionSuccess({
       run_id: request.run_id,
       node_id: request.node_id,
@@ -211,9 +610,16 @@ async function executeDeclaredCredentialBrokerCall(
       action: request.action,
       result,
     });
-    return { request_id: request.request_id, ok: true, result };
+    return {
+      request_id: request.request_id,
+      identity: dagCredentialBrokerCallIdentity(request),
+      request_digest: requestDigest,
+      ok: true,
+      outcome: "completed",
+      result,
+    };
   } catch (error) {
-    const rawMessage = error instanceof Error ? error.message : String(error);
+    const rawMessage = boundedMessage(error);
     const message = materializedSecret && Object.values(materializedSecret).some((value) => rawMessage.includes(value))
       ? "Credential broker call failed without exposing provider details"
       : rawMessage;
@@ -231,15 +637,198 @@ async function executeDeclaredCredentialBrokerCall(
         // Failure auditing must not replace the original bounded error.
       }
     }
-    return fail(message);
+    if (registered?.effect === "mutation") {
+      if (!mutationAttempt) {
+        return resultForFailure(
+          request,
+          controller.signal.aborted ? "cancelled" : "failed_pre_dispatch",
+          message,
+          requestDigest,
+        );
+      }
+      const current = getCredentialBrokerMutationAttempt(mutationAttempt.request_id) ?? mutationAttempt;
+      if (current.state === "prepared") {
+        const terminal = controller.signal.aborted
+          ? cancelCredentialBrokerMutationAttempt(current.request_id, message)
+          : failCredentialBrokerMutationBeforeDispatch(current.request_id, message);
+        return attemptFailureResult(terminal, requestDigest);
+      }
+      if (current.state === "dispatched" || current.state === "cancel_requested") {
+        markCredentialBrokerMutationIndeterminate(current.request_id, message);
+      }
+      const reconciled = await reconcilePersistedCredentialBrokerMutation(
+        getCredentialBrokerMutationAttempt(current.request_id) ?? current,
+      );
+      return attemptFailureResult(reconciled, requestDigest);
+    }
+    return resultForFailure(
+      request,
+      controller.signal.aborted ? "cancelled" : "failed",
+      message,
+      requestDigest,
+    );
+  } finally {
+    if (inFlightCalls.get(request.request_id) === inFlight) inFlightCalls.delete(request.request_id);
   }
+}
+
+function attemptFailureResult(
+  attempt: CredentialBrokerMutationAttempt,
+  requestDigest = attempt.request_digest,
+): DagCredentialBrokerCallResult {
+  if (attempt.state === "completed") {
+    return resultForFailure(
+      attempt.request,
+      "reconciled",
+      "Credential broker mutation completed after the caller authority was revoked",
+      requestDigest,
+      "completed",
+    );
+  }
+  if (attempt.state === "reconciled") {
+    return resultForFailure(
+      attempt.request,
+      "reconciled",
+      attempt.error_message ?? `Credential broker mutation reconciled as ${attempt.resolution}`,
+      requestDigest,
+      attempt.resolution,
+    );
+  }
+  const outcome: DagCredentialBrokerCallResult["outcome"] = attempt.state === "failed_pre_dispatch"
+    ? "failed_pre_dispatch"
+    : attempt.state === "cancelled"
+      ? "cancelled"
+      : "indeterminate";
+  return resultForFailure(
+    attempt.request,
+    outcome,
+    attempt.error_message ?? `Credential broker mutation is ${attempt.state}`,
+    requestDigest,
+  );
+}
+
+function applyReconciliation(
+  attempt: CredentialBrokerMutationAttempt,
+  reconciliation: CredentialBrokerReconciliation,
+  secret: Readonly<Record<string, string>>,
+): CredentialBrokerMutationAttempt {
+  if (reconciliation.resolution === "indeterminate") {
+    const current = getCredentialBrokerMutationAttempt(attempt.request_id) ?? attempt;
+    if (current.state === "dispatched" || current.state === "cancel_requested") {
+      return markCredentialBrokerMutationIndeterminate(
+        current.request_id,
+        reconciliation.error ?? "Credential broker mutation outcome is indeterminate",
+      );
+    }
+    return current;
+  }
+  if (reconciliation.resolution === "completed") {
+    assertResultDoesNotRevealSecrets(reconciliation.result, secret);
+    if (safeJsonSize(reconciliation.result) > MAX_RESULT_BYTES) {
+      throw new Error("Credential broker reconciled result exceeds 256 KiB");
+    }
+    return reconcileCredentialBrokerMutation(attempt.request_id, "completed", { result: reconciliation.result });
+  }
+  return reconcileCredentialBrokerMutation(attempt.request_id, reconciliation.resolution, {
+    // A provider validation failure is the useful caller-facing reason. The
+    // read-back result proves only whether a write landed, so it must not
+    // replace the original error with a generic "not dispatched" message.
+    error: attempt.error_message
+      ?? reconciliation.error
+      ?? `Credential broker mutation reconciled as ${reconciliation.resolution}`,
+  });
+}
+
+async function reconcilePersistedCredentialBrokerMutation(
+  attempt: CredentialBrokerMutationAttempt,
+): Promise<CredentialBrokerMutationAttempt> {
+  if (attempt.state === "prepared") {
+    return failCredentialBrokerMutationBeforeDispatch(
+      attempt.request_id,
+      "Credential broker mutation was durably prepared but never dispatched",
+    );
+  }
+  if (!["dispatched", "cancel_requested", "indeterminate"].includes(attempt.state)) return attempt;
+  const registered = handlers.get(attempt.broker)?.get(attempt.action);
+  if (!registered?.reconcile) {
+    if (attempt.state === "dispatched" || attempt.state === "cancel_requested") {
+      return markCredentialBrokerMutationIndeterminate(
+        attempt.request_id,
+        "Credential broker mutation has no reconciliation handler",
+      );
+    }
+    return attempt;
+  }
+  let secret: Readonly<Record<string, string>> | undefined;
+  try {
+    const materialized = materializeCredential(attempt.credential_ref, {
+      actor: "credential-broker:recovery",
+      run_id: attempt.run_id,
+      node_id: attempt.node_id,
+      purpose: "reconcile durable credential broker mutation",
+      broker: attempt.broker,
+      action: attempt.action,
+    });
+    secret = materialized.secret;
+    const timeoutSignal = AbortSignal.timeout(30_000);
+    const transport = Object.fromEntries(
+      Object.entries(attempt.request).filter(([key]) => key !== "input"),
+    ) as unknown as Omit<DagCredentialBrokerCallRequest, "input">;
+    const reconciliation = await registered.reconcile({
+      credential: materialized.record,
+      secret: materialized.secret,
+      input: attempt.request.input,
+      transport,
+      signal: timeoutSignal,
+    }, attempt);
+    return applyReconciliation(attempt, reconciliation, materialized.secret);
+  } catch (error) {
+    const raw = boundedMessage(error);
+    const message = secret && Object.values(secret).some((value) => raw.includes(value))
+      ? "Credential broker reconciliation failed without exposing provider details"
+      : raw;
+    const current = getCredentialBrokerMutationAttempt(attempt.request_id) ?? attempt;
+    if (current.state === "dispatched" || current.state === "cancel_requested") {
+      return markCredentialBrokerMutationIndeterminate(current.request_id, message);
+    }
+    return current;
+  }
+}
+
+export interface CredentialBrokerRecoverySummary {
+  reconciled: string[];
+  unresolved: string[];
+  failed: Array<{ request_id: string; error: string }>;
+}
+
+export async function recoverCredentialBrokerMutations(): Promise<CredentialBrokerRecoverySummary> {
+  const summary: CredentialBrokerRecoverySummary = { reconciled: [], unresolved: [], failed: [] };
+  for (const attempt of listUnresolvedCredentialBrokerMutations()) {
+    try {
+      const current = await reconcilePersistedCredentialBrokerMutation(attempt);
+      if (current.state === "reconciled" || current.state === "failed_pre_dispatch") {
+        summary.reconciled.push(current.request_id);
+      } else {
+        summary.unresolved.push(current.request_id);
+      }
+    } catch (error) {
+      summary.failed.push({ request_id: attempt.request_id, error: boundedMessage(error) });
+    }
+  }
+  return summary;
 }
 
 export async function executeCredentialBrokerCall(
   workerId: string,
   request: DagCredentialBrokerCallRequest,
 ): Promise<DagCredentialBrokerCallResult> {
-  return await executeDeclaredCredentialBrokerCall(`credential-broker:worker:${workerId}`, request);
+  return await executeDeclaredCredentialBrokerCall(
+    `credential-broker:worker:${workerId}`,
+    workerId,
+    "worker_actor",
+    (candidate) => assertWorkerAuthority(workerId, candidate),
+    request,
+  );
 }
 
 export async function executeManagerCredentialBrokerCall(
@@ -247,11 +836,14 @@ export async function executeManagerCredentialBrokerCall(
 ): Promise<DagCredentialBrokerCallResult> {
   return await executeDeclaredCredentialBrokerCall(
     `credential-broker:manager:${request.node_id}`,
+    `manager:${request.node_id}`,
+    "manager_gateway",
+    assertManagerAuthority,
     request,
   );
 }
 
-registerCredentialBroker("lark_bot", "bot_info", async ({ credential, secret }) => {
+registerCredentialBroker("lark_bot", "bot_info", async ({ credential, secret, signal }) => {
   if (credential.credential_type !== "bot" || !secret.app_id || !secret.app_secret) {
     throw new Error("lark_bot requires a bot credential");
   }
@@ -261,7 +853,9 @@ registerCredentialBroker("lark_bot", "bot_info", async ({ credential, secret }) 
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ app_id: secret.app_id, app_secret: secret.app_secret }),
-      signal: AbortSignal.timeout(10_000),
+      signal: signal
+        ? AbortSignal.any([signal, AbortSignal.timeout(10_000)])
+        : AbortSignal.timeout(10_000),
     },
   );
   const tokenBody = await tokenResponse.json() as {
@@ -273,7 +867,9 @@ registerCredentialBroker("lark_bot", "bot_info", async ({ credential, secret }) 
   }
   const infoResponse = await fetch("https://open.feishu.cn/open-apis/bot/v3/info", {
     headers: { Authorization: `Bearer ${tokenBody.tenant_access_token}` },
-    signal: AbortSignal.timeout(10_000),
+    signal: signal
+      ? AbortSignal.any([signal, AbortSignal.timeout(10_000)])
+      : AbortSignal.timeout(10_000),
   });
   const infoBody = await infoResponse.json() as {
     code?: number;
@@ -297,8 +893,16 @@ registerCredentialBroker("github_pr", "assess_review", githubAssessReview);
 registerCredentialBroker("github_pr", "checks_snapshot", githubChecksSnapshot);
 registerCredentialBroker("github_pr", "required_checks", githubRequiredChecks);
 registerCredentialBroker("github_pr", "validate_head", githubValidateHead);
-registerCredentialBroker("github_pr", "commit_workspace", githubCommitWorkspace);
+registerCredentialBroker("github_pr", "commit_workspace", githubCommitWorkspace, {
+  effect: "mutation",
+  semanticTarget: githubMutationSemanticTarget,
+  reconcile: githubReconcileMutation,
+  maxInputBytes: MAX_CONFIGURED_INPUT_BYTES,
+});
 registerCredentialBroker("github_pr", "commit_files", githubCommitFiles, {
+  effect: "mutation",
+  semanticTarget: githubMutationSemanticTarget,
+  reconcile: githubReconcileMutation,
   // A 1 MiB decoded commit expands to roughly 1.4 MiB as base64 plus bounded
   // JSON/path overhead. Other broker actions retain the 64 KiB default.
   maxInputBytes: MAX_CONFIGURED_INPUT_BYTES,

--- a/homerail_manager/src/runtime/credential-broker.ts
+++ b/homerail_manager/src/runtime/credential-broker.ts
@@ -525,24 +525,40 @@ async function executeDeclaredCredentialBrokerCall(
       semantic_target: semanticTarget,
       source_id: sourceId,
     });
-    if (prepared.status === "blocked") {
-      const blocker = await reconcilePersistedCredentialBrokerMutation(prepared.attempt);
-      if (blocker.state === "reconciled" && blocker.resolution !== "completed") {
+    while (prepared.status === "blocked") {
+      const blockedAttempt = prepared.attempt;
+      if (inFlightCalls.has(blockedAttempt.request_id)) {
+        return resultForFailure(
+          request,
+          "indeterminate",
+          `Credential broker semantic target is owned by unresolved request ${blockedAttempt.request_id}`,
+          requestDigest,
+        );
+      }
+      const blocker = await reconcilePersistedCredentialBrokerMutation(blockedAttempt);
+      const safeToRetry = blocker.state === "failed_pre_dispatch"
+        || blocker.state === "cancelled"
+        || (blocker.state === "reconciled" && blocker.resolution !== "completed");
+      if (safeToRetry) {
         prepared = prepareCredentialBrokerMutation({
           request,
           request_digest: requestDigest,
           semantic_target: semanticTarget,
           source_id: sourceId,
         });
-      } else {
-        return resultForFailure(
-          request,
-          blocker.state === "reconciled" ? "reconciled" : "indeterminate",
-          `Credential broker semantic target is owned by unresolved request ${blocker.request_id}`,
-          requestDigest,
-          blocker.state === "reconciled" ? blocker.resolution : undefined,
-        );
+        continue;
       }
+      const completed = blocker.state === "completed"
+        || (blocker.state === "reconciled" && blocker.resolution === "completed");
+      return resultForFailure(
+        request,
+        completed ? "reconciled" : "indeterminate",
+        completed
+          ? `Credential broker semantic target was already completed by request ${blocker.request_id}`
+          : `Credential broker semantic target is owned by unresolved request ${blocker.request_id}`,
+        requestDigest,
+        completed ? "completed" : undefined,
+      );
     }
     mutationAttempt = prepared.attempt;
     if (prepared.status === "duplicate") {

--- a/homerail_manager/src/runtime/github-pr-broker.ts
+++ b/homerail_manager/src/runtime/github-pr-broker.ts
@@ -311,6 +311,13 @@ async function githubToken(context: CredentialBrokerContext): Promise<string> {
   return body.token;
 }
 
+class GithubApiResponseError extends Error {
+  constructor(readonly status: number) {
+    super(`GitHub API request failed (${status})`);
+    this.name = "GithubApiResponseError";
+  }
+}
+
 async function githubApi<T>(token: string, pathname: string, init: RequestInit = {}): Promise<T> {
   const response = await fetch(`https://api.github.com${pathname}`, {
     ...init,
@@ -326,7 +333,7 @@ async function githubApi<T>(token: string, pathname: string, init: RequestInit =
       ? AbortSignal.any([init.signal, AbortSignal.timeout(20_000)])
       : AbortSignal.timeout(20_000),
   });
-  if (!response.ok) throw new Error(`GitHub API request failed (${response.status})`);
+  if (!response.ok) throw new GithubApiResponseError(response.status);
   if (response.status === 204) return undefined as T;
   return await response.json() as T;
 }
@@ -1617,7 +1624,18 @@ async function commitFiles(
     const pull = await githubApi<PullResponse>(token, `${repository}/pulls/${binding.pull_number}`);
     const observedHead = pullHead(pull, binding);
     if (observedHead !== nextHead) {
-      if (observedHead === state.current_head_sha) setActiveRunBrokerState(runId, "github_pr", state);
+      if (observedHead === state.current_head_sha) {
+        // An HTTP error response proves the PATCH request has finished. Once a
+        // subsequent read still observes the previous head, the atomic ref
+        // update is known not to have landed and the semantic target is safe
+        // to release. A transport error has no such acknowledgement: the
+        // server may still finish an accepted request, so retain the
+        // ref_update_dispatched checkpoint and fail closed as indeterminate.
+        if (error instanceof GithubApiResponseError) {
+          lifecycle.checkpoint({ phase: "ref_update_failed" });
+        }
+        setActiveRunBrokerState(runId, "github_pr", state);
+      }
       throw error;
     }
   }
@@ -1725,6 +1743,9 @@ export async function githubReconcileMutation(
       resolution: "indeterminate",
       error: "GitHub ref update was dispatched but the bound head has not confirmed it",
     };
+  }
+  if (phase === "ref_update_failed") {
+    return { resolution: "absent", error: "GitHub ref update failed and did not change the bound head" };
   }
   return { resolution: "absent", error: "GitHub ref update was not dispatched" };
 }

--- a/homerail_manager/src/runtime/github-pr-broker.ts
+++ b/homerail_manager/src/runtime/github-pr-broker.ts
@@ -13,6 +13,8 @@ import {
   setActiveRunBrokerState,
 } from "./active-runs.js";
 import type { CredentialBrokerContext } from "./credential-broker.js";
+import type { CredentialBrokerMutationAttempt } from "../persistence/credential-broker-mutations.js";
+import type { CredentialBrokerReconciliation } from "./credential-broker.js";
 import { spawnManagerGitSync } from "./manager-git.js";
 import { runWorkspacePath } from "./workspace-retention.js";
 
@@ -299,7 +301,9 @@ async function githubToken(context: CredentialBrokerContext): Promise<string> {
       "user-agent": "HomeRail-Autofix-Broker",
       "x-github-api-version": "2022-11-28",
     },
-    signal: AbortSignal.timeout(15_000),
+    signal: context.signal
+      ? AbortSignal.any([context.signal, AbortSignal.timeout(15_000)])
+      : AbortSignal.timeout(15_000),
   });
   if (!response.ok) throw new Error(`GitHub App installation authentication failed (${response.status})`);
   const body = jsonRecord(await response.json(), "GitHub App token response");
@@ -318,7 +322,9 @@ async function githubApi<T>(token: string, pathname: string, init: RequestInit =
       "x-github-api-version": "2022-11-28",
       ...(init.headers ?? {}),
     },
-    signal: init.signal ?? AbortSignal.timeout(20_000),
+    signal: init.signal
+      ? AbortSignal.any([init.signal, AbortSignal.timeout(20_000)])
+      : AbortSignal.timeout(20_000),
   });
   if (!response.ok) throw new Error(`GitHub API request failed (${response.status})`);
   if (response.status === 204) return undefined as T;
@@ -662,7 +668,11 @@ async function boundPull(context: CredentialBrokerContext): Promise<{
   if (!runId) throw new Error("github_pr broker requires a run transport identity");
   const binding = parsePullRequestContext(runId);
   const token = await githubToken(context);
-  const pull = await githubApi<PullResponse>(token, `${repoPath(binding)}/pulls/${binding.pull_number}`);
+  const pull = await githubApi<PullResponse>(
+    token,
+    `${repoPath(binding)}/pulls/${binding.pull_number}`,
+    { signal: context.signal },
+  );
   const state = reconcileState(runId, binding, pullHead(pull, binding));
   return { token, binding, pull, state };
 }
@@ -1538,15 +1548,23 @@ function workspaceCommitInput(
 }
 
 async function commitFiles(
+  context: CredentialBrokerContext,
   runId: string,
   token: string,
   binding: GithubPullRequestContext,
   state: GithubPullRequestState,
   request: { expectedHead: string; message: string; files: GithubCommitFile[] },
 ): Promise<{ previousHead: string; nextHead: string }> {
+  const lifecycle = context.mutation;
+  if (!lifecycle) throw new Error("GitHub mutation requires a durable broker lifecycle");
+  lifecycle.assert_authority();
   if (request.expectedHead !== state.current_head_sha) throw new Error("commit_files expected head is stale");
   const repository = repoPath(binding);
-  const commit = await githubApi<{ tree?: { sha?: string } }>(token, `${repository}/git/commits/${state.current_head_sha}`);
+  const commit = await githubApi<{ tree?: { sha?: string } }>(
+    token,
+    `${repository}/git/commits/${state.current_head_sha}`,
+    { signal: context.signal },
+  );
   const baseTree = String(commit.tree?.sha ?? "").toLowerCase();
   if (!SHA.test(baseTree)) throw new Error("GitHub base tree SHA is invalid");
   const treeEntries = [];
@@ -1558,6 +1576,7 @@ async function commitFiles(
     const blob = await githubApi<{ sha?: string }>(token, `${repository}/git/blobs`, {
       method: "POST",
       body: JSON.stringify({ content: file.bytes.toString("base64"), encoding: "base64" }),
+      signal: context.signal,
     });
     const blobSha = String(blob.sha ?? "").toLowerCase();
     if (!SHA.test(blobSha)) throw new Error("GitHub blob SHA is invalid");
@@ -1566,6 +1585,7 @@ async function commitFiles(
   const tree = await githubApi<{ sha?: string }>(token, `${repository}/git/trees`, {
     method: "POST",
     body: JSON.stringify({ base_tree: baseTree, tree: treeEntries }),
+    signal: context.signal,
   });
   const treeSha = String(tree.sha ?? "").toLowerCase();
   if (!SHA.test(treeSha)) throw new Error("GitHub tree SHA is invalid");
@@ -1573,17 +1593,27 @@ async function commitFiles(
   const nextCommit = await githubApi<{ sha?: string }>(token, `${repository}/git/commits`, {
     method: "POST",
     body: JSON.stringify({ message: request.message, tree: treeSha, parents: [state.current_head_sha] }),
+    signal: context.signal,
   });
   const nextHead = String(nextCommit.sha ?? "").toLowerCase();
   if (!SHA.test(nextHead)) throw new Error("GitHub commit SHA is invalid");
+  lifecycle.checkpoint({
+    phase: "commit_created",
+    previous_head_sha: state.current_head_sha,
+    next_head_sha: nextHead,
+  });
+  lifecycle.assert_authority();
   setActiveRunBrokerState(runId, "github_pr", { ...state, pending_head_sha: nextHead } satisfies GithubPullRequestState);
   const refPath = binding.head_ref.split("/").map(encodeURIComponent).join("/");
+  lifecycle.checkpoint({ phase: "ref_update_dispatched" });
   try {
     await githubApi(token, `${repository}/git/refs/heads/${refPath}`, {
       method: "PATCH",
       body: JSON.stringify({ sha: nextHead, force: false }),
+      signal: context.signal,
     });
   } catch (error) {
+    if (context.signal?.aborted) throw error;
     const pull = await githubApi<PullResponse>(token, `${repository}/pulls/${binding.pull_number}`);
     const observedHead = pullHead(pull, binding);
     if (observedHead !== nextHead) {
@@ -1591,6 +1621,7 @@ async function commitFiles(
       throw error;
     }
   }
+  lifecycle.checkpoint({ phase: "ref_updated" });
   setActiveRunBrokerState(runId, "github_pr", {
     version: 1,
     identity: state.identity,
@@ -1604,13 +1635,17 @@ export async function githubCommitFiles(context: CredentialBrokerContext): Promi
   if (!runId) throw new Error("github_pr broker requires a run transport identity");
   const { token, binding, state } = await boundPull(context);
   const request = commitFilesInput(context.input, binding);
-  const committed = await commitFiles(runId, token, binding, state, request);
-  return {
+  const resultBase = {
     repository: `${binding.owner}/${binding.repo}`,
     pull_number: binding.pull_number,
+    committed_files: request.files.map((file) => file.path),
+  };
+  context.mutation?.checkpoint({ result_base: resultBase });
+  const committed = await commitFiles(context, runId, token, binding, state, request);
+  return {
+    ...resultBase,
     previous_head_sha: committed.previousHead,
     head_sha: committed.nextHead,
-    committed_files: request.files.map((file) => file.path),
   };
 }
 
@@ -1619,14 +1654,77 @@ export async function githubCommitWorkspace(context: CredentialBrokerContext): P
   if (!runId) throw new Error("github_pr broker requires a run transport identity");
   const { token, binding, state } = await boundPull(context);
   const request = workspaceCommitInput(context, binding);
-  const committed = await commitFiles(runId, token, binding, state, request);
-  return {
+  const resultBase = {
     repository: `${binding.owner}/${binding.repo}`,
     pull_number: binding.pull_number,
-    previous_head_sha: committed.previousHead,
-    head_sha: committed.nextHead,
     workspace_path: request.workspacePath,
     manifest_sha256: request.manifestSha256,
     committed_files: request.files.map((file) => file.path),
   };
+  context.mutation?.checkpoint({ result_base: resultBase });
+  const committed = await commitFiles(context, runId, token, binding, state, request);
+  return {
+    ...resultBase,
+    previous_head_sha: committed.previousHead,
+    head_sha: committed.nextHead,
+  };
+}
+
+export function githubMutationSemanticTarget(context: CredentialBrokerContext): string {
+  const runId = context.transport?.run_id;
+  if (!runId) throw new Error("github_pr mutation requires a run transport identity");
+  const binding = parsePullRequestContext(runId);
+  const expectedHead = String(context.input.expected_head_sha ?? "").toLowerCase();
+  if (!SHA.test(expectedHead)) throw new Error("GitHub mutation expected_head_sha is invalid");
+  return `${stateIdentity(binding)}@${expectedHead}`;
+}
+
+export async function githubReconcileMutation(
+  context: CredentialBrokerContext,
+  attempt: CredentialBrokerMutationAttempt,
+): Promise<CredentialBrokerReconciliation> {
+  const runId = context.transport?.run_id;
+  if (!runId) return { resolution: "failed", error: "GitHub reconciliation has no run identity" };
+  const binding = parsePullRequestContext(runId);
+  const token = await githubToken(context);
+  const pull = await githubApi<PullResponse>(
+    token,
+    `${repoPath(binding)}/pulls/${binding.pull_number}`,
+    { signal: context.signal },
+  );
+  const remoteHead = pullHead(pull, binding);
+  const providerState = attempt.provider_state ?? {};
+  const phase = typeof providerState.phase === "string" ? providerState.phase : "prepared";
+  const previousHead = typeof providerState.previous_head_sha === "string"
+    ? providerState.previous_head_sha.toLowerCase()
+    : String(context.input.expected_head_sha ?? "").toLowerCase();
+  const nextHead = typeof providerState.next_head_sha === "string"
+    ? providerState.next_head_sha.toLowerCase()
+    : undefined;
+  if (!SHA.test(previousHead)) return { resolution: "failed", error: "GitHub reconciliation previous head is invalid" };
+  if (nextHead && !SHA.test(nextHead)) return { resolution: "failed", error: "GitHub reconciliation next head is invalid" };
+  if (nextHead && remoteHead === nextHead) {
+    const resultBase = providerState.result_base;
+    if (!resultBase || typeof resultBase !== "object" || Array.isArray(resultBase)) {
+      return { resolution: "failed", error: "GitHub reconciliation result context is missing" };
+    }
+    return {
+      resolution: "completed",
+      result: {
+        ...(resultBase as Record<string, unknown>),
+        previous_head_sha: previousHead,
+        head_sha: nextHead,
+      },
+    };
+  }
+  if (remoteHead !== previousHead) {
+    return { resolution: "failed", error: "Draft PR head changed outside the unresolved broker mutation" };
+  }
+  if (phase === "ref_update_dispatched") {
+    return {
+      resolution: "indeterminate",
+      error: "GitHub ref update was dispatched but the bound head has not confirmed it",
+    };
+  }
+  return { resolution: "absent", error: "GitHub ref update was not dispatched" };
 }

--- a/homerail_manager/src/server/http.ts
+++ b/homerail_manager/src/server/http.ts
@@ -63,7 +63,10 @@ import { runArtifactRoutesHandler } from "./run-artifacts.js";
 import { startRunArtifactService } from "../runtime/run-artifact-service.js";
 import { startDagActorLeaseReaper } from "../runtime/dag-actor-lease-reaper.js";
 import { credentialRoutesHandler } from "./credentials.js";
-import { executeCredentialBrokerCall } from "../runtime/credential-broker.js";
+import {
+  cancelCredentialBrokerCall,
+  executeCredentialBrokerCall,
+} from "../runtime/credential-broker.js";
 import { setupBrowserToolsWebSocket } from "./browser-tools-websocket.js";
 import { toolProviderRoutesHandler } from "./tool-providers.js";
 import { browserUiToolRoutesHandler } from "./browser-ui-tools.js";
@@ -546,6 +549,7 @@ export function createServer(
       }
     },
     onCredentialBrokerCall: executeCredentialBrokerCall,
+    onCredentialBrokerCancel: cancelCredentialBrokerCall,
     onFirstWorkerRegistered: () => {
       // Consume waiting fallbacks first, dispatch their READY round nodes, then
       // retry only live commands that still have an active Worker target.

--- a/homerail_manager/src/worker/types.ts
+++ b/homerail_manager/src/worker/types.ts
@@ -62,6 +62,11 @@ export interface CredentialBrokerCallMessage {
   data: DagCredentialBrokerCallRequest;
 }
 
+export interface CredentialBrokerCancelMessage {
+  type: "credential_broker_cancel";
+  data: DagCredentialBrokerCancelRequest;
+}
+
 export interface DagActorLiveCommandStatusMessage {
   type: "dag_actor_command_status";
   data: DagActorLiveCommandStatusData;
@@ -110,6 +115,7 @@ export type IncomingWorkerMessage =
   | ContentMessage
   | ManagerCommandMessage
   | CredentialBrokerCallMessage
+  | CredentialBrokerCancelMessage
   | DagActorLiveCommandStatusMessage
   | NodeErrorMessage
   | SessionEndMessage
@@ -240,10 +246,16 @@ export function parseIncomingMessage(raw: unknown): IncomingWorkerMessage | null
       if (typeof obj.data !== "object" || obj.data === null || Array.isArray(obj.data)) return null;
       const data = obj.data as Record<string, unknown>;
       if (
-        typeof data.request_id !== "string"
+        data.transport_kind !== "worker_actor"
+        || typeof data.request_id !== "string"
+        || typeof data.idempotency_key !== "string"
         || typeof data.run_id !== "string"
         || typeof data.node_id !== "string"
         || typeof data.session_id !== "string"
+        || typeof data.round_id !== "string"
+        || typeof data.actor_id !== "string"
+        || typeof data.generation !== "number"
+        || typeof data.lease_generation !== "number"
         || typeof data.credential_ref !== "string"
         || typeof data.broker !== "string"
         || typeof data.action !== "string"
@@ -254,6 +266,27 @@ export function parseIncomingMessage(raw: unknown): IncomingWorkerMessage | null
       return {
         type: "credential_broker_call",
         data: data as unknown as DagCredentialBrokerCallRequest,
+      };
+    }
+    case "credential_broker_cancel": {
+      if (typeof obj.data !== "object" || obj.data === null || Array.isArray(obj.data)) return null;
+      const data = obj.data as Record<string, unknown>;
+      if (
+        data.transport_kind !== "worker_actor"
+        || typeof data.request_id !== "string"
+        || typeof data.idempotency_key !== "string"
+        || typeof data.run_id !== "string"
+        || typeof data.node_id !== "string"
+        || typeof data.session_id !== "string"
+        || typeof data.round_id !== "string"
+        || typeof data.actor_id !== "string"
+        || typeof data.generation !== "number"
+        || typeof data.lease_generation !== "number"
+        || (data.command_id !== undefined && typeof data.command_id !== "string")
+      ) return null;
+      return {
+        type: "credential_broker_cancel",
+        data: data as unknown as DagCredentialBrokerCancelRequest,
       };
     }
     case "dag_actor_command_status":
@@ -311,5 +344,6 @@ export function parseIncomingMessage(raw: unknown): IncomingWorkerMessage | null
 }
 import type {
   DagActorLiveCommandStatusData,
+  DagCredentialBrokerCancelRequest,
   DagCredentialBrokerCallRequest,
 } from "homerail-protocol";

--- a/homerail_manager/src/worker/websocket.ts
+++ b/homerail_manager/src/worker/websocket.ts
@@ -37,9 +37,11 @@ import { handleDagActorLiveCommandStatus } from "../runtime/dag-actor-live-comma
 import { ingestDagActorSurfacePatchStream } from "../runtime/dag-actor-surface-patch-stream.js";
 import { ingestDagActorSurfaceMediaStream } from "../runtime/dag-actor-surface-media-stream.js";
 import type {
+  DagCredentialBrokerCancelRequest,
   DagCredentialBrokerCallRequest,
   DagCredentialBrokerCallResult,
 } from "homerail-protocol";
+import { dagCredentialBrokerCallIdentity } from "homerail-protocol";
 
 const WS_URL_PATTERN = /^\/ws\/projects\/([^\/]+)\/workers\/([^\/]+)$/;
 const DEFAULT_REGISTRATION_TIMEOUT_MS = 10_000;
@@ -165,12 +167,13 @@ function isCurrentDagTransport(
   messageType: string,
   data: Record<string, unknown>,
   explicitSessionId?: string,
+  renewExpiredLease = true,
 ): boolean {
   const payload = transportPayload(data);
   const assessment = assessDagTransportFence(payload, {
     targetType: "worker",
     targetId: workerId,
-  });
+  }, { renewExpiredLease });
   if (assessment.status === "current") return true;
 
   const runId = assessment.status === "malformed_payload" ? streamRunId(data) : assessment.runId;
@@ -218,6 +221,10 @@ export interface WorkerWebSocketOptions {
     workerId: string,
     request: DagCredentialBrokerCallRequest,
   ) => Promise<DagCredentialBrokerCallResult>;
+  onCredentialBrokerCancel?: (
+    workerId: string,
+    request: DagCredentialBrokerCancelRequest,
+  ) => boolean;
   /** Fired once, after the first worker successfully registers. Used by the
    * cold-recovery boot path to re-dispatch READY nodes of recovered runs now
    * that a dispatch target exists. */
@@ -745,16 +752,21 @@ export function setupWorkerWebSocket(
             "credential_broker_call",
             { ...msg.data },
             msg.data.session_id,
+            false,
           )) {
             result = {
               request_id: msg.data.request_id,
+              identity: dagCredentialBrokerCallIdentity(msg.data),
               ok: false,
+              outcome: "failed_pre_dispatch",
               error: "Credential broker call has stale or invalid transport identity",
             };
           } else if (!options.onCredentialBrokerCall) {
             result = {
               request_id: msg.data.request_id,
+              identity: dagCredentialBrokerCallIdentity(msg.data),
               ok: false,
+              outcome: "failed_pre_dispatch",
               error: "Credential broker handler unavailable",
             };
           } else {
@@ -763,7 +775,9 @@ export function setupWorkerWebSocket(
             } catch {
               result = {
                 request_id: msg.data.request_id,
+                identity: dagCredentialBrokerCallIdentity(msg.data),
                 ok: false,
+                outcome: "failed",
                 error: "Credential broker call failed without exposing provider details",
               };
             }
@@ -771,6 +785,11 @@ export function setupWorkerWebSocket(
           if (ws.readyState === WebSocket.OPEN) {
             ws.send(JSON.stringify({ type: "credential_broker_result", data: result }));
           }
+          return;
+        }
+
+        if (msg.type === "credential_broker_cancel") {
+          options.onCredentialBrokerCancel?.(worker_id, msg.data);
           return;
         }
 

--- a/homerail_manager/tests/cold-recovery.test.ts
+++ b/homerail_manager/tests/cold-recovery.test.ts
@@ -2,15 +2,22 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { DagCredentialBrokerCallRequest } from "homerail-protocol";
 
 import type {
   DAGDispatcher,
   DispatchEnvelope,
   DispatchResult,
 } from "../src/orchestration/dag-dispatcher.js";
+import { parseWorkflowSource } from "../src/orchestration/workflow-spec-v1.js";
 import { parseDAGYaml } from "../src/orchestration/yaml-loader.js";
 import { _clearListeners, subscribe } from "../src/events/bus.js";
 import { closeDb, getDb } from "../src/persistence/db.js";
+import {
+  completeCredentialBrokerMutation,
+  dispatchCredentialBrokerMutation,
+  prepareCredentialBrokerMutation,
+} from "../src/persistence/credential-broker-mutations.js";
 import { getDagSessionIndex, listDagSessionIndex, upsertDagSessionIndex } from "../src/persistence/dag-session-index.js";
 import {
   _clearAllPersistence,
@@ -255,6 +262,94 @@ describe("manager cold recovery", () => {
       source: "https://x.com/i/status/2074169173178212621",
       parameters: { workflow_id: "cold-recovery" },
     });
+  });
+
+  it("fails a recovered broker gateway whose completed result violates its output contract", () => {
+    const runId = "run-recovered-broker-contract";
+    const parsed = parseWorkflowSource(`
+api_version: homerail.ai/v1
+kind: Workflow
+metadata: { id: recovered-broker-contract, name: Recovered broker contract }
+spec:
+  contracts:
+    Task: { type: object }
+    Text: { type: string }
+  agents:
+    worker: { system: Produce one candidate. }
+  nodes:
+    prepare:
+      kind: agent
+      agent: worker
+      inputs: { task: { contract: Task } }
+      outputs: { candidate: {} }
+    validate:
+      kind: broker
+      inputs: { candidate: {} }
+      outputs: { result: { contract: Text }, error: {} }
+      config:
+        input: candidate
+        credential_ref: recovery-credential
+        purpose: validate one candidate
+        broker: recovery_broker
+        action: validate
+        result_port: result
+        error_port: error
+    done: { kind: terminal, outcome: success, inputs: { result: { contract: Text } } }
+    failed: { kind: terminal, outcome: failure, inputs: { result: {} } }
+  edges:
+    - { from: $run.input, to: prepare.task }
+    - { from: prepare.candidate, to: validate.candidate }
+    - { from: validate.result, to: done.result }
+    - { from: validate.error, to: failed.result, condition: on_failure }
+`);
+    createActiveRun(runId, parsed);
+    const active = getActiveRun(runId)!;
+    active.dagRun.nodeStates.set("prepare", "COMPLETED");
+    active.dagRun.nodeStates.set("validate", "RUNNING");
+    active.dagRun.handoffedNodes.add("prepare");
+    const session = upsertDagSessionIndex({
+      run_id: runId,
+      node_id: "validate",
+      project_key: "recovery-project",
+      session_id: "recovery-gateway-session",
+      attempt: 1,
+      status: "running",
+    });
+    writeRunMetadata(runId, serializeRunMetadata(active));
+    const request: DagCredentialBrokerCallRequest = {
+      request_id: "recovered-gateway-request",
+      idempotency_key: "recovered-gateway-request",
+      transport_kind: "manager_gateway",
+      run_id: runId,
+      node_id: "validate",
+      session_id: session.session_id,
+      round_id: active.currentRound.round_id,
+      gateway_attempt: session.attempt,
+      credential_ref: "recovery-credential",
+      broker: "recovery_broker",
+      action: "validate",
+      input: {},
+    };
+    prepareCredentialBrokerMutation({
+      request,
+      request_digest: "a".repeat(64),
+      semantic_target: "resource:recovered-gateway",
+      source_id: "manager:validate",
+    });
+    dispatchCredentialBrokerMutation(request.request_id);
+    completeCredentialBrokerMutation(request.request_id, { invalid: "not text" });
+
+    _clearActiveRuns();
+    const summary = recoverAllActiveRuns();
+
+    expect(summary.skipped).not.toContain(runId);
+    expect(summary.failed.map((failure) => failure.runId)).toContain(runId);
+    const recovered = getActiveRun(runId);
+    expect(recovered).toBeDefined();
+    expect(recovered?.dagRun.nodeStates.get("validate")).toBe("FAILED");
+    expect(recovered?.status).not.toBe("active");
+    expect(loadRunMetadata(runId)?.status).not.toBe("active");
+    expect(getDagSessionIndex(runId, "validate")?.status).toBe("failed");
   });
 
   it("replays handoff history so a downstream node receives upstream output in its mailbox", () => {

--- a/homerail_manager/tests/credentials.test.ts
+++ b/homerail_manager/tests/credentials.test.ts
@@ -2,10 +2,13 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { DagCredentialBrokerCallRequest } from "homerail-protocol";
 
 import { dispatchEnvelopeAuditView } from "../src/orchestration/ws-dispatch-adapter.js";
 import { parseWorkflowSource } from "../src/orchestration/workflow-spec-v1.js";
 import { closeDb, getDb } from "../src/persistence/db.js";
+import { acquireDagActorLease } from "../src/persistence/dag-actor-leases.js";
+import { getCredentialBrokerMutationAttempt } from "../src/persistence/credential-broker-mutations.js";
 import { expectCurrentSchemaMigrationVersion } from "./schema-migration-helpers.js";
 import {
   createCredential,
@@ -20,11 +23,17 @@ import {
 import {
   _clearActiveRuns,
   buildCurrentDispatchEnvelope,
+  cancelActiveRun,
   createActiveRun,
+  getCurrentNodeSession,
+  markNodeDispatched,
 } from "../src/runtime/active-runs.js";
 import {
+  cancelCredentialBrokerCall,
   executeCredentialBrokerCall,
+  executeManagerCredentialBrokerCall,
   invokeCredentialBroker,
+  recoverCredentialBrokerMutations,
   registerCredentialBroker,
 } from "../src/runtime/credential-broker.js";
 import { parseIncomingMessage } from "../src/worker/types.js";
@@ -53,6 +62,41 @@ ${credentials.replace(/^/gm, "        ")}
     - { from: $run.input, to: work.task }
     - { from: work.done, to: done.result }
 `;
+}
+
+function startWorkerBrokerFence(
+  runId: string,
+  nodeId = "work",
+  workerId = "worker-1",
+): Pick<
+  DagCredentialBrokerCallRequest,
+  "transport_kind" | "run_id" | "node_id" | "session_id" | "round_id"
+  | "actor_id" | "generation" | "lease_generation" | "command_id"
+> {
+  const built = buildCurrentDispatchEnvelope(runId, nodeId);
+  if (!built.ok || !built.envelope.sessionId || !built.envelope.activity) {
+    throw new Error(`could not build broker test fence for ${runId}/${nodeId}`);
+  }
+  const lease = acquireDagActorLease({
+    run_id: runId,
+    actor_id: built.envelope.activity.actorId,
+    target_type: "worker",
+    target_id: workerId,
+  });
+  if (!markNodeDispatched(runId, nodeId)) throw new Error("could not start broker test node");
+  return {
+    transport_kind: "worker_actor",
+    run_id: runId,
+    node_id: nodeId,
+    session_id: built.envelope.sessionId,
+    round_id: built.envelope.activity.roundId,
+    actor_id: built.envelope.activity.actorId,
+    generation: built.envelope.activity.generation,
+    lease_generation: lease.lease_generation,
+    ...(built.envelope.activity.commandId
+      ? { command_id: built.envelope.activity.commandId }
+      : {}),
+  };
 }
 
 describe("generic credential store", () => {
@@ -115,7 +159,7 @@ describe("generic credential store", () => {
       "deleted",
     ]);
     expect(JSON.stringify(listCredentialAuditEvents("demo-api"))).not.toContain(secret);
-    expectCurrentSchemaMigrationVersion(undefined, 31);
+    expectCurrentSchemaMigrationVersion(undefined, 37);
   });
 
   it("does not reinterpret legacy encrypted_credentials rows as execution credentials", () => {
@@ -216,20 +260,21 @@ describe("generic credential store", () => {
     ].join("\n")));
     parsed.meta.agents!.worker.agent_type = "deterministic";
     createActiveRun("credential-broker-run", parsed);
+    const fence = startWorkerBrokerFence("credential-broker-run");
 
     const result = await executeCredentialBrokerCall("worker-1", {
       request_id: "request-1",
-      run_id: "credential-broker-run",
-      node_id: "work",
-      session_id: "credential-broker-run",
+      idempotency_key: "request-1",
+      ...fence,
       credential_ref: "broker-api",
       broker: "test_broker",
       action: "inspect",
       input: { question: "status" },
     });
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       request_id: "request-1",
       ok: true,
+      outcome: "completed",
       result: {
         credential_id: "broker-api",
         authorized: true,
@@ -240,9 +285,8 @@ describe("generic credential store", () => {
 
     const denied = await executeCredentialBrokerCall("worker-1", {
       request_id: "request-2",
-      run_id: "credential-broker-run",
-      node_id: "work",
-      session_id: "credential-broker-run",
+      idempotency_key: "request-2",
+      ...fence,
       credential_ref: "broker-api",
       broker: "test_broker",
       action: "delete",
@@ -251,9 +295,8 @@ describe("generic credential store", () => {
     expect(denied).toMatchObject({ ok: false, error: expect.stringContaining("not permitted") });
     const providerError = await executeCredentialBrokerCall("worker-1", {
       request_id: "request-3",
-      run_id: "credential-broker-run",
-      node_id: "work",
-      session_id: "credential-broker-run",
+      idempotency_key: "request-3",
+      ...fence,
       credential_ref: "broker-api",
       broker: "test_broker",
       action: "inspect",
@@ -264,6 +307,8 @@ describe("generic credential store", () => {
       error: "Credential broker call failed without exposing provider details",
     });
     expect(JSON.stringify(providerError)).not.toContain("broker-secret-value-123");
+    expect(getDb().prepare("SELECT COUNT(*) AS count FROM credential_broker_mutation_attempts").get())
+      .toEqual({ count: 0 });
     expect(listCredentialAuditEvents("broker-api")).toEqual(expect.arrayContaining([
       expect.objectContaining({
         event_type: "materialized",
@@ -271,6 +316,342 @@ describe("generic credential store", () => {
       }),
       expect.objectContaining({ event_type: "denied", result: "failed" }),
     ]));
+  });
+
+  it("records a late mutation as reconciled instead of reporting stale success", async () => {
+    createCredential({
+      id: "mutation-api",
+      credential_type: "api_key",
+      name: "Mutation API",
+      secret: { value: "mutation-secret" },
+    }, { actor: "test" });
+    let release!: () => void;
+    let started!: () => void;
+    const entered = new Promise<void>((resolve) => { started = resolve; });
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    let mutations = 0;
+    registerCredentialBroker("mutation_race", "write", async () => {
+      started();
+      await gate;
+      mutations += 1;
+      return { revision: mutations };
+    }, {
+      effect: "mutation",
+      semanticTarget: () => "resource:one",
+      reconcile: async () => ({ resolution: "indeterminate" }),
+    });
+    const parsed = parseWorkflowSource(workflow([
+      "- credential_ref: mutation-api",
+      "  purpose: mutate through Manager",
+      "  inject:",
+      "    mode: manager_broker",
+      "    broker: mutation_race",
+      "    allowed_actions: [write]",
+    ].join("\n")));
+    parsed.meta.agents!.worker.agent_type = "deterministic";
+    createActiveRun("credential-mutation-race", parsed);
+    const fence = startWorkerBrokerFence("credential-mutation-race");
+    const pending = executeCredentialBrokerCall("worker-1", {
+      request_id: "mutation-race-request",
+      idempotency_key: "mutation-race-request",
+      ...fence,
+      credential_ref: "mutation-api",
+      broker: "mutation_race",
+      action: "write",
+      input: {},
+    });
+
+    await entered;
+    cancelActiveRun("credential-mutation-race");
+    release();
+
+    await expect(pending).resolves.toMatchObject({
+      ok: false,
+      outcome: "reconciled",
+      reconciliation: "completed",
+    });
+    expect(mutations).toBe(1);
+    expect(getCredentialBrokerMutationAttempt("mutation-race-request")).toMatchObject({
+      state: "reconciled",
+      resolution: "completed",
+      result: { revision: 1 },
+    });
+  });
+
+  it("accepts cancellation only for the exact in-flight Actor fence", async () => {
+    createCredential({
+      id: "cancel-api",
+      credential_type: "api_key",
+      name: "Cancel API",
+      secret: { value: "cancel-secret" },
+    }, { actor: "test" });
+    let started!: () => void;
+    const entered = new Promise<void>((resolve) => { started = resolve; });
+    registerCredentialBroker("cancel_mutation", "write", async ({ signal }) => {
+      started();
+      await new Promise<never>((_resolve, reject) => {
+        signal!.addEventListener("abort", () => reject(signal!.reason), { once: true });
+      });
+    }, {
+      effect: "mutation",
+      semanticTarget: () => "resource:cancel",
+      reconcile: async () => ({ resolution: "absent" }),
+    });
+    const parsed = parseWorkflowSource(workflow([
+      "- credential_ref: cancel-api",
+      "  purpose: cancel an in-flight mutation",
+      "  inject:",
+      "    mode: manager_broker",
+      "    broker: cancel_mutation",
+      "    allowed_actions: [write]",
+    ].join("\n")));
+    parsed.meta.agents!.worker.agent_type = "deterministic";
+    createActiveRun("credential-cancel-fence", parsed);
+    const fence = startWorkerBrokerFence("credential-cancel-fence");
+    if (fence.transport_kind !== "worker_actor") throw new Error("expected Worker fence");
+    const request: DagCredentialBrokerCallRequest = {
+      request_id: "cancel-request",
+      idempotency_key: "cancel-request",
+      ...fence,
+      credential_ref: "cancel-api",
+      broker: "cancel_mutation",
+      action: "write",
+      input: {},
+    };
+    const pending = executeCredentialBrokerCall("worker-1", request);
+    await entered;
+
+    expect(cancelCredentialBrokerCall("worker-1", {
+      request_id: request.request_id,
+      idempotency_key: request.idempotency_key,
+      transport_kind: "worker_actor",
+      run_id: request.run_id,
+      node_id: request.node_id,
+      session_id: request.session_id,
+      round_id: request.round_id,
+      actor_id: request.actor_id,
+      generation: request.generation + 1,
+      lease_generation: request.lease_generation,
+    })).toBe(false);
+    expect(cancelCredentialBrokerCall("worker-1", {
+      request_id: request.request_id,
+      idempotency_key: request.idempotency_key,
+      transport_kind: "worker_actor",
+      run_id: request.run_id,
+      node_id: request.node_id,
+      session_id: request.session_id,
+      round_id: request.round_id,
+      actor_id: request.actor_id,
+      generation: request.generation,
+      lease_generation: request.lease_generation,
+    })).toBe(true);
+
+    await expect(pending).resolves.toMatchObject({
+      ok: false,
+      outcome: "reconciled",
+      reconciliation: "absent",
+    });
+    expect(getCredentialBrokerMutationAttempt("cancel-request")).toMatchObject({
+      state: "reconciled",
+      resolution: "absent",
+    });
+  });
+
+  it("applies the same late-mutation reconciliation to Manager-originated calls", async () => {
+    createCredential({
+      id: "manager-mutation-api",
+      credential_type: "api_key",
+      name: "Manager Mutation API",
+      secret: { value: "manager-mutation-secret" },
+    }, { actor: "test" });
+    let release!: () => void;
+    let started!: () => void;
+    const entered = new Promise<void>((resolve) => { started = resolve; });
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    registerCredentialBroker("manager_mutation", "write", async () => {
+      started();
+      await gate;
+      return { revision: 7 };
+    }, {
+      effect: "mutation",
+      semanticTarget: () => "resource:manager",
+      reconcile: async () => ({ resolution: "indeterminate" }),
+    });
+    const parsed = parseWorkflowSource(workflow([
+      "- credential_ref: manager-mutation-api",
+      "  purpose: Manager-owned mutation",
+      "  inject:",
+      "    mode: manager_broker",
+      "    broker: manager_mutation",
+      "    allowed_actions: [write]",
+    ].join("\n")));
+    parsed.meta.agents!.worker.agent_type = "deterministic";
+    createActiveRun("credential-manager-race", parsed);
+    const workerFence = startWorkerBrokerFence("credential-manager-race");
+    const session = getCurrentNodeSession("credential-manager-race", "work");
+    if (!session) throw new Error("missing Manager broker test session");
+    const pending = executeManagerCredentialBrokerCall({
+      request_id: "manager-race-request",
+      idempotency_key: "manager-race-request",
+      transport_kind: "manager_gateway",
+      run_id: "credential-manager-race",
+      node_id: "work",
+      session_id: workerFence.session_id,
+      round_id: workerFence.round_id,
+      gateway_attempt: session.attempt,
+      credential_ref: "manager-mutation-api",
+      broker: "manager_mutation",
+      action: "write",
+      input: {},
+    });
+
+    await entered;
+    cancelActiveRun("credential-manager-race");
+    release();
+
+    await expect(pending).resolves.toMatchObject({
+      ok: false,
+      outcome: "reconciled",
+      reconciliation: "completed",
+    });
+    expect(getCredentialBrokerMutationAttempt("manager-race-request")).toMatchObject({
+      source_type: "manager_gateway",
+      gateway_attempt: session.attempt,
+      state: "reconciled",
+      resolution: "completed",
+    });
+  });
+
+  it("deduplicates a completed mutation by its durable request identity", async () => {
+    createCredential({
+      id: "idempotent-api",
+      credential_type: "api_key",
+      name: "Idempotent API",
+      secret: { value: "idempotent-secret" },
+    }, { actor: "test" });
+    let mutations = 0;
+    registerCredentialBroker("idempotent_mutation", "write", async () => ({ revision: ++mutations }), {
+      effect: "mutation",
+      semanticTarget: () => "resource:idempotent",
+      reconcile: async () => ({ resolution: "indeterminate" }),
+    });
+    const parsed = parseWorkflowSource(workflow([
+      "- credential_ref: idempotent-api",
+      "  purpose: mutate exactly once",
+      "  inject:",
+      "    mode: manager_broker",
+      "    broker: idempotent_mutation",
+      "    allowed_actions: [write]",
+    ].join("\n")));
+    parsed.meta.agents!.worker.agent_type = "deterministic";
+    createActiveRun("credential-idempotency", parsed);
+    const request: DagCredentialBrokerCallRequest = {
+      request_id: "idempotent-request",
+      idempotency_key: "idempotent-request",
+      ...startWorkerBrokerFence("credential-idempotency"),
+      credential_ref: "idempotent-api",
+      broker: "idempotent_mutation",
+      action: "write",
+      input: {},
+    };
+
+    await expect(executeCredentialBrokerCall("worker-1", {
+      ...request,
+      request_id: "stale-lease-request",
+      idempotency_key: "stale-lease-request",
+      lease_generation: request.lease_generation + 1,
+    })).resolves.toMatchObject({ ok: false, outcome: "failed_pre_dispatch" });
+    expect(mutations).toBe(0);
+    expect(getCredentialBrokerMutationAttempt("stale-lease-request")).toBeUndefined();
+
+    const first = await executeCredentialBrokerCall("worker-1", request);
+    const duplicate = await executeCredentialBrokerCall("worker-1", request);
+
+    expect(first).toMatchObject({ ok: true, outcome: "completed", result: { revision: 1 } });
+    expect(duplicate).toMatchObject({ ok: true, outcome: "completed", result: { revision: 1 } });
+    expect(mutations).toBe(1);
+    expect(getDb().prepare(`
+      SELECT state FROM credential_broker_mutation_events
+      WHERE request_id = ? ORDER BY sequence
+    `).all("idempotent-request")).toEqual([
+      { state: "prepared" },
+      { state: "dispatched" },
+      { state: "completed" },
+    ]);
+    expect(() => getDb().prepare(`
+      UPDATE credential_broker_mutation_attempts SET semantic_target = 'tampered'
+      WHERE request_id = 'idempotent-request'
+    `).run()).toThrow(/identity is immutable/);
+    expect(() => getDb().prepare(`
+      DELETE FROM credential_broker_mutation_events WHERE request_id = 'idempotent-request'
+    `).run()).toThrow(/append-only/);
+
+    getDb().prepare("DELETE FROM schema_migrations WHERE version = 37").run();
+    closeDb();
+    expectCurrentSchemaMigrationVersion(undefined, 37);
+    expect(getCredentialBrokerMutationAttempt("idempotent-request")).toMatchObject({
+      state: "completed",
+      result: { revision: 1 },
+    });
+  });
+
+  it("blocks conflicting mutations until recovery reconciles the uncertain attempt", async () => {
+    createCredential({
+      id: "recover-api",
+      credential_type: "api_key",
+      name: "Recover API",
+      secret: { value: "recover-secret" },
+    }, { actor: "test" });
+    let calls = 0;
+    let observed = false;
+    registerCredentialBroker("recover_mutation", "write", async () => {
+      calls += 1;
+      throw new Error("provider response lost");
+    }, {
+      effect: "mutation",
+      semanticTarget: () => "resource:shared",
+      reconcile: async () => observed
+        ? { resolution: "completed", result: { revision: 42 } }
+        : { resolution: "indeterminate" },
+    });
+    const parsed = parseWorkflowSource(workflow([
+      "- credential_ref: recover-api",
+      "  purpose: mutate with recovery",
+      "  inject:",
+      "    mode: manager_broker",
+      "    broker: recover_mutation",
+      "    allowed_actions: [write]",
+    ].join("\n")));
+    parsed.meta.agents!.worker.agent_type = "deterministic";
+    createActiveRun("credential-recovery", parsed);
+    const fence = startWorkerBrokerFence("credential-recovery");
+    const makeRequest = (id: string): DagCredentialBrokerCallRequest => ({
+      request_id: id,
+      idempotency_key: id,
+      ...fence,
+      credential_ref: "recover-api",
+      broker: "recover_mutation",
+      action: "write",
+      input: {},
+    });
+
+    await expect(executeCredentialBrokerCall("worker-1", makeRequest("uncertain-request")))
+      .resolves.toMatchObject({ ok: false, outcome: "indeterminate" });
+    await expect(executeCredentialBrokerCall("worker-1", makeRequest("blocked-request")))
+      .resolves.toMatchObject({ ok: false, outcome: "indeterminate" });
+    expect(calls).toBe(1);
+
+    observed = true;
+    await expect(recoverCredentialBrokerMutations()).resolves.toMatchObject({
+      reconciled: ["uncertain-request"],
+      unresolved: [],
+      failed: [],
+    });
+    expect(getCredentialBrokerMutationAttempt("uncertain-request")).toMatchObject({
+      state: "reconciled",
+      resolution: "completed",
+      result: { revision: 42 },
+    });
   });
 
   it("rejects broker results that reflect a secret", async () => {
@@ -315,9 +696,15 @@ describe("generic credential store", () => {
       type: "credential_broker_call",
       data: {
         request_id: "request-transport",
+        idempotency_key: "request-transport",
+        transport_kind: "worker_actor",
         run_id: "run-transport",
         node_id: "node-transport",
         session_id: "session-transport",
+        round_id: "round-transport",
+        actor_id: "actor-transport",
+        generation: 1,
+        lease_generation: 1,
         credential_ref: "credential-transport",
         broker: "test_broker",
         action: "inspect",
@@ -331,14 +718,38 @@ describe("generic credential store", () => {
       type: "credential_broker_call",
       data: {
         request_id: "request-transport",
+        idempotency_key: "request-transport",
+        transport_kind: "worker_actor",
         run_id: "run-transport",
         node_id: "node-transport",
         session_id: "session-transport",
+        round_id: "round-transport",
+        actor_id: "actor-transport",
+        generation: 1,
+        lease_generation: 1,
         credential_ref: "credential-transport",
         broker: "test_broker",
         action: "inspect",
         input: "not-an-object",
       },
     })).toBeNull();
+    expect(parseIncomingMessage({
+      type: "credential_broker_cancel",
+      data: {
+        request_id: "request-transport",
+        idempotency_key: "request-transport",
+        transport_kind: "worker_actor",
+        run_id: "run-transport",
+        node_id: "node-transport",
+        session_id: "session-transport",
+        round_id: "round-transport",
+        actor_id: "actor-transport",
+        generation: 1,
+        lease_generation: 1,
+      },
+    })).toMatchObject({
+      type: "credential_broker_cancel",
+      data: { request_id: "request-transport", lease_generation: 1 },
+    });
   });
 });

--- a/homerail_manager/tests/credentials.test.ts
+++ b/homerail_manager/tests/credentials.test.ts
@@ -378,6 +378,180 @@ describe("generic credential store", () => {
     });
   });
 
+  it("does not reconcile a conflicting mutation that is still executing in this process", async () => {
+    createCredential({
+      id: "active-blocker-api",
+      credential_type: "api_key",
+      name: "Active Blocker API",
+      secret: { value: "active-blocker-secret" },
+    }, { actor: "test" });
+    let releaseMutation!: () => void;
+    let firstStarted!: () => void;
+    let duplicateStarted!: () => void;
+    const mutationGate = new Promise<void>((resolve) => { releaseMutation = resolve; });
+    const firstEntered = new Promise<void>((resolve) => { firstStarted = resolve; });
+    const duplicateEntered = new Promise<void>((resolve) => { duplicateStarted = resolve; });
+    let mutations = 0;
+    let reconciliations = 0;
+    registerCredentialBroker("active_blocker_mutation", "write", async () => {
+      mutations += 1;
+      if (mutations === 1) firstStarted();
+      else duplicateStarted();
+      await mutationGate;
+      return { revision: mutations };
+    }, {
+      effect: "mutation",
+      semanticTarget: () => "resource:active-blocker",
+      reconcile: async () => {
+        reconciliations += 1;
+        return { resolution: "absent" };
+      },
+    });
+    const parsed = parseWorkflowSource(workflow([
+      "- credential_ref: active-blocker-api",
+      "  purpose: protect an active mutation",
+      "  inject:",
+      "    mode: manager_broker",
+      "    broker: active_blocker_mutation",
+      "    allowed_actions: [write]",
+    ].join("\n")));
+    parsed.meta.agents!.worker.agent_type = "deterministic";
+    createActiveRun("credential-active-blocker", parsed);
+    const fence = startWorkerBrokerFence("credential-active-blocker");
+    const request = (id: string): DagCredentialBrokerCallRequest => ({
+      request_id: id,
+      idempotency_key: id,
+      ...fence,
+      credential_ref: "active-blocker-api",
+      broker: "active_blocker_mutation",
+      action: "write",
+      input: {},
+    });
+
+    const active = executeCredentialBrokerCall("worker-1", request("active-blocker-request"));
+    await firstEntered;
+    const conflicting = executeCredentialBrokerCall("worker-1", request("conflicting-request"));
+    try {
+      const observation = await Promise.race([
+        conflicting.then((result) => ({ kind: "blocked" as const, result })),
+        duplicateEntered.then(() => ({ kind: "duplicate-dispatch" as const })),
+      ]);
+      expect(observation.kind).toBe("blocked");
+      if (observation.kind !== "blocked") return;
+      expect(observation.result).toMatchObject({
+        request_id: "conflicting-request",
+        ok: false,
+        outcome: "indeterminate",
+        error: expect.stringContaining("active-blocker-request"),
+      });
+      expect(mutations).toBe(1);
+      expect(reconciliations).toBe(0);
+      expect(getCredentialBrokerMutationAttempt("active-blocker-request")).toMatchObject({ state: "dispatched" });
+      expect(getCredentialBrokerMutationAttempt("conflicting-request")).toBeUndefined();
+    } finally {
+      releaseMutation();
+      await Promise.allSettled([active, conflicting]);
+    }
+
+    await expect(active).resolves.toMatchObject({ ok: true, outcome: "completed" });
+    expect(getCredentialBrokerMutationAttempt("active-blocker-request")).toMatchObject({ state: "completed" });
+  });
+
+  it("rechecks a semantic blocker after concurrent reconciliation", async () => {
+    createCredential({
+      id: "recheck-blocker-api",
+      credential_type: "api_key",
+      name: "Recheck Blocker API",
+      secret: { value: "recheck-blocker-secret" },
+    }, { actor: "test" });
+    let raceReconciliation = false;
+    let racingRootReconciliations = 0;
+    let releaseReconciliation!: () => void;
+    let bothReconciliationsStarted!: () => void;
+    let releaseWinner!: () => void;
+    let winnerStarted!: () => void;
+    let winnerId = "";
+    const reconciliationGate = new Promise<void>((resolve) => { releaseReconciliation = resolve; });
+    const bothReconciliationsEntered = new Promise<void>((resolve) => { bothReconciliationsStarted = resolve; });
+    const winnerGate = new Promise<void>((resolve) => { releaseWinner = resolve; });
+    const winnerEntered = new Promise<void>((resolve) => { winnerStarted = resolve; });
+    const reconciledRequestIds: string[] = [];
+    registerCredentialBroker("recheck_blocker_mutation", "write", async ({ transport }) => {
+      const requestId = transport?.request_id ?? "";
+      if (requestId === "stale-root-request") throw new Error("provider response lost");
+      winnerId = requestId;
+      winnerStarted();
+      await winnerGate;
+      return { winner: requestId };
+    }, {
+      effect: "mutation",
+      semanticTarget: () => "resource:recheck-blocker",
+      reconcile: async (_context, attempt) => {
+        reconciledRequestIds.push(attempt.request_id);
+        if (!raceReconciliation) return { resolution: "indeterminate" };
+        if (attempt.request_id !== "stale-root-request") return { resolution: "indeterminate" };
+        racingRootReconciliations += 1;
+        if (racingRootReconciliations === 2) bothReconciliationsStarted();
+        await reconciliationGate;
+        return { resolution: "absent" };
+      },
+    });
+    const parsed = parseWorkflowSource(workflow([
+      "- credential_ref: recheck-blocker-api",
+      "  purpose: recheck a concurrently reconciled mutation",
+      "  inject:",
+      "    mode: manager_broker",
+      "    broker: recheck_blocker_mutation",
+      "    allowed_actions: [write]",
+    ].join("\n")));
+    parsed.meta.agents!.worker.agent_type = "deterministic";
+    createActiveRun("credential-recheck-blocker", parsed);
+    const fence = startWorkerBrokerFence("credential-recheck-blocker");
+    const request = (id: string): DagCredentialBrokerCallRequest => ({
+      request_id: id,
+      idempotency_key: id,
+      ...fence,
+      credential_ref: "recheck-blocker-api",
+      broker: "recheck_blocker_mutation",
+      action: "write",
+      input: {},
+    });
+
+    await expect(executeCredentialBrokerCall("worker-1", request("stale-root-request")))
+      .resolves.toMatchObject({ ok: false, outcome: "indeterminate" });
+    raceReconciliation = true;
+    const first = executeCredentialBrokerCall("worker-1", request("first-contender-request"));
+    const second = executeCredentialBrokerCall("worker-1", request("second-contender-request"));
+    await bothReconciliationsEntered;
+    releaseReconciliation();
+    await winnerEntered;
+    try {
+      const blocked = await Promise.race([first, second]);
+      expect(blocked).toMatchObject({
+        ok: false,
+        outcome: "indeterminate",
+        error: expect.stringContaining(winnerId),
+      });
+      expect(blocked.request_id).not.toBe(winnerId);
+      expect(reconciledRequestIds.every((requestId) => requestId === "stale-root-request")).toBe(true);
+      expect(getCredentialBrokerMutationAttempt(winnerId)).toMatchObject({ state: "dispatched" });
+      const blockedId = winnerId === "first-contender-request"
+        ? "second-contender-request"
+        : "first-contender-request";
+      expect(getCredentialBrokerMutationAttempt(blockedId)).toBeUndefined();
+    } finally {
+      releaseWinner();
+      await Promise.allSettled([first, second]);
+    }
+
+    const results = await Promise.all([first, second]);
+    expect(results).toEqual(expect.arrayContaining([
+      expect.objectContaining({ request_id: winnerId, ok: true, outcome: "completed" }),
+      expect.objectContaining({ ok: false, outcome: "indeterminate" }),
+    ]));
+    expect(getCredentialBrokerMutationAttempt(winnerId)).toMatchObject({ state: "completed" });
+  });
+
   it("accepts cancellation only for the exact in-flight Actor fence", async () => {
     createCredential({
       id: "cancel-api",

--- a/homerail_manager/tests/github-pr-broker.test.ts
+++ b/homerail_manager/tests/github-pr-broker.test.ts
@@ -109,6 +109,8 @@ describe("bounded GitHub Draft PR credential broker", () => {
   let brokerRequestSequence: number;
   let refUpdateStarted: (() => void) | undefined;
   let refUpdateGate: Promise<void> | undefined;
+  let refUpdateFailureStatus: number | undefined;
+  let refUpdateTransportError: boolean;
   let fetchSpy: ReturnType<typeof vi.spyOn>;
 
   class RecordingDispatcher implements DAGDispatcher {
@@ -219,6 +221,8 @@ describe("bounded GitHub Draft PR credential broker", () => {
     brokerRequestSequence = 0;
     refUpdateStarted = undefined;
     refUpdateGate = undefined;
+    refUpdateFailureStatus = undefined;
+    refUpdateTransportError = false;
     fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
       const url = new URL(String(input));
       const method = String(init?.method ?? "GET").toUpperCase();
@@ -298,6 +302,10 @@ describe("bounded GitHub Draft PR credential broker", () => {
       if (method === "PATCH" && url.pathname === "/repos/acme/widget/git/refs/heads/autofix/issue-172") {
         refUpdateStarted?.();
         if (refUpdateGate) await refUpdateGate;
+        if (refUpdateTransportError) throw new TypeError("GitHub connection reset");
+        if (refUpdateFailureStatus !== undefined) {
+          return json({ message: "ref update failed" }, refUpdateFailureStatus);
+        }
         remoteHead = NEXT_HEAD;
         return json({ object: { sha: NEXT_HEAD } });
       }
@@ -1232,6 +1240,66 @@ spec:
       files: [{ path: "src/fix.ts", content_base64: Buffer.from("stale\n").toString("base64") }],
     }, "github-stale-after-recovery");
     expect(stale).toMatchObject({ ok: false, error: expect.stringContaining("expected head is stale") });
+  });
+
+  it("releases the semantic target after a ref update returns an error and read-back confirms absence", async () => {
+    refUpdateFailureStatus = 500;
+    const failed = await call("aggregate", "commit_files", {
+      expected_head_sha: INITIAL_HEAD,
+      message: "fix: first ref update attempt",
+      files: [{ path: "src/fix.ts", content_base64: Buffer.from("first\n").toString("base64") }],
+    });
+
+    expect(failed).toMatchObject({
+      ok: false,
+      outcome: "reconciled",
+      reconciliation: "absent",
+      error: expect.stringContaining("GitHub API request failed (500)"),
+    });
+    expect(remoteHead).toBe(INITIAL_HEAD);
+    expect(getDb().prepare(`
+      SELECT state, resolution, provider_state_json
+      FROM credential_broker_mutation_attempts
+      WHERE request_id = ?
+    `).get(failed.request_id)).toMatchObject({
+      state: "reconciled",
+      resolution: "absent",
+      provider_state_json: expect.stringContaining('"phase":"ref_update_failed"'),
+    });
+
+    refUpdateFailureStatus = undefined;
+    const retried = await call("aggregate", "commit_files", {
+      expected_head_sha: INITIAL_HEAD,
+      message: "fix: retry ref update",
+      files: [{ path: "src/fix.ts", content_base64: Buffer.from("retry\n").toString("base64") }],
+    });
+    expect(retried).toMatchObject({ ok: true, outcome: "completed" });
+    expect(remoteHead).toBe(NEXT_HEAD);
+  });
+
+  it("keeps a response-less ref update transport failure indeterminate", async () => {
+    refUpdateTransportError = true;
+    const uncertain = await call("aggregate", "commit_files", {
+      expected_head_sha: INITIAL_HEAD,
+      message: "fix: uncertain ref update",
+      files: [{ path: "src/fix.ts", content_base64: Buffer.from("uncertain\n").toString("base64") }],
+    });
+
+    expect(uncertain).toMatchObject({
+      ok: false,
+      outcome: "indeterminate",
+      error: expect.stringContaining("connection reset"),
+    });
+    expect(remoteHead).toBe(INITIAL_HEAD);
+    expect(getDb().prepare(`
+      SELECT state, resolution, provider_state_json
+      FROM credential_broker_mutation_attempts
+      WHERE request_id = ?
+    `).get(uncertain.request_id)).toMatchObject({
+      state: "indeterminate",
+      resolution: null,
+      provider_state_json: expect.stringContaining('"phase":"ref_update_dispatched"'),
+    });
   });
 
   it("reconciles a ref update that completes after the Actor run is cancelled", async () => {

--- a/homerail_manager/tests/github-pr-broker.test.ts
+++ b/homerail_manager/tests/github-pr-broker.test.ts
@@ -7,14 +7,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { parseWorkflowSource } from "../src/orchestration/workflow-spec-v1.js";
 import type { DAGDispatcher, DispatchEnvelope } from "../src/orchestration/dag-dispatcher.js";
 import { GraphExecutor } from "../src/orchestration/graph-executor.js";
-import { closeDb } from "../src/persistence/db.js";
+import { closeDb, getDb } from "../src/persistence/db.js";
 import { createCredential } from "../src/persistence/credentials.js";
+import { getDagActorByNode } from "../src/persistence/dag-actors.js";
+import { acquireDagActorLease } from "../src/persistence/dag-actor-leases.js";
 import {
   resolveDagRunInputBindings,
   stageDagRunInputArtifact,
 } from "../src/persistence/run-input-artifacts.js";
 import {
   _clearActiveRuns,
+  cancelActiveRun,
   createActiveRun,
   getActiveRun,
   getCurrentNodeSession,
@@ -103,6 +106,9 @@ describe("bounded GitHub Draft PR credential broker", () => {
   let workflowDispatches: Array<Record<string, unknown>>;
   let jobLogs: Map<number, string>;
   let jobLogRequests: number[];
+  let brokerRequestSequence: number;
+  let refUpdateStarted: (() => void) | undefined;
+  let refUpdateGate: Promise<void> | undefined;
   let fetchSpy: ReturnType<typeof vi.spyOn>;
 
   class RecordingDispatcher implements DAGDispatcher {
@@ -210,6 +216,9 @@ describe("bounded GitHub Draft PR credential broker", () => {
     workflowDispatches = [];
     jobLogs = new Map();
     jobLogRequests = [];
+    brokerRequestSequence = 0;
+    refUpdateStarted = undefined;
+    refUpdateGate = undefined;
     fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
       const url = new URL(String(input));
       const method = String(init?.method ?? "GET").toUpperCase();
@@ -287,6 +296,8 @@ describe("bounded GitHub Draft PR credential broker", () => {
       if (method === "POST" && url.pathname === "/repos/acme/widget/git/trees") return json({ sha: createdTreeSha }, 201);
       if (method === "POST" && url.pathname === "/repos/acme/widget/git/commits") return json({ sha: NEXT_HEAD }, 201);
       if (method === "PATCH" && url.pathname === "/repos/acme/widget/git/refs/heads/autofix/issue-172") {
+        refUpdateStarted?.();
+        if (refUpdateGate) await refUpdateGate;
         remoteHead = NEXT_HEAD;
         return json({ object: { sha: NEXT_HEAD } });
       }
@@ -326,11 +337,38 @@ describe("bounded GitHub Draft PR credential broker", () => {
     runId = "github-broker-run",
     sessionId = `session-${nodeId}`,
   ) {
+    const run = getActiveRun(runId);
+    if (!run) throw new Error(`unknown broker test run ${runId}`);
+    if (run.dagRun.nodeStates.get(nodeId) !== "RUNNING") {
+      // These provider-contract tests call individual nodes directly instead
+      // of dispatching the whole graph. Give each call a real active Actor
+      // turn so the production transport fence remains fully enforced.
+      run.dagRun.nodeStates.set(nodeId, "READY");
+      if (!markNodeDispatched(runId, nodeId)) {
+        throw new Error(`could not start broker test node ${runId}/${nodeId}`);
+      }
+    }
+    const actor = getDagActorByNode(runId, nodeId);
+    const session = getCurrentNodeSession(runId, nodeId);
+    if (!actor || !session) throw new Error(`missing broker test Actor fence ${runId}/${nodeId}`);
+    const lease = acquireDagActorLease({
+      run_id: runId,
+      actor_id: actor.actor_id,
+      target_type: "worker",
+      target_id: "worker-one",
+    });
+    const requestId = `${nodeId}-${action}-${++brokerRequestSequence}`;
     return executeCredentialBrokerCall("worker-one", {
-      request_id: `${nodeId}-${action}`,
+      request_id: requestId,
+      idempotency_key: requestId,
+      transport_kind: "worker_actor",
       run_id: runId,
       node_id: nodeId,
-      session_id: sessionId,
+      session_id: session.sessionId,
+      round_id: run.currentRound.round_id,
+      actor_id: actor.actor_id,
+      generation: actor.generation,
+      lease_generation: lease.lease_generation,
       credential_ref: "github-autofix",
       broker: "github_pr",
       action,
@@ -1180,18 +1218,54 @@ spec:
     expect(fetchSpy.mock.calls.find(([, init]) => init?.method === "PATCH")?.[1]?.body)
       .toContain('"force":false');
 
+    handoffActiveRun("github-broker-run", "aggregate", "done", {});
     _clearActiveRuns();
     closeDb();
     expect(recoverAllActiveRuns().recovered).toContain("github-broker-run");
     const recovered = await call("reviewer", "pull_request_snapshot");
     expect(recovered).toMatchObject({ ok: true, result: { head_sha: NEXT_HEAD } });
 
+    createBoundRun("github-stale-after-recovery", ["src"], NEXT_HEAD);
     const stale = await call("aggregate", "commit_files", {
       expected_head_sha: INITIAL_HEAD,
       message: "stale write",
       files: [{ path: "src/fix.ts", content_base64: Buffer.from("stale\n").toString("base64") }],
-    });
+    }, "github-stale-after-recovery");
     expect(stale).toMatchObject({ ok: false, error: expect.stringContaining("expected head is stale") });
+  });
+
+  it("reconciles a ref update that completes after the Actor run is cancelled", async () => {
+    let releaseRefUpdate!: () => void;
+    const enteredRefUpdate = new Promise<void>((resolve) => { refUpdateStarted = resolve; });
+    refUpdateGate = new Promise<void>((resolve) => { releaseRefUpdate = resolve; });
+    const pending = call("aggregate", "commit_files", {
+      expected_head_sha: INITIAL_HEAD,
+      message: "fix: cancellation race",
+      files: [{
+        path: "src/fix.ts",
+        content_base64: Buffer.from("export const raced = true;\n").toString("base64"),
+      }],
+    });
+
+    await enteredRefUpdate;
+    cancelActiveRun("github-broker-run");
+    releaseRefUpdate();
+
+    await expect(pending).resolves.toMatchObject({
+      ok: false,
+      outcome: "reconciled",
+      reconciliation: "completed",
+    });
+    expect(remoteHead).toBe(NEXT_HEAD);
+    expect(getDb().prepare(`
+      SELECT state, resolution, result_json
+      FROM credential_broker_mutation_attempts
+      WHERE run_id = ? AND broker = 'github_pr' AND action = 'commit_files'
+    `).get("github-broker-run")).toMatchObject({
+      state: "reconciled",
+      resolution: "completed",
+      result_json: expect.stringContaining(NEXT_HEAD),
+    });
   });
 
   it("rejects a no-op tree instead of advancing the PR with an empty commit", async () => {

--- a/homerail_manager/tests/persistence-contracts.test.ts
+++ b/homerail_manager/tests/persistence-contracts.test.ts
@@ -184,7 +184,7 @@ describe("SQLite persistence contracts", () => {
   it("installs indexes for status filtering and updated-time run ordering", () => {
     const db = getDb();
     expect(db.prepare("SELECT MAX(version) AS version FROM schema_migrations").get())
-      .toEqual({ version: 36 });
+      .toEqual({ version: 37 });
     expect(db.prepare("PRAGMA index_info(idx_dag_runs_updated)").all())
       .toEqual([
         expect.objectContaining({ seqno: 0, name: "updated_at" }),
@@ -235,7 +235,7 @@ describe("SQLite persistence contracts", () => {
       },
     });
     expect(db.prepare("SELECT MAX(version) AS version FROM schema_migrations").get())
-      .toEqual({ version: 36 });
+      .toEqual({ version: 37 });
     expect(db.prepare("PRAGMA index_list(dag_review_evidence)").all()).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ name: "idx_dag_review_evidence_logical_fence_dedup", unique: 1 }),
@@ -319,7 +319,7 @@ describe("SQLite persistence contracts", () => {
     closeDb();
     const migrated = getDb();
     expect(migrated.prepare("SELECT MAX(version) AS version FROM schema_migrations").get())
-      .toEqual({ version: 36 });
+      .toEqual({ version: 37 });
     const indexes = migrated.prepare("PRAGMA index_list(dag_review_evidence)").all() as Array<{
       name: string;
       unique: number;

--- a/homerail_protocol/src/dag-credentials.ts
+++ b/homerail_protocol/src/dag-credentials.ts
@@ -37,27 +37,101 @@ export interface DagCredentialProjectionSummary {
   allowed_actions?: string[];
 }
 
-export interface DagCredentialBrokerCallRequest {
+interface DagCredentialBrokerCallRequestBase {
   request_id: string;
+  /** Stable replay identity. A reused key must describe the exact same request. */
+  idempotency_key: string;
+  /** Identifies which authority contract owns this operation. */
   run_id: string;
   node_id: string;
   session_id: string;
-  round_id?: string;
-  actor_id?: string;
-  generation?: number;
-  lease_generation?: number;
-  command_id?: string;
+  round_id: string;
   credential_ref: string;
   broker: string;
   action: string;
   input: Record<string, unknown>;
 }
 
+export type DagCredentialBrokerCallRequest = DagCredentialBrokerCallRequestBase & (
+  | {
+      transport_kind: "worker_actor";
+      actor_id: string;
+      generation: number;
+      lease_generation: number;
+      command_id?: string;
+      gateway_attempt?: never;
+    }
+  | {
+      transport_kind: "manager_gateway";
+      gateway_attempt: number;
+      actor_id?: never;
+      generation?: never;
+      lease_generation?: never;
+      command_id?: never;
+    }
+);
+
+export type DagCredentialBrokerCallOutcome =
+  | "completed"
+  | "failed"
+  | "failed_pre_dispatch"
+  | "cancelled"
+  | "indeterminate"
+  | "reconciled";
+
+type WithoutBrokerInput<T> = T extends unknown ? Omit<T, "input"> : never;
+
+/** Immutable correlation identity echoed by every broker result. */
+export type DagCredentialBrokerCallIdentity = WithoutBrokerInput<DagCredentialBrokerCallRequest>;
+
+export function dagCredentialBrokerCallIdentity(
+  request: DagCredentialBrokerCallRequest,
+): DagCredentialBrokerCallIdentity {
+  const { input: _input, ...identity } = request;
+  return identity;
+}
+
+export function matchesDagCredentialBrokerCallIdentity(
+  request: DagCredentialBrokerCallRequest,
+  identity: DagCredentialBrokerCallIdentity,
+): boolean {
+  const expected = dagCredentialBrokerCallIdentity(request) as Record<string, unknown>;
+  const received = identity as Record<string, unknown>;
+  const expectedKeys = Object.keys(expected).sort();
+  const receivedKeys = Object.keys(received).sort();
+  return expectedKeys.length === receivedKeys.length
+    && expectedKeys.every((key, index) => key === receivedKeys[index] && expected[key] === received[key]);
+}
+
 export interface DagCredentialBrokerCallResult {
   request_id: string;
+  identity: DagCredentialBrokerCallIdentity;
   ok: boolean;
+  outcome: DagCredentialBrokerCallOutcome;
+  /** Manager-authored digest of the immutable request and full execution fence. */
+  request_digest?: string;
   result?: unknown;
   error?: string;
+  reconciliation?: "completed" | "absent" | "failed";
+}
+
+/**
+ * Turn-scoped cancellation for an already-sent Worker broker call. The Manager
+ * matches every supplied fence field against the in-flight immutable request;
+ * cancellation by request_id alone is never authoritative.
+ */
+export interface DagCredentialBrokerCancelRequest {
+  request_id: string;
+  idempotency_key: string;
+  transport_kind: "worker_actor";
+  run_id: string;
+  node_id: string;
+  session_id: string;
+  round_id: string;
+  actor_id: string;
+  generation: number;
+  lease_generation: number;
+  command_id?: string;
 }
 
 export function summarizeDagCredentialProjection(

--- a/homerail_worker/src/__tests__/credential-broker-requests.test.ts
+++ b/homerail_worker/src/__tests__/credential-broker-requests.test.ts
@@ -1,13 +1,20 @@
 import { describe, expect, it } from "vitest";
+import { dagCredentialBrokerCallIdentity } from "homerail-protocol";
 
 import { CredentialBrokerRequestRegistry } from "../credential-broker-requests.js";
 
 function request(id: string) {
   return {
     request_id: id,
+    idempotency_key: id,
+    transport_kind: "worker_actor" as const,
     run_id: "run",
     node_id: "aggregate",
     session_id: "session",
+    round_id: "round",
+    actor_id: "actor",
+    generation: 1,
+    lease_generation: 1,
     credential_ref: "github-autofix",
     broker: "github_pr",
     action: "commit_workspace",
@@ -28,7 +35,9 @@ describe("CredentialBrokerRequestRegistry", () => {
     });
     expect(registry.settle({
       request_id: "request-1",
+      identity: dagCredentialBrokerCallIdentity(request("request-1")),
       ok: true,
+      outcome: "completed",
       result: { head_sha: "a".repeat(40), manifest_sha256: "b".repeat(64) },
     })).toBe(true);
     await expect(pending).resolves.toMatchObject({
@@ -47,9 +56,87 @@ describe("CredentialBrokerRequestRegistry", () => {
 
     await expect(pending).resolves.toEqual({
       request_id: "request-2",
+      identity: dagCredentialBrokerCallIdentity(request("request-2")),
       ok: false,
+      outcome: "indeterminate",
       error: "connection closed",
     });
     expect(registry.size).toBe(0);
+  });
+
+  it("forwards the complete transport fence when an in-flight turn is cancelled", async () => {
+    const registry = new CredentialBrokerRequestRegistry();
+    const controller = new AbortController();
+    const sent: string[] = [];
+    const pending = registry.call(
+      request("request-3"),
+      (payload) => sent.push(payload),
+      controller.signal,
+    );
+
+    controller.abort();
+
+    expect(sent.map((payload) => JSON.parse(payload))).toEqual([
+      expect.objectContaining({ type: "credential_broker_call" }),
+      {
+        type: "credential_broker_cancel",
+        data: {
+          request_id: "request-3",
+          idempotency_key: "request-3",
+          transport_kind: "worker_actor",
+          run_id: "run",
+          node_id: "aggregate",
+          session_id: "session",
+          round_id: "round",
+          actor_id: "actor",
+          generation: 1,
+          lease_generation: 1,
+        },
+      },
+    ]);
+    expect(registry.settle({
+      request_id: "request-3",
+      identity: dagCredentialBrokerCallIdentity(request("request-3")),
+      ok: false,
+      outcome: "cancelled",
+      error: "cancelled by Manager",
+    })).toBe(false);
+    await expect(pending).resolves.toMatchObject({ outcome: "indeterminate" });
+    expect(registry.size).toBe(0);
+  });
+
+  it("does not dispatch when the turn was already cancelled", async () => {
+    const registry = new CredentialBrokerRequestRegistry();
+    const controller = new AbortController();
+    const sent: string[] = [];
+    controller.abort();
+
+    await expect(registry.call(
+      request("request-4"),
+      (payload) => sent.push(payload),
+      controller.signal,
+    )).resolves.toMatchObject({ outcome: "cancelled" });
+    expect(sent).toEqual([]);
+  });
+
+  it("rejects a result whose echoed immutable identity does not match", async () => {
+    const registry = new CredentialBrokerRequestRegistry();
+    const pending = registry.call(request("request-5"), () => {});
+    const mismatchedIdentity = dagCredentialBrokerCallIdentity(request("request-5"));
+    if (mismatchedIdentity.transport_kind !== "worker_actor") throw new Error("expected Worker identity");
+
+    expect(registry.settle({
+      request_id: "request-5",
+      identity: {
+        ...mismatchedIdentity,
+        generation: 2,
+      },
+      ok: true,
+      outcome: "completed",
+      result: {},
+    })).toBe(false);
+    expect(registry.size).toBe(1);
+    registry.close("connection closed");
+    await expect(pending).resolves.toMatchObject({ outcome: "indeterminate" });
   });
 });

--- a/homerail_worker/src/__tests__/credential-projection.test.ts
+++ b/homerail_worker/src/__tests__/credential-projection.test.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import { describe, expect, it } from "vitest";
+import { dagCredentialBrokerCallIdentity } from "homerail-protocol";
 import {
   containsCredentialValue,
   materializeCredentialProjections,
@@ -87,6 +88,10 @@ describe("turn-scoped credential projection", () => {
       incoming_edges: [],
       graph_nodes: ["worker"],
       session_id: "session-1",
+      round_id: "round-1",
+      actor_id: "actor-1",
+      generation: 1,
+      lease_generation: 1,
     }, "run-1", () => {});
     const calls: unknown[] = [];
     const tool = createCredentialBrokerCallTool(state, [{
@@ -97,7 +102,13 @@ describe("turn-scoped credential projection", () => {
       allowed_actions: ["bot_info"],
     }], async (request) => {
       calls.push(request);
-      return { request_id: request.request_id, ok: true, result: { bot_name: "Codex" } };
+      return {
+        request_id: request.request_id,
+        identity: dagCredentialBrokerCallIdentity(request),
+        ok: true,
+        outcome: "completed",
+        result: { bot_name: "Codex" },
+      };
     });
 
     const accepted = await tool.handler({ credential_ref: "lark-bot", action: "bot_info", input: {} });

--- a/homerail_worker/src/__tests__/prompt-runner.test.ts
+++ b/homerail_worker/src/__tests__/prompt-runner.test.ts
@@ -11,6 +11,7 @@ import type { PromptJob } from "../prompt-runner.js";
 import {
   HOMERAIL_A2UI_CATALOG_ID,
   HOMERAIL_A2UI_VERSION,
+  dagCredentialBrokerCallIdentity,
   type DagNodeConfig,
 } from "homerail-protocol";
 import { registerAgentBackend } from "../agent/factory.js";
@@ -388,7 +389,13 @@ describe("prompt runner", () => {
       {
         wsSend: () => {},
         agentBackend: "test-correction-broker",
-        credentialBrokerCall: async (request) => ({ request_id: request.request_id, ok: true, result: {} }),
+        credentialBrokerCall: async (request) => ({
+          request_id: request.request_id,
+          identity: dagCredentialBrokerCallIdentity(request),
+          ok: true,
+          outcome: "completed",
+          result: {},
+        }),
       },
     );
 

--- a/homerail_worker/src/credential-broker-requests.ts
+++ b/homerail_worker/src/credential-broker-requests.ts
@@ -2,9 +2,15 @@ import type {
   DagCredentialBrokerCallRequest,
   DagCredentialBrokerCallResult,
 } from "homerail-protocol";
+import {
+  dagCredentialBrokerCallIdentity,
+  matchesDagCredentialBrokerCallIdentity,
+} from "homerail-protocol";
 
 type PendingRequest = {
+  request: DagCredentialBrokerCallRequest;
   resolve: (result: DagCredentialBrokerCallResult) => void;
+  removeAbortListener?: () => void;
 };
 
 /**
@@ -21,24 +27,93 @@ export class CredentialBrokerRequestRegistry {
   call(
     request: DagCredentialBrokerCallRequest,
     send: (payload: string) => void,
+    signal?: AbortSignal,
   ): Promise<DagCredentialBrokerCallResult> {
     return new Promise((resolve) => {
       if (this.pending.has(request.request_id)) {
         resolve({
           request_id: request.request_id,
+          identity: dagCredentialBrokerCallIdentity(request),
           ok: false,
+          outcome: "failed_pre_dispatch",
           error: "Duplicate credential broker request id",
         });
         return;
       }
-      this.pending.set(request.request_id, { resolve });
+      if (signal?.aborted) {
+        resolve({
+          request_id: request.request_id,
+          identity: dagCredentialBrokerCallIdentity(request),
+          ok: false,
+          outcome: "cancelled",
+          error: "Credential broker request cancelled before dispatch",
+        });
+        return;
+      }
+      const pending: PendingRequest = { request: structuredClone(request), resolve };
+      if (signal) {
+        const onAbort = () => {
+          try {
+            const {
+              request_id,
+              idempotency_key,
+              transport_kind,
+              run_id,
+              node_id,
+              session_id,
+              round_id,
+              actor_id,
+              generation,
+              lease_generation,
+              command_id,
+            } = request;
+            send(JSON.stringify({
+              type: "credential_broker_cancel",
+              data: {
+                request_id,
+                idempotency_key,
+                transport_kind,
+                run_id,
+                node_id,
+                session_id,
+                round_id,
+                actor_id,
+                generation,
+                lease_generation,
+                ...(command_id ? { command_id } : {}),
+              },
+            }));
+          } catch {
+            // The operation was already dispatched, so a send failure cannot
+            // make its provider outcome safe to assume.
+          } finally {
+            if (this.pending.get(request.request_id) === pending) {
+              this.pending.delete(request.request_id);
+              pending.removeAbortListener?.();
+              resolve({
+                request_id: request.request_id,
+                identity: dagCredentialBrokerCallIdentity(request),
+                ok: false,
+                outcome: "indeterminate",
+                error: "Credential broker caller cancelled; Manager reconciliation continues",
+              });
+            }
+          }
+        };
+        signal.addEventListener("abort", onAbort, { once: true });
+        pending.removeAbortListener = () => signal.removeEventListener("abort", onAbort);
+      }
+      this.pending.set(request.request_id, pending);
       try {
         send(JSON.stringify({ type: "credential_broker_call", data: request }));
       } catch {
         this.pending.delete(request.request_id);
+        pending.removeAbortListener?.();
         resolve({
           request_id: request.request_id,
+          identity: dagCredentialBrokerCallIdentity(request),
           ok: false,
+          outcome: "failed_pre_dispatch",
           error: "Credential broker request could not be sent",
         });
       }
@@ -47,15 +122,23 @@ export class CredentialBrokerRequestRegistry {
 
   settle(result: DagCredentialBrokerCallResult): boolean {
     const pending = this.pending.get(result.request_id);
-    if (!pending) return false;
+    if (!pending || !matchesDagCredentialBrokerCallIdentity(pending.request, result.identity)) return false;
     this.pending.delete(result.request_id);
+    pending.removeAbortListener?.();
     pending.resolve(result);
     return true;
   }
 
   close(error = "Worker shutting down"): void {
     for (const [requestId, pending] of this.pending) {
-      pending.resolve({ request_id: requestId, ok: false, error });
+      pending.removeAbortListener?.();
+      pending.resolve({
+        request_id: requestId,
+        identity: dagCredentialBrokerCallIdentity(pending.request),
+        ok: false,
+        outcome: "indeterminate",
+        error,
+      });
     }
     this.pending.clear();
   }

--- a/homerail_worker/src/dag-tools/credential-broker.ts
+++ b/homerail_worker/src/dag-tools/credential-broker.ts
@@ -10,12 +10,14 @@ import type { DagToolsState } from "./index.js";
 export type CredentialBrokerBinding = Extract<DagCredentialProjection, { mode: "manager_broker" }>;
 export type CredentialBrokerCaller = (
   request: DagCredentialBrokerCallRequest,
+  signal?: AbortSignal,
 ) => Promise<DagCredentialBrokerCallResult>;
 
 export function createCredentialBrokerCallTool(
   state: DagToolsState,
   bindings: readonly CredentialBrokerBinding[],
   call: CredentialBrokerCaller,
+  abortSignal?: AbortSignal,
 ): DagToolDefinition {
   const credentialRefs = Array.from(new Set(bindings.map((binding) => binding.credential_ref))).sort();
   const actions = Array.from(new Set(bindings.flatMap((binding) => binding.allowed_actions))).sort();
@@ -90,21 +92,30 @@ export function createCredentialBrokerCallTool(
           is_error: true,
         };
       }
+      if (!state.roundId || !state.actorId || state.generation === undefined || state.leaseGeneration === undefined) {
+        return {
+          content: [{ type: "text", text: "Credential broker requires the complete Actor round/generation/lease fence." }],
+          is_error: true,
+        };
+      }
+      const requestId = randomUUID();
       const result = await call({
-        request_id: randomUUID(),
+        request_id: requestId,
+        idempotency_key: requestId,
+        transport_kind: "worker_actor",
         run_id: state.runId,
         node_id: state.nodeId,
         session_id: state.sessionId,
-        ...(state.roundId ? { round_id: state.roundId } : {}),
-        ...(state.actorId ? { actor_id: state.actorId } : {}),
-        ...(state.generation !== undefined ? { generation: state.generation } : {}),
-        ...(state.leaseGeneration !== undefined ? { lease_generation: state.leaseGeneration } : {}),
+        round_id: state.roundId,
+        actor_id: state.actorId,
+        generation: state.generation,
+        lease_generation: state.leaseGeneration,
         ...(state.commandId ? { command_id: state.commandId } : {}),
         credential_ref: credentialRef,
         broker: binding.broker,
         action,
         input: input as Record<string, unknown> | undefined ?? {},
-      });
+      }, abortSignal);
       if (!result.ok) {
         return {
           content: [{ type: "text", text: result.error ?? "Credential broker call failed" }],

--- a/homerail_worker/src/dag-tools/index.ts
+++ b/homerail_worker/src/dag-tools/index.ts
@@ -55,6 +55,7 @@ export interface DagToolsOptions {
     Extract<DagCredentialProjection, { mode: "manager_broker" }>
   >;
   credentialBrokerCaller?: CredentialBrokerCaller;
+  abortSignal?: AbortSignal;
 }
 
 /** Mutable state shared across all DAG tools for a single prompt run. */
@@ -188,6 +189,7 @@ export function createDagTools(state: DagToolsState, options: DagToolsOptions = 
       state,
       options.credentialBrokerBindings,
       options.credentialBrokerCaller,
+      options.abortSignal,
     ));
   }
   if (options.surfacePatchEmitter) {

--- a/homerail_worker/src/index.ts
+++ b/homerail_worker/src/index.ts
@@ -24,6 +24,7 @@ import {
   type DagWorkspaceAccess,
   type DagCredentialProjection,
   type DagCredentialBrokerCallRequest,
+  type DagCredentialBrokerCallIdentity,
   type DagCredentialBrokerCallResult,
 } from "homerail-protocol";
 import { startManagerAgentServer } from "./manager-agent/server.js";
@@ -110,11 +111,12 @@ const pendingCredentialBrokerCalls = new CredentialBrokerRequestRegistry();
 
 function callCredentialBroker(
   request: DagCredentialBrokerCallRequest,
+  signal?: AbortSignal,
 ): Promise<DagCredentialBrokerCallResult> {
   return pendingCredentialBrokerCalls.call(request, (payload) => {
     if (!client.isConnected) throw new Error("Manager connection is unavailable");
     client.send(payload);
-  });
+  }, signal);
 }
 
 function stringField(data: Record<string, unknown>, ...keys: string[]): string {
@@ -454,12 +456,25 @@ client.on("dag_actor_command", (msg) => {
 
 client.on("credential_broker_result", (msg) => {
   const data = (msg.data ?? msg) as Partial<DagCredentialBrokerCallResult>;
-  if (typeof data.request_id !== "string" || typeof data.ok !== "boolean") return;
+  if (
+    typeof data.request_id !== "string"
+    || typeof data.identity !== "object"
+    || data.identity === null
+    || Array.isArray(data.identity)
+    || typeof data.ok !== "boolean"
+    || !["completed", "failed", "failed_pre_dispatch", "cancelled", "indeterminate", "reconciled"].includes(
+      String(data.outcome ?? ""),
+    )
+  ) return;
   pendingCredentialBrokerCalls.settle({
     request_id: data.request_id,
+    identity: data.identity as DagCredentialBrokerCallIdentity,
     ok: data.ok,
+    outcome: data.outcome!,
+    ...(typeof data.request_digest === "string" ? { request_digest: data.request_digest } : {}),
     ...(data.result !== undefined ? { result: data.result } : {}),
     ...(typeof data.error === "string" ? { error: data.error } : {}),
+    ...(data.reconciliation ? { reconciliation: data.reconciliation } : {}),
   });
 });
 
@@ -476,6 +491,7 @@ client.on("inject", (msg) => {
     activePrompt.identity.nodeId === nodeId
   ) {
     const interruptedPrompt = activePrompt;
+    interruptedPrompt.abortController.abort(new Error("manager inject interrupt"));
     void interruptedPrompt.controller.interrupt("manager inject interrupt").then((result) => {
       client.send(
         JSON.stringify({
@@ -514,6 +530,7 @@ async function shutdown() {
   console.log("[homerail_worker] shutting down...");
   const prompt = activePrompt;
   if (prompt) {
+    prompt.abortController.abort(new Error("Worker shutting down"));
     await prompt.controller.close({
       outcome: "failed",
       reason: "Worker shutting down",

--- a/homerail_worker/src/prompt-runner.ts
+++ b/homerail_worker/src/prompt-runner.ts
@@ -102,6 +102,7 @@ export interface PromptRunnerDeps {
   surfaceMediaDownloader?: SurfaceMediaDownloader;
   credentialBrokerCall?: (
     request: DagCredentialBrokerCallRequest,
+    signal?: AbortSignal,
   ) => Promise<DagCredentialBrokerCallResult>;
 }
 
@@ -353,6 +354,7 @@ export async function runPrompt(
     trustedInputs: job.trustedInputs,
     credentialBrokerBindings: job.credentialBrokerBindings,
     credentialBrokerCaller: deps.credentialBrokerCall,
+    abortSignal: deps.abortSignal,
     ...(surfacePatchAllowed
       ? {
           surfacePatchEmitter: ({ surface_id, patch }) => sendStream({


### PR DESCRIPTION
## Summary

- add required Worker and Manager broker fences, cancellation messages, explicit outcomes, and immutable identity echo validation
- add a durable mutation-attempt ledger with idempotency and semantic-target exclusion, provider checkpoints, reconciliation, and startup recovery
- propagate turn cancellation through Worker and Manager broker calls, re-check authority after provider completion, and fail closed on expired leases
- reconcile GitHub commit/ref-update races without projecting stale success into handoff or evidence state
- cover pre-dispatch rejection, cancellation, late completion, response loss, duplicate suppression, recovery, and both Worker/Manager call paths

## Testing

- `npm test`
- `npm run typecheck`

Fixes #253