### PR TITLE
fix: preserve terminal Auto Fix failures for Judger continuation

### DIFF
--- a/scripts/judged-autofix/README.md
+++ b/scripts/judged-autofix/README.md
@@ -147,8 +147,9 @@ and explicitly rerun tests. Do not modify saved receipts to manufacture success.
 When a terminal run produces evidence gaps (missing or unparseable result artifact),
 the controller enters `judging` with a structured failure record
 (`model_result`/`missing_result_artifact` or `model_result`/`invalid_result_json`)
-instead of polling indefinitely. The original model draft bytes are always retained
-on disk in `result.json` for inspection. Proposals emitted by unsuccessful runs
+instead of polling indefinitely. Downloaded artifact bytes, when available, are retained
+on disk in `result.json` for inspection; missing artifacts are recorded explicitly.
+Proposals emitted by unsuccessful runs
 (`model_terminal`/`run_not_completed`) remain drafts requiring explicit Judger
 review; they are never applied automatically. Transient collection failures
 (HTTP 503, network timeouts, filesystem errors) propagate as exceptions and remain

--- a/scripts/judged-autofix/README.md
+++ b/scripts/judged-autofix/README.md
@@ -144,6 +144,16 @@ leaves a live child, the task blocks instead of starting another test. After the
 recorded process is gone, the Judger can use `recover-tests`, reassess the result,
 and explicitly rerun tests. Do not modify saved receipts to manufacture success.
 
+When a terminal run produces evidence gaps (missing or unparseable result artifact),
+the controller enters `judging` with a structured failure record
+(`model_result`/`missing_result_artifact` or `model_result`/`invalid_result_json`)
+instead of polling indefinitely. The original model draft bytes are always retained
+on disk in `result.json` for inspection. Proposals emitted by unsuccessful runs
+(`model_terminal`/`run_not_completed`) remain drafts requiring explicit Judger
+review; they are never applied automatically. Transient collection failures
+(HTTP 503, network timeouts, filesystem errors) propagate as exceptions and remain
+retryable on the same run identity without resubmission or state regression.
+
 ## Platform requirements
 
 Process-level tests (Git operations, flock, /proc identity) require Linux; they

