### PR TITLE
Upgrade DeepSeek Harness to v0.1.2-rc.1

### DIFF
--- a/docs/architecture/deepseek-harness-integration.md
+++ b/docs/architecture/deepseek-harness-integration.md
@@ -1,16 +1,15 @@
 # DeepSeek Harness integration (WIP)
 
 Status: experimental Draft integration, validated against fork commit
-`f4fd5f005636cdcbf9d95f70f04d05afa8c0db54` on 2026-08-23. That commit
-merges official `dsh-v0.1.1-rc.2` (`b150a551b8d465e31e418e1b2eaf5e79bbb7d28e`)
-into the HomeRail integration branch.
+`f0fd50751713ab7e1b7cb1f13310a70c106d81b1` on 2026-09-05. That commit is
+based on official `dsh-v0.1.2-rc.1` (`a66e4702047846cdaa10c66c9d3df3951f5ea70d`).
 
 HomeRail uses the owner-maintained
 [`xiaotianfotos/deepseek-harness`](https://github.com/xiaotianfotos/deepseek-harness)
-fork. The integration branch is `agent/homerail-sdk-control` and tracks the
-official repository through explicit merge commits. The fork carries the HomeRail
-composition, SDK steering and cancellation requests, and an initialization
-contract compatible with the official runtime-readiness barrier, which prevents
+fork. The integration branch is `codex/homerail-sdk-v0.1.2`. The fork carries
+SDK steering and cancellation requests plus a Node-only deploy mode; the
+HomeRail composition is maintained in this repository as a patch over the
+official `sdk-minimal` profile. The upstream runtime-readiness barrier prevents
 a first prompt from racing asynchronous MCP discovery.
 
 ## Runtime boundary
@@ -67,15 +66,16 @@ registry entries and code paths.
 
 The standard Worker image builds the pinned fork in an isolated Docker stage,
 materializes its symlink-free Node deploy closure, and copies only that closure
-into `/opt/deepseek-harness-runtime`. It also sets the runtime command,
-arguments, and HomeRail Cordis config in the image, so ordinary DAG containers
+into `/opt/deepseek-harness-runtime`. It also sets the runtime module and
+HomeRail Cordis patch in the image. The SDK launches that module with
+`--profile sdk-minimal --patch <HomeRail patch>`, so ordinary DAG containers
 need no DSH-specific host setup. Changing the fork revision is an intentional
 Dockerfile change and therefore changes the Worker source fingerprint.
 
 For host-shell Manager Agent development, build the same pinned fork checkout:
 
 ```bash
-git clone --depth 1 --branch agent/homerail-sdk-control \
+git clone --depth 1 --branch codex/homerail-sdk-v0.1.2 \
   https://github.com/xiaotianfotos/deepseek-harness.git
 cd deepseek-harness
 corepack pnpm install --frozen-lockfile
@@ -83,12 +83,11 @@ corepack pnpm run build:lib:host
 corepack pnpm exec tsx scripts/build-exe-for-python-sdk.ts --skip-build --node-only
 ```
 
-Point the Worker at the fork's generic runtime and HomeRail composition. Values
-must be absolute paths; runtime arguments are a JSON string array.
+Point the Worker at the fork's `dsh` runtime module and HomeRail patch. Values
+must be absolute paths.
 
 ```bash
-export HOMERAIL_DSH_RUNTIME_COMMAND=/usr/bin/node
-export HOMERAIL_DSH_RUNTIME_ARGS='["/absolute/path/deepseek-harness/python/sdk-runtime/src/deepseek_harness_runtime/runtime/node/node_modules/@deepseek-ai/dsh-sdk-jsonrpc-demo/lib/packaged-bin.js"]'
+export HOMERAIL_DSH_RUNTIME_BIN=/absolute/path/deepseek-harness/python/sdk-runtime/src/deepseek_harness_runtime/runtime/node/node_modules/@deepseek-ai/dsh/lib/bin.js
 export HOMERAIL_DSH_CORDIS_CONFIG=/absolute/path/homerail/homerail_worker/dsh/homerail.cordis.yml
 ```
 
@@ -96,8 +95,8 @@ Select `deepseek_harness` (aliases `dsh`, `deepseek`, and `deepseek-harness`
 are accepted) and an active HomeRail model setting whose protocol is
 `openai_compatible`. Both Manager Agent host-shell placement and DAG container
 placement resolve through the same runtime contract. A missing fork runtime,
-invalid runtime-argument JSON, or non-OpenAI-compatible endpoint fails instead
-of falling back to another harness.
+invalid patch, or non-OpenAI-compatible endpoint fails instead of falling back
+to another harness.
 
 ## Control protocol
 

--- a/homerail_worker/Dockerfile
+++ b/homerail_worker/Dockerfile
@@ -25,7 +25,7 @@ ARG HOMERAIL_WORKER_BUILD_APT_MIRROR
 ARG HOMERAIL_WORKER_BUILD_APT_SECURITY_MIRROR
 ARG NPM_CONFIG_REGISTRY
 ARG HOMERAIL_DSH_FORK_REPOSITORY=https://github.com/xiaotianfotos/deepseek-harness.git
-ARG HOMERAIL_DSH_FORK_COMMIT=f4fd5f005636cdcbf9d95f70f04d05afa8c0db54
+ARG HOMERAIL_DSH_FORK_COMMIT=f0fd50751713ab7e1b7cb1f13310a70c106d81b1
 COPY homerail_worker/scripts/configure-apt-sources.mjs /opt/homerail/scripts/configure-apt-sources.mjs
 RUN node /opt/homerail/scripts/configure-apt-sources.mjs
 RUN apt-get update \
@@ -72,8 +72,7 @@ ENV HOMERAIL_WORKER_VERSION="${HOMERAIL_WORKER_VERSION}" \
     HOMERAIL_WORKER_PROTOCOL_VERSION="${HOMERAIL_WORKER_PROTOCOL_VERSION}" \
     HOMERAIL_WORKER_SOURCE_FINGERPRINT="${HOMERAIL_WORKER_SOURCE_FINGERPRINT}" \
     HOMERAIL_WORKER_IMAGE_REVISION="${HOMERAIL_WORKER_IMAGE_REVISION}"
-ENV HOMERAIL_DSH_RUNTIME_COMMAND="/usr/local/bin/node" \
-    HOMERAIL_DSH_RUNTIME_ARGS="[\"/opt/deepseek-harness-runtime/node_modules/@deepseek-ai/dsh-sdk-jsonrpc-demo/lib/packaged-bin.js\"]" \
+ENV HOMERAIL_DSH_RUNTIME_BIN="/opt/deepseek-harness-runtime/node_modules/@deepseek-ai/dsh/lib/bin.js" \
     HOMERAIL_DSH_CORDIS_CONFIG="/app/dsh/homerail.cordis.yml"
 
 RUN apt-get update \

--- a/homerail_worker/dsh/homerail.cordis.yml
+++ b/homerail_worker/dsh/homerail.cordis.yml
@@ -1,48 +1,51 @@
-# HomeRail-owned, unattended DeepSeek Harness composition.
-# stdout is reserved for the SDK JSON-RPC transport.
+# HomeRail-owned patch over the standalone sdk-minimal profile.
+# stdout remains reserved for the SDK JSON-RPC transport.
 
-- id: llm-pi-ai
-  name: '@deepseek-ai/dsh-llm-pi-ai'
-  config:
-    providers: !!js JSON.parse(process.env.HOMERAIL_DSH_PROVIDERS_JSON || '{}')
+- id: llm-deepseek
+  disabled: true
 
-- id: homerail-tools
-  name: '@deepseek-ai/dsh-mcp-client'
-  config:
-    serverName: homerail
-    transport: stdio
-    command: !!js process.execPath
-    args:
-      - !!js process.env.HOMERAIL_DSH_MCP_SCRIPT
-    cwd: !!js process.env.DSH_CWD
-    env:
-      HOMERAIL_MCP_BRIDGE_URL: !!js process.env.HOMERAIL_MCP_BRIDGE_URL
-      HOMERAIL_MCP_BRIDGE_TOKEN: !!js process.env.HOMERAIL_MCP_BRIDGE_TOKEN
-    failOnStartupError: true
-    reconnect:
-      enabled: false
-
-- id: agent-spine
-  name: '@deepseek-ai/dsh-agent-spine-demo'
+- id: system-prompt
   config:
     includeHarnessIdentity: false
     includeRuntimeContext: false
     persona: !!js process.env.DSH_SYSTEM_PROMPT
-    workspaceContext: false
-    skills:
-      enabled: false
-    toolBash: false
-    toolJobs: false
+
+- id: persistent-bash
+  disabled: true
+
+- id: persistent-pwsh
+  disabled: true
+
+- id: str-replace-editor
+  disabled: true
 
 - id: sessions
-  name: '@deepseek-ai/dsh-session-persistence-jsonl'
   config:
     root: !!js process.env.DSH_SESSION_ROOT
     compression: none
 
-# The fork's protocol handshake waits for Loader settlement, so MCP discovery
-# is complete before the caller can send the first turn.
 - id: sdk-jsonrpc-server
-  name: '@deepseek-ai/dsh-sdk-jsonrpc-server'
   config:
     maxTokensAsSuccess: true
+
+- insert:
+    - id: llm-pi-ai
+      name: '@deepseek-ai/dsh-llm-pi-ai'
+      config:
+        providers: !!js JSON.parse(process.env.HOMERAIL_DSH_PROVIDERS_JSON || '{}')
+
+    - id: homerail-tools
+      name: '@deepseek-ai/dsh-mcp-client'
+      config:
+        serverName: homerail
+        transport: stdio
+        command: !!js process.execPath
+        args:
+          - !!js process.env.HOMERAIL_DSH_MCP_SCRIPT
+        cwd: !!js process.env.DSH_CWD
+        env:
+          HOMERAIL_MCP_BRIDGE_URL: !!js process.env.HOMERAIL_MCP_BRIDGE_URL
+          HOMERAIL_MCP_BRIDGE_TOKEN: !!js process.env.HOMERAIL_MCP_BRIDGE_TOKEN
+        failOnStartupError: true
+        reconnect:
+          enabled: false

--- a/homerail_worker/package-lock.json
+++ b/homerail_worker/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.251",
-        "@deepseek-ai/dsh-sdk-client": "0.0.1-rc.1",
+        "@deepseek-ai/dsh-sdk-client": "0.1.2-rc.1",
         "@moonshot-ai/kimi-agent-sdk": "^0.1.8",
         "@moonshot-ai/kimi-code": "^0.24.2",
         "@openai/codex": "0.145.0",
@@ -46,6 +46,15 @@
       "engines": {
         "node": ">=20",
         "npm": ">=10"
+      }
+    },
+    "node_modules/@agentclientprotocol/sdk": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-1.4.0.tgz",
+      "integrity": "sha512-/eufudw+aFY1LKLolT6yFE6UMmYRl7fMJ/DEONSIyR6wI3slHWITBsANRGqXEY8FRzqUxwh7QEaGiZHcJPVThg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
@@ -105,9 +114,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -120,9 +126,6 @@
       "integrity": "sha512-RTUf7TPBUkQ6oV3pDkEdcD47I0uH0ZpvmZlXHnrLGznFqyLr+7XHupOxUMJD0Jwm9v5qeqpNiPAYB0dL4RYiHg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -137,9 +140,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -152,9 +152,6 @@
       "integrity": "sha512-SzXrdy7jjrjJIuTG+VMRAY0YZ3G/8w21WuhAozwnvnEUAPo6NDv6lgFinu7NO8J6CPE+MK2sGze6JeCF+ljgUg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -210,32 +207,485 @@
         }
       }
     },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+      "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-node": "^3.972.42",
+        "@aws-sdk/eventstream-handler-node": "^3.972.16",
+        "@aws-sdk/middleware-eventstream": "^3.972.12",
+        "@aws-sdk/middleware-websocket": "^3.972.19",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.977.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.9.tgz",
+      "integrity": "sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@aws-sdk/xml-builder": "^3.972.40",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.33.3",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.70.tgz",
+      "integrity": "sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.72",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.72.tgz",
+      "integrity": "sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.12.1.tgz",
+      "integrity": "sha512-ThMkboGeONWXAelq9FvGsuJC4rOi+qyC4/zhUF58xYpxUg5sQKx2VXZYJmtNjr4dSuBJ1HeJXETQILCz3wOHvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.18.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.15.tgz",
+      "integrity": "sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/credential-provider-env": "^3.972.70",
+        "@aws-sdk/credential-provider-http": "^3.972.72",
+        "@aws-sdk/credential-provider-login": "^3.972.77",
+        "@aws-sdk/credential-provider-process": "^3.972.70",
+        "@aws-sdk/credential-provider-sso": "^3.973.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.77",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.77.tgz",
+      "integrity": "sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.82",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.82.tgz",
+      "integrity": "sha512-znDkEOGXB8W3kG1LJUKP3foBZY/9qLM0eil/DxWXSp37XsdsRLQHE/d/OaCGGVgKpA6znR38h/+INk8do1FjiA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.70",
+        "@aws-sdk/credential-provider-http": "^3.972.72",
+        "@aws-sdk/credential-provider-ini": "^3.973.15",
+        "@aws-sdk/credential-provider-process": "^3.972.70",
+        "@aws-sdk/credential-provider-sso": "^3.973.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.70.tgz",
+      "integrity": "sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.14.tgz",
+      "integrity": "sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/token-providers": "3.1116.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1116.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1116.0.tgz",
+      "integrity": "sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.76",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.76.tgz",
+      "integrity": "sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.34.tgz",
+      "integrity": "sha512-cTeVzpu1xEAkryTZBYhGwnQ6gOGyp8ZYZvmn0Sg/nI/ABmy/CRHHxPDJDUi9PxwxUtGGaatvfRUB3FCgT/rSWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.29.tgz",
+      "integrity": "sha512-dlRzHCgyB8W6hLuDC5pcT5q+ziPt00n4QGgGBE17ucLVU4zMa6lsbuUdQ2Pm75Z5VA8GF+R/+SgrRcaTdIzSIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.52.tgz",
+      "integrity": "sha512-vsPPM+nMbKJlUCFU+eoGZbdxdxDIAX9LbpjSXaR5Ufpmqgp8TdYQnoExhLu4T3umW/JIIPny1ydbhWidZZYokQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.44.tgz",
+      "integrity": "sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.12.1.tgz",
+      "integrity": "sha512-ThMkboGeONWXAelq9FvGsuJC4rOi+qyC4/zhUF58xYpxUg5sQKx2VXZYJmtNjr4dSuBJ1HeJXETQILCz3wOHvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.18.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.46.tgz",
+      "integrity": "sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.5.tgz",
+      "integrity": "sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.10.tgz",
+      "integrity": "sha512-ycwH6Zd2GhuSqdXX9ihbCjeGTB6xOJs+O3+Jb8/zDG9978XU80qs75dfkPJRMNKe5MvBZPuNeFpd4JZKPoUF4g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.40.tgz",
+      "integrity": "sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@deepseek-ai/cordis": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis/-/cordis-4.0.1.tgz",
-      "integrity": "sha512-YBdskTU2Po1kru3GgcUWUbkTsPMA9LkSQDAY8rBkFJeajdgcQad3QPJZE26JyK99Xb6HaASvoXg2DSUTeN/0Nw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis/-/cordis-4.0.2.tgz",
+      "integrity": "sha512-asOnXP1TzFSFQlHb1iegDZp0z/8WD1c7YNrwJR/Tx2bzNuMXfcekE/I67Iv6SQXeLB4csxqCngzQKANP7gdw0g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@deepseek-ai/cosmokit": "^1.8.2",
+        "@deepseek-ai/cosmokit": "^1.8.3",
         "@standard-schema/spec": "^1.1.0"
       },
       "bin": {
         "cordis": "bin.js"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis-plugin-include": "^1.0.6",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2"
+        "@deepseek-ai/cordis-plugin-include": "^1.0.7",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/cordis-plugin-include": {
@@ -246,175 +696,2755 @@
         }
       }
     },
