### PR TITLE
fix(deploy): retire automatic DAG smoke validation

### DIFF
--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -3,8 +3,8 @@
 `.github/workflows/deploy-production.yml` deploys the latest `main` revision
 only through an owner-initiated manual dispatch. Merging a pull request does
 not start a deployment workflow. It runs on a dedicated self-hosted runner
-labeled `homerail-deploy`; the live DAG, PR Review, and Auto Fix labels must
-stay on separate runners.
+labeled `homerail-deploy`; PR Review and Auto Fix use separate runners.
+The live DAG validation runner is retired.
 
 Each deployment runner keeps its machine-specific paths and public address in
 `~/.config/homerail/production.env` with mode `0600`. The tracked workflow does
@@ -64,8 +64,7 @@ This Manager is also the single durable automation control plane. PR Review and
 Auto Fix use separate Actions runner processes so they can execute concurrently,
 but both submit to this service and retain their DAG history in its database.
 They do not start alternate Managers, allocate dynamic Manager ports, or clone
-the production Home. Live DAG compatibility CI remains the only workflow that
-may start a transient current-commit runtime.
+the production Home. Live DAG compatibility validation is retired.
 
 The production Manager enables only the fixed `node` executable for
 deterministic DAG command nodes. Built-in PR Review and Auto Fix use that
@@ -87,8 +86,8 @@ into a new release directory, and atomically switches `current`. The systemd
 user service owns Manager, Node, and the static Agent UI as one cgroup and
 restarts after a process or health failure. Deployment waits for both Manager
 and HTTPS UI health through its LAN address, requires a connected Docker Node,
-and runs the deterministic public two-node DAG through a provisioned Docker
-Worker before accepting the release. Deployment rejects loopback-only Manager
+and accepts the release after these checks without starting a validation DAG.
+Deployment rejects loopback-only Manager
 binds, loopback-only UI binds, and loopback public addresses.
 A failed health check switches `current` back to the prior release and restarts it. The
 dedicated Manager port prevents desktop/E2E runtimes from being mistaken for

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -391,15 +391,6 @@ for _ in $(seq 1 "$HEALTH_ATTEMPTS"); do
   sleep 2
 done
 
-if [ "$healthy" = "1" ]; then
-  smoke_output=""
-  if ! smoke_output="$(verify_production_dag_smoke "$PRODUCTION_ROOT" "$HOMERAIL_HOME" "$MANAGER_URL" 2>&1)"; then
-    echo "Production Docker Worker DAG smoke failed for $REVISION." >&2
-    printf '%s\n' "$smoke_output" >&2
-    healthy=0
-  fi
-fi
-
 if [ "$healthy" != "1" ]; then
   echo "Production health check failed for $REVISION; rolling back." >&2
   systemctl --user stop "$SERVICE_NAME" >/dev/null 2>&1 || true

--- a/scripts/lib/production-runtime.sh
+++ b/scripts/lib/production-runtime.sh
@@ -41,32 +41,3 @@ initialize_production_tokens() {
   HOMERAIL_DAG_MUTATION_TOKEN="$(load_or_create_production_token "$node_bin" "$secret_dir/dag-mutation.token" "DAG mutation")" || return 1
   export HOMERAIL_NODE_TOKEN HOMERAIL_WORKER_TOKEN HOMERAIL_DAG_MUTATION_TOKEN
 }
-
-verify_production_dag_smoke() {
-  local production_root="$1"
-  local homerail_home="$2"
-  local manager_url="$3"
-  local token_file="$homerail_home/manager/secrets/dag-mutation.token"
-  if [ ! -f "$token_file" ]; then
-    echo "Production DAG mutation token is missing after service startup." >&2
-    return 1
-  fi
-  local token
-  token="$(tr -d '[:space:]' < "$token_file")"
-  if [ -z "$token" ]; then
-    echo "Production DAG mutation token is empty after service startup." >&2
-    return 1
-  fi
-  HOMERAIL_REPO_ROOT="$production_root/current" \
-    HOMERAIL_DAG_MUTATION_TOKEN="$token" \
-    "$production_root/current/runtime/node" \
-    "$production_root/current/homerail_cli/dist/cli.js" \
-    --base-url "$manager_url" \
-    --request-timeout 180000 \
-    --json \
-    smoke dag \
-    --template "assets/orchestrations/public-two-node.yaml.template" \
-    --profile offline-deterministic \
-    --timeout 120 \
-    --interval 1
-}

