### PR TITLE
test(manager): stabilize Windows PR Review integration timeouts

### DIFF
--- a/homerail_manager/tests/pr-review-scenario.test.ts
+++ b/homerail_manager/tests/pr-review-scenario.test.ts
@@ -47,6 +47,11 @@ import { ensureManagerSkillsInstalled, readManagerSkill } from "../src/server/ma
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const workflowPath = path.join(repositoryRoot, "assets", "orchestrations", "pr-review.yaml.template");
 
+// These integration scenarios run real command subprocesses and persist DAG state.
+// Hosted Windows runs can exceed the 15s CI default (observed: 15.5s and 23.8s).
+// Keep the normal timeout elsewhere and allow bounded Windows runner variance.
+const windowsIntegrationTimeout = process.platform === "win32" ? 60_000 : undefined;
+
 type ModelId = "qwen" | "kimi" | "glm";
 type Vote = "approve" | "request_changes" | "abstain";
 type Coverage = { digest: string; count: number };
@@ -1538,7 +1543,7 @@ describe("PR Review scenario assets", () => {
         output_tokens: 700,
       }),
     ]);
-  });
+  }, windowsIntegrationTimeout);
 
   it("rejects a stale transport handoff without altering the current projection or mailbox", () => {
     const parsed = parseWorkflowSource(fs.readFileSync(workflowPath, "utf8"));
@@ -1641,7 +1646,7 @@ describe("PR Review scenario assets", () => {
       });
       expect(getActiveRun(runId)?.status).toBe("completed");
     }
-  });
+  }, windowsIntegrationTimeout);
 
   it("computes trusted digest/count outside model output and reconstructs canonical reviewed files", () => {
     const cwd = path.join(tmpHome, "prepare-50-file-coverage");


### PR DESCRIPTION
The Windows Node 24 CI run after #267 failed because two PR Review integration tests exceeded the 15-second default (15.5s and 23.8s). These scenarios execute real command subprocesses and persist DAG state.

Give only these two tests a 60-second timeout on Windows, consistent with the existing heavier review scenarios. Other platforms retain their configured default, and every assertion remains enabled.

Validation for `e9ed77140d7257edbd28b9425c0758b8f60b8604`:

- Local Manager TypeScript check and all 40 tests in `pr-review-scenario.test.ts` passed.
- [Full manual CI](https://github.com/xiaotianfotos/homerail/actions/runs/34132264719) passed: Windows Node 24, Linux Node 20/24, UI coverage, and Docker smoke.
- Windows Manager suite: 1,452 passed, 7 existing skips. The affected tests passed in 3.475s and 1.593s; the scenario file retained its 2 existing Windows skips.
- [PR CI](https://github.com/xiaotianfotos/homerail/actions/runs/34132295673) and [HomeRail PR Review](https://github.com/xiaotianfotos/homerail/actions/runs/34132295643) passed.

The previous successful Windows run completed the same tests in 0.515s and 1.461s, while the failed run took 15.511s and 23.793s. This supports allowing hosted-runner timing variance; the new run did not reproduce the original slow timings.

Original failure: https://github.com/xiaotianfotos/homerail/actions/runs/34126493272