-    "node_modules/@deepseek-ai/cosmokit": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/cosmokit/-/cosmokit-1.8.2.tgz",
-      "integrity": "sha512-muBOKtSrUKU5m/xpq8ZXWL6hQ/jgd4PhU2PqH97bcxIiLEJfNwZOGQEx4t/aS/GgxRAR+ra9pMHPMtTHU4sqqA==",
+    "node_modules/@deepseek-ai/cordis-plugin-group": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-group/-/cordis-plugin-group-1.0.2.tgz",
+      "integrity": "sha512-OeGiPD793Mhma9+rGIox95neuufwOFTqQ5jooFgrMK/Mn7Fp7Hkv/d7VKMXZz40iks2fZCbiFE6p9WjTVTQRdg==",
       "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@deepseek-ai/dsh-agent": {
-      "version": "0.0.1-rc.5",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent/-/dsh-agent-0.0.1-rc.5.tgz",
-      "integrity": "sha512-eJoG89GRf8d7SCjGiSsC5g0fPijuNnJWIis5MmzIRoPSEv73PFOYs+EBHDEpPCQkFNmQjYtviiFhbhNPg9+3CQ==",
-      "license": "BSD-3-Clause",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1-rc.4",
-        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5",
-        "@deepseek-ai/dsh-llm": "^0.0.1-rc.5",
-        "@deepseek-ai/dsh-scope": "^0.0.1-rc.5",
-        "@deepseek-ai/dsh-session": "^0.0.1-rc.5",
-        "@deepseek-ai/dsh-system-prompt": "^0.0.1-rc.5",
-        "@deepseek-ai/dsh-typert-protocol": "^0.0.1-rc.5"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3"
+      }
+    },
+    "node_modules/@deepseek-ai/cordis-plugin-hmr": {
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-hmr/-/cordis-plugin-hmr-1.0.17.tgz",
+      "integrity": "sha512-o1BooaJpwd+C80Tn5+B48MGqrfNZydlfRVQjmCrrULA4nCmlMqBKjDF2FmcZoNP+L2uX9m/6DdGKVtFpQRQVUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@deepseek-ai/cosmokit": "^1.8.3",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "chokidar": "^4.0.3",
+        "picomatch": "^4.0.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-timer": "^1.1.4"
+      }
+    },
+    "node_modules/@deepseek-ai/cordis-plugin-include": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-include/-/cordis-plugin-include-1.0.7.tgz",
+      "integrity": "sha512-bZ4S1YuOmwOeE97HnslQ6ggVQbaWz4GejJ8OcY4P/DIyc1Qhu/3Szt1XSw6c/pd37kRkxxJXGwt4cmCxWSBBuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.3",
+        "js-yaml": "^4.1.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3"
+      }
+    },
+    "node_modules/@deepseek-ai/cordis-plugin-loader": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-loader/-/cordis-plugin-loader-1.0.3.tgz",
+      "integrity": "sha512-YNcHiH7TRFrgnRbQU7qdS1spABUFFHg04QpB9DdboPEjgKLTFfeEAvr6Y7qll3/nGgqywDQdk1tYshqKO0p1WQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "node-addon-require-builtin": "^0.1.4"
+      },
+      "peerDependenciesMeta": {
+        "node-addon-require-builtin": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/cordis-plugin-timer": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-timer/-/cordis-plugin-timer-1.1.4.tgz",
+      "integrity": "sha512-GhxOiU+TF2BbNBKlV2N24zvfv2Kh7RxkFW1hjML6s+DOb+y2zomzbeC5zHIIjsc/rpRwbKpDNucPGSwkH0ChXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/cosmokit": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cosmokit/-/cosmokit-1.8.3.tgz",
+      "integrity": "sha512-qBo+ronVM6Eu2WNVJXi8JcMiqZ19T9BRIpV+5qJUFPXjGH/Z0QKcQMC/IZJ7L394YTOtJgcovbk9qP0w2GsBXQ==",
+      "license": "MIT"
+    },
+    "node_modules/@deepseek-ai/dsh": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh/-/dsh-0.1.2-rc.1.tgz",
+      "integrity": "sha512-RPq48TzxvwpdT9/7W1tbhZDBMmeK+bxDrX9cqQC27Wx/LqtgJF8PSa3b3xriU8oxtvhwYmk21w2cej3uMQrnVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-hmr": "^1.0.17",
+        "@deepseek-ai/cordis-plugin-include": "^1.0.7",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/cordis-plugin-timer": "^1.1.4",
+        "@deepseek-ai/dsh-acp-app": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-agent-instructions": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-agent-tool-presentation": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-app-boot": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-base": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-agent-preset": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-cordis": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-cmdline": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-command-compact": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-command-goal": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-compaction-basic": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-fs-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-goal-round-driver": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-headless": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-hooks-claude-code": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-hooks-codex": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-jobs-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-mcp-client": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-persona": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-plan-mode": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-pwsh-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-pwsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-schedule": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sdk-app": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sdk-minimal": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-reference": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-skill": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-skill-filesystem": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-terminal": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-terminal-bash": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-time-context": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tmux-context": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-token-meter": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-ask-user": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-bash": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-bash-persistent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-cordis": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-fs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-fs-search": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-goal": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-jobs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-pwsh": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-pwsh-persistent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-ralph": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-skill": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-str-replace-editor": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-subagent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-subagent-control": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-todo": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-web": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-workflow": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-web-app": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-webhook": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-webhook-github": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-workflow-worker-thread": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "commander": "^15.0.0",
+        "js-yaml": "^4.2.0",
+        "node-addon-require-builtin": "^0.1.4"
+      },
+      "bin": {
+        "dsh": "lib/bin.js"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-acp": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-acp/-/dsh-acp-0.1.2-rc.1.tgz",
+      "integrity": "sha512-NeMdvjOaKUJXViXlaP9stKnrpYKnk07MVqMneznl5nHlQIjF7ddGDCGD+fsMkQ6qT4166UjCQQaoX2kO6E7/KQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@agentclientprotocol/sdk": "1.4.0",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-mcp-client": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-token-meter": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.2-rc.1"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-token-meter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-acp-app": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-acp-app/-/dsh-acp-app-0.1.2-rc.1.tgz",
+      "integrity": "sha512-GP3TxD+gWQrF3hLn7gUWIgAZJt1mvHBffQGZ7/dqbn6lcBFXduZXZrkVCEosY8l+iGW4r0Y/gFd3aFOSZo8gtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-acp": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-cmdline": "^0.1.2-rc.1",
+        "commander": "^15.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-agent": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent/-/dsh-agent-0.1.2-rc.1.tgz",
+      "integrity": "sha512-lfaqN34vUCWvbn1kJVHrhfJ6Dvt1HDHCm33ZCpmKkl07/5q6FxWqVv6rOdVX5QnM/9xz/uYiN0nQwUtBg4+Skg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-agent-default-model": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-default-model/-/dsh-agent-default-model-0.1.2-rc.1.tgz",
+      "integrity": "sha512-feuTXXl6jIAp71O77l8XzeKcpgahlCXQ7YUjM+Cl/VF0EBpctKkdvwbvTalImRzYYzX5qGK74hblsT2HC4xEwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-agent-instructions": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-instructions/-/dsh-agent-instructions-0.1.2-rc.1.tgz",
+      "integrity": "sha512-9AHeOBe7+KimM2ystfesEYhqcmCuAnrU5MK9qzaYv6HBvQZrU8zYgRAxoqSxeUB5eJoYPvWMvBTBPIRAyvzpjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-fs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-agent-loop": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-loop/-/dsh-agent-loop-0.1.2-rc.1.tgz",
+      "integrity": "sha512-4h16Gn/5oXLTFeorehdlKe5xmDKscR/eRsUu3cs6clKgaTrn6YvnWNB0XkYEg+AXiXbsyfl5MW5Bs4576t7vZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-agent-presets": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-presets/-/dsh-agent-presets-0.1.2-rc.1.tgz",
+      "integrity": "sha512-vNvDw8DYtZ8ySublYY6gFPPruNIST3Xq9bf7RlgoAY4xJxc4w3+/+HOhoYrxQRDWk+FQgYkBnSfnT0OTSOY3RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "js-yaml": "^4.1.0",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-include": "^1.0.7",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-atomic-write": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-agent-tool-presentation": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-tool-presentation/-/dsh-agent-tool-presentation-0.1.2-rc.1.tgz",
+      "integrity": "sha512-flBhNmq0KfIlyy2/8TqmjH1aE9kgaz4S25RhAhOOpHiE7HCcbXePd/+nEPpi9MBlCit8lgHcueznwHpHQLTz+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-anonymous-user-id": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-anonymous-user-id/-/dsh-anonymous-user-id-0.1.2-rc.1.tgz",
+      "integrity": "sha512-8skUsMXiGnyKJi+AiRjGoXIl8inJHgeHgoruW8pjPpWN6g3qJSbO8U9JRZtvwymtjJsQuHmKPI28jc4H6jOCOQ==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-api-gateway": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-gateway/-/dsh-api-gateway-0.1.2-rc.1.tgz",
+      "integrity": "sha512-9jYky3tan2ZFAyaNP2+wbOvwGiUwJdvqqBVUJ6370+2d7OeZIfPu4PMLLFvPqGXR28a9TwuhWoT7i9gpHxRmmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-deque": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "ws": "^8.21.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-api-remotes": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-remotes/-/dsh-api-remotes-0.1.2-rc.1.tgz",
+      "integrity": "sha512-brMHiYcOVt5nXeuiDz1jw6dTJbyZSl/sA4KeZ00vGmYDaIseO6Ujz33zRUjuLMqgvQU4xBFBYXKCU5TLgqlfrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-deque": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-api-session-controller": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-session-controller/-/dsh-api-session-controller-0.1.2-rc.1.tgz",
+      "integrity": "sha512-zmhpkf6ydnYKYw+dmSeGube5py1gUfpIKW3pRMQpX+LOO3xCsAhlRgVnaTTnDveNcZugBEljcVeefOqbJiiadQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-deque": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-agent-default-model": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-api-gateway": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-file-reference": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-native-command": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-query": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-skill": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-registry": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-time": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-workspace-path": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-workspace": "^0.1.2-rc.1"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-jobs": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-persistence": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-projection-cache": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-api-settings-controller": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-settings-controller/-/dsh-api-settings-controller-0.1.2-rc.1.tgz",
+      "integrity": "sha512-xcLcONiPWHOcFcmseYH0suKITI8sAQv4APPD+MdYPUn2fetPKCB6Lh3AJtAOors4ESabGq6lZ56hrsYzcYYcDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-credentials": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-native-command": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-api-workspace-controller": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-workspace-controller/-/dsh-api-workspace-controller-0.1.2-rc.1.tgz",
+      "integrity": "sha512-tfBLMGhU+otJudklD5e9JAK2jq3bSbsAM0LahLZyDpivUYMh56YbLFOLM0yG1qdvgfq2K1MVzssaw3vkq1P1zg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-deque": "^0.1.2-rc.1",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-api-gateway": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-host-directory-picker": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-storage-domain": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-workspace": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-app-boot": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-app-boot/-/dsh-app-boot-0.1.2-rc.1.tgz",
+      "integrity": "sha512-1vltL0FvLjn1Cx1WqAzqGrEJY/gFx7ec8/ZPi2Dxon3Et1IOupJiuze2nZ3Wi7sfgGl5CxytktSkGmJtfTD3mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-atomic-write": "^0.1.2-rc.1",
+        "js-yaml": "^4.2.0",
+        "resolve.exports": "^2.0.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-group": "^1.0.2",
+        "@deepseek-ai/cordis-plugin-hmr": "^1.0.17",
+        "@deepseek-ai/cordis-plugin-include": "^1.0.7",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/dsh-home-paths": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/cordis-plugin-hmr": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-atomic-write": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-atomic-write/-/dsh-atomic-write-0.1.2-rc.1.tgz",
+      "integrity": "sha512-lwWwdXRZrL/xCluykwh+HSFzNPlSyhLPP3oyXas5Zp0e+bc7blk9u6J7bY2GTNBQBIUC7AN+xwFKd3fnkIXGIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-attachment": {
-      "version": "0.0.1-rc.5",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-attachment/-/dsh-attachment-0.0.1-rc.5.tgz",
-      "integrity": "sha512-mjv3gtW39nFJX0MQHZlW9PBlZVLDUZ5HqCfr2gr+ypPQ86RNtHzmLI/9XHF0xcMkT8VMCs6x53bipi87BEQMCg==",
-      "license": "BSD-3-Clause",
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-attachment/-/dsh-attachment-0.1.2-rc.1.tgz",
+      "integrity": "sha512-QISKUjEITusLvAkqPLRn70xDUt+GjjY41pISjtPKYcZ4EGmayzhgZ3VJNYEcC+rbaF44hs2o/0VhOwHA7lyxjw==",
+      "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1-rc.4",
-        "@deepseek-ai/dsh-brand": "^0.0.1-rc.5",
-        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-attachment-local": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-attachment-local/-/dsh-attachment-local-0.1.2-rc.1.tgz",
+      "integrity": "sha512-9G0ytf9s0ONxnRjOjbAhsHj1eeiQtqb6qBeqp9mWT/9/e1Da7GX/YNlwgSnfyi8EUQEG/rh2PM25dC7DNkWK0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "sharp": "^0.35.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-attachment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-authorization": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-authorization/-/dsh-authorization-0.1.2-rc.1.tgz",
+      "integrity": "sha512-ixmc2KAx27KS0Dx2zpjH9/cJAQi6IEmiN9bokUL7GdTAeAMu8uz6ajO59YDYYLZSUWemj5nEvRn/55B20fekcQ==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-credentials": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-base/-/dsh-base-0.1.2-rc.1.tgz",
+      "integrity": "sha512-ir6FKWuuO40E5HgB1vsXKUk9oDxrPIlE39TBwazPc8qkgg42NeSM1OmlpCDo4/wdZh50xPxfdI4EVQI7fN8YMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cordis-plugin-hmr": "^1.0.17",
+        "@deepseek-ai/cordis-plugin-timer": "^1.1.4",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-agent-default-model": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-agent-instructions": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-agent-loop": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-api-gateway": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-attachment-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-bash-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-command-compact": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-command-feedback": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-command-goal": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-compaction-basic": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-credentials-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-deepseek-llm-api-extensions": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-fs-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-fs-observation-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-fs-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-goal-round-driver": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-jobs-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm-deepseek": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm-pi-ai": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm-retry": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-permission-presets": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-plan-mode": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-plugin-package-inventory-deepseek": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-pwsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-repeat-tool-reminder": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-checkpoint-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-log-deepseek": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence-jsonl": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-query-sqlite": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-telemetry-otel": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-title-first-prompt-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-settings-file": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-shell-env": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-skill": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-skill-badge": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-skill-filesystem": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-spill-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-spill-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-storage": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-storage-domain": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-storage-json": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent-fork-in-process": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent-spawn-in-process": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subprocess-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-token-meter": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-bash": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-call-timeout-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-fs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-fs-search": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-goal": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-jobs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-pwsh": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-ralph": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-skill": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-str-replace-editor": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-subagent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-subagent-control": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-todo": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-web": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-workflow": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-loader": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-registry": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-user-questions": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-web": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-web-fetch-http": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-web-search-deepseek": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-workflow-worker-thread": "^0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-bash-local": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-bash-local/-/dsh-bash-local-0.1.2-rc.1.tgz",
+      "integrity": "sha512-/3+AO2TSC5RUKzP0/UZuWhIdwUUd30fx35/eTn8+KlntD7gPgDRMIv1JfXVTxk2pCU3K1V9JX3XjdJ5dHpEObA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-bash-sandbox": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-bash-sandbox/-/dsh-bash-sandbox-0.1.2-rc.1.tgz",
+      "integrity": "sha512-dF9PfBWus80Juj3VjUmndbGw1/6cT1BY7BLFuXUi7SDMV1fA4iwA2c7HuvezYFGvpE/8QRZ+c5ZiRfxbWGYktw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-bash-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.2-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-brand": {
-      "version": "0.0.1-rc.5",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-brand/-/dsh-brand-0.0.1-rc.5.tgz",
-      "integrity": "sha512-aVHMvG5hYLYIXUsvf9mfi0Fvr8w3oU6y1qbhiOiWUVSQu2pKkFgiKJGPIHhMLoj0q4IkewNvsVFQeECdsLLXYg==",
-      "license": "BSD-3-Clause",
-      "peer": true,
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-brand/-/dsh-brand-0.1.2-rc.1.tgz",
+      "integrity": "sha512-y2RHIag3kzLdY8kTBuSUSTsKzWPscJrysNObXTiNM7stXLpa3jXpshsB1caqGzNx50vYcmHeN1gFVECgx3NZHg==",
+      "license": "MIT",
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1-rc.4",
-        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5"
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-connection": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-connection/-/dsh-client-connection-0.1.2-rc.1.tgz",
+      "integrity": "sha512-30g7JG+Z8bDj+ux+KsDfMSXPI6zXotMAFNCxI8O8mJiutJNlZxIL5LXQeDrJpVOW9MWWQkoMp+R+Dxzp5DNDSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-credentials": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-hmr": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-hmr/-/dsh-client-hmr-0.1.2-rc.1.tgz",
+      "integrity": "sha512-gMw6iSn8va2Nt11Tp8zl7q8riaPp3/3wANqZCExLarKCZUs+6fw5MRbbpV7egX3RbsD/Wiihuw0Mhqxsa3Lwqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-locale": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-locale/-/dsh-client-locale-0.1.2-rc.1.tgz",
+      "integrity": "sha512-p34i5WcZ0+b77RKEatGLc6Rh4OgJJmc15kWbBqtCtSI1BxpwZxjDzoNIMTTS3jDGUQqfEd9X7Js9D4uNJDUewg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-modules": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-modules/-/dsh-client-modules-0.1.2-rc.1.tgz",
+      "integrity": "sha512-neStnvWlar+qmADi32QBIJ3m0gmWEk1U0YT9WrTKEfkwQiooPU8lJQjXNfv93x6dgtqieCUhMtUR2a4925R38Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-agent-preset": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-agent-preset/-/dsh-client-ui-agent-preset-0.1.2-rc.1.tgz",
+      "integrity": "sha512-MOlqFzA/TXyvMq9/hAs6C7J1VzZAU9JwJmHqk+RXr1lTYkez0ciXP3hxURyddyRUKt9+C4vSWirJfrSv6woOCw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-approval": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-approval/-/dsh-client-ui-approval-0.1.2-rc.1.tgz",
+      "integrity": "sha512-5mi8xwZd9AiiYtii5PamrU8VogxvBENViTyxMuJIWogR3RnzuItPvyNoD5+H32d0yIWrKr25V+9xFZo17QXKqQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-attachment": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-attachment/-/dsh-client-ui-attachment-0.1.2-rc.1.tgz",
+      "integrity": "sha512-JKescxUlp1I4RBb5uhIaeEF23qYAdkSCMOmQ8lreVXOnerSisSaEhTThocmvmIksi5uUjqH0uxlM8IAtiKsuLg==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-brand-official": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-brand-official/-/dsh-client-ui-brand-official-0.1.2-rc.1.tgz",
+      "integrity": "sha512-BX07g202Uo6PtSvE3unzEl9KcbCbuX/3ORbTktjuc2scnjLLrAjBiWm5pirX8m8hYaOVdobcB8xkvLRlR4X1Mw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-chat": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-chat/-/dsh-client-ui-chat-0.1.2-rc.1.tgz",
+      "integrity": "sha512-uqP142/EzvlJmqgl6gwCT8dTk9ZM8HusaXLrlircOmVxxrwydeHPb2VvRlcbdW1dzJdrlP7hzGVQJegJBa3AIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-commands": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-commands/-/dsh-client-ui-commands-0.1.2-rc.1.tgz",
+      "integrity": "sha512-icfc+d0IAFj8Yd8l8Bq00AsOKAlUTDQfYDICiCIwkqhRzqJgjZGpLIe+M7idr2iZUmM0xstr+r+H+nzi/336OA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-conversation": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-conversation/-/dsh-client-ui-conversation-0.1.2-rc.1.tgz",
+      "integrity": "sha512-PDrV7twPfmZE5TjdvdVVZMHOla36wCojRC8GJBUp1cdXsWUP+Omk10gxYbH1g5TQPdAWgSL+GktdjondSXMSNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "@lexical/history": "^0.49.0",
+        "@lexical/plain-text": "^0.49.0",
+        "@lexical/text": "^0.49.0",
+        "@lexical/utils": "^0.49.0",
+        "clsx": "^2.0.0",
+        "lexical": "^0.49.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-cordis": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-cordis/-/dsh-client-ui-cordis-0.1.2-rc.1.tgz",
+      "integrity": "sha512-2ZtuMYvUOoZraYeXZKh+RkPq0RJFJxPCZIyBdrU6o7k8+WJEflGX0eq3GZ7uy/p97v2V9blqCdIRPz8AAm5UXA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-deliverables": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-deliverables/-/dsh-client-ui-deliverables-0.1.2-rc.1.tgz",
+      "integrity": "sha512-1w8SNnxXA+9xuHqPRb9Z8lesQbik9zYN43+NwzNQT4uoqIcxNpZkiUFa7qG1qRD8Du02D7J0gObVbRJMPnBSkg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-directory-picker-browse": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-directory-picker-browse/-/dsh-client-ui-directory-picker-browse-0.1.2-rc.1.tgz",
+      "integrity": "sha512-11BYh3EOZWbTMjMeskE0Np244b4YYcMkKe5JSSqISL8FT8De3SpOQdKjijt9bX498a6kNlhKWQ27nEzJ7yat6A==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-directory-picker-native": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-directory-picker-native/-/dsh-client-ui-directory-picker-native-0.1.2-rc.1.tgz",
+      "integrity": "sha512-jiUaBBc3XGgS073YhoODC3xFBkG57yznkegbh2V6CFp9c7GLXnIs/7yK1JYA5zxSiOMeEBqynphXMGyAABZdfA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-goal": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-goal/-/dsh-client-ui-goal-0.1.2-rc.1.tgz",
+      "integrity": "sha512-vdB8TZyHM8xLUKmKsZtBQa0gQV0YR0uM2HjkpqAgOhVFeykGWhLtdhi+7kagEAAlthCQAFh4aYmdhWLfr8l/oQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-input-trigger": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-input-trigger/-/dsh-client-ui-input-trigger-0.1.2-rc.1.tgz",
+      "integrity": "sha512-TqdW8VLfNUQYg4g+hVKn22lzpUFMWYbziSBNvi8KVg+aK+SiX+q2UHSGbUQzfYy6TGz+d9HHG9gts7Um/5cHLw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-jobs": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-jobs/-/dsh-client-ui-jobs-0.1.2-rc.1.tgz",
+      "integrity": "sha512-yMvMk1yPinci0U2nqTyaxu+/IXI5DlFmTac3QBoaQGwu31SoreuPjThjPcxnTyJCR9MAwyWcgkpGoXpK0Z/DyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-layout": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-layout/-/dsh-client-ui-layout-0.1.2-rc.1.tgz",
+      "integrity": "sha512-hV/FMsJ/JjaCDxfaRH4+V2t7RauiQqo0vr5Ql0wi32dC4EYT/thhslu9TNCaHpm92SkOkgGFrlwmjYB+slq3FA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-message-feedback": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-message-feedback/-/dsh-client-ui-message-feedback-0.1.2-rc.1.tgz",
+      "integrity": "sha512-JBjZtx5IyrYuYgGnZBuMWKWrH9BDX5uDcEM7dxoUWGwhTca1sDw4I3eKGnIRng6pFoG9SdlXR5lkz18cZd7JCw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-model-selection": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-model-selection/-/dsh-client-ui-model-selection-0.1.2-rc.1.tgz",
+      "integrity": "sha512-eJaZkGhFSS9Wr7rKEoGtei8LoHfsDyHiLpamaZ8eyHS4FN7auqgSUD32MymOqsrrh9+BWNJ8iltncpt8vCFGCA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-permission-presets": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-permission-presets/-/dsh-client-ui-permission-presets-0.1.2-rc.1.tgz",
+      "integrity": "sha512-8SwRFa37w52JO5N7XzsHNQwVLgwqE2avnQpsqrRq40x45i2IKDbA2KFmqBAwIB+2yO/jVGyrtU6SZHelN2T+JQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-plan": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-plan/-/dsh-client-ui-plan-0.1.2-rc.1.tgz",
+      "integrity": "sha512-eu7bRtNkXCmaKc1CR/TEVhdB+ZzT8iPI9/YOm9ao2yteey5uNVxelSWoO/eENs60twVQ8w25MibDRfGNshuZ4A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-reference": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-reference/-/dsh-client-ui-reference-0.1.2-rc.1.tgz",
+      "integrity": "sha512-apaG3DlG6bPlwyfSezu71MiFdJJp18gQS4zlNNrAAaZf8sEn+n6eNfoaBsMCzdchwQNTp1dLDkLK88q4RMG9Bw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-renderer": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-renderer/-/dsh-client-ui-renderer-0.1.2-rc.1.tgz",
+      "integrity": "sha512-mG4aNL7dL57i6I6FLol3AWWp3g2C+EV3jYt2MZHzbfMcS0gQnEd/BSGH3T5DfNCQcOEIGqu0TQ0B3bxnJatmTA==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-schedule": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-schedule/-/dsh-client-ui-schedule-0.1.2-rc.1.tgz",
+      "integrity": "sha512-yZK6iQrePXHNUmlqzPH7jhrv8Kd00tw5/R5kuFfYlXzC7D01TPirYhviJu+fx3TNp5/pI8wP0QHg4Z5Fd+/VuQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-session": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-session/-/dsh-client-ui-session-0.1.2-rc.1.tgz",
+      "integrity": "sha512-A54OtGqniFgT/FHnuUXRLsmR8bJwM3pJrHkgQCvblrDSVdzfjqqglRLcdE0y0W6v2w9V4KpdLuqMW56VoqL42Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-settings": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings/-/dsh-client-ui-settings-0.1.2-rc.1.tgz",
+      "integrity": "sha512-/S16tlS84fggURMqO94HjYbE0xIH82aRJ2E4UupgM9acD3yJ6SCVam17tMcWKnqA6UWJK9llEHhl+KN9JyI/0Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-settings-general": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-general/-/dsh-client-ui-settings-general-0.1.2-rc.1.tgz",
+      "integrity": "sha512-qJfUARsCQ6uqwk2dPrspw30JKUrzTXwPtFcoSCra9ZNTweNcS60FxqwtoCA64//PZ2DMxD/OeuOYQQh3HnniFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-settings-models": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-models/-/dsh-client-ui-settings-models-0.1.2-rc.1.tgz",
+      "integrity": "sha512-r4ErsBy1NE9QWqZmFyxoBFQhCc+pymmc62PFN7PBxFAX85JRJ3asWwjZPpgXW+y7AkqNWy1JVJqlLdf7W5pCIA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-settings-plugin-inventory": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-plugin-inventory/-/dsh-client-ui-settings-plugin-inventory-0.1.2-rc.1.tgz",
+      "integrity": "sha512-FIZptwP3ZvoxsebwqnXyKWvxv2lPte7W2dJwmU8cb/BPJ6MqpQpHKWEaidVErwNDzgvGH02P3wP2lUkvGL1nAw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-settings-plugins": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-plugins/-/dsh-client-ui-settings-plugins-0.1.2-rc.1.tgz",
+      "integrity": "sha512-duv2kU94U2Kz3czBABCCz5yCm22gH3zUoPRyjhD9aykxbXUw7CaJuuv7PqedMdWB9JJT2MKpc/K2t7CkYqCeDg==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-sidebar": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-sidebar/-/dsh-client-ui-sidebar-0.1.2-rc.1.tgz",
+      "integrity": "sha512-+KSFQIsoRK/L2vgExSWQqApeDcE3gJB0l8F+f2wa3t1j4yU1i8GhoIrtjDj+tC7rNVX3oWDOpGE5Hui/GubU/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-skill": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-skill/-/dsh-client-ui-skill-0.1.2-rc.1.tgz",
+      "integrity": "sha512-ec5WDXW8VYnL7IW/FAC4LhnCWEoS1khDdv6McYOk/BUrOhkjymEwIE8GZdBgRW3Lp/uPXE5dHfPsr6B4p8SqSA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-subagent": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-subagent/-/dsh-client-ui-subagent-0.1.2-rc.1.tgz",
+      "integrity": "sha512-LG5XDUoNBMDgNrXyyYbxKZN/0hJ4oPjzAoIrg8NPfZea7HAfHGQ8L7Vdc4e5xhJs69TFWy99glhi0L7VU5bfig==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-theme": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-theme/-/dsh-client-ui-theme-0.1.2-rc.1.tgz",
+      "integrity": "sha512-JqSxsN510rmJl14IKpcZcDmO7qOrr0ftY/anRhgzJ2gDsamUXlLraaUGpcLgGBnNRvWO7X5N22R8HKPUo4uLQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-tool": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-tool/-/dsh-client-ui-tool-0.1.2-rc.1.tgz",
+      "integrity": "sha512-rr3ENrcaRZ8Vb1RkfLaFWUZTGoSfr01GZmwtXi0NHc3HFrRlZwPy0aGeKeMNF/TBoOsV57gxGdWMAPMKWHlTlA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-trajectory": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-trajectory/-/dsh-client-ui-trajectory-0.1.2-rc.1.tgz",
+      "integrity": "sha512-Q+O0cvpr2fzqPAWUEG+CbUVXu0nS1Fnt8a4tJBk0qeWSBfserCTCs3/pGhx7h+lIm/uwjfPsVp8G9M0RQCR+RA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/react-virtual": "^3.14.9",
+        "diff": "^9.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-trajectory/node_modules/@tanstack/react-virtual": {
+      "version": "3.14.10",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.10.tgz",
+      "integrity": "sha512-SRyoUbdFMRHuYXMijV5H4ZarQWpXkj3iANq8OFre+pybeVap8ZJjZ3Nz9bVjx4d8PfobVUQUdKyyyHYk3E+djw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-trajectory/node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-trajectory/node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-user-questions": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-user-questions/-/dsh-client-ui-user-questions-0.1.2-rc.1.tgz",
+      "integrity": "sha512-WNy9euPx0U6HI0SxzujRFG2hVI8MYtLZdVrzMUxzUfrelWdXMRUvneiYcabm0Ss14u47E0tZAetuJaKlwTyK3g==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-workflow-run": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-workflow-run/-/dsh-client-ui-workflow-run-0.1.2-rc.1.tgz",
+      "integrity": "sha512-UXST3yp9tMuRIP5RqXkmShJqtnYcRJE7J0Ujcj1uVcac3JWaoEI8Ijka+Pb3DJlwCHN8bpLpynmgwyqu/A5gdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-workspace": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-workspace/-/dsh-client-ui-workspace-0.1.2-rc.1.tgz",
+      "integrity": "sha512-9zp9ZRfC1nmGEvtF6g5aP9gSgIhA6wAv1LPldxCs5Iicv+5oXr32JqhUzC0X7uCEnh2cFLEcYtEmEllcXsislQ==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-cmdline": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-cmdline/-/dsh-cmdline-0.1.2-rc.1.tgz",
+      "integrity": "sha512-5lSAhyFiJkJFsNzAu3oAgK5Bur9syR/Iq7XVgkC4zA5BmPb+0OAxZ8V/Ihj3JnhrtC4Q3+J6jsZyZRnk3M8x+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3"
       }
     },
     "node_modules/@deepseek-ai/dsh-code-runtime": {
-      "version": "0.0.1-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-code-runtime/-/dsh-code-runtime-0.0.1-rc.1.tgz",
-      "integrity": "sha512-lfHc2HevlivlnKWt876s1rOSov5PyR9tPpPiQFEs46jREF5JjwMdE8yTUbpEnBt9A97NZ+vKl2o7LbqVZPSSxg==",
-      "license": "BSD-3-Clause",
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-code-runtime/-/dsh-code-runtime-0.1.2-rc.1.tgz",
+      "integrity": "sha512-dv5UszPJb/AFcarZc2c6h5z/X80bsrSd3bfIOugwNVclSI6P+L3ixseoZKgyks7T0Ap0h6ngXGk2WeoUkmYxnQ==",
+      "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.1"
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
-    "node_modules/@deepseek-ai/dsh-invariants": {
-      "version": "0.0.1-rc.5",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.0.1-rc.5.tgz",
-      "integrity": "sha512-63LTrIMPAeJowv5E9Sr87w1SPs1Ign2/ofr+LPdrgAi4Pi32YFK9o4vSVv7osRHAIzlwxRCoFksythq+Jire3w==",
-      "license": "BSD-3-Clause",
-      "peer": true,
+    "node_modules/@deepseek-ai/dsh-code-runtime-worker-thread": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-code-runtime-worker-thread/-/dsh-code-runtime-worker-thread-0.1.2-rc.1.tgz",
+      "integrity": "sha512-0Y/Uiq9iK2Z8/ODL+KOsjbPzZ+n3D+j52CcBpblzysKw2GOF/zAoQtEZHhtgy3oK2R8HRxrQo4zJI20v7fC43A==",
+      "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1-rc.4"
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1-rc.4"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-code-runtime": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-llm": {
-      "version": "0.0.1-rc.5",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm/-/dsh-llm-0.0.1-rc.5.tgz",
-      "integrity": "sha512-+w+bYuimnZZwQshdEkZynFPH9FwYfRrEDkgnBshfkjDe1nqqH3h/K6amu8pcIZ2J8XaI6osAImyz7BAAuN589g==",
-      "license": "BSD-3-Clause",
-      "peer": true,
+    "node_modules/@deepseek-ai/dsh-command-compact": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-command-compact/-/dsh-command-compact-0.1.2-rc.1.tgz",
+      "integrity": "sha512-b0E3HxpitGd15csYx97AiQtGb09AARJDQ0/mvrT1DFrPHOHnep+ybayq8VeOrcDhspTz72PwA7OgxZe/I1yvLA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-commands": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-compaction": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-command-feedback": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-command-feedback/-/dsh-command-feedback-0.1.2-rc.1.tgz",
+      "integrity": "sha512-gA9MVB5LW82dvKm1Rxz9fN0smz/7ZJ/H131iz5AWFYhQsJ4OaDFJU6SxudHfLrAEiVN7ZEGyMU5zqqW1DNtC6w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-telemetry": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-command-goal": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-command-goal/-/dsh-command-goal-0.1.2-rc.1.tgz",
+      "integrity": "sha512-+MwYtJnr9/oZ4WWcz3g7IRoIt+OUR1F+KZ0Xq3IEVSq8z5A8KBenRz7jVVG2LMksQFlEPxB7kas8SI+WEpWNAQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-commands": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-commands": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-commands/-/dsh-commands-0.1.2-rc.1.tgz",
+      "integrity": "sha512-uBh4JTX7pOkFhmbWjXjVLnOQOawyccC7+DazbHrLRN6/wy4OgTRH+DaW0+ibLq+XRAO19OvBTtuoh3x/KkJx1Q==",
+      "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1-rc.4"
+        "@deepseek-ai/dsh-util-crypto": "^0.1.2-rc.1",
+        "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1-rc.4",
-        "@deepseek-ai/dsh-attachment": "^0.0.1-rc.5",
-        "@deepseek-ai/dsh-brand": "^0.0.1-rc.5",
-        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5",
-        "@deepseek-ai/dsh-timeout": "^0.0.1-rc.5"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-scope": {
-      "version": "0.0.1-rc.5",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-scope/-/dsh-scope-0.0.1-rc.5.tgz",
-      "integrity": "sha512-9dPbw8Lj2VMmbFqUKMlzhudSN/Z5xVY6otDMSKBqnF88WnOugslZXkYToOMQO8EUEJorE0d0M+aUAq4titzOwA==",
-      "license": "BSD-3-Clause",
+    "node_modules/@deepseek-ai/dsh-compaction": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction/-/dsh-compaction-0.1.2-rc.1.tgz",
+      "integrity": "sha512-omzrM2EQdoUvQ41PbbXiFERC7I4FYiLNmHIYrlCZfCAdxo0G4u3kt7eahhVaSSi2YsinL7sW79C7cTVaUWlZVg==",
+      "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1-rc.4",
-        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-sdk-client": {
-      "version": "0.0.1-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sdk-client/-/dsh-sdk-client-0.0.1-rc.1.tgz",
-      "integrity": "sha512-qHdB9PIkLwbX0HATMLPaYq69up7Ny/ooFh0Da3UCM2qkXj4k7ZmAl35WXLA01anuapdWl17sH78bvVO2Nu41iA==",
-      "license": "BSD-3-Clause",
+    "node_modules/@deepseek-ai/dsh-compaction-basic": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction-basic/-/dsh-compaction-basic-0.1.2-rc.1.tgz",
+      "integrity": "sha512-x4HEQ4hiPwHE5nljFXsVzG8nOVnEQIwmIxVB9csnWyKcika6yoAGPujeFcGdZKoMPiADt2JglO8fLuAj3ROCXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-sdk-protocol": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.0.1-rc.1"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-compaction": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-token-meter": "^0.1.2-rc.1"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-compaction-tool-result-pruner": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@deepseek-ai/dsh-sdk-protocol": {
-      "version": "0.0.1-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sdk-protocol/-/dsh-sdk-protocol-0.0.1-rc.1.tgz",
-      "integrity": "sha512-qFR4rvJvgUTvzEtDPCQtzrAM0MS0WAjIyXiWcYeNj+dJjSHXm8/9TJBzNAscrR4V7aI4tnx6tdfw5OlYyHzj6g==",
-      "license": "BSD-3-Clause",
+    "node_modules/@deepseek-ai/dsh-compaction-tool-result-pruner": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction-tool-result-pruner/-/dsh-compaction-tool-result-pruner-0.1.2-rc.1.tgz",
+      "integrity": "sha512-4QcB5CY5+ubrIoNLJBZwNV+2mnagwn4JwDW9qunr7UL29cS8AeWAksqMbpDZOMmyDuLpg4Alcnb5kqKtfZFNug==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-compaction": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-token-meter": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-cordis-client-runner": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-cordis-client-runner/-/dsh-cordis-client-runner-0.1.2-rc.1.tgz",
+      "integrity": "sha512-CjJ1x8Ub/GTbMsAXBpdGK10ZMoLRLQxnJDM7hUb/HhCOSwjfRiUYXw4KyPl3Ez7ariW/qIlI+HZBLiaDb8AUWg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-cordis-host-runner": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-cordis-host-runner/-/dsh-cordis-host-runner-0.1.2-rc.1.tgz",
+      "integrity": "sha512-fI2eavQhDiEXdwpnGc484/05xFMBwgu71Yw4pNyCYVfdH5y54i2vJ91EqOAiVjLx0SYwdrcnNo+ON7+zqayjnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-credentials": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-credentials/-/dsh-credentials-0.1.2-rc.1.tgz",
+      "integrity": "sha512-e7DGpuYQqiD4dOWGQeY/XAWPTjbax/MkrXBwsB8wBtNpoPiAKiLYgd+iFiQc66BGOlutSRFz31IKdbduqPbTxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-credentials-local": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-credentials-local/-/dsh-credentials-local-0.1.2-rc.1.tgz",
+      "integrity": "sha512-CuIREkLNPytX0Cl/TSVehdVXz6+QBkY8wjhkSMpOIrtK8hC18c3Hs/kUBwlCk68bbWDvUk+pSrc/l3D4NPwHhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "chokidar": "^4.0.3",
+        "yaml": "^2.9.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-atomic-write": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-credentials": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-deepseek-llm-api-extensions": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-deepseek-llm-api-extensions/-/dsh-deepseek-llm-api-extensions-0.1.2-rc.1.tgz",
+      "integrity": "sha512-7UTnGeKWpxfJRewQ8uADe2CoSCaJesI6W8YXJ/SzHA9hvHx8KM3hZl0fD6OxlQszUFoSeWdkCFZocAd97Dw5Eg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-deque": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-deque/-/dsh-deque-0.1.2-rc.1.tgz",
+      "integrity": "sha512-v2HL9e6NER5Yv8p3+8zls9YvhG3NeRRMVg0GZ/4VgOJcVDgZp14EYVVbheX9HzYlyiic41ciAf1T8Y2pkV41OQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-file-reference": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-file-reference/-/dsh-file-reference-0.1.2-rc.1.tgz",
+      "integrity": "sha512-m4Rvk7tpOep62Q1UCceeqFKSM0K4Y6igZopuKn+AZkL2FAM2JISojMefXq5SKtjPiZP0Vg4BpDey3M63Bnl4xw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-file-reference-local": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-file-reference-local/-/dsh-file-reference-local-0.1.2-rc.1.tgz",
+      "integrity": "sha512-TFqBWigbO/yQDHgmGjY+gcSs3VjEXDqw+uWxMDvpgLvGArhUR03/cXrxF2pnKOjSZGx79tTLWo2YbaYKuKJSuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-file-reference": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-fs": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs/-/dsh-fs-0.1.2-rc.1.tgz",
+      "integrity": "sha512-BSIB2j8WvATQ1mf7wUIpHPftDwbzz246qp6aUpLGSzBWGmLBdX3O1oDhyNV1YhgPmDQlwovac2odcAb62tuDdw==",
+      "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-subagent": "^0.0.1-rc.1"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-session": {
-      "version": "0.0.1-rc.5",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session/-/dsh-session-0.0.1-rc.5.tgz",
-      "integrity": "sha512-/xFNk3scb0KXGKW9vjpW4drNTHVJYEw5gdW8xOPbgO+8/4AEtrS2m69P5ancdgcpufheLgJQ1H6sacFUAP1IpQ==",
-      "license": "BSD-3-Clause",
+    "node_modules/@deepseek-ai/dsh-fs-local": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs-local/-/dsh-fs-local-0.1.2-rc.1.tgz",
+      "integrity": "sha512-tFHHKtD11tIk3FpkWF0vBKdX05zKbwqXQW9LhreA5hErCKEsulUsQLamf+kF1D8fuKqa8Yb+yWQIfYS93cy39w==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "koffi": "^3.1.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-fs": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-fs-observation-policy": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs-observation-policy/-/dsh-fs-observation-policy-0.1.2-rc.1.tgz",
+      "integrity": "sha512-Uw3ErcPwQZUvXylLSf+CDjzfAza5ZVNOMkG4hIJjvgG4WBg3tqoCOY2OQk4O1DGTie4EzL4mHpAe5auwoV4JTw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-fs": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-fs-sandbox": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs-sandbox/-/dsh-fs-sandbox-0.1.2-rc.1.tgz",
+      "integrity": "sha512-nnZnsOYLWrN2AnoB0qvQBLhh2VdU4A39AqOgWwsxnT3JrScGpvBcBMCt4fpLP9l5VjOY1qhIbLf6xd5p93C/6Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-fs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-fs-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-goal": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-goal/-/dsh-goal-0.1.2-rc.1.tgz",
+      "integrity": "sha512-djzY1oNZV5RwnOFXmDeWFbyswInV9RVWAD0qryxMznQtEDF31PUJ8BQfqs9tVrTV36V3a0neYrZP0DDvRP8ZCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-goal-round-driver": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-goal-round-driver/-/dsh-goal-round-driver-0.1.2-rc.1.tgz",
+      "integrity": "sha512-TNlX5K7EL+hNGqegaEs3ODGKhEGtUll368Gtmw+uRmgVzJIUIBiyH4JIDQSIwO8PcYQ2wIpXuipRTgQCp/9K+w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-headless": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-headless/-/dsh-headless-0.1.2-rc.1.tgz",
+      "integrity": "sha512-tKJ1/7wHAwDY2mBz5DJnEq2JvkusN3srbyH5kCXUW8131bwvJkkMLMyUfGnf5ASlFe9vmBapF8sYU9KPWUgh0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-cmdline": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-code-runtime-worker-thread": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "commander": "^15.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-agent-default-model": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-home-paths": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-home-paths/-/dsh-home-paths-0.1.2-rc.1.tgz",
+      "integrity": "sha512-DeDXxvrhAlkS+hxNLSFvWp8LDFhn26pO8gcutptOgSkrObM0yYW5119kyduwD1ExW0v1geToX+uDjBxO/SS/pQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-hook-protocol": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-hook-protocol/-/dsh-hook-protocol-0.1.2-rc.1.tgz",
+      "integrity": "sha512-D/HfjuhFN+wGnXRgim4jESDcOoR/FiyL4TIjkKAurJgYYUrvWyCpRR0U+eGt+/xTVqGKwGCYqcmOyxr236CkHw==",
+      "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1-rc.4",
-        "@deepseek-ai/dsh-brand": "^0.0.1-rc.5",
-        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5",
-        "@deepseek-ai/dsh-llm": "^0.0.1-rc.5",
-        "@deepseek-ai/dsh-scope": "^0.0.1-rc.5",
-        "@deepseek-ai/dsh-typert-protocol": "^0.0.1-rc.5"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-subagent": {
-      "version": "0.0.1-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent/-/dsh-subagent-0.0.1-rc.1.tgz",
-      "integrity": "sha512-HBx1nUlXSHzDGk9OqnNBGVxWW9PVjJpgD0ifklU66Y0wKyXbgv858+75+9oGYdFyi0AVYxF7IJ443yDvEubeEQ==",
-      "license": "BSD-3-Clause",
-      "peer": true,
+    "node_modules/@deepseek-ai/dsh-hooks-claude-code": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-hooks-claude-code/-/dsh-hooks-claude-code-0.1.2-rc.1.tgz",
+      "integrity": "sha512-NyM09zrzBhYlLDT2/9NepRWt9MEANFsxzptEVMTdVNjY6kiMFSkdzDh51bcGzdMpacCdj5LzxR5tQhKqK5otPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-hook-protocol": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-hooks-codex": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-hooks-codex/-/dsh-hooks-codex-0.1.2-rc.1.tgz",
+      "integrity": "sha512-l/IFUr7c85Rz21ZuoFH/+XufTf2FMr6Nyqr71qUaWW4XCu3SkpOnr04oh5TFGHJF4iS6u7ZdP+Nupe1mH6/Dbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-hook-protocol": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-host-directory-picker": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker/-/dsh-host-directory-picker-0.1.2-rc.1.tgz",
+      "integrity": "sha512-OQUMJFzqz+AD2ONXxC6pxSxEW20Nbq8xENhRkAMRi9eGfdUxt+4ANB2JN8LPXYs0Kzd+/azNTghsearQnVU7xw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-host-directory-picker-auto": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker-auto/-/dsh-host-directory-picker-auto-0.1.2-rc.1.tgz",
+      "integrity": "sha512-krm27o84Gpy20QaeiUaGJH0EMhw0ajt9riJ+3A+KDklwYcZ/x0H5T+PNnejUI0x2mELIQDrFg/95dlzET1wJ1w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/dsh-client-ui-directory-picker-browse": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-directory-picker-native": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-host-directory-picker-browse": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-host-directory-picker-native": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-host-directory-picker-browse": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker-browse/-/dsh-host-directory-picker-browse-0.1.2-rc.1.tgz",
+      "integrity": "sha512-YNQgkWBT3f3aImtb7rUGkVy/0uJy2x/T3G+v7SWIMkOO+7XWvqxJ3Y9alU0GcaFbnTMepfnZzv5S8s/IJy1mGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-host-directory-picker": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-host-directory-picker-native": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker-native/-/dsh-host-directory-picker-native-0.1.2-rc.1.tgz",
+      "integrity": "sha512-ThdAccRwHx1UwKeIuySCR2msDOEk4q12bqFOTbpa9TaZtbMQDIIyvNeXrXXNAxkTo7WKi6Nz6KNYEorOUnizSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-host-directory-picker": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-native-command": "^0.1.2-rc.1",
+        "koffi": "^3.1.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-host-frontend-static": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-frontend-static/-/dsh-host-frontend-static-0.1.2-rc.1.tgz",
+      "integrity": "sha512-MYBkvRe62S1Gkt1YMTXUF55CbOB7RMVulTdzfABwCK1LgKvYur6cILkHLP4jUM3Hi0XJp7IdITmvTjjeFHFYrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-client-connection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-host-plugin-inventory": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-plugin-inventory/-/dsh-host-plugin-inventory-0.1.2-rc.1.tgz",
+      "integrity": "sha512-MyLA5XncFdfk9btv29FZSg+ojFOOsHEiPkGWAQiRw+EG/2HlVUEm/9KqPxh2jxB5eFge9GahTg2e7x3Veziadw==",
+      "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1-rc.1",
-        "@deepseek-ai/dsh-agent": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-agent-presets": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-brand": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-sandbox": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-scope": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-session-persistence": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-session-projection": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-session-projection-cache": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-tasks": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-user-approval": "^0.0.1-rc.1"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/dsh-agent-presets": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-host-webserver": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-webserver/-/dsh-host-webserver-0.1.2-rc.1.tgz",
+      "integrity": "sha512-QVcaf4qnIa1t215Y8TRiRhqkEz4Lu5/F+KqvWT+4sHOiyWmZr8g1JndqlwP6MBnMQEPmp0I/EKYJ7PWMV32gkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "compression": "^1.8.1",
+        "negotiator": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-invariants": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.1.2-rc.1.tgz",
+      "integrity": "sha512-zSjuFJYcEB94kPwn7SicqAV1dfVWZkjt1I8luDboxtjfp5CN6ziwJhLv3KaB+Dh9tgkyGY4mvo886W/HhE9L9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-jobs": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-jobs/-/dsh-jobs-0.1.2-rc.1.tgz",
+      "integrity": "sha512-VuNPXosjgRbEg0tp+GXsdAqkicwSk5Ynl2AezUQheJgpmw5cvWy3rLEg79B686xGc72tIA6pCW6eBbZGnKOmIg==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-jobs-local": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-jobs-local/-/dsh-jobs-local-0.1.2-rc.1.tgz",
+      "integrity": "sha512-bfNV6IJRG7vPWg+Rp3siRCA0BVK8rB1aqn0BG2nPKzCIA2coKqeJ8uPbEm+GuyW/naMR4uCOrrCVLyrwBuMwzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-launch-environment": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-launch-environment/-/dsh-launch-environment-0.1.2-rc.1.tgz",
+      "integrity": "sha512-f9yDccTKrbClo71pIiAGqBxPsYf+vvcYA5zxkfgmjphpxI3HMwdDl+LNyqTHBe9UxpbgBzQNYQGtfWO0kDTefg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-llm": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm/-/dsh-llm-0.1.2-rc.1.tgz",
+      "integrity": "sha512-7VYsha5AXsVLnsAwYJffWXz9bwUbElw8i5N8tlTSdai9Bupk3sMbsotzPf8ZbsuGAxQYErahMwQwgGEu4qZO6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-crypto": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-llm-deepseek": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-deepseek/-/dsh-llm-deepseek-0.1.2-rc.1.tgz",
+      "integrity": "sha512-FWt7UZ6l0XN2IFIBYVPJUQkFI0knmA3kZiNIhsdQCjJT5zGe1ZzH1EqqpO5Rzc6THIox58VkvLIllU6Mns4dIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "eventsource-parser": "^3.1.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-atomic-write": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-credentials": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-deepseek-llm-api-extensions": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-fs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-llm-pi-ai": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-pi-ai/-/dsh-llm-pi-ai-0.1.2-rc.1.tgz",
+      "integrity": "sha512-aT+21AUbZ1JYco9bBcmCgLYG85LLeWTCWUysBqcAkZADb7Vfn5F77LEpztE6BvRHKCtzVvsgp/HKKESwkK0zNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "@earendil-works/pi-ai": "^0.84.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-attachment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-authorization": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-credentials": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-fs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-llm-retry": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-retry/-/dsh-llm-retry-0.1.2-rc.1.tgz",
+      "integrity": "sha512-WRpanzi4u2Z2X2uv/rwRZh5HTYUtd5smFTBMT4jYd1UpFOmjoMY/grDboZG9KI1OsgaS1vadiBJT4vvixFDEAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-mcp-client": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-mcp-client/-/dsh-mcp-client-0.1.2-rc.1.tgz",
+      "integrity": "sha512-2DTncjbQfEODOpdADJp6HsGVEGIYTHogGNS7VgpLKtHJ0gDa6nc8ebtrJWZhXojNtS0aZz/nmqGNWCf163hpYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "@modelcontextprotocol/sdk": "^1.12.0",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-attachment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-message-feedback": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-message-feedback/-/dsh-message-feedback-0.1.2-rc.1.tgz",
+      "integrity": "sha512-uqgPGGES05+CME5A+/Asm0eWAXHVaTR2/DBqaAH0o0zW+9IQr9DP77DC6zb7jFbUuqQ4a1Ntvu9wWmuYrlUudA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-storage-domain": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-native-command": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-native-command/-/dsh-native-command-0.1.2-rc.1.tgz",
+      "integrity": "sha512-dBVql+9hXcdnWcfwBiFAfzz9CmAnx6iWYsBFQNdPgVu9m7VcOyiIT8ZQ47BVm7GHmpDXmqiI7pL1iwnI56hrzg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-output-retention": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-output-retention/-/dsh-output-retention-0.1.2-rc.1.tgz",
+      "integrity": "sha512-QkLhJVGmausQ3kYORlp1aP1XjloG2J0mJZvnplNJt6iWPmzkE8ObAWOBpQGMVNrNAsucrXr/haeGU1gXLUSXsg==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-permission-presets": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-permission-presets/-/dsh-permission-presets-0.1.2-rc.1.tgz",
+      "integrity": "sha512-CYGxMvAlePbMMHoIBdmrpdbDtea+mcr9/L4i50CoMGafeihwrkrCOowdYutOUbKWgdVeetME/UCkcdTEDRU+vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-commands": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-persona": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-persona/-/dsh-persona-0.1.2-rc.1.tgz",
+      "integrity": "sha512-OBlNDneeoIjXRJY8miV5rKMv4gnVLj+WAbs2tN9U0JO/p8Nd1gCFI+YCN0tt9Jd11ifBAD7q+IXK/WQldAsXcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-plan-mode": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-plan-mode/-/dsh-plan-mode-0.1.2-rc.1.tgz",
+      "integrity": "sha512-dYdmByVI0C94nY+dVO3a2uLofVc+p87Ld04CFtqXLabcsneKp9Oj1sK3qlIaFfSHgrTFCBeTrs8znHxNAb/xqw==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-user-questions": "^0.1.2-rc.1"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-commands": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-plugin-package-inventory-deepseek": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-plugin-package-inventory-deepseek/-/dsh-plugin-package-inventory-deepseek-0.1.2-rc.1.tgz",
+      "integrity": "sha512-9pZh7d2/vGXgGbu6USy6/f14wxbydnnBJItOnoGWWXEwXL9D5zL51u564r6RFxcMuJVWFWFExEd9a2oPRodq3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-deepseek-llm-api-extensions": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-agent-presets": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-pwsh-local": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-pwsh-local/-/dsh-pwsh-local-0.1.2-rc.1.tgz",
+      "integrity": "sha512-jFJQOWkQ3qHWj4xg5he0pjJtzktZYnrjMmDTJmxI4vyMK8UxpEoR0tD4p6eNAJoxZusot9o1/SUqe+HJcjoSrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-pwsh-sandbox": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-pwsh-sandbox/-/dsh-pwsh-sandbox-0.1.2-rc.1.tgz",
+      "integrity": "sha512-QjJzrM/tJDkgvtVzYz2bmCxBzdSUo/YwI/rPBJeTwLbWBuehyhX6BueCwU6Ja1Bsdm9crz2D7rVc/DU/xrFttw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-pwsh-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-repeat-tool-reminder": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-repeat-tool-reminder/-/dsh-repeat-tool-reminder-0.1.2-rc.1.tgz",
+      "integrity": "sha512-p2KQ+EHEUNS9rx4oxJpmLTdB6bdwfmfHA7viUr+2LIiUaUB2nxsOPat33CS/4oOpbgw6DzRWIUGJ1BLW9+ZM1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sandbox": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox/-/dsh-sandbox-0.1.2-rc.1.tgz",
+      "integrity": "sha512-nTO350NlVo9cvKzbeILcPIRIk9ijidrv29snRjTOx7kP5aO/BI2b4KxsRCYoXg8WGAMbIkGbsmZKUD4qz7hyXQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sandbox-local": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-local/-/dsh-sandbox-local-0.1.2-rc.1.tgz",
+      "integrity": "sha512-RLmSPqNivNg+Q+kmKbMuwwH13QTcT5TlJT8rRja/sDxaePS8btya7wWDRsjNDbSs1NjRRi3Plulvw9/BEs8ARw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-sandbox-windows-acl": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/node-addon-landlock-run": "^0.1.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sandbox-policy": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-policy/-/dsh-sandbox-policy-0.1.2-rc.1.tgz",
+      "integrity": "sha512-nLARL84X6K4DCUJsqRWINg3+1EVxsw70hbP+Yl92W/PsquQVs/UJQc55gnhYGmIMf6eJ0vQv39fziNSnAxdx5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sandbox-windows-acl": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-windows-acl/-/dsh-sandbox-windows-acl-0.1.2-rc.1.tgz",
+      "integrity": "sha512-BPaOnN86YDNzLywOCUHNFW9KbUXFZpVUbuU2Djmnnsi+tl/g3qyhOR0ROJDV1Jb5NMYDcw3c5E72Hi0fgCrIAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-win32-process": "^0.1.2-rc.1",
+        "koffi": "^3.1.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-schedule": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-schedule/-/dsh-schedule-0.1.2-rc.1.tgz",
+      "integrity": "sha512-16HNYSyG6rZjTRUL/3ZMYWSim9TpBx8vo9E0eRcEyeDkUafPig9fxqF8iSYiOElPXWr/CniepkwBwLc5av6LwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-scope": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-scope/-/dsh-scope-0.1.2-rc.1.tgz",
+      "integrity": "sha512-GHwbzWrGbmE0ZGzAZsXBudpyCM9ENCpXxlKODIaPFbIWhRePh6nH2jW47TAOqCIsPPedWC2p3w8Tx5WAa3I/2A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-app": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sdk-app/-/dsh-sdk-app-0.1.2-rc.1.tgz",
+      "integrity": "sha512-aewk23zvjr4QMVTnAGaBBRlWEtdKyDuuG3BAfUeAfoOwmM+5LtK71VrVODFDybT+stn/FQfdL/vFeQ4GSs1y+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-cmdline": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sdk-jsonrpc-server": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "commander": "^15.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-client": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sdk-client/-/dsh-sdk-client-0.1.2-rc.1.tgz",
+      "integrity": "sha512-ql++c5cuTWhUkh0aFW6rgBf4ZPEh8gP59Xkjy7vKTj7Bj+GGWkiaAQx2bBfkHz+B/92Qrpnqmk24T7lTGu8QiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh": "0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sdk-protocol": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-jsonrpc-server": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sdk-jsonrpc-server/-/dsh-sdk-jsonrpc-server-0.1.2-rc.1.tgz",
+      "integrity": "sha512-eoZSnH2kReDvAHihFnWmbqryTMO+mV1nrhoCGJ4mzhLAguFWxJB2CRJ1ZO9hqTukoKYhqp2BpvSvtZIjKIzTQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm-deepseek": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sdk-protocol": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sdk-minimal/-/dsh-sdk-minimal-0.1.2-rc.1.tgz",
+      "integrity": "sha512-dzpZgq72dGZ0pt4GCSWRL4p+tnGjB8qATxQ9h1LvYvppT39MFImN1SI6mqLf0xS6Ur7UJGxW8UoILyfJLocpDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cordis-plugin-timer": "^1.1.4",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-agent-loop": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-deepseek-llm-api-extensions": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-fs-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-jobs-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm-deepseek": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm-retry": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-plugin-package-inventory-deepseek": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sdk-app": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sdk-jsonrpc-server": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-log-deepseek": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence-jsonl": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subprocess-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-terminal": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-terminal-bash": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-bash-persistent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-pwsh-persistent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-str-replace-editor": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-protocol": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sdk-protocol/-/dsh-sdk-protocol-0.1.2-rc.1.tgz",
+      "integrity": "sha512-tt0kRuk6Wqwiytx3XVz8gitFqMn097INtDdCnWofRjgJqwUv+n+vsXAzCYNucATp7lxhYzsayzLR0FfacYoZtA==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session/-/dsh-session-0.1.2-rc.1.tgz",
+      "integrity": "sha512-jRGNPTbQcvIx1F2MVmmkoiHLgpC3Btqo1wkl/3JDLlOWRVWKOuaC+5fQiMrFPOYfno6YiX/c2UvmA0td8qB92w==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-checkpoint-policy": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-checkpoint-policy/-/dsh-session-checkpoint-policy-0.1.2-rc.1.tgz",
+      "integrity": "sha512-wccstcC9NdeXnqq1Uqgf5P5U5YRgSqVqudvgWLS6ldj0wIRKAmv4fQsi9E+dRlxtxfLdSsHGh9o0SnIPb0syIQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-log-deepseek": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-log-deepseek/-/dsh-session-log-deepseek-0.1.2-rc.1.tgz",
+      "integrity": "sha512-+nSHnhXgIlGg1iE2EWJSCTiGW+DZNFqzCU120RNLoIUkkPzTTtB9p7lwG8fcmddSM/tgBVF9SQzcvSriRwcumQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-deepseek-llm-api-extensions": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-log-export": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-log-export/-/dsh-session-log-export-0.1.2-rc.1.tgz",
+      "integrity": "sha512-S3r4GSNP0LPI1qf7psVNByeEf3p96JoP7jtBOLgWa4tdgbqtYvGADQmMGcR624EwVlf7APPqcFePxpGqGnoXbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "fflate": "^0.8.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-persistence": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-persistence/-/dsh-session-persistence-0.1.2-rc.1.tgz",
+      "integrity": "sha512-8dnQGgqA8yK7SIxyC2utRdkHhM7mxw9iidDlPOx4GRO4fgY8+UpjxFvWPshkKsY2WNYY/nYcZQt5NNoE/Br4Dw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-persistence-jsonl": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-persistence-jsonl/-/dsh-session-persistence-jsonl-0.1.2-rc.1.tgz",
+      "integrity": "sha512-YR5PFDFsM7CLp0zWcLbldfmnPA0T9kROiP7+g1uflBGvhK2JoaH+UM06JGWe7EvnplCGNTnAzcXhAQp7dwz/iw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "koffi": "^3.1.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-projection": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-projection/-/dsh-session-projection-0.1.2-rc.1.tgz",
+      "integrity": "sha512-qVWlIzPm4u9vzQ5G/QtE6jeSJ3b3b42hWVJj664BurEZlHbAfdqkhYc1QsoBU+5k5kUEJFHh07z8HxuXA9kTnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-projection-cache": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-projection-cache/-/dsh-session-projection-cache-0.1.2-rc.1.tgz",
+      "integrity": "sha512-FfdT3Jtv4+wlBp5B3F7zBKrUlkbQc/xmdKAtAK+paoH45xjDu3nrW2vhXD8mYDSa3TYsxYaji5gk96Bn0UipOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-storage-domain": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-query": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-query/-/dsh-session-query-0.1.2-rc.1.tgz",
+      "integrity": "sha512-cubi3flRd66ebzJ/My5t9YIB7ymLdmQonjb07oU5btMHO/ln+gpKnqq2DcnfsdKkktSR+f5VpLMbfTNtoBuRCw==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-todo": "^0.1.2-rc.1"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-session-persistence": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-projection": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-projection-cache": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-query-sqlite": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-query-sqlite/-/dsh-session-query-sqlite-0.1.2-rc.1.tgz",
+      "integrity": "sha512-FwHIJe5/HtRnyl3NjHB+r+PmzuADmjwpfgJIDsurar05/YyeiVqmyIIThUw1g+X2YBezAm4s+gUk32GE26/Nfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-query": "^0.1.2-rc.1"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-session-persistence": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-reference": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-reference/-/dsh-session-reference-0.1.2-rc.1.tgz",
+      "integrity": "sha512-pVMQYFFejT53nJOcaqNRaUq9VInAFovkwe7TmeeNSgbUZUVY4W7nyNYGKxzo9u7eqs+8ASqCgsIEM8WRVUymGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-compaction": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-output-retention": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-query": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-session-projection-cache": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-stats": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-stats/-/dsh-session-stats-0.1.2-rc.1.tgz",
+      "integrity": "sha512-NCxXJPPeWwtbkF+bnzVXdknbafgmQi5vxPsY89ABEs40jJa81OeY95sFnqdedjtKXH2nPycX99P49i28gX2PPg==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-telemetry": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-telemetry/-/dsh-session-telemetry-0.1.2-rc.1.tgz",
+      "integrity": "sha512-bchNYxgXzsBZylG5QBQinlq3jsUboMDXSG1BgoQlJ8KHvYxbNP2dINEZ1Z5aEnAiZv+FeuXzSRU4capDpaUhbA==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-telemetry-otel": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-telemetry-otel/-/dsh-session-telemetry-otel-0.1.2-rc.1.tgz",
+      "integrity": "sha512-WF9VMDX8yNqZ2fI7lvt4Rpzr867M+QkEzRRpEQQluwJa2ynz8hSe/tB9GM2wQvcNRp8voB3k8v9eNSBC/fziWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/api-logs": "^0.220.0",
+        "@opentelemetry/exporter-logs-otlp-http": "^0.220.0",
+        "@opentelemetry/otlp-exporter-base": "^0.220.0",
+        "@opentelemetry/resources": "^2.9.0",
+        "@opentelemetry/sdk-logs": "^0.220.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-command-feedback": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-telemetry": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-title": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title/-/dsh-session-title-0.1.2-rc.1.tgz",
+      "integrity": "sha512-hCffH0uZWEM9p3MPkOQOFUxpPwfV48N8KDc3hYX7zVOFgHBY93ylwkEEVVkWN+sNp2zJmFrZSya23jFVshDtQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-title-first-prompt-llm": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title-first-prompt-llm/-/dsh-session-title-first-prompt-llm-0.1.2-rc.1.tgz",
+      "integrity": "sha512-lM6DozrWjxXGGIrMmtAfp3cN8jKt4Xy8e34odR/B6tzUKIJZtQFHaGD7FTsl3GGG7+LRQD7QCvo5dXNHQbjbHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-title-llm": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-title-llm": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title-llm/-/dsh-session-title-llm-0.1.2-rc.1.tgz",
+      "integrity": "sha512-LVKZQHGbafRkbz9XT25lquZNd15oStlktGqQ6oxv6utdCzqwlAhFy5K7sAUlVPkqLDqGh9JnTm75hs+GX6OlUw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-turn-outline": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-turn-outline/-/dsh-session-turn-outline-0.1.2-rc.1.tgz",
+      "integrity": "sha512-cJrQOI6T5W8mDv17wUngS1/ogAtoC9dmPy2nl+8V0X1u1xyLzD1SceBgapUZ6NBBX8cX5gutI+Ub7802MVgAdA==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-settings": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-settings/-/dsh-settings-0.1.2-rc.1.tgz",
+      "integrity": "sha512-wMmJ2w5S6I7hgmgPppuAVemltEcTmAa8gvii7fk4T2KGVCuBYgig8xPwQ8Lp2ukLZSzzE6ZVCQxhdYZyJX/USA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-settings-file": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-settings-file/-/dsh-settings-file-0.1.2-rc.1.tgz",
+      "integrity": "sha512-UdNAyQBL2cVKrxKc3lifwhldvMjfoKuwcnnDOrKrscDSIO6zTfr6otfTsO5ChPSZPVLNwnH6kj6vgRr9td7L7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "chokidar": "^4.0.3",
+        "yaml": "^2.9.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-atomic-write": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-shell": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-shell/-/dsh-shell-0.1.2-rc.1.tgz",
+      "integrity": "sha512-uFrSY0nNKzh5orGl2B0B4RfK7wTdIlwhPQc7aLA44jyjioLlqhF7PUek/NWtye2scwp3YHOw158XeOQUD8qTFg==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-shell-env": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-shell-env/-/dsh-shell-env-0.1.2-rc.1.tgz",
+      "integrity": "sha512-o1VqxyHp1OrMB8aHnzYAPwuU4giUErCxBg0yr035r6f3Le36viS0sUHsnjcAsMdbaQJf/XvzbaokYDVrdVHE4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-home-paths": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-skill": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill/-/dsh-skill-0.1.2-rc.1.tgz",
+      "integrity": "sha512-oaHunkTZ9gtlxp66GcqZ3tQmPXEgbu/KNCnc9JipaIwfLHFYiU3CKuFjVAiu82qtSr9w7umRMFKAstkr1R30jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-skill-badge": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill-badge/-/dsh-skill-badge-0.1.2-rc.1.tgz",
+      "integrity": "sha512-bhPQBAWpKhVlPURULy1ZqhVxJZ2+Jq8Yj1wtV0+nY5StTq3UqaIMELtdpklILHqqwExFMk65RYabBtS6qApOEw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-skill": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-skill-filesystem": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill-filesystem/-/dsh-skill-filesystem-0.1.2-rc.1.tgz",
+      "integrity": "sha512-kDciORrnBhA3KuSOcqG5cOPO6QYu0TyYHRQBO+v4Vc7sLyry/2mdWRR8OI9hDEkkjqMiupYRVrgNlj2hfSMKWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "chokidar": "^5.0.0",
+        "yaml": "^2.4.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-fs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-skill": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-skill-filesystem/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-skill-filesystem/node_modules/readdirp": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-spill": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-spill/-/dsh-spill-0.1.2-rc.1.tgz",
+      "integrity": "sha512-tt5DfoVmLHWwGPumYSBXWNzf43Kmp8xiWwGb19w+UuiCgDo/zWzTIKyBHI2fUyuwoc9Itk7zDu2WOp/o21XDWw==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-spill-local": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-spill-local/-/dsh-spill-local-0.1.2-rc.1.tgz",
+      "integrity": "sha512-BIm26ncQXCih4LBK9+Xh7ffBrW98wVHTzCtlZ7KXXxVvsuJe0nITrUxcTeBmc9x1qh8ndBil2Y8Dk8apvCeLJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-spill": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-spill-policy": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-spill-policy/-/dsh-spill-policy-0.1.2-rc.1.tgz",
+      "integrity": "sha512-uRQ698e9YV/s605KzVODcKxOIw2t1/tzVDtUoEd47Gh5SeawD51qBTxlGuFWdu9VoYD4tmlaAtjUDEBQFZqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-output-retention": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-spill": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-storage": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage/-/dsh-storage-0.1.2-rc.1.tgz",
+      "integrity": "sha512-tMtOe7GkHKZ71QpOzp2Mfisg37aAYjPCRS2MYfDrgM0pmj29Gn7HOxAPCk6gEqxs6rZbPbG1/SB9esWuQNfITg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-storage-domain": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage-domain/-/dsh-storage-domain-0.1.2-rc.1.tgz",
+      "integrity": "sha512-Ee+fI/46ZXgKV4bfLeiNJMhlo9Mx0jT9GXzuJ0DcdGGOsNSZrY/EQAzVXHJJu6EVwIJqBkv1bxEKijVSF2YhZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-storage": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-storage-json": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage-json/-/dsh-storage-json-0.1.2-rc.1.tgz",
+      "integrity": "sha512-vYQ/0Eh2Uzjdxi6vf3Y3WZg2ux4pG0ubgtC6VHGngtQekgIdtk4aRTvRAtBdFgfmyewM9XjLgvKxTUtkh000Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-storage": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-subagent": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent/-/dsh-subagent-0.1.2-rc.1.tgz",
+      "integrity": "sha512-GhRsymKb1uYbc7OwHh8WTdSXqAcx/KHFJwYX4BYJk90dsOkVx9ccBq6QoJfDYja34s1KCyv2UO/8MUtrzBsITw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-query": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-time": "^0.1.2-rc.1"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-agent-presets": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-jobs": {
           "optional": true
         },
         "@deepseek-ai/dsh-sandbox": {
@@ -432,7 +3462,7 @@
         "@deepseek-ai/dsh-session-projection-cache": {
           "optional": true
         },
-        "@deepseek-ai/dsh-tasks": {
+        "@deepseek-ai/dsh-session-query": {
           "optional": true
         },
         "@deepseek-ai/dsh-user-approval": {
@@ -440,94 +3470,1030 @@
         }
       }
     },
-    "node_modules/@deepseek-ai/dsh-system-prompt": {
-      "version": "0.0.1-rc.5",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.0.1-rc.5.tgz",
-      "integrity": "sha512-IMB3dT8ErPWq15tIXdItQ+OOzHKYdLGl6vwNkeZf2n3hlw0bxDzj1AmLCgE4vDByDue9BQTWl4cMfNN0NxVMfA==",
-      "license": "BSD-3-Clause",
-      "peer": true,
+    "node_modules/@deepseek-ai/dsh-subagent-fork-in-process": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent-fork-in-process/-/dsh-subagent-fork-in-process-0.1.2-rc.1.tgz",
+      "integrity": "sha512-zXlwMkp6Bps70s5asN6XtHGjETlKzfbAYOkBEc9sVzBu7Do6vmfNg4NZQMzE3cSm2O7wx28Mmjpiy3/bh+RFVg==",
+      "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1-rc.4"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1-rc.4",
-        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5",
-        "@deepseek-ai/dsh-llm": "^0.0.1-rc.5",
-        "@deepseek-ai/dsh-scope": "^0.0.1-rc.5"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent-in-process-driver": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-timeout": {
-      "version": "0.0.1-rc.5",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-timeout/-/dsh-timeout-0.0.1-rc.5.tgz",
-      "integrity": "sha512-SxuBtgHCQx5bOqua/U/5H2jMio8w1SXpjcDqmd0WBZ7OvmgnLovvbmCrEQeH0jtbkqL25yEZ/dDCr6cE27Pi5Q==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1-rc.4",
-        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-tools": {
-      "version": "0.0.1-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tools/-/dsh-tools-0.0.1-rc.1.tgz",
-      "integrity": "sha512-mrtq+UXc6UVidrGo4GM8RAH0Gqc4iFOmtPeQAz59Phhjl3EmzkFI0Mo6dQlHQamrc2J9jppPtGtUzW9qHmwxDQ==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1-rc.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1-rc.1",
-        "@deepseek-ai/dsh-agent": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-code-runtime": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-scope": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-system-prompt": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-user-approval": "^0.0.1-rc.1"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-typert-protocol": {
-      "version": "0.0.1-rc.5",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-protocol/-/dsh-typert-protocol-0.0.1-rc.5.tgz",
-      "integrity": "sha512-8ierrjmlloXATrJHeIE6EeItOT0M1kPmk+MTvV4600CD1XuAigVpktYc4HsbXw5jaKzt/jQK4eRCARYWeuvwhw==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1-rc.4",
-        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-user-approval": {
-      "version": "0.0.1-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-approval/-/dsh-user-approval-0.0.1-rc.1.tgz",
-      "integrity": "sha512-28J7iT2fl9I0haeCRwVIWqhFBO3xG+A1GAdfhLJG/9YkB0F3Cs6FUoRtNQ7pjxkJ6QzELY/gRBE7axCP0ETHcA==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1-rc.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1-rc.1",
-        "@deepseek-ai/dsh-agent": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-brand": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-scope": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-system-prompt": "^0.0.1-rc.1"
-      }
-    },
-    "node_modules/@deepseek-ai/schemastery": {
-      "version": "3.18.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.1.tgz",
-      "integrity": "sha512-Qn0FCSwCQnpnj6SB31I6i2sIKgKWnkbJM8O0EU91Gv2UsYVvtZTl6IA0sCwk2e2MZf5S8w5hpq9QkeVvK9qwxg==",
+    "node_modules/@deepseek-ai/dsh-subagent-in-process-driver": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent-in-process-driver/-/dsh-subagent-in-process-driver-0.1.2-rc.1.tgz",
+      "integrity": "sha512-z7+cVtkC5TlseV61ZsMlU89+3WF3WHyPfyLNrvas6R2De+nfUigRedVX3TfEpOmQBwfuuVmtHjNDiua5QJiSYg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@deepseek-ai/cosmokit": "^1.8.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-subagent-spawn-in-process": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent-spawn-in-process/-/dsh-subagent-spawn-in-process-0.1.2-rc.1.tgz",
+      "integrity": "sha512-7R3pcxOS0S2yZrkJ8smbvkX9kZH2Xj3LJ9HYp12UHeNj4tB/vk9kUZK9lW0wk03WSxUdgefOhsVjeKsrWjGOwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-subagent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent-in-process-driver": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-subprocess": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subprocess/-/dsh-subprocess-0.1.2-rc.1.tgz",
+      "integrity": "sha512-roTna1QHNpR5NsOLBWRai+GxW1hQAUyIyXOg5tsAIPXt7dug/kZJXeryiR9e92Fc/yoXzHMgrBQCThuXuo97LA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-subprocess-local": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subprocess-local/-/dsh-subprocess-local-0.1.2-rc.1.tgz",
+      "integrity": "sha512-Spc/IXWvjEteGysifGr6JvCokcH8T88z0mdxIGcu9SFdgDyY8HKR+h5yq73+rbo4RYzT7+TBE43TIZy5LfmzgQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "koffi": "^3.1.0",
+        "node-pty": "1.2.0-beta.15"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-subprocess": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-subprocess-local/node_modules/node-pty": {
+      "version": "1.2.0-beta.15",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.2.0-beta.15.tgz",
+      "integrity": "sha512-vORSzHXi4Ofl7HemVWpuudLqCPdaQb4LfpRCUpE5HPxhp4JYscl8zZwxh11p26v2wvW24WMwnMfLjhRLixrfxA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-system-prompt": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.1.2-rc.1.tgz",
+      "integrity": "sha512-7W93PZKIk4CHvjZGgLIxrrEKpk+6t8nQXje1vKR5vG73dfXH0t1MJ5WWH/fngadYc7c6KzM84ihQ66tJqJqyNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-terminal": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-terminal/-/dsh-terminal-0.1.2-rc.1.tgz",
+      "integrity": "sha512-O9MJdEpZBvoYzjWXycmgh/nMmXTgXoArZOXwld9q34cSgkXSUOVOPSiPuN5HjPZYZcT4aeT7Q4Wdr4LxezbshA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-terminal-bash": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-terminal-bash/-/dsh-terminal-bash-0.1.2-rc.1.tgz",
+      "integrity": "sha512-tDEjaycT+2ZRmy8yVZb/1p/ZvulfPtfiRVfYqOENNSitlWIUgZWq5JH32JuGsXZpYJTUhwrDLHXSR1Lwls29ew==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-pwsh-local": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "@xterm/headless": "^6.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-terminal": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-time-context": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-time-context/-/dsh-time-context-0.1.2-rc.1.tgz",
+      "integrity": "sha512-e5sjsgEJNT6cF8dFCernoXazypALlJOrwb1bOfJvPwrdcYbztNifGR8jDoFj88i6hor7twpf4LSU2dqzGc0QJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-timeout": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-timeout/-/dsh-timeout-0.1.2-rc.1.tgz",
+      "integrity": "sha512-llz11yxWeJB8suKCa6hRLjNBWVaPn3Fbd0XoBS0bkZLhPFzO1mDorx/XMca2GhI7XF9A86CURQcDt+aGjjvqJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tmux-context": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tmux-context/-/dsh-tmux-context-0.1.2-rc.1.tgz",
+      "integrity": "sha512-WOSrPXbAqegbEKJfATRB0F214aQzE9zMlJ4k65Urf+xjcY1t4OcDtjuk6QV6CNGeG2U6V6dvEol4lQF9Aj47qg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-token-meter": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-token-meter/-/dsh-token-meter-0.1.2-rc.1.tgz",
+      "integrity": "sha512-6mlC89JNGudPvR9LekEo2mnEo/DXf60ZjekIKXxZqpf66AOQ2/pa2HJuFikEd9WWRvu2D96Qvx3rILxi1vXVww==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-compaction": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm-retry": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-ask-user": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-ask-user/-/dsh-tool-ask-user-0.1.2-rc.1.tgz",
+      "integrity": "sha512-4x7Y6DxaUClUllZ2jOusuukz8LPBotUinfRhf615sDm5JMk8JVD8tHjpFZ6eUX505wIyWgjDWLePb5s99j69/w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-user-questions": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-bash": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-bash/-/dsh-tool-bash-0.1.2-rc.1.tgz",
+      "integrity": "sha512-xKc4oXVDBwM/PaicpjGdWEaJ1N14B7KPmOzdpQ7ynE4gKUnvGU/eTg18EHamdyDOidh5ox0fNUnxk0rQjVo2+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-shell-env": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-bash-persistent": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-bash-persistent/-/dsh-tool-bash-persistent-0.1.2-rc.1.tgz",
+      "integrity": "sha512-AcWq9UHKmLyNTh67Aa5UapmuLYdDVUJy4aJ9NvrI1DJLHCZQCs9NCUDx3UecyCwfa7qHtOEz205LY5HRACMqQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-terminal": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-call-timeout-policy": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-call-timeout-policy/-/dsh-tool-call-timeout-policy-0.1.2-rc.1.tgz",
+      "integrity": "sha512-mKKoboZVhMjJ/SIgtd/xR54KRrG4s5+YYBtkqvxKdQn3tjFxJZ4HkJ41DauwfZqTOXz2r0rWJ4neNqc5ZNaOdw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-cordis": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-cordis/-/dsh-tool-cordis-0.1.2-rc.1.tgz",
+      "integrity": "sha512-EJKVeKgAR+J3Bz/HeXU+Xeh0KTEp04JYuOf3tdiiOsEr0Aed8OL5Wr4YUJb8uvU8xLZPBWYjGlUJG7bx0rg/dA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-fs": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-fs/-/dsh-tool-fs-0.1.2-rc.1.tgz",
+      "integrity": "sha512-9a1lcPGD4Z3p7OLTMkkCdwN0w7Gl96Jlypq6qopUA0WMkKai83VfeLZvramPnTJo6ezpuPXcLFWGm/2UDSlbcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "diff": "^9.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-attachment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-fs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-fs-search": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-fs-search/-/dsh-tool-fs-search-0.1.2-rc.1.tgz",
+      "integrity": "sha512-F6j7OhMCowlOwIYmB4hA6sqenw2V7Eez90BjLww87iM9YarR6D/CQcHJN4OIViepuyE4sLtk5gkXM8oT/PeTNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "@vscode/ripgrep": "^1.18.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-output-retention": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-spill": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-goal": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-goal/-/dsh-tool-goal-0.1.2-rc.1.tgz",
+      "integrity": "sha512-ooHKN6Eqy3owNS/oCDO7mR+UalEE4AxJMXou29waahIdSQsFAlk4pPApvhrwg1lpchF5CKwBPOtsVmjq2HfBKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-jobs": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-jobs/-/dsh-tool-jobs-0.1.2-rc.1.tgz",
+      "integrity": "sha512-ya7E6zToAdJ+GvNeZFPx8jNx0CfI52tlp0NCGzXHeB0S74haGWCV0iFe1nyoDJg7SDiN1xc1d2nV9klOqWtd5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-output-retention": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-pwsh": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-pwsh/-/dsh-tool-pwsh-0.1.2-rc.1.tgz",
+      "integrity": "sha512-LaImOCdizIGkQnxzzkoaqzRWGZLsuDuqqF2adgJ3zeG0nDwan4Sz+1wYz4YSp0Gg6mJ79CYacsbYmGhYYyKY/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-shell-env": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-pwsh-persistent": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-pwsh-persistent/-/dsh-tool-pwsh-persistent-0.1.2-rc.1.tgz",
+      "integrity": "sha512-Y8hRn41iRaRY88qH2zvR9sk3VSPnfqkLybqoOSepezfM6LXtrY24hNS0GTmRd88hlSre0DtB92c0WAJ+QLixmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-terminal": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-ralph": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-ralph/-/dsh-tool-ralph-0.1.2-rc.1.tgz",
+      "integrity": "sha512-HRgdfKxuEaFZNyDahTsDrA22EU3UfG70j5kDMtE3aImM8DSvfFIZ0yvjfFG39WBI+uxDy1b7j5HcAImaa87Htg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-workflow": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-skill": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-skill/-/dsh-tool-skill-0.1.2-rc.1.tgz",
+      "integrity": "sha512-H4dORZoB2wuTcHjE1uMvos7D850mE9X1ETjXdzr6+1JTTw8uOeDsHhmNfpOMjhA4/ztFEW7QAQlymI25Er6yAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-skill": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-str-replace-editor": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-str-replace-editor/-/dsh-tool-str-replace-editor-0.1.2-rc.1.tgz",
+      "integrity": "sha512-vD4GEYQ9iOkGaPCLbY4rziAxxAnNwrPS8rgrMkf1R0kfrSSPkAqVaepvuskgxV6M6lyduIKFu5yEHQZwVZbMFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-fs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-subagent": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-subagent/-/dsh-tool-subagent-0.1.2-rc.1.tgz",
+      "integrity": "sha512-7rQfZsMWYv5oPMvVvQTv+rEDd6CFz4YimJHlSH56fsEwxW/A6Eg3jDBHLpiZpuk03gP6WIzcyExaC9adPq1ohg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-subagent-control": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-subagent-control/-/dsh-tool-subagent-control-0.1.2-rc.1.tgz",
+      "integrity": "sha512-ogSTUIs3z20weu4dHIHUHL5kzJ+wnjQETGfsrU3qb2ChAbx6LpJvNN788YMI2RP6udVbEJV/0HjkMhIuZsazZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-todo": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-todo/-/dsh-tool-todo-0.1.2-rc.1.tgz",
+      "integrity": "sha512-NFDdJNwryfwrNDsy9XeYYB9NaI/GAfgNMKvMlMxgXXuvmVoeLD71o5r2/S5Cl0unXLRfV+dP91hkj4Z+aVYTzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-web": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-web/-/dsh-tool-web-0.1.2-rc.1.tgz",
+      "integrity": "sha512-hpBy6VhE12fDeZ1a6bSOOg3msvJCMS4nwD1R2Nm7sjkBCiXR/BYAHmpkHXhNEMvTY2KhnH6qRhx7SFGSstfwwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "@joplin/turndown-plugin-gfm": "^1.0.67",
+        "turndown": "^7.2.4"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-web": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-workflow": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-workflow/-/dsh-tool-workflow-0.1.2-rc.1.tgz",
+      "integrity": "sha512-tqZJcQO7wOgLgT0XLyRjSkMpri0//6WmOVjcoY7+BeybtqJg9OTL31dXBIYpR7QkhQXmeEhHAZl0Lz/7kR+Qdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-workflow": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tools": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tools/-/dsh-tools-0.1.2-rc.1.tgz",
+      "integrity": "sha512-W9kUio00s7WbM8kEwniyd4hfb3CeUxVczsjXbOcKtakfiTywNLeyRWkpx2fvwRAH2rBfg3qCgczVfS0DOw1csg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-code-runtime": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-typert-loader": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-loader/-/dsh-typert-loader-0.1.2-rc.1.tgz",
+      "integrity": "sha512-Zbwvblrb+6exFu5Atb0ShONAUsdoA6kcAZGi436JAB2SWfYbh62KdcahHDrQh/2GQaJgc+WjvKT9qoHTx0U5NA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/dsh-typert-registry": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-typert-protocol": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-protocol/-/dsh-typert-protocol-0.1.2-rc.1.tgz",
+      "integrity": "sha512-vBWD0NpriPd96ltbWaAw+iKeWFIEjiAcCWYtmqEcV1Ms+FaV02usjjm7LCmhSQhMZpBSBc7EZUX0spGlpjI1bA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-typert-registry": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-registry/-/dsh-typert-registry-0.1.2-rc.1.tgz",
+      "integrity": "sha512-Y6eWVTp3GBDt9DYjYqsLIHG3SJelBZvhDpBipz0Cam1Al85MQyecqdMrmOmvCZZ7nDwelC6xkZfg7vikrtpB/w==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-user-approval": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-approval/-/dsh-user-approval-0.1.2-rc.1.tgz",
+      "integrity": "sha512-oYkLE4a/TwqVNi299pUf/QP1Yku6KScdUCTUyYbjaRBcN+/pXPpHikl2aoE2thH9D0uT/Kj6T2kz+wDDcFd9Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-user-questions": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-questions/-/dsh-user-questions-0.1.2-rc.1.tgz",
+      "integrity": "sha512-ZXSliLrhEx92TUsjXeNzr3fKLIexnGV+KPcgs+HRUESlsCGs9wuZH6ep4rfrRLc4dYBbw4bbgNKQct7RftJ4eA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-util-crypto": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-util-crypto/-/dsh-util-crypto-0.1.2-rc.1.tgz",
+      "integrity": "sha512-gE8FznQ1hkknw9QMrHNSlm3UEyRYuj3MLVvlJ6NyH1kmOsdjnbrVbSs+Pn72k2oIV4Fiyu3Umg0sLznUEcsiXw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-util-time": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-util-time/-/dsh-util-time-0.1.2-rc.1.tgz",
+      "integrity": "sha512-OoudDLoYothbZKDbjO6kFu3NLgAnglIS8NFkg5fjnBtz8LGwplN8w7kRURLIrZtH38HknYhpDsdJh8LZai3U6A==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-util-values": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-util-values/-/dsh-util-values-0.1.2-rc.1.tgz",
+      "integrity": "sha512-FQdgoK+KYVR0pBQb9fTsajvGb3gzUxEzJQEYnFOt+Qdwc4nkxJOPwJJdIvXuqvZaQ33DaOoqpnpcr2p5HpLu4g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-util-workspace-path": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-util-workspace-path/-/dsh-util-workspace-path-0.1.2-rc.1.tgz",
+      "integrity": "sha512-cT9mxw5dS7YTbUoMDLmX4HeMKnqovCMnSsAVDU1fr3zKv7YAdT76rW6fjOkV/NGJBQRxUsbYdXKjqeYFosAmUw==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-web": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web/-/dsh-web-0.1.2-rc.1.tgz",
+      "integrity": "sha512-+umPNfJ+1Gshq38jR3tjgf4j0QaJZT5PretdHi1J+RU61Ou9Sc5w9n8haxa69os7g6FjBNxvGv8fnMeFDgcLKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-web-app": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-app/-/dsh-web-app-0.1.2-rc.1.tgz",
+      "integrity": "sha512-QGh+XWRgrsVktKD3YHw+cY/knwBESq+2TtyOGNc+V7GU3LG9qL6EPB0M8pIDjxF1jLls+M71LIVbevuFx3oZ6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-agent-presets": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-api-session-controller": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-api-settings-controller": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-api-workspace-controller": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-app-boot": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-hmr": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-modules": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-agent-preset": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-approval": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-attachment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-brand-official": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-chat": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-commands": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-cordis": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-deliverables": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-directory-picker-browse": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-directory-picker-native": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-goal": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-jobs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-layout": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-message-feedback": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-model-selection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-permission-presets": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-plan": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-reference": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-renderer": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-schedule": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings-general": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings-models": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings-plugin-inventory": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings-plugins": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-skill": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-subagent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-theme": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-tool": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-trajectory": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-user-questions": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-workflow-run": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-workspace": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-cmdline": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-code-runtime-worker-thread": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-file-reference": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-file-reference-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-host-directory-picker-auto": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-host-directory-picker-browse": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-host-directory-picker-native": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-host-frontend-static": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-host-plugin-inventory": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-message-feedback": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-log-export": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-reference": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-stats": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-turn-outline": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-subagent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-web-frontend": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-workspace": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "commander": "^15.0.0",
+        "open": "^11.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/dsh-shell-env": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-web-fetch-http": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-fetch-http/-/dsh-web-fetch-http-0.1.2-rc.1.tgz",
+      "integrity": "sha512-yA2oxrCnRxSVYVOFr94ChB/m6TtOgPc7GZT78Ps2EtBPbAP5MnVSHM6JoVeqlHkFwtQ+qw/Hri9KBnOQtpgg1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "ipaddr.js": "^2.5.0",
+        "undici": "^8.10.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-web": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-web-fetch-http/node_modules/ipaddr.js": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.5.0.tgz",
+      "integrity": "sha512-aq+t5NAc+cS6rZQQVWC2x98CPqGtKKTMDd4Gaodv0wShnItdKg/51djkGJ1hqH+Oy0ivDftCbSLCQob8zso01w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-web-frontend": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-frontend/-/dsh-web-frontend-0.1.2-rc.1.tgz",
+      "integrity": "sha512-4f82gSDByk+h9nGfsmoDdRcoEXtsE4W7w5n9aJRRHIzNwHFe8Z1rtl3PafdVBZcSrZ/0bouxDMknA+F3FZAG4Q==",
+      "license": "MIT"
+    },
+    "node_modules/@deepseek-ai/dsh-web-search-deepseek": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-search-deepseek/-/dsh-web-search-deepseek-0.1.2-rc.1.tgz",
+      "integrity": "sha512-EjnDmaiQdNmD3dAZKWssMgLWm0b+AidB7j5B0YoOMIzrLhajI1Uggnf2Er8L+869P99GJjB1nUm1otzoQ8yL9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-credentials": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-web": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-webhook": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-webhook/-/dsh-webhook-0.1.2-rc.1.tgz",
+      "integrity": "sha512-zpOB9obPJgsLEF8uVzG61v7MPgyhMJbiI4EzV6iK0rkFulV0Tm6G+iQhRYB8tUHEaLCgOzUBCo32lrx+YnhypQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-agent-default-model": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-permission-presets": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-workspace": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-webhook-github": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-webhook-github/-/dsh-webhook-github-0.1.2-rc.1.tgz",
+      "integrity": "sha512-RGwuVtaHDTtXaKtHDZ59uErpzIjrO0K6U7arKCi0HDNuDvBHiU70bpn431Cax+6ynLfH5VZqtSDb0qmHnRTdOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "@octokit/webhooks": "^14.2.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-credentials": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-webhook": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-win32-process": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-win32-process/-/dsh-win32-process-0.1.2-rc.1.tgz",
+      "integrity": "sha512-egG88t1NDajO8YfjYQpHxBx0xR8CB/K+GTU9c0W1Tn8YX6GiFXqOZLiaCNj2mVIv7WnMShzZIX6bVkFrg5oTag==",
+      "license": "MIT",
+      "dependencies": {
+        "koffi": "^3.1.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-workflow": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workflow/-/dsh-workflow-0.1.2-rc.1.tgz",
+      "integrity": "sha512-JjadkNhYAeU8bD8immmpJyX9zbqke5Y9rWCf9m+vzvE+GUqPwSILTTVzESUxl7rEJtI99UAL6dYy0qbkYIq6HQ==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-workflow-worker-thread": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workflow-worker-thread/-/dsh-workflow-worker-thread-0.1.2-rc.1.tgz",
+      "integrity": "sha512-33fzDRvZSa46l7MPD44ti8lNeGGMI8dTHsoAF/h+puzfEjOBJ4g75sh6oxs7sgszcTUSr5UQAZ2XGU1LC/9DoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-workflow": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-workspace": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workspace/-/dsh-workspace-0.1.2-rc.1.tgz",
+      "integrity": "sha512-8q1e4a9K8ON4VabR6VfachNnuOHKvfBlQlv07mFT6CwoaCZXB1WwZxjJFOnIcF7R05uRAPJSVAgUMedgWMxVEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-storage": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-storage-domain": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/node-addon-landlock-run": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/node-addon-landlock-run/-/node-addon-landlock-run-0.1.1.tgz",
+      "integrity": "sha512-aHGhlQJEutfobKM/4K59SERbT7RmQdD2oMKzD8Bne/Ps7TeT8AweCN+dpdfuxQhMNbFcJMymrgPnID0WYQ30Tw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@deepseek-ai/node-addon-landlock-run-linux-arm64": "0.1.1",
+        "@deepseek-ai/node-addon-landlock-run-linux-x64": "0.1.1"
+      }
+    },
+    "node_modules/@deepseek-ai/node-addon-landlock-run-linux-arm64": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/node-addon-landlock-run-linux-arm64/-/node-addon-landlock-run-linux-arm64-0.1.1.tgz",
+      "integrity": "sha512-lYY2RbcPW4rGRM5hVJbrXlvLqyBxeJBjBqvt+QTHTU+GtfUVVjTODKa4e3CRwMQoCEpOjoARdQBHbN7HvE72WQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@deepseek-ai/node-addon-landlock-run-linux-x64": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/node-addon-landlock-run-linux-x64/-/node-addon-landlock-run-linux-x64-0.1.1.tgz",
+      "integrity": "sha512-OHAzPW2Coe/iYobAJAAA8CeVrBoKV4BnNHsgwvXwOfishxkUVSWSvdyxrZPiwYRXutpIGVrSo9zV3WOQy2euBA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@deepseek-ai/schemastery": {
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.2.tgz",
+      "integrity": "sha512-njDtZsznjYxok7KLLlHOPyuv2efdWVbSflAHgztSfbMsg+CVraEoRe2DjOCgClYv3ZCSm7WXoaUkbB/+RY7tWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.3",
         "@standard-schema/spec": "^1.1.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-ai": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.4.tgz",
+      "integrity": "sha512-AClAZxf5+c4RRu44NJPS6wyQy+Nmq+Mzyyrdvm4ZVMNuixelO02RZX4G4Aq1F145Yzp43wnM5S+hLlSI7ypfVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@earendil-works/pi-telemetry": "^0.84.4",
+        "@google/genai": "1.52.0",
+        "@smithy/node-http-handler": "4.7.3",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
+        "openai": "6.40.0",
+        "partial-json": "0.1.7",
+        "typebox": "1.3.7"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-ai/node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-telemetry": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.4.tgz",
+      "integrity": "sha512-8e2CuxM+ht+hedQXTZmi5JVl6/xDK9RpSDL2+MbITevKYQhMZ/z6lJOTFgox3HQyGxO8mOZEtYGVeQNaD4OzqA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -564,12 +4530,35 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.14",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
       "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.14.1"
       },
@@ -577,12 +4566,1030 @@
         "hono": "^4"
       }
     },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.4.tgz",
+      "integrity": "sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.4.tgz",
+      "integrity": "sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.4.tgz",
+      "integrity": "sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.3.tgz",
+      "integrity": "sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.3.tgz",
+      "integrity": "sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.3.tgz",
+      "integrity": "sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.3.tgz",
+      "integrity": "sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.3.tgz",
+      "integrity": "sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.3.tgz",
+      "integrity": "sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.3.tgz",
+      "integrity": "sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.3.tgz",
+      "integrity": "sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.3.tgz",
+      "integrity": "sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.3.tgz",
+      "integrity": "sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.4.tgz",
+      "integrity": "sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.4.tgz",
+      "integrity": "sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.4.tgz",
+      "integrity": "sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.4.tgz",
+      "integrity": "sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.4.tgz",
+      "integrity": "sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.4.tgz",
+      "integrity": "sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.4.tgz",
+      "integrity": "sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.4.tgz",
+      "integrity": "sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.4.tgz",
+      "integrity": "sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==",
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-wasm32/node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.4.tgz",
+      "integrity": "sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.4.tgz",
+      "integrity": "sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.4.tgz",
+      "integrity": "sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.4.tgz",
+      "integrity": "sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@joplin/turndown-plugin-gfm": {
+      "version": "1.0.67",
+      "resolved": "https://registry.npmjs.org/@joplin/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.67.tgz",
+      "integrity": "sha512-FZfW5EZfidhzd1IaY1uxHnIZPTVOxAdleMZ4/1U6Nt5b7+Qj5JThDnaIomuJtetnUBzuRNbe9FWMuqD4B3dlWA==",
+      "license": "MIT"
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@koromix/koffi-android-arm64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-android-arm64/-/koffi-android-arm64-3.2.1.tgz",
+      "integrity": "sha512-1pJQ4jnZlUJduK9u9DC5CGy3aOgDUPvIXpNb6syV3+Dh5Q/ugezAIGCqvY+w+1mgXsve0pd0NVvJRjdZNHQ6MA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-android-x64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-android-x64/-/koffi-android-x64-3.2.1.tgz",
+      "integrity": "sha512-HH40xGh3gVQifjOBnhwT2tECC0lL1lYe+nxHvWNSzxDIyQNcVPXg38ta7vuONRFpD+uIrw7fqGYLzbZIagkVcg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-darwin-arm64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-arm64/-/koffi-darwin-arm64-3.2.1.tgz",
+      "integrity": "sha512-Vj4h+xcjc5+Cn0DhPHjgRX4omKAv96Kehtcd+1YgYuY2W7FvQn9vS+3SmzVwhC5Qmg9bIwUZObYQ8T/4hBqQqA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-darwin-x64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-x64/-/koffi-darwin-x64-3.2.1.tgz",
+      "integrity": "sha512-gFCWxNBTZIvxo1p+PURWfsy2Ctj5FGnVVs1f03lTLhBvmxEto70pdIiFztdFLDFkAJ1pmtQmruRKapeK+E8YPA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-arm64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-arm64/-/koffi-freebsd-arm64-3.2.1.tgz",
+      "integrity": "sha512-qj+f1s2e6vULaUG1cdlTcCXmunCq2t+rjxku1+esaMIqVnHpOwj0QzPuInG0AFdXjwBNQhyVR/HpDj8daEwwsQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-ia32": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-ia32/-/koffi-freebsd-ia32-3.2.1.tgz",
+      "integrity": "sha512-6olHb1Qfgai0jjs6ddlDDD0ZfsCxy7SPi8rMRpuYQWH0qhgtyQu82hw5b1p7z+TJ0zZP3ZeQQ6l+U/MlM1ICHQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-x64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-x64/-/koffi-freebsd-x64-3.2.1.tgz",
+      "integrity": "sha512-Dikhw1ySYNVMkmeFvFVjnU5Wdk6mffNoOjJxm9bTG96vg7OlemylxqdEven47R1YJ3yzNVJn/MlQ207ORWfi2w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-arm": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-arm/-/koffi-linux-arm-3.2.1.tgz",
+      "integrity": "sha512-OfwUwZylidq95wQKp6ClInULrfB2giu7dqM6Rhe0zAe6lES5I2SXNw15T9+GnRHk3/9hKT2XZ37OZLaKSyWNLA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-arm64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-arm64/-/koffi-linux-arm64-3.2.1.tgz",
+      "integrity": "sha512-K+cGUL5iBcDqxmsocrjmlASqDf24gc7artbVW3PewG2c9AqwC63lezgwvB85Nx4lZAQjB6zIFHh9A7t1yGbwhw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-ia32": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-ia32/-/koffi-linux-ia32-3.2.1.tgz",
+      "integrity": "sha512-rxj6UYjU1qd98gxNQOSCdLpc5cPRi5Giq9rNd3jnGuSNIyMkwa6Dxw4cUjmhIBCYESMJtmNt5NWnJp5u9wTfYQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-loong64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-loong64/-/koffi-linux-loong64-3.2.1.tgz",
+      "integrity": "sha512-aHhnHzkPRmT/IHDlGvESJ/Bs32m8N6UE6Ab6kMeJzgk74IN8af2m/81/wZJtybR1M2UxCV4NmlVNUYQQvSAO3Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-riscv64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-riscv64/-/koffi-linux-riscv64-3.2.1.tgz",
+      "integrity": "sha512-qtQBsjbm3LiirLJvajWmKkNb7ARk7fvJVXdftJ7NtAnF3Xw8EbDvrtvmvtNI1yLPlYcBmlzCCD71hwhWYk0SIA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-x64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-x64/-/koffi-linux-x64-3.2.1.tgz",
+      "integrity": "sha512-c7hw7Qs/r5gnFRTQLcbifBwRU7wiocj+2pVuDQ5Ahb3r36SZmupmgYbTWcLvTW+hul1jd7SKRV0d14ZJq/tvSw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-openbsd-ia32": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-ia32/-/koffi-openbsd-ia32-3.2.1.tgz",
+      "integrity": "sha512-mmY8fY8LQ/CB52+h3yrMYmVyoxzW3x08S0yI6VNfHWdfU6yJtZkKCbhjmQCYMrWbYKC4gMvwZwCywIGPAkLyeA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-openbsd-x64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-x64/-/koffi-openbsd-x64-3.2.1.tgz",
+      "integrity": "sha512-k4ig6aAPbFSRATOIIOfdf/KtlOGH4SVls6L9fy0QnTxRJYvY2oSltTsQtBDANgEQldlq8Kl5WnpRa1VSibP4Lw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-arm64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-arm64/-/koffi-win32-arm64-3.2.1.tgz",
+      "integrity": "sha512-cTWBJGK//pDMeKQJE/79Aq9MiOAF4H8QyLZHSQ9IWm8czOfwjG4J1AhsQ9DjI9KFOykH77hhnpmQTGVMIubGig==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-ia32": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-ia32/-/koffi-win32-ia32-3.2.1.tgz",
+      "integrity": "sha512-Z50EM6TAZ7CFyMmyX6thv8eNpJchqe9eenhibSIy2Eq/FQYF76gU2VK/LEoaF46L8hfC7TpTp9b10MvReHEyFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-x64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-x64/-/koffi-win32-x64-3.2.1.tgz",
+      "integrity": "sha512-ZmZNiBO6bkOSh3QNzgfvb1cMY0yMobn6ZQrSMqbAce21qyYL8niIbyipz9N/PIRDciGhsV0wUxnZsxIO+yWsHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@lexical/clipboard": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.49.0.tgz",
+      "integrity": "sha512-AVKj21xH1qU7JAFA/v0hCoafa+Yti1I7cHG+JQIgc/EqCtP8ePeJyIfTPNN/tXskoCdq++HewQoiSXRwwlocVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.49.0",
+        "@lexical/html": "0.49.0",
+        "@lexical/internal": "0.49.0",
+        "@lexical/list": "0.49.0",
+        "@lexical/selection": "0.49.0",
+        "@lexical/utils": "0.49.0",
+        "@types/trusted-types": "^2.0.7",
+        "lexical": "0.49.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/dragon": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.49.0.tgz",
+      "integrity": "sha512-62/4DP5qyX/l4Yf5qRyyQrs9BV725eRU3OmLUW6g7T5xrcHXxAo7tia/NvqjqvXdpvQzyHjWgsy7dMitGITUsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.49.0",
+        "lexical": "0.49.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/extension": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.49.0.tgz",
+      "integrity": "sha512-Wv0VsuqxorbxHCK4ms1PwAu6cXIGNLtflq66auF+zwxOtBprkSFV8VzzzdKLOYD2admP0VK6EqVCeGXFK1GggA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/internal": "0.49.0",
+        "@lexical/utils": "0.49.0",
+        "@preact/signals-core": "^1.14.1",
+        "lexical": "0.49.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/history": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.49.0.tgz",
+      "integrity": "sha512-uQdtEd34gIJklXNSdHS2Wko1zxx1xUMVXbiodcLO6a3GeFTE5bKnx6af1zGX78KpYhUQYnHWorKuUvtdZlJPaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.49.0",
+        "@lexical/utils": "0.49.0",
+        "lexical": "0.49.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/html": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.49.0.tgz",
+      "integrity": "sha512-NQqAydKzRjQl7Jx+bTTyC2iuz5uhuDaQX0SSPrdfgaFDCPjqQEejcBkCt1QXnu1CkbVHutZKVGVzljx40Y6y+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.49.0",
+        "@lexical/internal": "0.49.0",
+        "@lexical/selection": "0.49.0",
+        "@lexical/utils": "0.49.0",
+        "lexical": "0.49.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/internal": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@lexical/internal/-/internal-0.49.0.tgz",
+      "integrity": "sha512-s+XjPC7Qb39A/Xx9ahcz1s69CPix4ultaqyW+MDG0AXYW2quDr7m0USqReKIAiuoLIWtGN5HW8BwV2Y6t4qr6Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/list": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.49.0.tgz",
+      "integrity": "sha512-zs6wYkxakDRcJO0KmwrPPHgeLLIxzjD+P2CRu+scJCHRuA5e2iSw2iFjH5n/LlWBrlnPMSjeQse4QqsRy9nnqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.49.0",
+        "@lexical/html": "0.49.0",
+        "@lexical/internal": "0.49.0",
+        "@lexical/utils": "0.49.0",
+        "lexical": "0.49.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/plain-text": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.49.0.tgz",
+      "integrity": "sha512-l7IuUj9n9CtFfz4Fz6zU6mmO+VkcnvyyebABx+lHevvTa7B6YI5PPVgABFfzdyPanyW/FGs7qpKBf59inAqbkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/clipboard": "0.49.0",
+        "@lexical/dragon": "0.49.0",
+        "@lexical/extension": "0.49.0",
+        "@lexical/selection": "0.49.0",
+        "@lexical/utils": "0.49.0",
+        "lexical": "0.49.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/selection": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.49.0.tgz",
+      "integrity": "sha512-08Vd1+VoC6YnztWOFWVsqF/Hxw5EP8qeL1c7t3+rVCV8revLzXxdQw+vbPX3tgM4fmjOBDUXk6Ws1+rTtsqjcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/internal": "0.49.0",
+        "lexical": "0.49.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/text": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.49.0.tgz",
+      "integrity": "sha512-mowedvbvx0HDaW+ymVdYmWVhueqgauhhqIWaCtbJj33tPk8pOu1BB0pZuJQbOB+1bDnFiZhkJV8W/CvR2M9lEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/internal": "0.49.0",
+        "lexical": "0.49.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/utils": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.49.0.tgz",
+      "integrity": "sha512-Jaa6DERBqxiFOFa49VPRV1WOb7mzRbMZ5U+v+RFagjzTmBhfxDmEkbQQ9nYTU3n3DPfdT8Hkyffextmw04etXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/internal": "0.49.0",
+        "@lexical/selection": "0.49.0",
+        "lexical": "0.49.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@mariozechner/clipboard": {
       "version": "0.3.9",
@@ -763,12 +5770,17 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -855,6 +5867,62 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "29.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-29.0.1.tgz",
+      "integrity": "sha512-9qWOMFNxxLokERcms42rU0PTLqQmVs7g5E41TI4mCOxmpFayD1rfC7XxOL55cG9MBZLFlC31BrR37myMKardwg==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/openapi-webhooks-types": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-webhooks-types/-/openapi-webhooks-types-12.1.0.tgz",
+      "integrity": "sha512-WiuzhOsiOvb7W3Pvmhf8d2C6qaLHXrWiLBP4nJ/4kydu+wpagV5Fkz9RfQwV2afYzv3PB+3xYgp4mAdNGjDprA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.2.tgz",
+      "integrity": "sha512-XZRuT3xZ84D3gYErI1DZvhJ33dCWVV6uzBtWkaBB4TvA/L6eOeTZodxLFVB44bBEEo3vEx7y00UfX1tBLrtLRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^18.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-18.0.0.tgz",
+      "integrity": "sha512-l6bAF43PNxkJp6g+W4PjoUSSkxHomXw2nOum5CTftJz1NlV3vu93NImgOYtLf6CbBUb5j+fiuzW0PPQ5JTSvZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^29.0.1"
+      }
+    },
+    "node_modules/@octokit/webhooks": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-14.2.0.tgz",
+      "integrity": "sha512-da6KbdNCV5sr1/txD896V+6W0iamFWrvVl8cHkBSPT+YlvmT3DwXa4jxZnQc+gnuTEqSWbBeoSZYTayXH9wXcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-webhooks-types": "12.1.0",
+        "@octokit/request-error": "^7.0.0",
+        "@octokit/webhooks-methods": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/webhooks-methods": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-6.0.0.tgz",
+      "integrity": "sha512-MFlzzoDJVw/GcbfzVC1RLR36QqkTLUf79vLVO3D+xn7r0QgxnFoLZgtrzxiQErAjFUOdH6fas2KeQJ1yr/qaXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/@openai/codex": {
@@ -979,6 +6047,252 @@
         "node": ">=16"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+      "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.220.0.tgz",
+      "integrity": "sha512-8186thl+pTw64iz/qEEen5oJZoZ/gO73XruChdaGlYdWOdBIQ42r+vHLf6a7vIDqTD4b8ZOoMlyxptanECaI9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.220.0",
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/otlp-exporter-base": "0.220.0",
+        "@opentelemetry/otlp-transformer": "0.220.0",
+        "@opentelemetry/sdk-logs": "0.220.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.220.0.tgz",
+      "integrity": "sha512-CXYo8UD5Mn9YbgebO2EL4wejtA+gxLmLiu6HCk2KH2BR7XhFN6/6p1UlCb23DYCjeYkndevLHuejCCN1yx4+OQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/otlp-transformer": "0.220.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.220.0.tgz",
+      "integrity": "sha512-lXGrv7KXZ0gNH9SVNUaa6vv6phVYGvJxfXAlMbzbakiXru75f5MZl8Z7oqiMMQD77riVHJCFlQvbZs/VVN2/4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.220.0",
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/sdk-logs": "0.220.0",
+        "@opentelemetry/sdk-metrics": "2.9.0",
+        "@opentelemetry/sdk-trace": "2.9.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.11.0.tgz",
+      "integrity": "sha512-Ie7+8q8MDF4FAEQCKVMTx3ReUvxiIAgIiiW3c9JdmP8+HMcDy20puT+AHjexnExgnbvBxjQ9fjkFDWrikJ2jQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.11.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.11.0.tgz",
+      "integrity": "sha512-7YP44XH0tV6+Mb54x2YGf84i7yi+31MBZlE8JwvozkxyTvXbSp10X7cI7YE49ChJ3shMJoBmCJF3+1QFBJctGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.220.0.tgz",
+      "integrity": "sha512-WywcTkQtv2iNmt+6y5Kcd4rzvx9bLVsBa2Nwcmg01IUaBTkTow3W4d9KE5vNBpEDtb9tp21WcRBY/lANRrApYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.220.0",
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.9.0.tgz",
+      "integrity": "sha512-Xx8RGS4H5XEBl01WuCreMIpiah9cCXMbSkeuIePPdD2cUpq/vUzYmj8E/MK1OsbOc93FuAD4jfn2WOacKwLn7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.9.0.tgz",
+      "integrity": "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace/node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.139.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
@@ -988,6 +6302,73 @@
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
+    },
+    "node_modules/@preact/signals-core": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.4.tgz",
+      "integrity": "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.5",
@@ -1253,6 +6634,125 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@smithy/core": {
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.3.tgz",
+      "integrity": "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
+      "integrity": "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.8.0.tgz",
+      "integrity": "sha512-ycSJu3tFAQ4v04CBB0agqFMVsSQ1iG3yw+SpgxRqKfaURpQD4CZ8Wn0zPMmSnOuTpTh65Vz+EA0rMrw089wvkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.18.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.3.tgz",
+      "integrity": "sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.18.0.tgz",
+      "integrity": "sha512-CgB6HHWer/vrKps24ulRIbpcpb7K4xAU7SkZ7YHzBPlwHsvsrCJFEXK421s+cJzX+ZrqtA/TuU5w1HzI7k9N8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@stablelib/base64": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
@@ -1265,6 +6765,16 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.8",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.8.tgz",
+      "integrity": "sha512-BfEvehNpOT75r5Ksc5xW6NZuXujTfb7nlSEyVu4XHG3gdxNg1KqXruWbDewXOUaUYIo4oRbSfkjIajz4MAT8tA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
@@ -1306,11 +6816,22 @@
       "version": "20.19.43",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
       "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -1435,12 +6956,196 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vscode/ripgrep": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.18.0.tgz",
+      "integrity": "sha512-ns5lWe44tSfbTMbVUsyB+I1819PVSw4AdpgK0RNkzfWfwy6+3IUNSxwSrfTno1/oWaS/hERNz+XLWVyga2aJBQ==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@vscode/ripgrep-darwin-arm64": "1.18.0",
+        "@vscode/ripgrep-darwin-x64": "1.18.0",
+        "@vscode/ripgrep-linux-arm": "1.18.0",
+        "@vscode/ripgrep-linux-arm64": "1.18.0",
+        "@vscode/ripgrep-linux-ia32": "1.18.0",
+        "@vscode/ripgrep-linux-ppc64": "1.18.0",
+        "@vscode/ripgrep-linux-riscv64": "1.18.0",
+        "@vscode/ripgrep-linux-s390x": "1.18.0",
+        "@vscode/ripgrep-linux-x64": "1.18.0",
+        "@vscode/ripgrep-win32-arm64": "1.18.0",
+        "@vscode/ripgrep-win32-ia32": "1.18.0",
+        "@vscode/ripgrep-win32-x64": "1.18.0"
+      }
+    },
+    "node_modules/@vscode/ripgrep-darwin-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-darwin-arm64/-/ripgrep-darwin-arm64-1.18.0.tgz",
+      "integrity": "sha512-r3ktHSvbFycQNF6sl7sNDPocpsI7J+mEzh1IaZFkY0spm3k2Z9t8hPAeOK7+p0l6p6/swkQC14XWX01low+94Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-darwin-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-darwin-x64/-/ripgrep-darwin-x64-1.18.0.tgz",
+      "integrity": "sha512-25b4gWbL138dGuQU244ebCKKc0q05ULBMoFSz9oAEUHNeqK/lOJViDS7DRvbDazzAzSEdan391Znks/R5mkaTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-arm": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-arm/-/ripgrep-linux-arm-1.18.0.tgz",
+      "integrity": "sha512-GDAvufNDHu8zqLEmXstalQF0Wh6wQvdsBi/Vg3Yi3CK4a8XoFXqqXVEHEZ9xQz3t0NfoSEc9JbvK9DDS6FxyxQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-arm64/-/ripgrep-linux-arm64-1.18.0.tgz",
+      "integrity": "sha512-lQ/5zTG++U0E3IhVgS4EPTTn/U4okncaRMM5GOFfOYZywS4nuD31GhkHbNYlDk5CuDC68+hYJ0/eQeyCKJDA+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-ia32": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-ia32/-/ripgrep-linux-ia32-1.18.0.tgz",
+      "integrity": "sha512-YWLkSUtFd4Jh5EepIhA9RJSfv3uMAVMo+2rBIGHPBnvgLrZciIs2cDKei1/p6Wc/aCzUoHyMAg2R6tw4ZCBKGg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-ppc64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-ppc64/-/ripgrep-linux-ppc64-1.18.0.tgz",
+      "integrity": "sha512-quXVY8fwQ8O/lvU1yrSqSl3jlUzysRSb+AfUfCL/tRtphxsKlFvPAejryZ6vg4Bgvn8XL74xb4qMCDmWgYrT5w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-riscv64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-riscv64/-/ripgrep-linux-riscv64-1.18.0.tgz",
+      "integrity": "sha512-f5kBQBrWfQt8Q7OhSORuNDei5dkYagBj3y4jImSUXGMy8B/Ke7SltSRcUtjPv166FAFfHCAmWuZp3+cWnX2/Vw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-s390x": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-s390x/-/ripgrep-linux-s390x-1.18.0.tgz",
+      "integrity": "sha512-rTOcJFGGcl2c07RUOWUo4U1ndnemKhY6A9hnMB18uk7jSgJc0d/QLBGWMWpumdtoJtpizn/wIv5mXIisJukusQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-x64/-/ripgrep-linux-x64-1.18.0.tgz",
+      "integrity": "sha512-mQ3bVrUpnD2vs7QT0vX90Lt0cnUq467uFtEktIdsJJmW296RoSULRGqWgzG1AKxyBpNDD6l4ZO4qKf6SgyC23Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-win32-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-arm64/-/ripgrep-win32-arm64-1.18.0.tgz",
+      "integrity": "sha512-vfTIjq1OHnzUjxZcHVQAMbnggp8dpGf+0QKFOZHwWPqFwXxQC8eCWM+5NUdoJ6yrElCeMzoUTXoK/LdZaniB+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-win32-ia32": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-ia32/-/ripgrep-win32-ia32-1.18.0.tgz",
+      "integrity": "sha512-//rfAE+BOw5AC2EMmepmiE36jUuevtQYNQqqlw1s3m9FlRxjxEut97RkRPHAu9BG4mSojatZx+kXZXNdyI9caQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-win32-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-x64/-/ripgrep-win32-x64-1.18.0.tgz",
+      "integrity": "sha512-KNPvtElldqILHdnAetujPaowkNbpqJy3ssIGGN6F6Kve9Qi+nNLI2DN01O83JjCEVQbCzl8Ov3QZ9Eov3BR8Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@xterm/headless": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/headless/-/headless-6.0.0.tgz",
+      "integrity": "sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw==",
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-types": "^3.0.0",
         "negotiator": "^1.0.0"