--- a/scripts/production-deploy-contracts.test.mjs
+++ b/scripts/production-deploy-contracts.test.mjs
@@ -91,13 +91,9 @@ test("production deployment is atomic, health checked, and rollback capable", ()
   assert.match(deploy, /loopback and wildcard binds are not supported/);
   assert.match(deploy, /MANAGER_HOST" != "\$DOCKER_BRIDGE_GATEWAY/);
   assert.match(deploy, /Production Manager may bind only to the Docker bridge gateway/);
-  assert.match(deploy, /verify_production_dag_smoke/);
-  assert.match(deploy, /Production Docker Worker DAG smoke failed/);
-  assert.match(runtime, /smoke dag/);
-  assert.match(runtime, /public-two-node\.yaml\.template/);
-  assert.match(runtime, /offline-deterministic/);
-  assert.match(runtime, /manager\/secrets\/dag-mutation\.token/);
-  assert.match(runtime, /Production DAG mutation token is missing after service startup/);
+  assert.doesNotMatch(deploy, /verify_production_dag_smoke|smoke dag/);
+  assert.doesNotMatch(runtime, /verify_production_dag_smoke|smoke dag/);
+  assert.match(runtime, /initialize_production_tokens/);
   assert.match(deploy, /HOMERAIL_PRODUCTION_MANAGER_PORT=\$MANAGER_PORT/);
   assert.match(deploy, /HOMERAIL_PRODUCTION_ALLOW_INSECURE_REMOTE_WS:-0/);
   assert.match(deploy, /Environment=HOMERAIL_ALLOW_INSECURE_REMOTE_WS=\$ALLOW_INSECURE_REMOTE_WS/);
@@ -209,66 +205,13 @@ test("production tokens are distinct, persistent, private, and fail closed", { s
   }
 });
 
