### PR TITLE
fix: drain DAG failure handlers after zero successful dispatches

### DIFF
--- a/homerail_manager/src/runtime/active-runs.ts
+++ b/homerail_manager/src/runtime/active-runs.ts
@@ -6515,9 +6515,18 @@ export function dispatchReadyNodesUntilStable(
   const maxPasses = Math.max(1, run.dagRun.graph.nodes.length * 2);
   let total = 0;
   for (let pass = 0; pass < maxPasses; pass++) {
+    const before = new Map(run.dagRun.nodeStates);
     const advanced = dispatchReadyNodes(runId, dispatcher);
     total += advanced;
-    if (advanced === 0) break;
+    if (advanced === 0) {
+      const after = run.dagRun.nodeStates;
+      if (after.size !== before.size) continue;
+      let changed = false;
+      for (const [k, v] of after) {
+        if (before.get(k) !== v) { changed = true; break; }
+      }
+      if (!changed) break;
+    }
   }
   return total;
 }

--- a/homerail_manager/tests/dag-failure-drain.test.ts
+++ b/homerail_manager/tests/dag-failure-drain.test.ts
@@ -1,0 +1,73 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {afterEach,beforeEach,expect,it,vi} from 'vitest';
+import {GraphExecutor} from '../src/orchestration/graph-executor.js';
+import {parseWorkflowSource} from '../src/orchestration/workflow-spec-v1.js';
+import {FakeDAGDispatcher,type DAGDispatcher} from '../src/orchestration/dag-dispatcher.js';
+import {closeDb} from '../src/persistence/db.js';
+import {loadRunSnapshot} from '../src/persistence/store.js';
+import {_clearActiveRuns,getActiveRun} from '../src/runtime/active-runs.js';
+
+let home:string;
+let prior:Record<string,string|undefined>;
+beforeEach(()=>{
+ prior=Object.fromEntries(['HOMERAIL_HOME','HOMERAIL_DAG_COMMAND_ALLOWLIST','HOMERAIL_DAG_ALLOW_DYNAMIC_COMMANDS'].map(k=>[k,process.env[k]]));
+ home=fs.mkdtempSync(path.join(os.tmpdir(),'homerail-failure-drain-'));process.env.HOMERAIL_HOME=home;process.env.HOMERAIL_DAG_COMMAND_ALLOWLIST='node';process.env.HOMERAIL_DAG_ALLOW_DYNAMIC_COMMANDS='true';closeDb();_clearActiveRuns();
+});
+afterEach(()=>{_clearActiveRuns();closeDb();for(const [k,v] of Object.entries(prior)){if(v===undefined)delete process.env[k];else process.env[k]=v;}fs.rmSync(home,{recursive:true,force:true});});
+function workflow(){return parseWorkflowSource(`
+api_version: homerail.ai/v1
+kind: Workflow
+metadata: {id: failure-drain, name: Failure drain}
+spec:
+  contracts: {Task: {type: object}}
+  agents: {actor: {system: Fixture only}}
+  nodes:
+    actor:
+      kind: agent
+      agent: actor
+      inputs: {task: {contract: Task}}
+      outputs: {done: {}, failed: {}}
+    recover:
+      kind: command
+      inputs: {reason: {}}
+      outputs: {recovered: {}, failed: {}}
+      config:
+        command: [node, -e, 'console.log(JSON.stringify({recovered:true}))']
+        timeout_ms: 5000
+        success_port: recovered
+        failure_port: failed
+        parse_stdout: json
+        result_payload: value
+    direct_done: {kind: terminal, outcome: success, inputs: {result: {}}}
+    done: {kind: terminal, outcome: success, inputs: {result: {}}}
+    failed: {kind: terminal, outcome: failure, inputs: {result: {}}}
+  edges:
+    - {from: $run.input, to: actor.task}
+    - {from: actor.done, to: direct_done.result}
+    - {from: actor.failed, to: recover.reason, condition: on_failure}
+    - {from: recover.recovered, to: done.result}
+    - {from: recover.failed, to: failed.result, condition: on_failure}
+`);}
+
+it('drains a newly READY failure handler after runtime binding rejection with zero model dispatches',()=>{
+ const parsed=workflow();parsed.meta.agents!.actor={...parsed.meta.agents!.actor,agent_type:'claude-sdk',llm_setting_id:'does-not-exist'};
+ const dispatcher=new FakeDAGDispatcher();const executor=new GraphExecutor(dispatcher);executor.createRun('binding-reject',parsed,'{}');
+ expect.soft(executor.tick('binding-reject')).toBe(1);
+ expect(dispatcher.dispatched).toHaveLength(0);expect(getActiveRun('binding-reject')?.counters.dispatches).toBe(0);
+ expect(getActiveRun('binding-reject')?.dagRun.nodeStates.get('actor')).toBe('FAILED');expect(getActiveRun('binding-reject')?.dagRun.nodeStates.get('recover')).toBe('COMPLETED');expect(getActiveRun('binding-reject')?.status).toBe('completed');
+ const before=JSON.stringify(loadRunSnapshot('binding-reject')?.handoffs);expect(executor.tick('binding-reject')).toBe(0);expect(JSON.stringify(loadRunSnapshot('binding-reject')?.handoffs)).toBe(before);
+});
+
+it('drains a nonretryable dispatch failure without replaying dispatch or recovery side effects',()=>{
+ const parsed=workflow();parsed.meta.agents!.actor={...parsed.meta.agents!.actor,agent_type:'deterministic'};
+ const dispatch=vi.fn(()=>({status:'failed' as const,reason:'no compatible worker',retryable:false}));const executor=new GraphExecutor({dispatch} satisfies DAGDispatcher);executor.createRun('dispatch-reject',parsed,'{}');
+ expect.soft(executor.tick('dispatch-reject')).toBe(1);expect(dispatch).toHaveBeenCalledTimes(1);expect(getActiveRun('dispatch-reject')?.counters.dispatches).toBe(1);expect(getActiveRun('dispatch-reject')?.status).toBe('completed');expect(executor.tick('dispatch-reject')).toBe(0);expect(dispatch).toHaveBeenCalledTimes(1);
+});
+
+it('stops immediately at unchanged capacity-blocked READY nodes without spinning',()=>{
+ const parsed=workflow();parsed.meta.agents!.actor={...parsed.meta.agents!.actor,agent_type:'deterministic'};
+ const dispatch=vi.fn(()=>({status:'skipped' as const,reason:'waiting for capacity'}));const executor=new GraphExecutor({dispatch} satisfies DAGDispatcher);executor.createRun('capacity-wait',parsed,'{}');
+ expect(executor.tick('capacity-wait')).toBe(0);expect(dispatch).toHaveBeenCalledTimes(1);expect(getActiveRun('capacity-wait')?.status).toBe('active');expect(getActiveRun('capacity-wait')?.dagRun.nodeStates.get('actor')).toBe('READY');expect(getActiveRun('capacity-wait')?.dagRun.nodeStates.get('recover')).toBe('PENDING');
+});


### PR DESCRIPTION
A runtime binding rejection or nonretryable dispatch failure could enable a downstream failure handler while recording zero successful dispatches. The drain loop treated that zero as no progress and returned, leaving an active DAG with a READY handler and no running work.

Continue bounded draining when node states changed, while preserving successful-dispatch counts. An unchanged capacity-blocked READY node still stops immediately.

Validation on `cc5b6487c1a576526f741f377bae8c1359d29424`:
- 59 focused Manager tests pass, including independent regressions for pre-dispatch rejection, nonretryable dispatch failure, and no busy loop while waiting for capacity.
- Full CI: 3602 passing tests, 3 existing platform skips.
- Isolated Manager API run `9d6c3d71a0d075fed365f48a`: a deliberately unsupported local-Qwen reasoning selector is rejected before model dispatch; the recovery command runs once and the DAG completes. Model dispatch count stays zero.
- Restarting that isolated Manager preserves the exact terminal status and single recovery handoff.

Implemented through local `qwen38-flash-next` Auto Fix from a Judger-authored plan and independently failing regressions. The implementation round took 29.660 seconds and observed 5731 tokens; the handoff usage snapshot is not claimed as complete billing. No production deployment.

Fixes #278.