@@ -1449,12 +7154,20 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1471,7 +7184,6 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -1484,6 +7196,12 @@
         }
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1494,12 +7212,40 @@
         "node": ">=12"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
       "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^2.0.0",
@@ -1524,7 +7270,6 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
       "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1533,12 +7278,38 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -1548,7 +7319,6 @@
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -1562,7 +7332,6 @@
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -1584,12 +7353,98 @@
         "node": ">=18"
       }
     },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/compression/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
       "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1603,7 +7458,6 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1620,7 +7474,6 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1630,7 +7483,6 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.6.0"
       }
@@ -1640,7 +7492,6 @@
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
       "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "object-assign": "^4",
         "vary": "^1"
@@ -1658,7 +7509,6 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -1666,6 +7516,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/debug": {
@@ -1685,12 +7544,51 @@
         }
       }
     },
+    "node_modules/default-browser": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.1.tgz",
+      "integrity": "sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -1699,10 +7597,18 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dunder-proto": {
@@ -1710,7 +7616,6 @@
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -1720,19 +7625,26 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -1742,7 +7654,6 @@
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -1752,7 +7663,6 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -1769,7 +7679,6 @@
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -1781,8 +7690,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
@@ -1799,7 +7707,6 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1809,7 +7716,6 @@
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eventsource-parser": "^3.0.1"
       },
