### PR TITLE
fix: reconcile ambiguous DAG creates and verify completed evidence

### DIFF
--- a/agent-ui/src/generative-ui/custom-renderer-browser.test.ts
+++ b/agent-ui/src/generative-ui/custom-renderer-browser.test.ts
@@ -4,8 +4,8 @@ import * as http from 'node:http'
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
-import { chromium, type Browser } from 'playwright'
+import { afterEach, beforeEach, describe, expect, it, onTestFailed } from 'vitest'
+import { chromium, type Browser, type Page } from 'playwright'
 import { validateHomerailA2uiSurface } from 'homerail-protocol'
 import {
   buildCustomRendererSrcdoc,
@@ -16,6 +16,24 @@ import {
 
 let browser: Browser | undefined
 let server: http.Server | undefined
+let page: Page
+let origin: string
+let phase = 'not started'
+let phaseStartedAt = 0
+let completedPhases: { phase: string; duration_ms: number }[] = []
+let consoleMessages: string[] = []
+
+function enterPhase(next: string): void {
+  const now = performance.now()
+  if (phaseStartedAt) completedPhases.push({ phase, duration_ms: Math.round(now - phaseStartedAt) })
+  phase = next
+  phaseStartedAt = now
+}
+
+// Browser cold startup has its own bounded fixture budget; it must not consume
+// the renderer's assertion budget or outlive a timed-out test.
+const browserSetupTimeout = process.platform === 'win32' ? 120_000 : 60_000
+const browserLaunchTimeout = process.platform === 'win32' ? 90_000 : 50_000
 const browserIsolationTimeout = process.platform === 'win32' ? 120_000 : 45_000
 
 async function listen(): Promise<{ origin: string }> {
@@ -32,6 +50,61 @@ async function listen(): Promise<{ origin: string }> {
   return { origin: `http://127.0.0.1:${address.port}` }
 }
 
+beforeEach(async () => {
+  phase = 'not started'
+  phaseStartedAt = 0
+  completedPhases = []
+  consoleMessages = []
+  onTestFailed(() => {
+    // Use only in-memory diagnostics: a stuck page must not stall reporting.
+    console.error('Custom Renderer browser failure', JSON.stringify({
+      phase,
+      phase_elapsed_ms: Math.round(performance.now() - phaseStartedAt),
+      completedPhases,
+      consoleMessages,
+    }))
+  })
+  enterPhase('listen fixture')
+  origin = (await listen()).origin
+  const programFiles = process.env.ProgramFiles ?? process.env.PROGRAMFILES
+  const programFilesX86 = process.env['ProgramFiles(x86)'] ?? process.env['PROGRAMFILES(X86)']
+  const localAppData = process.env.LocalAppData ?? process.env.LOCALAPPDATA
+  const windowsBrowserPaths = process.platform === 'win32'
+    ? [
+        programFiles && path.join(programFiles, 'Google', 'Chrome', 'Application', 'chrome.exe'),
+        programFilesX86 && path.join(programFilesX86, 'Google', 'Chrome', 'Application', 'chrome.exe'),
+        localAppData && path.join(localAppData, 'Google', 'Chrome', 'Application', 'chrome.exe'),
+        programFiles && path.join(programFiles, 'Microsoft', 'Edge', 'Application', 'msedge.exe'),
+        programFilesX86 && path.join(programFilesX86, 'Microsoft', 'Edge', 'Application', 'msedge.exe'),
+      ].filter((candidate): candidate is string => Boolean(candidate))
+    : []
+  const executablePath = [
+    process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH,
+    process.env.CHROME_BIN,
+    ...windowsBrowserPaths,
+    path.join(os.homedir(), '.local/bin/google-chrome'),
+    '/usr/bin/google-chrome',
+    '/usr/bin/chromium',
+  ].find(candidate => candidate && fs.existsSync(candidate))
+  enterPhase(`launch Chromium (${executablePath ?? chromium.executablePath()})`)
+  browser = await chromium.launch({ headless: true, timeout: browserLaunchTimeout, ...(executablePath ? { executablePath } : {}) })
+  enterPhase('create browser context')
+  const browserContext = await browser.newContext()
+  browserContext.setDefaultTimeout(10_000)
+  browserContext.setDefaultNavigationTimeout(10_000)
+  enterPhase('create page')
+  page = await browserContext.newPage()
+  page.on('console', message => {
+    if (consoleMessages.length < 50) consoleMessages.push(`${message.type()}: ${message.text()}`)
+  })
+  page.on('pageerror', error => {
+    if (consoleMessages.length < 50) consoleMessages.push(`pageerror: ${error.message}`)
+  })
+  enterPhase('navigate fixture')
+  await page.goto(origin, { waitUntil: 'domcontentloaded' })
+  enterPhase('fixture ready')
+}, browserSetupTimeout)
+
 afterEach(async () => {
   await browser?.close()
   browser = undefined
@@ -41,7 +114,6 @@ afterEach(async () => {
 
 describe('Custom Renderer real Chromium isolation', () => {
   it('contains untrusted code and returns only native A2UI JSON without iframe DOM', async () => {
-    const { origin } = await listen()
     const identity: CustomRendererIdentityV1 = {
       plugin_id: 'com.example.malicious',
       plugin_version: '1.0.0',
@@ -89,38 +161,13 @@ describe('Custom Renderer real Chromium isolation', () => {
       context: { device: 'desktop' },
     } as never)
 
-    const programFiles = process.env.ProgramFiles ?? process.env.PROGRAMFILES
-    const programFilesX86 = process.env['ProgramFiles(x86)'] ?? process.env['PROGRAMFILES(X86)']
-    const localAppData = process.env.LocalAppData ?? process.env.LOCALAPPDATA
-    const windowsBrowserPaths = process.platform === 'win32'
-      ? [
-          programFiles && path.join(programFiles, 'Google', 'Chrome', 'Application', 'chrome.exe'),
-          programFilesX86 && path.join(programFilesX86, 'Google', 'Chrome', 'Application', 'chrome.exe'),
-          localAppData && path.join(localAppData, 'Google', 'Chrome', 'Application', 'chrome.exe'),
-          programFiles && path.join(programFiles, 'Microsoft', 'Edge', 'Application', 'msedge.exe'),
-          programFilesX86 && path.join(programFilesX86, 'Microsoft', 'Edge', 'Application', 'msedge.exe'),
-        ].filter((candidate): candidate is string => Boolean(candidate))
-      : []
-    const executablePath = [
-      process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH,
-      process.env.CHROME_BIN,
-      ...windowsBrowserPaths,
-      path.join(os.homedir(), '.local/bin/google-chrome'),
-      '/usr/bin/google-chrome',
-      '/usr/bin/chromium',
-    ].find(candidate => candidate && fs.existsSync(candidate))
-    browser = await chromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}) })
-    const browserContext = await browser.newContext()
-    const page = await browserContext.newPage()
     const leakedRequests: string[] = []
     const navigations: string[] = []
-    const consoleMessages: string[] = []
     page.on('request', request => {
       if (request.url().includes('attacker.invalid')) leakedRequests.push(request.url())
     })
     page.on('framenavigated', frame => navigations.push(frame.url()))
-    page.on('console', message => consoleMessages.push(`${message.type()}: ${message.text()}`))
-    await page.goto(origin, { waitUntil: 'domcontentloaded' })
+    enterPhase('worker bootstrap probe')
 
     const bootstrapProbe = await page.evaluate(({ bootstrap, probeIdentity, probeNonce }) => new Promise<string>((resolve) => {
       const url = URL.createObjectURL(new Blob([bootstrap], { type: 'text/javascript' }))
@@ -143,6 +190,7 @@ describe('Custom Renderer real Chromium isolation', () => {
     }), { bootstrap: CUSTOM_RENDERER_WORKER_BOOTSTRAP, probeIdentity: identity, probeNonce: nonce })
     expect(bootstrapProbe).toBe('homerail.custom-renderer.worker.ready')
 
+    enterPhase('mount renderer frame')
     await page.evaluate(({ frameSource, envelope }) => {
       const messages: unknown[] = []
       Object.defineProperty(window, '__customRendererMessages', { value: messages, configurable: true })
@@ -158,6 +206,7 @@ describe('Custom Renderer real Chromium isolation', () => {
       document.querySelector('#host')?.append(frame)
     }, { frameSource: srcdoc, envelope: init })
 
+    enterPhase('wait for renderer A2UI')
     try {
       // Playwright defaults to requestAnimationFrame polling here. Hosted
       // Windows browsers may throttle rAF even though postMessage delivery
@@ -168,10 +217,11 @@ describe('Custom Renderer real Chromium isolation', () => {
         timeout: 10_000,
       })
     } catch (cause) {
-      const messages = await page.evaluate(() => (window as any).__customRendererMessages)
-      throw new Error(`Renderer did not return A2UI: messages=${JSON.stringify(messages)} console=${JSON.stringify(consoleMessages)}`, { cause })
+      // Do not issue another potentially unbounded evaluate on a stalled page.
+      throw new Error(`Renderer did not return A2UI: console=${JSON.stringify(consoleMessages)}`, { cause })
     }
 
+    enterPhase('validate A2UI and isolation')
     const messages = await page.evaluate(() => (window as any).__customRendererMessages)
     expect(messages.map((message: any) => message?.type)).toEqual([
       'homerail.custom-renderer.ready',

--- a/docs/scenarios/event-supervision.md
+++ b/docs/scenarios/event-supervision.md
@@ -128,6 +128,10 @@ promotes a valid completed receipt, or exits 75 for an unresolved interruption.
 A registration that has never executed also returns 75, without an alert or
 queue delivery: absent execution is not corrupt evidence. Digest/log/receipt
 mismatches still produce an evidence error and an idempotent alert.
+Already-completed executions also revalidate the stored runner digest, log and
+summary before reusing the result. This checks historical evidence without
+rewriting the original completion or requiring the checkout to remain at its
+old head. Judger separately checks whether that result applies to the current task.
 Check `status`/event outcome to distinguish a completed failed command from a
 passed command. Changed specs or receipts are errors, not permission to retry.
 

--- a/docs/scenarios/event-supervision.zh-CN.md
+++ b/docs/scenarios/event-supervision.zh-CN.md
@@ -57,6 +57,9 @@ python3 scripts/event-supervisor/durable.py reconcile /absolute/registration.jso
 `reconcile` 只观察已有执行；结果未知且原进程已消失时返回 75，不编造退出码或重启任务。
 从未启动的注册同样返回 75，不写误报警或发送通知；没有执行记录不等于证据损坏。
 真实的摘要、日志或收据不匹配仍返回错误，并保留一次幂等告警。
+已完成的执行也会重新核对保存的执行器收据摘要、日志和汇总内容，不能仅凭 finished 状态复用。
+历史完成记录保持原样；工作区后续推进到新提交不影响历史证据校验，结果是否适用于当前任务
+仍由 Judger 单独判断。
 完成但命令失败与命令通过由 `status` 和事件 outcome 区分。
 
 读取通知后核对本地事件、当前 round/plan/head、执行收据及独立测试/审查产物，再由 Judger

--- a/docs/scenarios/pr-review.md
+++ b/docs/scenarios/pr-review.md
@@ -227,7 +227,7 @@ stable runner reads the existing 0600 DAG mutation token from the persistent
 Home; it never places that token in GitHub Secrets or a Worker environment.
 
 When `dag run-template --run-id` loses the create acknowledgement after a
-transport failure, the CLI performs read-only status queries for that exact
+transport failure or an HTTP 5xx server/proxy response, the CLI performs read-only status queries for that exact
 run ID. Reconciliation is bounded by the requested timeout and capped at 180
 seconds, including each request and polling delay. A successful observation
 with the matching run ID resumes normal terminal/artifact waiting; the run
@@ -235,6 +235,9 @@ need not already be terminal. If identity observation remains unavailable, the
 CLI exits 75 and the stable runner retains evidence without issuing stop. The
 later terminal-wait deadline remains a separate error path. No second create
 is sent, and retry-safe create is not assumed on an older Manager.
+An HTTP 5xx response can arrive after Manager persisted the run. HTTP 4xx
+rejections, including authentication errors and identity conflicts, remain errors
+and do not adopt an existing run.
 
 After a successful create or adoption, continuous terminal-status or artifact
 observation failure for 180 seconds also exits 75, including HTTP errors such

--- a/homerail_cli/src/client.ts
+++ b/homerail_cli/src/client.ts
@@ -11,6 +11,13 @@ export class HomeRailTransportError extends Error {
   }
 }
 
+export class HomeRailHttpError extends Error {
+  constructor(readonly status: number, message: string) {
+    super(message);
+    this.name = "HomeRailHttpError";
+  }
+}
+
 export interface BaseResponse {
   success: boolean;
   message: string;
@@ -242,7 +249,7 @@ export class HomeRailClient {
           // ignore parse error on error body
         }
         httpRejection = true;
-        throw new Error(message);
+        throw new HomeRailHttpError(response.status, message);
       }
 
       return (await response.json()) as T;
@@ -251,6 +258,9 @@ export class HomeRailClient {
         throw new HomeRailTransportError(`Request timed out after ${effectiveTimeout}ms`);
       }
       const redacted = redactClientError(err, this.adminToken, this.mutationToken);
+      if (err instanceof HomeRailHttpError) {
+        throw new HomeRailHttpError(err.status, redacted.message);
+      }
       if (!httpRejection) throw new HomeRailTransportError(redacted.message);
       throw redacted;
     } finally {

--- a/homerail_cli/src/commands/dag-run-template.ts
+++ b/homerail_cli/src/commands/dag-run-template.ts
@@ -5,7 +5,7 @@ import {
   isFullGitRevision,
 } from "homerail-protocol";
 
-import { HomeRailTransportError, type BaseResponse, type HomeRailClient } from "../client.js";
+import { HomeRailHttpError, HomeRailTransportError, type BaseResponse, type HomeRailClient } from "../client.js";
 import { parseSettingIdOption } from "../command-options.js";
 import { getClient } from "../index.js";
 import {
@@ -286,7 +286,11 @@ async function startTemplateRun(
       ...(opts.runId ? { runId: opts.runId } : {}),
     });
   } catch (err: unknown) {
-    if (err instanceof HomeRailTransportError && opts.runId) {
+    // A server/proxy can fail after Manager has persisted the run. Read the
+    // known identity before deciding; an HTTP 5xx does not prove rejection.
+    const ambiguous = err instanceof HomeRailTransportError
+      || (err instanceof HomeRailHttpError && err.status >= 500 && err.status < 600);
+    if (ambiguous && opts.runId) {
       return reconcileAfterLostCreate(
         client, opts.runId, workflowId,
         recoveryTimeoutSeconds ?? 0, recoveryIntervalSeconds ?? 0, err,

--- a/homerail_cli/tests/client.test.ts
+++ b/homerail_cli/tests/client.test.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { HomeRailClient } from "../src/client.js";
+import { HomeRailClient, HomeRailHttpError } from "../src/client.js";
 import {
   HOMERAIL_MANAGER_ADMIN_TOKEN,
   configuredManagerPort,
@@ -314,6 +314,20 @@ describe("HomeRailClient.delete", () => {
 });
 
 describe("HomeRailClient error handling", () => {
+  it("preserves HTTP status while redacting credentials from server errors", async () => {
+    const token = "fixture-private-token";
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      status: 502,
+      json: async () => ({ message: `upstream failed: ${token}` }),
+    } as unknown as Response);
+    const client = new HomeRailClient({ mutationToken: token });
+    const error = await client.post("/api/runs/create-and-run", {}).catch(err => err);
+    expect(error).toBeInstanceOf(HomeRailHttpError);
+    expect(error.status).toBe(502);
+    expect(error.message).not.toContain(token);
+  });
+
   it("throws on non-ok response with message from body", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue({
       ok: false,

--- a/homerail_cli/tests/dag-run-template-recovery.test.ts
+++ b/homerail_cli/tests/dag-run-template-recovery.test.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import * as http from "node:http";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -98,6 +99,60 @@ describe("known-run submission recovery", () => {
       expect(r.calls.filter(x => x.method === "POST")).toHaveLength(2);
     }, 1500);
   }
+
+  for (const httpError of [500, 502, 503, 504]) {
+    it(`reconciles HTTP ${httpError} after the run was accepted without issuing another create`, async () => {
+      const r = await exercise({ httpError });
+      expect(process.exitCode).toBeUndefined();
+      expect(r.output.some(x => JSON.parse(x).run_id === RUN)).toBe(true);
+      expect(r.calls.filter(x => x.url.endsWith("/create-and-run"))).toHaveLength(1);
+      expect(r.calls.filter(x => x.method === "POST")).toHaveLength(2);
+    });
+  }
+
+  it("leaves an ambiguous HTTP 502 create available for Judger reconciliation", async () => {
+    const r = await exercise({ httpError: 502, unavailable: "missing" });
+    expect(process.exitCode).toBe(75);
+    expect(r.output).toEqual([]);
+    expect(r.calls.filter(x => x.url.endsWith("/create-and-run"))).toHaveLength(1);
+  });
+
+  it("recovers through real HTTP when a proxy returns 502 after accepting the create", async () => {
+    const calls: string[] = [];
+    let accepted = false;
+    const server = http.createServer((req, res) => {
+      calls.push(`${req.method} ${req.url}`);
+      req.resume();
+      res.setHeader("content-type", "application/json");
+      let data: unknown;
+      if (req.url === "/api/dag/workflows/sync") data = { workflow: { workflow_id: "recover" } };
+      else if (req.url === "/api/runs/create-and-run") {
+        accepted = true;
+        res.writeHead(502, { "content-type": "text/html" });
+        res.end("<html>upstream response lost</html>");
+        return;
+      } else if (req.url === `/api/runs/${RUN}/status` && accepted) {
+        data = { run_id: RUN, status: "completed" };
+      } else if (req.url === `/api/runs/${RUN}/artifacts` && accepted) data = { artifacts: [] };
+      else { res.statusCode = 404; res.end("{}"); return; }
+      res.end(JSON.stringify({ success: true, data }));
+    });
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      const address = server.address() as { port: number };
+      await createProgram().parseAsync(["node", "hr", "--json", "--base-url", `http://127.0.0.1:${address.port}`,
+        "dag", "run-template", "recover", "--input", "{}", "--run-id", RUN,
+        "--wait", "--timeout", "2", "--interval", "0.01"]);
+      expect(process.exitCode).toBeUndefined();
+      expect(log.mock.calls.some(([value]) => JSON.parse(String(value)).run_id === RUN)).toBe(true);
+      expect(calls.filter(call => call.startsWith("POST "))).toEqual([
+        "POST /api/dag/workflows/sync", "POST /api/runs/create-and-run",
+      ]);
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
+    }
+  });
 
   for (const httpError of [401, 409]) {
     it(`does not adopt an existing run after explicit HTTP ${httpError} rejection`, async () => {

--- a/scripts/event-supervisor/supervise.py
+++ b/scripts/event-supervisor/supervise.py
@@ -115,6 +115,26 @@ def validate(spec, snapshot):
         raise ValueError('stale job: current repository head differs from immutable spec')
 
 
+def completed_receipt(root, record):
+    """Check preserved completion evidence even on a terminal-state replay."""
+    path = root / 'runner.json'
+    raw = path.read_bytes()
+    receipt = json.loads(raw)
+    if receipt.get('status') != 'finished' or receipt['spec_digest'] != record['spec_digest']:
+        raise ValueError('completed runner receipt is missing or belongs to another spec')
+    receipt_digest = hashlib.sha256(raw).hexdigest()
+    if record.get('runner_receipt_digest') != receipt_digest:
+        raise ValueError('completed runner receipt changed')
+    if hashlib.sha256((root / 'execution.log').read_bytes()).hexdigest() != receipt['log_digest']:
+        raise ValueError('runner log differs from completed receipt')
+    for field in ('exit_code', 'after', 'outcome', 'finished_at'):
+        if record[field] != receipt[field]:
+            raise ValueError('execution summary differs from completed receipt: ' + field)
+    # The checkout may legitimately have advanced after completion. Validate
+    # historical evidence here; current candidate acceptance belongs to Judger.
+    return receipt
+
+
 def promote_receipt(root, spec, record):
     """Caller holds the execution lock. Preserve original interruption evidence."""
     path = root / 'runner.json'
@@ -178,6 +198,8 @@ def main(spec_path, reconcile_only=False, expected_digest=None):
                     if reconcile_only and not recovered:
                         return 75
             else:
+                if old.get('event_kind') != 'preflight_failed':
+                    completed_receipt(root, old)
                 notify(root, spec, old.get('event_kind', 'finished'), old)
             return 0
         if reconcile_only:

--- a/scripts/event-supervisor/test_durable.py
+++ b/scripts/event-supervisor/test_durable.py
@@ -344,6 +344,51 @@ class DurableTests(unittest.TestCase):
         self.assertEqual(reconcile.returncode, 1)
         self.assertEqual((self.root / 'deliveries').read_text(), 'queue\nqueue\n')
 
+    def test_completed_evidence_is_revalidated_without_reexecution(self):
+        for corruption in ('log', 'receipt', 'summary', 'missing_receipt'):
+            with self.subTest(corruption=corruption):
+                self.spec.update(execution_id=corruption, event_dir=str(self.root / corruption))
+                record, r = self.register()
+                self.assertEqual(self.run_record(record).returncode, 0)
+                events = Path(self.spec['event_dir'])
+                completion = (events / 'finished.json').read_bytes()
+                if corruption == 'log':
+                    (events / 'execution.log').write_text('modified after completion')
+                elif corruption == 'missing_receipt':
+                    (events / 'runner.json').unlink()
+                else:
+                    path = events / ('runner.json' if corruption == 'receipt' else 'execution.json')
+                    value = durable.read(path)
+                    value['exit_code'] = 7
+                    durable.save(path, value)
+                for _ in range(2):
+                    result = subprocess.run([sys.executable, str(Path(r['runtime']) / 'durable.py'),
+                                             'reconcile', str(record)], capture_output=True)
+                    self.assertEqual(result.returncode, 1)
+                self.assertEqual(durable.read(events / 'evidence_invalid.json')['delivery'], 'queued')
+                self.assertEqual((events / 'finished.json').read_bytes(), completion)
+        self.assertEqual((self.root / 'runs').read_text(), 'run\n' * 4)
+        self.assertEqual((self.root / 'deliveries').read_text(), 'queue\n' * 8)
+
+    def test_completed_receipt_remains_reusable_after_checkout_advances(self):
+        repo = self.root / 'repo'
+        subprocess.run(['git', 'init', '-q', str(repo)], check=True)
+        commit = ['git', '-C', str(repo), '-c', 'user.name=Test',
+                  '-c', 'user.email=test@example.invalid', 'commit', '--allow-empty', '-qm']
+        subprocess.run(commit + ['tested'], check=True)
+        head = subprocess.check_output(['git', '-C', str(repo), 'rev-parse', 'HEAD'], text=True).strip()
+        self.spec.update(repo_dir=str(repo), head=head)
+        record, r = self.register()
+        self.assertEqual(self.run_record(record).returncode, 0)
+        completion = (self.root / 'events/finished.json').read_bytes()
+        subprocess.run(commit + ['next candidate'], check=True)
+        result = subprocess.run([sys.executable, str(Path(r['runtime']) / 'durable.py'),
+                                 'reconcile', str(record)], capture_output=True)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual((self.root / 'events/finished.json').read_bytes(), completion)
+        self.assertEqual((self.root / 'runs').read_text(), 'run\n')
+        self.assertEqual((self.root / 'deliveries').read_text(), 'queue\n')
+
     def test_changed_head_refuses_command_before_execution(self):
         repo = self.root / 'repo'
         subprocess.run(['git', 'init', '-q', str(repo)], check=True)

--- a/scripts/pr-review-execution-evidence.test.mjs
+++ b/scripts/pr-review-execution-evidence.test.mjs
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import http from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const runId='run-audit-1';
 const slots={qwen_review:'qwen',kimi_review:'kimi',glm_review:'glm'};
@@ -128,6 +129,6 @@ stable_hr() {
 test('an explicitly supplied corrupt evidence file fails rendering instead of hiding the corruption',async()=>{
  const {spawnSync}=await import('node:child_process');const dir=fs.mkdtempSync(path.join(os.tmpdir(),'render-corrupt-audit-'));
  try{fs.writeFileSync(path.join(dir,'command.json'),JSON.stringify({run_id:runId}));fs.writeFileSync(path.join(dir,'report.json'),JSON.stringify({report:{reviewer_results:[{},{},{}],findings:[]},quorum:{}}));fs.writeFileSync(path.join(dir,'evidence.json'),'{broken');
- const r=spawnSync(process.execPath,[new URL('./render-pr-review-markdown.mjs',import.meta.url).pathname,path.join(dir,'command.json'),path.join(dir,'report.json'),path.join(dir,'evidence.json')],{encoding:'utf8'});assert.notEqual(r.status,0);assert.match(r.stderr,/Unable to render/);
+ const r=spawnSync(process.execPath,[fileURLToPath(new URL('./render-pr-review-markdown.mjs',import.meta.url)),path.join(dir,'command.json'),path.join(dir,'report.json'),path.join(dir,'evidence.json')],{encoding:'utf8'});assert.notEqual(r.status,0);assert.match(r.stderr,/Unable to render/);
  }finally{fs.rmSync(dir,{recursive:true,force:true});}
 });


### PR DESCRIPTION
Manual audit and subsequent CI validation found recovery and test-harness defects. This PR fixes them together:

- Preserve redacted HTTP status and reconcile an explicit run ID after create HTTP 5xx. Unknown results exit75 without another create or stop; 4xx remains rejected.
- Revalidate completed runner receipts, log digests and result summaries before reuse. Corruption raises one alert without rewriting evidence or reexecuting; valid historical results survive checkout advancement.
- Convert the review renderer file URL with `fileURLToPath`, fixing the doubled drive path in the Windows corruption test.
- Give Chromium fixture setup its own bounded deadline, separate from the unchanged renderer assertion deadline. Bound launch/navigation, record failure phase/timings, and avoid another page evaluation while reporting a stalled renderer. All isolation assertions and coverage thresholds remain enabled.

Validation:

- Original recovery commit `4b49164`: full local CI3800 tests passed,3 existing platform skips;41 supervisor tests and real systemd recovery/reinstall proof passed.
- Windows follow-up `6815d2a`: GitHub CI34231552796 passed Linux Node20/24, Windows Node24 and Docker. UI coverage failed because its Chromium test exceeded45s; the original log cannot establish which phase stalled.
- Browser follow-up `5b4fea0bb3362b0d28afbf4834eb812660bb8c84`: injected46s browser startup fails before the fix and passes all isolation assertions afterward. An injected failed launch still fails with phase diagnostics. Full local UI coverage699 tests/107 files and UI typecheck pass; coverage:52.75% statements,45.96% branches,51.75% functions,54.67% lines.
- Current head `5b4fea0bb3362b0d28afbf4834eb812660bb8c84`: CI34234589731 passed all five jobs. Independent review34234593532 completed all three reviewers: Kimi/Qwen approve, GLM request_changes with the same version-inapplicable idle-connection finding. The owner explicitly accepts all-green CI plus two complete review approvals; this head meets that criterion. The original stricter formal review gate remains failed and its report is preserved.

The old-head formal review completed all three reviewers with one retained keep-alive teardown finding. Codex Judger dismissed that finding against Node's documented idle-connection closure since v19 (repository minimum20) and a31ms focused test; the original negative report is retained, not rewritten as approval.