-test("production DAG smoke helper enforces token presence and command success", { skip: process.platform === "win32" }, () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "homerail-production-smoke-"));
-  const productionRoot = path.join(tempRoot, "production");
-  const home = path.join(tempRoot, "home");
-  const current = path.join(productionRoot, "current");
-  const capture = path.join(tempRoot, "capture.json");
-  const helper = path.join(repoRoot, "scripts", "lib", "production-runtime.sh");
-  const fakeNode = path.join(current, "runtime", "node");
-  const fakeCli = path.join(current, "homerail_cli", "dist", "cli.js");
-  const invoke = (extraEnv = {}) => spawnSync("bash", [
-    "-c",
-    'source "$1"; verify_production_dag_smoke "$2" "$3" "$4"',
-    "production-smoke-test",
-    helper,
-    productionRoot,
-    home,
-    "http://127.0.0.1:39191",
-  ], { encoding: "utf8", env: { ...process.env, CAPTURE_PATH: capture, ...extraEnv } });
-
-  try {
-    fs.mkdirSync(path.dirname(fakeNode), { recursive: true });
-    fs.mkdirSync(path.dirname(fakeCli), { recursive: true });
-    fs.mkdirSync(path.join(current, "assets", "orchestrations"), { recursive: true });
-    fs.writeFileSync(fakeCli, "// fake cli\n");
-    fs.writeFileSync(path.join(current, "assets", "orchestrations", "public-two-node.yaml.template"), "schema_version: 1\n");
-    fs.writeFileSync(fakeNode, `#!/usr/bin/env bash\nprintf '{"token":"%s","repoRoot":"%s","args":"%s"}\\n' "$HOMERAIL_DAG_MUTATION_TOKEN" "$HOMERAIL_REPO_ROOT" "$*" > "$CAPTURE_PATH"\nexit "${'${FAKE_SMOKE_EXIT:-0}'}"\n`);
-    fs.chmodSync(fakeNode, 0o755);
-
-    const missing = invoke();
-    assert.notEqual(missing.status, 0);
-    assert.match(missing.stderr, /token is missing/);
-
-    const secretDir = path.join(home, "manager", "secrets");
-    fs.mkdirSync(secretDir, { recursive: true });
-    fs.writeFileSync(path.join(secretDir, "dag-mutation.token"), "test-dag-token\n", { mode: 0o600 });
-    const failed = invoke({ FAKE_SMOKE_EXIT: "7" });
-    assert.equal(failed.status, 7);
-
-    const passed = invoke();
-    assert.equal(passed.status, 0, passed.stderr);
-    const observed = JSON.parse(fs.readFileSync(capture, "utf8"));
-    assert.equal(observed.token, "test-dag-token");
-    assert.equal(observed.repoRoot, current);
-    assert.match(observed.args, /--base-url http:\/\/127\.0\.0\.1:39191/);
-    assert.match(observed.args, /smoke dag/);
-    assert.match(observed.args, /--template assets\/orchestrations\/public-two-node\.yaml\.template/);
-    assert.doesNotMatch(observed.args, /--template \/.*public-two-node\.yaml\.template/);
-    assert.match(observed.args, /offline-deterministic/);
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
 test("production deployment preserves database compatibility across success and rollback", { skip: process.platform === "win32" }, () => {
   const deployScript = path.join(repoRoot, "scripts", "deploy-production.sh");
   const revision = "a".repeat(40);
   const previousRevision = "b".repeat(40);
   const workerFingerprint = "c".repeat(16);
 
-  const runDeployment = (smokeExit, {
+  const runDeployment = (healthExit, {
     previousDatabaseCompatible = true,
     failUnitMove = false,
     extraEnv = {},
@@ -345,13 +288,7 @@ test("production deployment preserves database compatibility across success and 
       `export function dagWorkerSourceFingerprint() { return "${workerFingerprint}"; }\n`,
     );
     write("homerail_node/dist/cli.js", "// node\n");
-    write(
-      "homerail_cli/dist/cli.js",
-      'require("node:fs").appendFileSync(require("node:path").join(process.env.HOMERAIL_PRODUCTION_HOME, "manager", "homerail.db"), "rollout-write\\n");\n'
-        + 'require("node:fs").appendFileSync(require("node:path").join(process.env.HOMERAIL_PRODUCTION_HOME, "manager", "homerail.db-wal"), "rollout-wal-write\\n");\n'
-        + 'require("node:fs").writeFileSync(require("node:path").join(process.env.HOMERAIL_PRODUCTION_HOME, "manager", "homerail.db-shm"), "rollout-shm\\n");\n'
-        + "process.exit(Number(process.env.FAKE_SMOKE_EXIT || 0));\n",
-    );
+    write("homerail_cli/dist/cli.js", 'throw new Error("Deployment must not start DAG validation");\n');
     write("homerail_protocol/package.json", '{"type":"module"}\n');
     write("homerail_protocol/dist/index.js", 'export const WORKER_CONTRACT_VERSION = "1";\n');
     write("homerail_worker/package.json", '{"version":"0.1.0"}\n');
@@ -374,9 +311,24 @@ test("production deployment preserves database compatibility across success and 
     fakeCommand("loginctl", "#!/usr/bin/env bash\nprintf 'yes\\n'\n");
     fakeCommand("mv", `#!/usr/bin/env bash\nif [ "${'${FAIL_UNIT_MOVE:-0}'}" = 1 ] && [[ "${'${1:-}'}" == *.service.tmp ]]; then exit 19; fi\nif [ "${'${1:-}'}" = -Tf ]; then source_path="$2"; destination="$3"; /bin/rm -f "$destination"; exec /bin/mv -f "$source_path" "$destination"; fi\nexec /bin/mv "$@"\n`);
     fakeCommand("stat", `#!/usr/bin/env bash\ncase "${'${2:-}'}" in '%u') id -u ;; '%a') printf '755\\n' ;; *) exit 1 ;; esac\n`);
-    fakeCommand("systemctl", "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"$CAPTURE_SYSTEMCTL\"\nexit 0\n");
+    fakeCommand("systemctl", `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$CAPTURE_SYSTEMCTL"
+# Simulate a write during the initial rollout, before the health check.
+if [ "$2" = restart ] && [ ! -e "$CAPTURE_SYSTEMCTL.rollout-written" ] && [ "$(cat "$HOMERAIL_PRODUCTION_ROOT/current/REVISION")" = "$HOMERAIL_DEPLOY_REVISION" ]; then
+  touch "$CAPTURE_SYSTEMCTL.rollout-written"
+  printf 'rollout-write\n' >> "$HOMERAIL_PRODUCTION_HOME/manager/homerail.db"
+  printf 'rollout-wal-write\n' >> "$HOMERAIL_PRODUCTION_HOME/manager/homerail.db-wal"
+  printf 'rollout-shm\n' > "$HOMERAIL_PRODUCTION_HOME/manager/homerail.db-shm"
+fi
+exit 0
+`);
     fakeCommand("journalctl", "#!/usr/bin/env bash\nexit 0\n");
-    fakeCommand("curl", `#!/usr/bin/env bash\nurl="${'${!#}'}"\ncase "$url" in */runtime/status) printf '{"connected_nodes":1}\\n' ;; esac\nexit 0\n`);
+    fakeCommand("curl", `#!/usr/bin/env bash
+if [ "$FAKE_HEALTH_EXIT" != 0 ]; then exit "$FAKE_HEALTH_EXIT"; fi
+url="${'${!#}'}"
+case "$url" in */runtime/status) printf '{"connected_nodes":1}\n' ;; esac
+exit 0
+`);
     fakeCommand("rsync", `#!/usr/bin/env bash\nprevious=""\nfor arg in "$@"; do source_path="$previous"; destination="$arg"; previous="$arg"; done\nmkdir -p "$destination"\ncp -a "${'${source_path%/}'}/." "$destination/"\n`);
 
     const result = spawnSync("bash", [deployScript], {
@@ -394,7 +346,7 @@ test("production deployment preserves database compatibility across success and 
         HOMERAIL_PRODUCTION_ALLOW_INSECURE_REMOTE_WS: "1",
         HOMERAIL_PRODUCTION_HEALTH_ATTEMPTS: "1",
         HOMERAIL_CODEX_BIN: path.join(fakeBin, "codex"),
-        FAKE_SMOKE_EXIT: String(smokeExit),
+        FAKE_HEALTH_EXIT: String(healthExit),
         FAIL_UNIT_MOVE: failUnitMove ? "1" : "0",
         CAPTURE_DOCKER_BUILD_ARGS: dockerBuildArgsPath,
         CAPTURE_DOCKER_REMOVALS: dockerRemovalsPath,
@@ -431,7 +383,7 @@ test("production deployment preserves database compatibility across success and 
   const failed = runDeployment(7);
   try {
     assert.notEqual(failed.result.status, 0);
-    assert.match(failed.result.stderr, /DAG smoke failed/);
+    assert.match(failed.result.stderr, /Production health check failed/);
     assert.match(failed.result.stderr, /rolling back/);
     assert.equal(fs.readlinkSync(path.join(failed.productionRoot, "current")), "releases/previous");
     assert.equal(fs.readFileSync(failed.unitPath, "utf8"), "previous-unit\n");


### PR DESCRIPTION
Production deployment still ran an offline Docker Worker DAG after service health checks, despite DAG validation being retired. Remove that automatic smoke invocation and its unused helper. Deployment continues to check Manager/UI health and Node connectivity, with database snapshots and rollback preserved.

Validation: all 7 production deployment contract tests pass, including successful rollout, health failure rollback, incompatible database rollback, and interrupted unit replacement. Bash syntax checks and `git diff --check` pass. The deployment fixture rejects any attempted DAG CLI invocation.

Deployed code commit `71c6ae4c847ef82105463e982937435f99dc17a8` successfully on the migrated production runner: https://github.com/xiaotianfotos/homerail/actions/runs/34072829857 (4m28s). Post-deployment checks confirmed Manager health, one connected Node, HTTPS UI HTTP 200, and all three runners online. Production and automation services are enabled and active with zero automatic restarts. The later commit only updates deployment documentation.