@@ -1822,7 +7728,6 @@
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
       "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       }
@@ -1842,7 +7747,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1886,7 +7790,6 @@
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
       "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ip-address": "^10.2.0"
       },
@@ -1900,12 +7803,17 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fast-sha256": {
       "version": "1.3.0",
@@ -1928,8 +7836,7 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1949,12 +7856,40 @@
         }
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "encodeurl": "^2.0.0",
@@ -1971,12 +7906,23 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1986,7 +7932,6 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2011,9 +7956,36 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+      "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/get-intrinsic": {
@@ -2021,7 +7993,6 @@
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -2046,7 +8017,6 @@
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -2055,12 +8025,37 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+      "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -2073,7 +8068,6 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -2086,7 +8080,6 @@
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -2103,7 +8096,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
       "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2113,7 +8105,6 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "depd": "~2.0.0",
         "inherits": "~2.0.4",
@@ -2129,12 +8120,37 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
       "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -2150,15 +8166,13 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/ip-address": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -2168,33 +8182,126 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
       "license": "MIT",
-      "peer": true
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/jose": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
       "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
       }
     },
     "node_modules/json-schema-to-ts": {
@@ -2202,7 +8309,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
       "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "ts-algebra": "^2.0.0"
@@ -2215,15 +8321,81 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json-schema-typed": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/koffi": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-3.2.1.tgz",
+      "integrity": "sha512-0qE3lZ8jllRqPN4Ob6Ajl7c2bJSJDhQWuKLGP5hIEpHLllJWv1ydHFMhHmHc5p/W9GticKVDbYzZd7TBoQ4CZg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      },
+      "optionalDependencies": {
+        "@koromix/koffi-android-arm64": "3.2.1",
+        "@koromix/koffi-android-x64": "3.2.1",
+        "@koromix/koffi-darwin-arm64": "3.2.1",
+        "@koromix/koffi-darwin-x64": "3.2.1",
+        "@koromix/koffi-freebsd-arm64": "3.2.1",
+        "@koromix/koffi-freebsd-ia32": "3.2.1",
+        "@koromix/koffi-freebsd-x64": "3.2.1",
+        "@koromix/koffi-linux-arm": "3.2.1",
+        "@koromix/koffi-linux-arm64": "3.2.1",
+        "@koromix/koffi-linux-ia32": "3.2.1",
+        "@koromix/koffi-linux-loong64": "3.2.1",
+        "@koromix/koffi-linux-riscv64": "3.2.1",
+        "@koromix/koffi-linux-x64": "3.2.1",
+        "@koromix/koffi-openbsd-ia32": "3.2.1",
+        "@koromix/koffi-openbsd-x64": "3.2.1",
+        "@koromix/koffi-win32-arm64": "3.2.1",
+        "@koromix/koffi-win32-ia32": "3.2.1",
+        "@koromix/koffi-win32-x64": "3.2.1"
+      }
+    },
+    "node_modules/lexical": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.49.0.tgz",
+      "integrity": "sha512-9V1ZIzGpJEd8rIN+nN7veL4fW4fFWbS66Un4JNqSZB4D5t9euzN9+3+jEXy83FjNjNy0MiiUI3+DQaGCLYko0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/internal": "0.49.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -2486,6 +8658,25 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2501,7 +8692,6 @@
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -2511,7 +8701,6 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2521,7 +8710,6 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2534,7 +8722,6 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2544,7 +8731,6 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -2586,7 +8772,6 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2595,8 +8780,208 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
+    "node_modules/node-addon-native-custom-loader": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/node-addon-native-custom-loader/-/node-addon-native-custom-loader-0.1.5.tgz",
+      "integrity": "sha512-rL0XXRytayIChYf1xaG9/1NzGBRTyFkQTIpn+MDz/hpr0PZw1a9PZIoH9HlYfagNawhXU+jfN650EvoSIvR7Vw==",
       "license": "MIT",
