### PR TITLE
fix(autofix): preserve raw Git patches during candidate application

### DIFF
--- a/scripts/judged-autofix/evidence.mjs
+++ b/scripts/judged-autofix/evidence.mjs
@@ -44,7 +44,8 @@ export function validatePlan(plan) {
 }
 export class Repository {
   constructor(root, gitBin = 'git') { this.root = root; this.gitBin = gitBin; }
-  git(args, options = {}) { return command(this.gitBin, ['-C', this.root, ...args], options).trimEnd(); }
+  gitRaw(args, options = {}) { return command(this.gitBin, ['-C', this.root, ...args], options); }
+  git(args, options = {}) { return this.gitRaw(args, options).trimEnd(); }
   entries(tree) {
     return this.git(['ls-tree', '-rz', tree]).split('\0').filter(Boolean).map(line => {
       const [meta, name] = line.split('\t'); const [mode, type, sha] = meta.split(' ');

--- a/scripts/judged-autofix/loop.mjs
+++ b/scripts/judged-autofix/loop.mjs
@@ -145,7 +145,7 @@ export class JudgedLoop {
     const head=this.repo.git(['rev-parse','HEAD']);
     if(head===r.base){
       const index=this.repo.git(['write-tree']);
-      if(index===r.base_tree){const patch=this.repo.git(['diff','--binary',r.base_tree,r.candidate_tree]);this.repo.git(['apply','--index','--binary','-'],{input:patch+'\n'});}
+      if(index===r.base_tree){const patch=this.repo.gitRaw(['diff','--binary',r.base_tree,r.candidate_tree]);this.repo.git(['apply','--index','--binary','-'],{input:patch});}
       else if(index!==r.candidate_tree)throw new Error('index drift during recovery');
       if(this.repo.git(['diff','--name-only']))throw new Error('worktree drift during recovery');
       this.repo.git(['update-ref','HEAD',r.candidate_commit,r.base]);

--- a/scripts/judged-autofix/loop.test.mjs
+++ b/scripts/judged-autofix/loop.test.mjs
@@ -272,6 +272,29 @@ test('candidate application recovers staged changes and a lost HEAD-update ackno
  f.loop.apply();assert.equal(git(['rev-parse','HEAD']),commit);assert.equal(f.loop.state.phase,'test');
  fs.writeFileSync(path.join(f.root,'state.json'),durable);const restored=new JudgedLoop(f.root);restored.apply();assert.equal(git(['rev-list','--count','HEAD']),'2');assert.equal(git(['status','--porcelain']),'');
 });
+for (const trailing of ['\n', 'keep with trailing spaces   \n']) {
+ test(`unstaged candidate application preserves raw final patch context ${JSON.stringify(trailing)}`, t => {
+  const f=loopFixture(t);const git=args=>{const p=spawnSync('git',['-C',f.repo,...args],{encoding:'utf8'});assert.equal(p.status,0,p.stderr);return p.stdout.trim();};
+  const original='original\nkeep-a\nkeep-b\n'+trailing;
+  const updated='candidate\nkeep-a\nkeep-b\n'+trailing;
+  fs.writeFileSync(path.join(f.repo,'source.txt'),original);git(['add','source.txt']);git(['commit','-qm','trailing-context-base']);
+  const base=git(['rev-parse','HEAD']),baseTree=git(['rev-parse','HEAD^{tree}']);
+  fs.writeFileSync(path.join(f.repo,'source.txt'),updated);git(['add','source.txt']);const tree=git(['write-tree']);const commit=git(['commit-tree',tree,'-p',base,'-m','saved candidate']);
+  // Unlike the existing staged-index recovery fixture, force the normal
+  // application path to generate a patch and apply it from the base index.
+  git(['read-tree',baseTree]);fs.writeFileSync(path.join(f.repo,'source.txt'),original);
+  assert.equal(git(['status','--porcelain']),'');
+  Object.assign(f.loop.round,{base,base_tree:baseTree,candidate_tree:tree,candidate_commit:commit});
+  f.loop.state.phase='apply';f.loop.save('candidate_intent');const durable=fs.readFileSync(path.join(f.root,'state.json'));
+  const resumed=new JudgedLoop(f.root);resumed.apply();
+  assert.equal(git(['rev-parse','HEAD']),commit);assert.equal(git(['write-tree']),tree);
+  assert.equal(fs.readFileSync(path.join(f.repo,'source.txt'),'utf8'),updated);assert.equal(git(['status','--porcelain']),'');
+  fs.writeFileSync(path.join(f.root,'state.json'),durable);
+  new JudgedLoop(f.root).apply();assert.equal(git(['rev-parse','HEAD']),commit);
+  assert.equal(git(['rev-list','--count','HEAD']),'3','restart must not create another candidate commit');
+ });
+}
+
 test('a second CLI controller cannot enter while the task lock is held',async t=>{
  const f=loopFixture(t);const lock=path.join(f.root,'lock');
  const holder=spawn('flock',[lock,process.execPath,'-e',`require('fs').writeFileSync(${JSON.stringify(path.join(f.root,'locked'))},'1');setInterval(()=>{},1000)`],{detached:true,stdio:'ignore'});


### PR DESCRIPTION
Fixes #276. Depends on #275; this PR targets `codex/autofix-terminal-recovery`.

When a model candidate’s Git diff ends with an empty or whitespace-bearing context line, the generic Git helper trims significant patch bytes. Applying the already saved candidate then fails repeatedly with `corrupt patch`, wasting a valid model result. Add a raw Git output method and pass its patch unchanged to `git apply`; keep existing trimmed SHA/status behavior.

Validation: two independent regressions fail before the fix and pass afterward, covering application from a clean base index, exact file/tree/commit bytes, and retry after lost acknowledgement. All 33 focused tests and full CI (3,651 passing tests, 3 existing skips) passed. Local Qwen implemented the repair through an actual Auto Fix DAG (`aeb3f19a5e8bb721aed95d24`, 13.034s, 3,838 observed tokens); implementation and test execution were separately judged.

The original #181 candidate `fd020aa11cff884c129ea58c1c3e78ab84a90f04` was then recovered using the verified fixed controller. Its saved candidate, task config and model history were preserved, with zero new model requests. No merge or production deployment.