--- a/scripts/judged-autofix/loop.mjs
+++ b/scripts/judged-autofix/loop.mjs
@@ -64,12 +64,15 @@ export class JudgedLoop {
     const result=await collectModel(this.config,r,dir);if(!result)return;
     r.state='finished';r.finished_at=now();
     if(result.failed){r.failure=result.failure??{category:'model_transport',status:result.status};this.state.phase='judging';this.save('model_failed');return;}
+    let edits;
     try {
       if(!result.value||typeof result.value!=='object'||Array.isArray(result.value))throw new Error('proposal must be a non-null object');
       if(typeof result.value.summary!=='string'||!result.value.summary.length||result.value.summary.length>1500)throw new Error('proposal requires a summary string of 1-1500 characters');
-      const edits=result.value.edits;
+      edits=result.value.edits;
       if(!Array.isArray(edits)||!edits.length||edits.length>20)throw new Error('invalid edits');
-      atomic(path.join(dir,'proposal.json'),result.value);r.summary=result.value.summary;
+    }catch(e){r.failure={category:'proposal',message:e.message};this.state.phase='judging';this.save('proposal_rejected');return;}
+    atomic(path.join(dir,'proposal.json'),result.value);r.summary=result.value.summary;
+    try {
       this.assertHead(r.base);
       const current=new Map(this.repo.entries(r.base_tree).filter(f=>r.plan.allowed_paths.includes(f.path)).map(f=>[f.path,this.repo.bytes(f.sha).toString('utf8')]));const output=new Map();
       if(Buffer.byteLength(JSON.stringify(result.value))>96000)throw new Error('proposal exceeds 96 KiB');

--- a/scripts/judged-autofix/loop.mjs
+++ b/scripts/judged-autofix/loop.mjs
@@ -64,11 +64,13 @@ export class JudgedLoop {
     const result=await collectModel(this.config,r,dir);if(!result)return;
     r.state='finished';r.finished_at=now();
     if(result.failed){r.failure=result.failure??{category:'model_transport',status:result.status};this.state.phase='judging';this.save('model_failed');return;}
-    atomic(path.join(dir,'proposal.json'),result.value);r.summary=result.value.summary;
     try {
-      this.assertHead(r.base);
+      if(!result.value||typeof result.value!=='object'||Array.isArray(result.value))throw new Error('proposal must be a non-null object');
+      if(typeof result.value.summary!=='string'||!result.value.summary.length||result.value.summary.length>1500)throw new Error('proposal requires a summary string of 1-1500 characters');
       const edits=result.value.edits;
       if(!Array.isArray(edits)||!edits.length||edits.length>20)throw new Error('invalid edits');
+      atomic(path.join(dir,'proposal.json'),result.value);r.summary=result.value.summary;
+      this.assertHead(r.base);
       const current=new Map(this.repo.entries(r.base_tree).filter(f=>r.plan.allowed_paths.includes(f.path)).map(f=>[f.path,this.repo.bytes(f.sha).toString('utf8')]));const output=new Map();
       if(Buffer.byteLength(JSON.stringify(result.value))>96000)throw new Error('proposal exceeds 96 KiB');
       for(const e of edits){

--- a/scripts/judged-autofix/loop.mjs
+++ b/scripts/judged-autofix/loop.mjs
@@ -63,7 +63,7 @@ export class JudgedLoop {
     }
     const result=await collectModel(this.config,r,dir);if(!result)return;
     r.state='finished';r.finished_at=now();
-    if(result.failed){r.failure={category:'model_transport',status:result.status};this.state.phase='judging';this.save('model_failed');return;}
+    if(result.failed){r.failure=result.failure??{category:'model_transport',status:result.status};this.state.phase='judging';this.save('model_failed');return;}
     atomic(path.join(dir,'proposal.json'),result.value);r.summary=result.value.summary;
     try {
       this.assertHead(r.base);

--- a/scripts/judged-autofix/loop.test.mjs
+++ b/scripts/judged-autofix/loop.test.mjs
@@ -177,6 +177,27 @@ test('transient result fetch failure remains retryable on the same run',async t=
  assert.equal(restarted.round.failure,undefined);
  assert.ok(f.calls.every(c=>c.method==='GET'));
 });
+test('proposal persistence failure propagates and resumes the saved run after controller restart',async t=>{
+ const raw=JSON.stringify({edits:[{path:'source.txt',old:'original',new:'recovered'}],summary:'saved valid proposal'});
+ const f=terminalModelFixture(t,{raw});
+ const rename=fs.renameSync;let fail=true;
+ t.mock.method(fs,'renameSync',(from,to)=>{
+  if(fail&&String(to).endsWith('/proposal.json')){fail=false;throw Object.assign(new Error('simulated proposal persistence ENOSPC'),{code:'ENOSPC'});}
+  return rename(from,to);
+ });
+ await assert.rejects(f.loop.step(),/ENOSPC/);
+ // The CLI persists controller_error before exiting; exercise that same
+ // save, so retry cannot depend on discarding in-memory mutations.
+ f.loop.save('controller_error',{message:'simulated proposal persistence ENOSPC'});
+ const restarted=new JudgedLoop(f.root);
+ assert.equal(restarted.state.phase,'model');assert.equal(restarted.round.failure,undefined);
+ assert.equal(restarted.round.run_id,'saved-run');
+ assert.equal(fs.readFileSync(path.join(f.root,'rounds/1/result.json'),'utf8'),raw);
+ await restarted.step();assert.equal(restarted.state.phase,'apply');
+ assert.equal(restarted.round.run_id,'saved-run');assert.equal(restarted.round.failure,undefined);
+ restarted.apply();assert.equal(fs.readFileSync(path.join(f.repo,'source.txt'),'utf8'),'recovered\n');
+ assert.ok(f.calls.every(c=>c.method==='GET'),'recovery must not create another model run');
+});
 test('loop records durable receipts and refuses acceptance after evidence tampering',async t=>{
  const f=loopFixture(t);await f.loop.test();const r=f.loop.round;
  assert.equal(f.loop.state.phase,'judging');assert.equal(r.receipts[0].status,'passed');assert.ok(r.receipts[0].runner_digest);

--- a/scripts/judged-autofix/loop.test.mjs
+++ b/scripts/judged-autofix/loop.test.mjs
@@ -100,6 +100,73 @@ function loopFixture(t,code="console.log('trusted')",overrides={}){
  fs.writeFileSync(path.join(root,'config.json'),JSON.stringify(config));const loop=new JudgedLoop(root);
  loop.state.phase='test';loop.state.rounds=[{index:1,plan:{checks:['oracle']},plan_digest:'plan',candidate_commit:f.spec.commit,candidate_tree:f.spec.tree}];loop.save('fixture');return {...f,root,loop};
 }
+function terminalModelFixture(t, options={}) {
+ const f=loopFixture(t,"console.log('trusted')",{manager_url:'http://manager.invalid'});
+ const r=f.loop.round;
+ r.plan.allowed_paths=['source.txt'];
+ Object.assign(r,{base:r.candidate_commit,base_tree:r.candidate_tree,run_id:'saved-run',state:'running',kind:'propose'});
+ delete r.candidate_commit;delete r.candidate_tree;
+ f.loop.state.phase='model';f.loop.save('terminal_model_fixture');
+ const calls=[];
+ t.mock.method(globalThis,'fetch',async(url,init)=>{
+  calls.push({url,method:init?.method});
+  if(url.endsWith('/status'))return new Response(JSON.stringify({data:{terminal:true,status:options.status??'completed',created_at:'2026-09-08T00:00:00Z',completed_at:'2026-09-08T00:00:10Z'}}));
+  if(url.endsWith('/chat'))return new Response(JSON.stringify({data:{messages:[{content:{type:'usage',execution_id:'first',usage:{input_tokens:10,output_tokens:5}}},{content:{text:'Saved candidate draft'}}]}}));
+  if(url.endsWith('/artifacts'))return new Response(JSON.stringify({data:{artifacts:options.raw===undefined?[]:[{name:'result.json',status:'ready'}]}}));
+  if(url.endsWith('/content'))return options.httpError?new Response('temporarily unavailable',{status:503}):new Response(options.raw);
+  throw new Error('unexpected request '+url);
+ });
+ return {...f,calls};
+}
+test('terminal run without result enters durable judgment instead of polling forever',async t=>{
+ const f=terminalModelFixture(t);
+ await f.loop.step();
+ assert.equal(f.loop.state.phase,'judging');
+ assert.equal(f.loop.round.failure.category,'model_result');
+ assert.equal(f.loop.round.failure.code,'missing_result_artifact');
+ assert.equal(f.loop.round.failure.status,'completed');
+ assert.equal(f.loop.round.metrics.tokens,15);
+ assert.equal(f.loop.round.candidate_commit,undefined);
+ assert.ok(fs.existsSync(path.join(f.root,'rounds/1/chat.json')));
+ const restarted=new JudgedLoop(f.root),count=f.calls.length;
+ assert.deepEqual(restarted.round.failure,f.loop.round.failure);
+ await restarted.step();assert.equal(f.calls.length,count,'terminal evidence gap must not keep polling');
+ const j=path.join(f.root,'revise.json');fs.writeFileSync(j,JSON.stringify({round:1,plan_digest:'plan',verdict:'revise',reason:'Saved terminal evidence inspected; authorize a new scoped attempt'}));
+ restarted.judge(j);
+ const p=path.join(f.root,'plan.json');fs.writeFileSync(p,JSON.stringify({objective:'repair remaining issue',strategy:'Edit only source.txt using a fresh context',allowed_paths:['source.txt'],checks:['oracle'],context:[{path:'source.txt'}]}));
+ restarted.plan(p);
+ assert.equal(restarted.round.index,2);assert.equal(restarted.round.base,f.spec.commit);
+ const input=JSON.parse(fs.readFileSync(path.join(f.root,'rounds/2/input.json'),'utf8'));
+ assert.equal(input.previous[0].failure.code,'missing_result_artifact');
+ assert.equal(f.calls.length,count,'authorizing next round must not resubmit the completed run');
+});
+test('invalid JSON result is retained verbatim and reaches judgment',async t=>{
+ const raw='{"edits":[{"path":"source.txt","old":"original"';
+ const f=terminalModelFixture(t,{raw});await f.loop.step();
+ assert.equal(f.loop.state.phase,'judging');
+ assert.equal(f.loop.round.failure.category,'model_result');
+ assert.equal(f.loop.round.failure.code,'invalid_result_json');
+ assert.equal(fs.readFileSync(path.join(f.root,'rounds/1/result.json'),'utf8'),raw);
+ assert.equal(f.loop.round.candidate_commit,undefined);
+ assert.equal(new JudgedLoop(f.root).round.failure.code,'invalid_result_json');
+});
+test('failed or cancelled terminal runs cannot apply a ready proposal',async t=>{
+ for(const status of ['failed','cancelled'])await t.test(status,async child=>{
+  const raw=JSON.stringify({edits:[{path:'source.txt',old:'original',new:'unexpected'}],summary:'must remain a draft'});
+  const f=terminalModelFixture(child,{status,raw});await f.loop.step();
+  assert.equal(f.loop.state.phase,'judging');assert.equal(f.loop.round.failure.status,status);
+  assert.equal(f.loop.round.failure.category,'model_terminal');assert.equal(f.loop.round.candidate_commit,undefined);
+  assert.equal(fs.readFileSync(path.join(f.repo,'source.txt'),'utf8'),'original\n');
+  assert.equal(fs.readFileSync(path.join(f.root,'rounds/1/result.json'),'utf8'),raw);
+ });
+});
+test('transient result fetch failure remains retryable on the same run',async t=>{
+ const f=terminalModelFixture(t,{raw:'{}',httpError:true});
+ await assert.rejects(f.loop.step(),/503/);
+ const restarted=new JudgedLoop(f.root);assert.equal(restarted.state.phase,'model');assert.equal(restarted.round.run_id,'saved-run');
+ assert.equal(restarted.round.failure,undefined);
+ assert.ok(f.calls.every(c=>c.method==='GET'));
+});
 test('loop records durable receipts and refuses acceptance after evidence tampering',async t=>{
  const f=loopFixture(t);await f.loop.test();const r=f.loop.round;
  assert.equal(f.loop.state.phase,'judging');assert.equal(r.receipts[0].status,'passed');assert.ok(r.receipts[0].runner_digest);

--- a/scripts/judged-autofix/loop.test.mjs
+++ b/scripts/judged-autofix/loop.test.mjs
@@ -146,9 +146,19 @@ test('invalid JSON result is retained verbatim and reaches judgment',async t=>{
  assert.equal(f.loop.state.phase,'judging');
  assert.equal(f.loop.round.failure.category,'model_result');
  assert.equal(f.loop.round.failure.code,'invalid_result_json');
+ assert.equal(f.loop.round.failure.status,'completed');
  assert.equal(fs.readFileSync(path.join(f.root,'rounds/1/result.json'),'utf8'),raw);
  assert.equal(f.loop.round.candidate_commit,undefined);
  assert.equal(new JudgedLoop(f.root).round.failure.code,'invalid_result_json');
+});
+test('JSON null and invalid summary proposals reach judgment without escaping the collection boundary',async t=>{
+ for(const value of [null,{edits:[{path:'source.txt',old:'original',new:'changed'}],summary:null}])await t.test(JSON.stringify(value),async child=>{
+  const f=terminalModelFixture(child,{raw:JSON.stringify(value)});await f.loop.step();
+  assert.equal(f.loop.state.phase,'judging');assert.equal(f.loop.round.failure.category,'proposal');
+  assert.equal(f.loop.round.candidate_commit,undefined);
+  assert.equal(new JudgedLoop(f.root).round.failure.category,'proposal');
+  assert.equal(fs.readFileSync(path.join(f.root,'rounds/1/result.json'),'utf8'),JSON.stringify(value));
+ });
 });
 test('failed or cancelled terminal runs cannot apply a ready proposal',async t=>{
  for(const status of ['failed','cancelled'])await t.test(status,async child=>{

--- a/scripts/judged-autofix/model.mjs
+++ b/scripts/judged-autofix/model.mjs
@@ -63,11 +63,13 @@ export async function collectModel(plan, attempt, directory) {
   attempt.metrics = { run_seconds: (Date.parse(status.completed_at) - Date.parse(status.created_at)) / 1000, tokens: tokens || null, usage: [...latest.values()], tool_calls: tools, corrections: status.counters?.corrections, terminal: status.status };
   const artifacts = await api(plan, `/api/runs/${attempt.run_id}/artifacts`);
   const result = artifacts.artifacts?.find(a => a.name === 'result.json' && a.status === 'ready');
-  if (!result) {
-    if (status.status === 'completed') throw new Error('completed run missing declared result artifact');
-    return { failed: true, status: status.status };
+  if (result) {
+    const text = await api(plan, `/api/runs/${attempt.run_id}/artifacts/result.json/content`, undefined, true);
+    fs.writeFileSync(`${directory}/result.json`, text);
+    if (status.status !== 'completed') return { failed: true, status: status.status, failure: { category: 'model_terminal', status: status.status, code: 'run_not_completed', message: `terminal run status ${status.status} cannot yield a valid proposal` } };
+    try { return { value: JSON.parse(text) }; }
+    catch (e) { if (e instanceof SyntaxError) return { failed: true, status: 'completed', failure: { category: 'model_result', code: 'invalid_result_json', message: e.message.slice(0, 200) } }; throw e; }
   }
-  const text = await api(plan, `/api/runs/${attempt.run_id}/artifacts/result.json/content`, undefined, true);
-  fs.writeFileSync(`${directory}/result.json`, text);
-  return { value: JSON.parse(text) };
+  if (status.status === 'completed') return { failed: true, status: 'completed', failure: { category: 'model_result', status: 'completed', code: 'missing_result_artifact', message: 'completed run has no ready result artifact' } };
+  return { failed: true, status: status.status, failure: { category: 'model_terminal', status: status.status, code: 'run_not_completed', message: `terminal run status ${status.status} produced no result artifact` } };
 }

--- a/scripts/judged-autofix/model.mjs
+++ b/scripts/judged-autofix/model.mjs
@@ -68,7 +68,7 @@ export async function collectModel(plan, attempt, directory) {
     fs.writeFileSync(`${directory}/result.json`, text);
     if (status.status !== 'completed') return { failed: true, status: status.status, failure: { category: 'model_terminal', status: status.status, code: 'run_not_completed', message: `terminal run status ${status.status} cannot yield a valid proposal` } };
     try { return { value: JSON.parse(text) }; }
-    catch (e) { if (e instanceof SyntaxError) return { failed: true, status: 'completed', failure: { category: 'model_result', code: 'invalid_result_json', message: e.message.slice(0, 200) } }; throw e; }
+    catch (e) { if (e instanceof SyntaxError) return { failed: true, status: 'completed', failure: { category: 'model_result', status: 'completed', code: 'invalid_result_json', message: 'result artifact is not valid JSON' } }; throw e; }
   }
   if (status.status === 'completed') return { failed: true, status: 'completed', failure: { category: 'model_result', status: 'completed', code: 'missing_result_artifact', message: 'completed run has no ready result artifact' } };
   return { failed: true, status: status.status, failure: { category: 'model_terminal', status: status.status, code: 'run_not_completed', message: `terminal run status ${status.status} produced no result artifact` } };


### PR DESCRIPTION
Terminal Auto Fix runs with a missing result artifact, malformed JSON or a JSON `null` result previously left the controller unable to reach its Judger. Collection now preserves available raw evidence and records a durable failure for the next explicitly authorized repair round. Failed/cancelled runs cannot automatically apply a ready proposal; transient fetch errors remain retryable using the same saved run.

Depends on #272 and targets its branch so this PR contains only the follow-up fix. Fixes #274.

Implemented by local `qwen38-flash-next` through three real DAG rounds, from externally authored plans; the supervising Judger wrote the regression tests, rejected the first candidate after semantic review, and accepted the exact final tree only after trusted checks.

Validation: 31 focused controller cases; full `npm run ci` (3,649 passing tests, 3 existing skips); old frozen-controller recovery for missing artifact, malformed JSON and JSON null, preserving run/config/source with zero new model submissions. Raw failure/retry evidence is retained. No production deployment or model settings changed.

PR-review follow-up: Kimi identified that proposal-file write errors had entered the proposal-rejection catch. A third local-model round now keeps that persistence boundary retryable; an injected ENOSPC test saves controller state, restarts, and successfully applies the retained proposal without a new model submission.