-      "optional": true
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-addon-require-builtin": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/node-addon-require-builtin/-/node-addon-require-builtin-0.1.5.tgz",
+      "integrity": "sha512-isaquiStlp7qdFpaffy+2ssJPUR/kLPRE5gqfeWbb0Ahph9H7O3BOFwThqkVaTrxfpnjrQauxlOEgvzD+snhUg==",
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-native-custom-loader": "0.1.5"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "node-addon-require-builtin-darwin-arm64": "0.1.5",
+        "node-addon-require-builtin-darwin-x64": "0.1.5",
+        "node-addon-require-builtin-linux-arm64-gnu": "0.1.5",
+        "node-addon-require-builtin-linux-x64-gnu": "0.1.5",
+        "node-addon-require-builtin-win32-arm64-msvc": "0.1.5",
+        "node-addon-require-builtin-win32-ia32-msvc": "0.1.5",
+        "node-addon-require-builtin-win32-x64-msvc": "0.1.5"
+      }
+    },
+    "node_modules/node-addon-require-builtin-darwin-arm64": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/node-addon-require-builtin-darwin-arm64/-/node-addon-require-builtin-darwin-arm64-0.1.5.tgz",
+      "integrity": "sha512-MZ5RyGhuU7DTbwuNpOQW81/ep8n5Yd5YlZa6dWiEfJEh+01Dl4cCKGmMCWNgb0VtqAImRtAOtmZIPtwngiemKQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "node-addon-native-custom-loader": "0.1.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-addon-require-builtin-darwin-x64": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/node-addon-require-builtin-darwin-x64/-/node-addon-require-builtin-darwin-x64-0.1.5.tgz",
+      "integrity": "sha512-wdCSPn49AdNZ2EXHQqswiXk1cROFe9zSRaAX8PwQLxmjdLt+xZF7vZP6VlqgXm+VAOHv98q8kp9m7mO9jY3OgQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "node-addon-native-custom-loader": "0.1.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-addon-require-builtin-linux-arm64-gnu": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/node-addon-require-builtin-linux-arm64-gnu/-/node-addon-require-builtin-linux-arm64-gnu-0.1.5.tgz",
+      "integrity": "sha512-hCqzKpQiknDDv6rUdZqrxCBXROg/uUruO0geUuZsdM9M/Lds45gSb4bDE958HlPaCvrDyR0wTHl3II8A7yQeew==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "dependencies": {
+        "node-addon-native-custom-loader": "0.1.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-addon-require-builtin-linux-x64-gnu": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/node-addon-require-builtin-linux-x64-gnu/-/node-addon-require-builtin-linux-x64-gnu-0.1.5.tgz",
+      "integrity": "sha512-lgP+ruwWXbcXDslhp5uIc+dFgzITEGPZ4E50WdHGt/OzcoVhN6y5z72pRRvxy8DE661//QxqmCLe72rS3SVg+w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "dependencies": {
+        "node-addon-native-custom-loader": "0.1.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-addon-require-builtin-win32-arm64-msvc": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/node-addon-require-builtin-win32-arm64-msvc/-/node-addon-require-builtin-win32-arm64-msvc-0.1.5.tgz",
+      "integrity": "sha512-KEO2eWS4lvZg6JmPPz04OdI4Ojrc7YzOs++4r6VnvwsqYN2r6mjGSGpouQkk8J2eLXBzC7X/D9wYTbUuQS8u1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "dependencies": {
+        "node-addon-native-custom-loader": "0.1.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-addon-require-builtin-win32-ia32-msvc": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/node-addon-require-builtin-win32-ia32-msvc/-/node-addon-require-builtin-win32-ia32-msvc-0.1.5.tgz",
+      "integrity": "sha512-iSC988EqZm5XbKWp/giW6K6EBRTrHt/YQbAkKsZLglt7PplmvvrZ7C3tUsyh1wVxUTYAaxFdE2xbqSdpw0rb6g==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "dependencies": {
+        "node-addon-native-custom-loader": "0.1.5"
+      },
+      "engines": {
+        "node": ">=20 <23"
+      }
+    },
+    "node_modules/node-addon-require-builtin-win32-x64-msvc": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/node-addon-require-builtin-win32-x64-msvc/-/node-addon-require-builtin-win32-x64-msvc-0.1.5.tgz",
+      "integrity": "sha512-pjuco/ESU3ChIp7WwacWfY2ENu2K5rGAgqjcXedoiFcTrjTf5Ln/miKSuNfE6IiuJ7tfMTJH6VH5hq+C1Y8JMQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "dependencies": {
+        "node-addon-native-custom-loader": "0.1.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
     },
     "node_modules/node-pty": {
       "version": "1.1.0",
@@ -2614,7 +8999,6 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2624,7 +9008,6 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -2651,10 +9034,18 @@
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ee-first": "1.1.1"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -2664,9 +9055,59 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/open": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.2.tgz",
+      "integrity": "sha512-RWqF+pBSkqecEvCKOn8QYhaNdRMJDZRIrlS/7rTDdLHaPcfXGCZ/h8zb413NfvdeAV0MR7T1yJcA34/q+CSm1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.5.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
+        "is-inside-container": "^1.0.0",
+        "powershell-utils": "^0.2.1",
+        "wsl-utils": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.40.0.tgz",
+      "integrity": "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/parseurl": {
@@ -2674,17 +9115,21 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "license": "MIT"
     },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2694,7 +9139,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
       "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
@@ -2711,14 +9155,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2732,7 +9174,6 @@
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -2766,12 +9207,46 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/powershell-utils": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.2.1.tgz",
+      "integrity": "sha512-C+y9x90UElAddDZmV4qOx9W53B61PO7cIqWz2dQsWlwswuq4mr8NEwytdGKboYbQlGZ3awrkTeNvcZiZNHnQ8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.6.tgz",
+      "integrity": "sha512-dYDWdjSl5RNb7SgPxGQcRU+GtvP7s2fpkrY0r432PcOIaZ0/rBcxEZnQN67iJhFuQiVw754JDoPruPCNdGsbjg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
@@ -2785,7 +9260,6 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
       "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "es-define-property": "^1.0.1",
         "side-channel": "^1.1.1"
@@ -2802,7 +9276,6 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
       "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       },
@@ -2816,7 +9289,6 @@
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bytes": "~3.1.2",
         "http-errors": "~2.0.1",
@@ -2827,14 +9299,57 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve.exports": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/rolldown": {
@@ -2876,7 +9391,6 @@
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "depd": "^2.0.0",
@@ -2888,19 +9402,68 @@
         "node": ">= 18"
       }
     },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
@@ -2927,7 +9490,6 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
@@ -2946,15 +9508,62 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.4.tgz",
+      "integrity": "sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.5"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.4",
+        "@img/sharp-darwin-x64": "0.35.4",
+        "@img/sharp-freebsd-wasm32": "0.35.4",
+        "@img/sharp-libvips-darwin-arm64": "1.3.3",
+        "@img/sharp-libvips-darwin-x64": "1.3.3",
+        "@img/sharp-libvips-linux-arm": "1.3.3",
+        "@img/sharp-libvips-linux-arm64": "1.3.3",
+        "@img/sharp-libvips-linux-ppc64": "1.3.3",
+        "@img/sharp-libvips-linux-riscv64": "1.3.3",
+        "@img/sharp-libvips-linux-s390x": "1.3.3",
+        "@img/sharp-libvips-linux-x64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3",
+        "@img/sharp-linux-arm": "0.35.4",
+        "@img/sharp-linux-arm64": "0.35.4",
+        "@img/sharp-linux-ppc64": "0.35.4",
+        "@img/sharp-linux-riscv64": "0.35.4",
+        "@img/sharp-linux-s390x": "0.35.4",
+        "@img/sharp-linux-x64": "0.35.4",
+        "@img/sharp-linuxmusl-arm64": "0.35.4",
+        "@img/sharp-linuxmusl-x64": "0.35.4",
+        "@img/sharp-webcontainers-wasm32": "0.35.4",
+        "@img/sharp-win32-arm64": "0.35.4",
+        "@img/sharp-win32-ia32": "0.35.4",
+        "@img/sharp-win32-x64": "0.35.4"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -2967,7 +9576,6 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2977,7 +9585,6 @@
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
       "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.4",
@@ -2997,7 +9604,6 @@
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.4"
@@ -3014,7 +9620,6 @@
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -3033,7 +9638,6 @@
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -3088,7 +9692,6 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -3149,7 +9752,6 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -3164,23 +9766,32 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
+    },
+    "node_modules/turndown": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.4.tgz",
+      "integrity": "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
     },
     "node_modules/type-is": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
       "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
@@ -3199,7 +9810,6 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
       "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -3208,11 +9818,17 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/typebox": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+      "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -3222,11 +9838,19 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici": {
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.2.tgz",
+      "integrity": "sha512-/y4/bH9YNU5hi9NIrpOuvGXFcxrj3CMrV+/AYpowAYTpHn8gX/XPFjNy766FPoYY0miQhdW977JFWKGNhBdwyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -3234,9 +9858,17 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/vary": {
@@ -3244,7 +9876,6 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -3417,12 +10048,20 @@
         }
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -3454,8 +10093,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.21.0",
@@ -3476,6 +10114,49 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-1.0.0.tgz",
+      "integrity": "sha512-Hl0ZOAs672vg+06kfujwRhoS6/jehvULrlFkuF2dRu6pHgA8U06h3xqNIqNNU1LTXPcedxByAR4GS6pwQK0mgA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wsl-utils/node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/zod": {

--- a/homerail_worker/package.json
+++ b/homerail_worker/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.251",
-    "@deepseek-ai/dsh-sdk-client": "0.0.1-rc.1",
+    "@deepseek-ai/dsh-sdk-client": "0.1.2-rc.1",
     "@moonshot-ai/kimi-agent-sdk": "^0.1.8",
     "@moonshot-ai/kimi-code": "^0.24.2",
     "@openai/codex": "0.145.0",

--- a/homerail_worker/src/__tests__/deepseek-harness-runtime.integration.test.ts
+++ b/homerail_worker/src/__tests__/deepseek-harness-runtime.integration.test.ts
@@ -11,7 +11,7 @@ interface MockProvider {
 }
 
 const servers: Server[] = [];
-const runtimeConfigured = Boolean(process.env.HOMERAIL_DSH_RUNTIME_COMMAND?.trim());
+const runtimeConfigured = Boolean(process.env.HOMERAIL_DSH_RUNTIME_BIN?.trim());
 
 afterEach(async () => {
   await Promise.all(servers.splice(0).map((server) => new Promise<void>((resolve, reject) => {
@@ -150,6 +150,10 @@ describe.skipIf(!runtimeConfigured)("DeepSeek Harness packaged runtime", () => {
       "/v1/chat/completions",
       "/v1/chat/completions",
     ]);
+    const exposedToolNames = (provider.requests[0]?.body.tools as Array<{
+      function?: { name?: string };
+    }> | undefined)?.map((tool) => tool.function?.name);
+    expect(exposedToolNames).toEqual(["mcp__homerail__handoff"]);
     expect(JSON.stringify(provider.requests[0]?.body)).toContain("mcp__homerail__handoff");
     expect(JSON.stringify(provider.requests[1]?.body)).toContain("accepted");
 

--- a/homerail_worker/src/__tests__/deepseek-harness.test.ts
+++ b/homerail_worker/src/__tests__/deepseek-harness.test.ts
@@ -69,8 +69,7 @@ describe("DeepSeekHarnessAdapter", () => {
     vi.stubEnv("HOMERAIL_WORKER_TOKEN", "manager-secret");
     vi.stubEnv("HOMERAIL_DSH_CORDIS_CONFIG", customConfig);
     const adapter = new DeepSeekHarnessAdapter({
-      runtimeCommand: process.execPath,
-      runtimeArgs: [fakeRuntime],
+      runtimeBin: fakeRuntime,
     });
     const events = await collect(adapter, context({
       environmentVariables: {
@@ -108,11 +107,26 @@ describe("DeepSeekHarnessAdapter", () => {
     const recorded = JSON.parse(readFileSync(recordFile, "utf8").trim()) as Record<string, unknown>;
     expect(recorded.managerToken).toBeUndefined();
     expect(recorded.baseUrl).toBe("https://example.invalid/v1");
-    expect(recorded.cordisConfig).toBe(customConfig);
+    expect(recorded.cordisConfig).toBeUndefined();
+    expect(recorded.dshHome).toEqual(expect.stringMatching(/homerail-dsh-/));
+    expect(recorded.argv).toEqual([
+      "--profile",
+      "sdk-minimal",
+      "--patch",
+      customConfig,
+    ]);
     expect(recorded.reasoningEffort).toBeUndefined();
     expect(recorded.reasoningEfforts).toBeUndefined();
     expect(recorded.apiKeyPresent).toBe(true);
     expect(recorded.params).toMatchObject({ maxTokens: 32_768 });
+    expect(events).toContainEqual(expect.objectContaining({
+      type: "debug",
+      data: expect.objectContaining({
+        runtime_bin: fakeRuntime,
+        runtime_profile: "sdk-minimal",
+        runtime_patch: customConfig,
+      }),
+    }));
   });
 
   it("runs the generated MCP proxy through the authenticated loopback tool bridge", async () => {
@@ -129,8 +143,7 @@ describe("DeepSeekHarnessAdapter", () => {
       },
     };
     const adapter = new DeepSeekHarnessAdapter({
-      runtimeCommand: process.execPath,
-      runtimeArgs: [fakeRuntime],
+      runtimeBin: fakeRuntime,
     });
     const events = await collect(adapter, context({
       environmentVariables: {
@@ -214,8 +227,7 @@ describe("DeepSeekHarnessAdapter", () => {
     const root = tempRoot();
     const recordFile = join(root, "runtime.jsonl");
     const adapter = new DeepSeekHarnessAdapter({
-      runtimeCommand: process.execPath,
-      runtimeArgs: [fakeRuntime],
+      runtimeBin: fakeRuntime,
     });
     await collect(adapter, context({
       reasoningEffort: "medium",
@@ -230,8 +242,7 @@ describe("DeepSeekHarnessAdapter", () => {
 
   it("rejects a reasoning selector the selected model did not declare", async () => {
     const adapter = new DeepSeekHarnessAdapter({
-      runtimeCommand: process.execPath,
-      runtimeArgs: [fakeRuntime],
+      runtimeBin: fakeRuntime,
     });
 
     const events = await collect(adapter, context({
@@ -249,8 +260,7 @@ describe("DeepSeekHarnessAdapter", () => {
     const root = tempRoot();
     const recordFile = join(root, "runtime.jsonl");
     const adapter = new DeepSeekHarnessAdapter({
-      runtimeCommand: process.execPath,
-      runtimeArgs: [fakeRuntime],
+      runtimeBin: fakeRuntime,
       maxTokens: 16_384,
     });
     await collect(adapter, context({
@@ -264,8 +274,7 @@ describe("DeepSeekHarnessAdapter", () => {
   it("routes queued live steering through the fork session/steer method", async () => {
     const controller = new AgentTurnController({ capabilities: { liveSteer: true } });
     const adapter = new DeepSeekHarnessAdapter({
-      runtimeCommand: process.execPath,
-      runtimeArgs: [fakeRuntime],
+      runtimeBin: fakeRuntime,
     });
     const eventsPromise = collect(adapter, context({
       turnController: controller,
@@ -287,8 +296,7 @@ describe("DeepSeekHarnessAdapter", () => {
     mkdirSync(join(workspace, "repository"));
     writeFileSync(join(workspace, "repository", "README.md"), "fixture\n");
     const adapter = new DeepSeekHarnessAdapter({
-      runtimeCommand: process.execPath,
-      runtimeArgs: [fakeRuntime],
+      runtimeBin: fakeRuntime,
     });
     const events = await collect(adapter, context({
       workspace,
@@ -313,8 +321,7 @@ describe("DeepSeekHarnessAdapter", () => {
     const workspace = tempRoot();
     mkdirSync(join(workspace, "repository"));
     const adapter = new DeepSeekHarnessAdapter({
-      runtimeCommand: process.execPath,
-      runtimeArgs: [fakeRuntime],
+      runtimeBin: fakeRuntime,
     });
     const events = await collect(adapter, context({
       workspace,
@@ -331,8 +338,7 @@ describe("DeepSeekHarnessAdapter", () => {
 
   it("surfaces structured DSH turn failures as actionable agent errors", async () => {
     const adapter = new DeepSeekHarnessAdapter({
-      runtimeCommand: process.execPath,
-      runtimeArgs: [fakeRuntime],
+      runtimeBin: fakeRuntime,
     });
     const events = await collect(adapter, context({
       environmentVariables: { DSH_FAKE_TURN_ERROR: "provider connection refused" },
@@ -350,8 +356,7 @@ describe("DeepSeekHarnessAdapter", () => {
     const readyFile = join(root, "ready");
     const controller = new AgentTurnController({ capabilities: { liveSteer: true } });
     const adapter = new DeepSeekHarnessAdapter({
-      runtimeCommand: process.execPath,
-      runtimeArgs: [fakeRuntime],
+      runtimeBin: fakeRuntime,
     });
     const eventsPromise = collect(adapter, context({
       turnController: controller,
@@ -380,8 +385,7 @@ describe("DeepSeekHarnessAdapter", () => {
     const readyFile = join(root, "ready");
     const abortController = new AbortController();
     const adapter = new DeepSeekHarnessAdapter({
-      runtimeCommand: process.execPath,
-      runtimeArgs: [fakeRuntime],
+      runtimeBin: fakeRuntime,
     });
     const originalClose = DeepSeekHarness.prototype.close;
     const closeSpy = vi.spyOn(DeepSeekHarness.prototype, "close")

--- a/homerail_worker/src/__tests__/fixtures/fake-dsh-runtime.mjs
+++ b/homerail_worker/src/__tests__/fixtures/fake-dsh-runtime.mjs
@@ -180,6 +180,8 @@ lines.on("line", async (line) => {
       appendFileSync(process.env.DSH_FAKE_RECORD_FILE, `${JSON.stringify({
         params: request.params,
         cordisConfig: process.env.DSH_CORDIS_CONFIG,
+        dshHome: process.env.DSH_HOME,
+        argv: process.argv.slice(2),
         baseUrl: providerProfile?.baseURL,
         reasoningEffort: providerProfile?.reasoning,
         reasoningEfforts: providerProfile?.models?.[0]?.reasoningEfforts,

--- a/homerail_worker/src/agent/deepseek-harness.ts
+++ b/homerail_worker/src/agent/deepseek-harness.ts
@@ -17,6 +17,7 @@ import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   DeepSeekHarness,
+  type DeepSeekHarnessOptions,
   type HarnessNotification,
 } from "@deepseek-ai/dsh-sdk-client";
 import { sanitizedAgentChildEnv } from "./child-env.js";
@@ -31,16 +32,15 @@ import type { AgentTurnDriverBindingResult } from "./turn-controller.js";
 import { createDeepSeekHarnessReadTools } from "./deepseek-harness-read-tools.js";
 import { WORKER_RUNTIME_VERSION } from "../runtime-version.js";
 
-const DEFAULT_DSH_RUNTIME_COMMAND = "dsh-jsonrpc-agent-pkg";
+const DEFAULT_DSH_RUNTIME_BIN = "/opt/deepseek-harness-runtime/node_modules/@deepseek-ai/dsh/lib/bin.js";
 const DEFAULT_DSH_MAX_TOKENS = 32_768;
 const DEFAULT_DSH_CONTEXT_WINDOW = 200_000;
-const DSH_FORK_COMMIT = "f4fd5f005636cdcbf9d95f70f04d05afa8c0db54";
+const DSH_FORK_COMMIT = "f0fd50751713ab7e1b7cb1f13310a70c106d81b1";
 const MCP_TOOL_PREFIX = "mcp__homerail__";
 const DEFAULT_SYSTEM_PROMPT = "You are a HomeRail DAG worker. Complete the assigned task and call the provided handoff tool exactly once.";
 
 interface DeepSeekHarnessAdapterOptions {
-  runtimeCommand?: string;
-  runtimeArgs?: string[];
+  runtimeBin?: string;
   cordisConfigPath?: string;
   maxTokens?: number;
 }
@@ -100,15 +100,6 @@ class AsyncQueue<T> implements AsyncIterable<T> {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
-}
-
-function parseRuntimeArgs(value: string | undefined): string[] {
-  if (!value?.trim()) return [];
-  const parsed: unknown = JSON.parse(value);
-  if (!Array.isArray(parsed) || !parsed.every((entry) => typeof entry === "string")) {
-    throw new Error("HOMERAIL_DSH_RUNTIME_ARGS must be a JSON array of strings");
-  }
-  return parsed;
 }
 
 function parseMaxTokens(value: number | string | undefined): number {
@@ -354,17 +345,16 @@ function isIdleStatus(notification: HarnessNotification, sessionId: string): boo
 }
 
 export class DeepSeekHarnessAdapter implements AgentClient {
-  private readonly runtimeCommand: string;
-  private readonly runtimeArgs: string[];
+  private readonly runtimeBin: string;
   private readonly cordisConfigPath: string;
   private readonly maxTokens: number;
 
   constructor(options: DeepSeekHarnessAdapterOptions = {}) {
-    this.runtimeCommand = options.runtimeCommand
-      ?? process.env.HOMERAIL_DSH_RUNTIME_COMMAND?.trim()
-      ?? DEFAULT_DSH_RUNTIME_COMMAND;
-    this.runtimeArgs = options.runtimeArgs
-      ?? parseRuntimeArgs(process.env.HOMERAIL_DSH_RUNTIME_ARGS);
+    this.runtimeBin = resolve(
+      options.runtimeBin
+        ?? process.env.HOMERAIL_DSH_RUNTIME_BIN?.trim()
+        ?? DEFAULT_DSH_RUNTIME_BIN,
+    );
     this.cordisConfigPath = resolve(
       options.cordisConfigPath
         ?? process.env.HOMERAIL_DSH_CORDIS_CONFIG?.trim()
@@ -416,7 +406,6 @@ export class DeepSeekHarnessAdapter implements AgentClient {
           ...process.env,
           ...context.environmentVariables,
         }),
-        DSH_CORDIS_CONFIG: this.cordisConfigPath,
         DSH_CWD: context.workspace ?? process.cwd(),
         DSH_SESSION_ROOT: join(runtimeRoot, "sessions"),
         DSH_SYSTEM_PROMPT: projectedSystemPrompt(context),
@@ -427,15 +416,16 @@ export class DeepSeekHarnessAdapter implements AgentClient {
         HOMERAIL_MCP_BRIDGE_TOKEN: bridge.token,
       };
       harness = new DeepSeekHarness({
-        launch: {
-          command: this.runtimeCommand,
-          args: this.runtimeArgs,
-          cwd: context.workspace ?? process.cwd(),
-          env: childEnv,
-        },
+        dshBin: this.runtimeBin,
+        profile: "sdk-minimal",
+        patches: [this.cordisConfigPath],
+        dshHome: runtimeRoot,
+        processCwd: context.workspace ?? process.cwd(),
+        env: childEnv,
         cwd: context.workspace,
         provider: providerProfile.provider,
         model: context.model,
+        reasoningEffort: providerProfile.reasoningEffort as DeepSeekHarnessOptions["reasoningEffort"],
         maxTokens: this.maxTokens,
       });
 
@@ -445,8 +435,9 @@ export class DeepSeekHarnessAdapter implements AgentClient {
         message: "runtime_prepared",
         data: {
           fork_commit: DSH_FORK_COMMIT,
-          runtime_command: this.runtimeCommand,
-          runtime_args_count: this.runtimeArgs.length,
+          runtime_bin: this.runtimeBin,
+          runtime_profile: "sdk-minimal",
+          runtime_patch: this.cordisConfigPath,
           session_id: sessionId,
           tool_count: bridgeTools.length,
           builtin_tools: builtinTools.map((tool) => tool.name),


### PR DESCRIPTION
## Summary

- upgrade the Worker SDK client to `0.1.2-rc.1`
- pin the runtime to fork commit `f0fd50751713ab7e1b7cb1f13310a70c106d81b1`, based on official `dsh-v0.1.2-rc.1`
- launch the standalone `sdk-minimal` profile with a HomeRail-owned fail-closed patch
- retain cooperative live steering and cancellation through the fork JSON-RPC methods
- verify that only HomeRail MCP tools reach the model

## Validation

- `npm run install:all`
- `HOMERAIL_HOME=/tmp/homerail-dsh-upgrade-ci npm run ci` (3,578 tests passed)
- real fork runtime integration test on the host
- Worker Docker image build from the pinned remote commit
- real packaged runtime integration test inside the built image
- focused adapter suite on Node 20

The dependency audit findings are unchanged from `main`; this upgrade adds no new advisory versions.